### PR TITLE
FinePrint 401 error for API's

### DIFF
--- a/config/initializers/fine_print.rb
+++ b/config/initializers/fine_print.rb
@@ -43,7 +43,9 @@ FinePrint.configure do |config|
       format.html { redirect_to(fine_print.new_contract_signature_path(
                       contract_id: contract_ids.first)) }
       format.json { render status: :unauthorized,
-                           json: {'errors' => [{'message' => 'You must accept the terms of use and privacy policy to continue', 'term_ids' => contract_ids}]} }
+                           json: {'errors' => [{'status' => 401,
+                                                'message' => 'You must accept the terms of use and privacy policy to continue',
+                                                'term_ids' => contract_ids}]} }
     end }
 
 end


### PR DESCRIPTION
If you don't merge this: FinePrint will keep issuing redirects if contracts are invalid. Phil then has to receive the redirect response and redirect appropriately.

If you merge this: FinePrint will issue a 401 Unauthorized with the contract ids in the WWW-Authenticate header. Phil then has to redirect appropriately.

Another option might be making an API for Phil to get the contract text from, and then handle the signing himself. This will likely live in Tutor, outside of FinePrint.
