### PR TITLE
adds code for creating interactives, puts it in sprint 2

### DIFF
--- a/app/representers/api/v1/interactive_representer.rb
+++ b/app/representers/api/v1/interactive_representer.rb
@@ -1,0 +1,26 @@
+module Api::V1
+  class InteractiveRepresenter < Roar::Decorator
+    include Api::V1::TaskProperties
+
+    property :url,
+             type: String,
+             writeable: false,
+             readable: true,
+             as: :content_url,
+             schema_info: {
+               required: false,
+               description: "The URL where the interactive can be found"
+             }
+
+    property :content,
+             type: String,
+             writeable: false,
+             readable: true,
+             as: :content_html,
+             schema_info: {
+               required: false,
+               description: "The interactive content as HTML"
+             }
+                          
+  end
+end

--- a/app/representers/api/v1/task_representer_mapper.rb
+++ b/app/representers/api/v1/task_representer_mapper.rb
@@ -2,26 +2,32 @@ module Api::V1
   class TaskRepresenterMapper
     include Uber::Callable
 
-    def self.map
-      @@map ||= {
-        Reading => Api::V1::ReadingRepresenter
-      }
-    end
-
     def self.models 
       map.keys
     end
 
     def self.representers
-      map.values
+      map.values.collect{|v| v.call}
     end
 
     def call(*args)
-      if args[0] == :all_sub_representers
+      if args[2].is_a?(Hash) && args[2][:all_sub_representers]
         self.class.representers
       else
-        self.class.map[args[1].class]
+        representer = self.class.map[args[1].class].call
+        raise NotYetImplemented if representer.nil?
+        representer
       end
     end
+
+protected
+
+    def self.map
+      @@map ||= {
+        Reading => ->(*) {Api::V1::ReadingRepresenter},
+        Interactive => ->(*) {Api::V1::InteractiveRepresenter}
+      }
+    end
+
   end
 end

--- a/app/routines/create_interactive.rb
+++ b/app/routines/create_interactive.rb
@@ -1,0 +1,25 @@
+class CreateInteractive
+
+  lev_routine
+
+  uses_routine GetOrCreateResource,
+               translations: { outputs: {type: :verbatim} }
+
+protected
+
+  def exec(options={}); debugger
+    run(GetOrCreateResource, options.slice(:url))
+    transfer_errors_from(outputs[:resource], {type: :verbatim}, true)
+
+    outputs[:interactive] = Interactive.create(resource: outputs[:resource])
+    transfer_errors_from(outputs[:interactive], {type: :verbatim}, true)
+
+    task = Task.create(details: outputs[:interactive], 
+                       title: 'placeholder', 
+                       opens_at: options[:opens_at], 
+                       due_at: options[:due_at])
+
+    transfer_errors_from(task, {type: :verbatim}, true)
+  end
+
+end

--- a/app/routines/create_reading.rb
+++ b/app/routines/create_reading.rb
@@ -9,6 +9,7 @@ protected
 
   def exec(options={})
     run(GetOrCreateResource, options.slice(:url, :content))
+    transfer_errors_from(outputs[:resource], {type: :verbatim}, true)
 
     outputs[:reading] = Reading.create(resource: outputs[:resource])
     transfer_errors_from(outputs[:reading], {type: :verbatim}, true)

--- a/lib/sprint/002.rake
+++ b/lib/sprint/002.rake
@@ -6,7 +6,7 @@ namespace :sprint do
     result = Sprint002.call(args.username)
 
     if result.errors.none?
-      puts "Created a user with username '#{args.username}' with one reading task"
+      puts "Created a user with username '#{args.username}' with one reading and one interactive task"
     else
       result.errors.each{|error| puts "Error: " + Lev::ErrorTranslator.translate(error)}
     end

--- a/lib/sprint/sprint_002.rb
+++ b/lib/sprint/sprint_002.rb
@@ -9,6 +9,9 @@ class Sprint002
   uses_routine CreateReading,
                translations: { outputs: {type: :verbatim} }
 
+  uses_routine CreateInteractive,
+               translations: { outputs: {type: :verbatim} }
+
   uses_routine AssignTask
 
 protected
@@ -16,8 +19,15 @@ protected
   def exec(username)
     run(:create_account, username: username)
     user = UserMapper.account_to_user(outputs[:account])
-    run(CreateReading, url: "http://archive.cnx.org/contents/3e1fc4c6-b090-47c1-8170-8578198cc3f0@8.html")
+
+    run(CreateReading, url: "http://archive.cnx.org/contents/3e1fc4c6-b090-47c1-8170-8578198cc3f0@8.html",
+                       opens_at: Time.now)
     run(AssignTask, task: outputs[:reading], assignee: user)
+
+    run(CreateInteractive, url: "http://connexions.github.io/simulations",
+                           opens_at: Time.now,
+                           due_at: Time.now + 1.week)
+    run(AssignTask, task: outputs[:interactive], assignee: user)
   end
 
 end


### PR DESCRIPTION
@Dantemss to review, @philschatz to use after merged -- same way as do existing sprint2 setup, now it'll just give the following on the API call:

```
{
  total_count: 2,
  items: [
    {
      id: 1,
      type: "reading",
      task_plan_id: null,
      opens_at: "2014-10-15T17:16:59.657Z",
      is_shared: false,
      content_url: "http://archive.cnx.org/contents/3e1fc4c6-b090-47c1-8170-8578198cc3f0@8.html"
    },
    {
      id: 2,
      type: "interactive",
      task_plan_id: null,
      opens_at: "2014-10-15T17:16:59.723Z",
      due_at: "2014-10-22T17:16:59.723Z",
      is_shared: false,
      content_url: "http://connexions.github.io/simulations"
    }
  ]
}
```
