### PR TITLE
CreateUser sets User's exchange_identifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'whenever'
 # OpenStax Accounts integration
 gem 'openstax_accounts', '~> 3.1.1'
 
+# OpenStax Exchange integration
+gem 'openstax_exchange', git: 'https://github.com/openstax/exchange-ruby.git'
+
 # Respond_with and respond_to methods
 gem 'responders', '~> 2.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'whenever'
 gem 'openstax_accounts', '~> 3.1.1'
 
 # OpenStax Exchange integration
-gem 'openstax_exchange', git: 'https://github.com/openstax/exchange-ruby.git'
+gem 'openstax_exchange'
 
 # Respond_with and respond_to methods
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/openstax/exchange-ruby.git
+  revision: 415ef89f7aab25d69e1fa61c448ab3793ca2db80
+  specs:
+    openstax_exchange (0.0.1)
+      oauth2 (>= 0.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -423,6 +430,7 @@ DEPENDENCIES
   nifty-generators
   openstax_accounts (~> 3.1.1)
   openstax_api (~> 3.1.1)
+  openstax_exchange!
   openstax_utilities (~> 4.1.0)
   pg
   quiet_assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/openstax/exchange-ruby.git
-  revision: 415ef89f7aab25d69e1fa61c448ab3793ca2db80
-  specs:
-    openstax_exchange (0.0.1)
-      oauth2 (>= 0.5.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -224,6 +217,8 @@ GEM
       representable (>= 1.8)
       roar (>= 0.12.1)
       roar-rails (>= 0.1.2)
+    openstax_exchange (0.0.1)
+      oauth2 (>= 0.5.0)
     openstax_utilities (4.1.0)
       keyword_search
       lev
@@ -430,7 +425,7 @@ DEPENDENCIES
   nifty-generators
   openstax_accounts (~> 3.1.1)
   openstax_api (~> 3.1.1)
-  openstax_exchange!
+  openstax_exchange
   openstax_utilities (~> 4.1.0)
   pg
   quiet_assets

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ActiveRecord::Base
   has_many :students, dependent: :destroy
 
   validates :account, presence: true, uniqueness: true
+  validates :exchange_identifier, presence: true
 
   delegate :username, :first_name, :last_name, :full_name, :title,
            :name, :casual_name, :first_name=, :last_name=, :full_name=,

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -13,8 +13,5 @@ class CreateUser
     end
 
     transfer_errors_from(outputs[:user], {type: :verbatim})
-  rescue StandardError => error
-    fatal_error(code: :exception_raised, data: error)
   end
-
 end

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -1,0 +1,20 @@
+require 'openstax_exchange'
+
+class CreateUser
+
+  lev_routine
+
+  protected
+
+  def exec(account)
+    outputs[:user] = User.create do |user|
+      user.account = account
+      user.exchange_identifier = OpenStax::Exchange.create_identifier
+    end
+
+    transfer_errors_from(outputs[:user], {type: :verbatim})
+  rescue StandardError => error
+    fatal_error(code: :exception_raised, data: error)
+  end
+
+end

--- a/config/initializers/openstax_exchange.rb
+++ b/config/initializers/openstax_exchange.rb
@@ -1,1 +1,7 @@
-## TODO: read credentials and set config
+OpenStax::Exchange.configure do |config|
+  config.client_platform_id     = Rails.application.secrets[:application_openstax_exchange_id]
+  config.client_platform_secret = Rails.application.secrets[:application_openstax_exchange_secret]
+  config.client_server_url      = 'https://exchange.openstax.org'
+  config.client_api_version     = 'v1'
+end
+OpenStax::Exchange.reset!

--- a/config/initializers/openstax_exchange.rb
+++ b/config/initializers/openstax_exchange.rb
@@ -1,0 +1,1 @@
+## TODO: read credentials and set config

--- a/db/migrate/20140724184630_create_users.rb
+++ b/db/migrate/20140724184630_create_users.rb
@@ -1,9 +1,9 @@
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|
-      t.references :account, null: false
-      t.string :exchange_identifier
-      t.datetime :deleted_at
+      t.references  :account, null: false
+      t.string      :exchange_identifier, null: false
+      t.datetime    :deleted_at
 
       t.timestamps null: false
     end

--- a/db/migrate/20150106202716_add_exchange_identifier_not_null_constraint_to_users.rb
+++ b/db/migrate/20150106202716_add_exchange_identifier_not_null_constraint_to_users.rb
@@ -1,0 +1,5 @@
+class AddExchangeIdentifierNotNullConstraintToUsers < ActiveRecord::Migration
+  def change
+    change_column :users, :exchange_identifier, :string, :null => false
+  end
+end

--- a/db/migrate/20150106202716_add_exchange_identifier_not_null_constraint_to_users.rb
+++ b/db/migrate/20150106202716_add_exchange_identifier_not_null_constraint_to_users.rb
@@ -1,5 +1,0 @@
-class AddExchangeIdentifierNotNullConstraintToUsers < ActiveRecord::Migration
-  def change
-    change_column :users, :exchange_identifier, :string, :null => false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141110212240) do
+ActiveRecord::Schema.define(version: 20150106202716) do
 
   create_table "administrators", force: true do |t|
     t.integer  "user_id",    null: false
@@ -394,7 +394,7 @@ ActiveRecord::Schema.define(version: 20141110212240) do
 
   create_table "users", force: true do |t|
     t.integer  "account_id",          null: false
-    t.string   "exchange_identifier"
+    t.string   "exchange_identifier", null: false
     t.datetime "deleted_at"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150106202716) do
+ActiveRecord::Schema.define(version: 20141110212240) do
 
   create_table "administrators", force: true do |t|
     t.integer  "user_id",    null: false

--- a/lib/generators/secrets/templates/secrets.yml.erb
+++ b/lib/generators/secrets/templates/secrets.yml.erb
@@ -14,14 +14,20 @@ development:
   secret_key_base: <%= SecureRandom.hex(64) %>
   openstax_application_id: ~
   openstax_application_secret: ~
+  application_openstax_exchange_id:     '123'
+  application_openstax_exchange_secret: 'abc'
 
 test:
   secret_key_base: <%= SecureRandom.hex(64) %>
   openstax_application_id: ~
   openstax_application_secret: ~
+  application_openstax_exchange_id:     '123'
+  application_openstax_exchange_secret: 'abc'
 
 # Do not keep production secrets in the repository.
 production:
   secret_key_base: <%= SecureRandom.hex(64) %>
   openstax_application_id: ~
   openstax_application_secret: ~
+  application_openstax_exchange_id:     '123'
+  application_openstax_exchange_secret: 'abc'

--- a/lib/user_mapper.rb
+++ b/lib/user_mapper.rb
@@ -2,7 +2,14 @@ module UserMapper
 
   def self.account_to_user(account)
     return User.anonymous if account.is_anonymous?
-    User.find_or_create_by(account_id: account.id)
+
+    user = User.where{:account_id == account_id}.first
+    return user if user.present?
+
+    outcome = CreateUser(account)
+    raise "CreateUser failed" unless outcome.errors.none?
+
+    outcome.outputs.user
   end
 
   def self.user_to_account(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe User, :type => :model do
   it { is_expected.to have_many(:students).dependent(:destroy) }
 
   it { is_expected.to validate_presence_of(:account) }
+  it { is_expected.to validate_presence_of(:exchange_identifier) }
 
   it 'must enforce that one account is only used by one user' do
     user1 = FactoryGirl.create(:user)

--- a/spec/routines/create_user_spec.rb
+++ b/spec/routines/create_user_spec.rb
@@ -4,17 +4,13 @@ describe CreateUser do
   let!(:account) { FactoryGirl.create(:openstax_accounts_account) }
 
   before(:each) do
-    OpenStax::Exchange.configure do |config|
-      config.client_platform_id     = '123'
-      config.client_platform_secret = 'abc'
-      config.client_server_url      = 'https://exchange.openstax.org'
-      config.client_api_version     = 'v1'
-    end
-
     OpenStax::Exchange::FakeClient.configure do |config|
-      config.registered_platforms   = { '123' => 'abc'}
-      config.server_url             = 'https://exchange.openstax.org'
-      config.supported_api_versions = ['v1']
+      config.registered_platforms   = {
+        OpenStax::Exchange.configuration.client_platform_id =>
+        OpenStax::Exchange.configuration.client_platform_secret
+      }
+      config.server_url             = OpenStax::Exchange.configuration.client_server_url
+      config.supported_api_versions = [OpenStax::Exchange.configuration.client_api_version]
     end
 
     OpenStax::Exchange.use_fake_client

--- a/spec/routines/create_user_spec.rb
+++ b/spec/routines/create_user_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe CreateUser do
+  let!(:account) { FactoryGirl.create(:openstax_accounts_account) }
+
+  before(:each) do
+    OpenStax::Exchange.configure do |config|
+      config.client_platform_id     = '123'
+      config.client_platform_secret = 'abc'
+      config.client_server_url      = 'https://exchange.openstax.org'
+      config.client_api_version     = 'v1'
+    end
+
+    OpenStax::Exchange::FakeClient.configure do |config|
+      config.registered_platforms   = { '123' => 'abc'}
+      config.server_url             = 'https://exchange.openstax.org'
+      config.supported_api_versions = ['v1']
+    end
+
+    OpenStax::Exchange.use_fake_client
+    OpenStax::Exchange.reset!
+  end
+
+  context "success" do
+    it "creates a new User" do
+      expect {
+        CreateUser.call(account)
+      }.to change{User.count}.by 1
+    end
+    it "initializes the User's exchange_identifier" do
+      outcome = CreateUser.call(account)
+      expect(outcome.outputs[:user].exchange_identifier).to match(/^[a-fA-F0-9]+$/)
+    end
+    it "returns an outcome without errors" do
+      outcome = CreateUser.call(account)
+      expect(outcome.errors).to be_empty
+    end
+  end
+
+  context "when account is not passed in" do
+    it "raises an exception" do
+      expect {
+        outcome = CreateUser.call()
+      }.to raise_error
+    end
+  end
+
+  context "when exchange_identifier is not set" do
+    before(:each) do
+      OpenStax::Exchange::FakeClient.configure do |config|
+        config.server_url = 'https://some.fake.address'
+      end
+      OpenStax::Exchange.reset!
+    end
+
+    it "does not create a new User" do
+      expect {
+        CreateUser.call(account)
+      }.to change{User.count}.by 0
+    end
+    it "returns an outcome with errors" do
+      outcome = CreateUser.call(account)
+      expect(outcome.errors).to_not be_empty
+    end
+  end
+end

--- a/spec/routines/create_user_spec.rb
+++ b/spec/routines/create_user_spec.rb
@@ -33,11 +33,10 @@ describe CreateUser do
     end
   end
 
-  context "when account is not passed in" do
-    it "raises an exception" do
-      expect {
-        outcome = CreateUser.call()
-      }.to raise_error
+  context "when account is nil" do
+    it "returns an outcome with errors" do
+      outcome = CreateUser.call(nil)
+      expect(outcome.errors).to_not be_empty
     end
   end
 
@@ -49,14 +48,18 @@ describe CreateUser do
       OpenStax::Exchange.reset!
     end
 
-    it "does not create a new User" do
+    it "raises an exception" do
       expect {
         CreateUser.call(account)
-      }.to change{User.count}.by 0
+      }.to raise_error(StandardError)
     end
-    it "returns an outcome with errors" do
-      outcome = CreateUser.call(account)
-      expect(outcome.errors).to_not be_empty
+    it "does not create a new User" do
+      expect {
+        begin
+          CreateUser.call(account)
+        rescue
+        end
+      }.to change{User.count}.by 0
     end
   end
 end


### PR DESCRIPTION
This PR has the `CreateUser` routine set the `exchange_identifier` in the `User` model.  Specs, initializers, and `secrets.yml` (really `lib/generators/secrets/templates/secrets.yml.erb`) have been updated accordingly.

@jpslav @Dantemss 