### PR TITLE
Initial pass at OX Exercises wrapper inside Tutor

### DIFF
--- a/app/external/openstax/exercises/v1.rb
+++ b/app/external/openstax/exercises/v1.rb
@@ -1,0 +1,41 @@
+module OpenStax::Exercises::V1
+
+  #
+  # API Wrappers
+  #
+
+  # GET /api/exercises
+  # options can have :tag, :id, :number, :version keys
+  def self.exercises(options={})
+    client.exercises(options)
+  end
+
+  #
+  # Configuration
+  #
+
+  # accessor for the fake client, which has some extra fake methods on it
+  def self.fake_client
+    @fake_client
+  end
+
+  def self.use_fake_client
+    @client = @fake_client
+  end
+
+  # The real client is used by default, so this only exists in case you said
+  # use_fake_client but wanted to switch
+  def self.use_real_client
+    @client = @real_client
+  end
+
+  private
+
+  @fake_client = FakeClient.new
+  @real_client = RealClient.new
+
+  def self.client
+    @client ||= @real_client
+  end
+
+end

--- a/app/external/openstax/exercises/v1/fake_client.rb
+++ b/app/external/openstax/exercises/v1/fake_client.rb
@@ -54,12 +54,16 @@ class OpenStax::Exercises::V1::FakeClient
     )
   end
 
-  attr_reader :exercises_array
-
-  def initialize
+  def reset!
     @exercises_array = []
     @uid = 0
     @exercise_number = 0
+  end
+
+  attr_reader :exercises_array
+
+  def initialize
+    reset!
   end
 
   private

--- a/app/external/openstax/exercises/v1/fake_client.rb
+++ b/app/external/openstax/exercises/v1/fake_client.rb
@@ -1,0 +1,102 @@
+class OpenStax::Exercises::V1::FakeClient
+
+  #
+  # Api wrappers
+  #
+
+  def exercises(options={})
+    arrayify(options, :number)
+    arrayify(options, :version)
+    arrayify(options, :id)
+    arrayify(options, :tag)
+
+    match_sets = []
+
+    match_sets.push( @exercises_array.select{|ee| options[:id].include?(ee[:id])}           ) if options[:id]
+    match_sets.push( @exercises_array.select{|ee| (options[:tag] & ee[:tags]).any?}         ) if options[:tag]
+    match_sets.push( @exercises_array.select{|ee| options[:number].include?(ee[:number])}   ) if options[:number]
+    match_sets.push( @exercises_array.select{|ee| options[:version].include?(ee[:version])} ) if options[:version] 
+
+    result = nil
+
+    match_sets.each do |match_set|
+      if result.nil?
+        result = match_set
+      else
+        result = result & match_set
+      end
+    end
+
+    (result || []).collect{|exercise| exercise[:content]}
+  end
+
+  #
+  # Methods to help fake the fake content
+  #
+
+  def add_exercise(options={})
+    exercise_number = next_exercise_number
+
+    options[:number] ||= exercise_number
+    options[:content] ||= new_exercise_hash(options[:number])
+    options[:tags] ||= []
+    options[:version] ||= 1
+    options[:id] ||= "e#{options[:number]}v#{options[:version]}"
+
+    @exercises_array.push(
+      {
+        content: options[:content],
+        tags: options[:tags],
+        number: options[:number],
+        version: options[:version],
+        id: options[:id]
+      }
+    )
+  end
+
+  attr_reader :exercises_array
+
+  def initialize
+    @exercises_array = []
+    @uid = 0
+    @exercise_number = 0
+  end
+
+  private
+
+  def new_exercise_hash(exercise_number = next_exercise_number)
+    {
+      stimulus: "This is fake exercise #{exercise_number}.  <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span>",
+      questions: [
+        {
+          id: "#{next_uid}",
+          format: "short-answer",
+          stem: "What is the answer to this question?"
+        },
+        {
+          id: "#{next_uid}",
+          format: "multiple-choice",
+          stem: "Select the answer that makes the most sense.",
+          answers:[
+            {id: "#{next_uid}", content: "10 N"},
+            {id: "#{next_uid}", content: "1 N"}
+          ]
+        }
+      ]
+    } 
+  end
+
+  def next_uid
+    @uid += 1
+  end
+
+  def next_exercise_number
+    @exercise_number += 1
+  end
+
+  # Makes the value of hash[:key] an array if isn't already one and the key exists
+  def arrayify(hash, key)
+    hash[key] = [hash[key]].flatten if hash[key]
+  end
+
+end

--- a/app/external/openstax/exercises/v1/real_client.rb
+++ b/app/external/openstax/exercises/v1/real_client.rb
@@ -1,0 +1,7 @@
+class OpenStax::Exercises::V1::RealClient
+
+  def exercises(options={})
+    raise NotYetImplemented
+  end
+
+end

--- a/spec/external/openstax/exercises/v1/fake_client_spec.rb
+++ b/spec/external/openstax/exercises/v1/fake_client_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe OpenStax::Exercises::V1::FakeClient do
+
+  let(:fake_client) {OpenStax::Exercises::V1.fake_client}
+
+  it 'allows adding of exercises' do
+    expect{fake_client.add_exercise}.to change{fake_client.exercises_array.count}.by(1)
+  end
+
+  it 'allows searching of exercises by number' do
+    fake_client.add_exercise(number: 42)
+    expect(fake_client.exercises(number: 42).count).to eq 1
+  end
+
+end
+
+
+

--- a/spec/external/openstax/exercises/v1/fake_client_spec.rb
+++ b/spec/external/openstax/exercises/v1/fake_client_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe OpenStax::Exercises::V1::FakeClient do
 
   let(:fake_client) {OpenStax::Exercises::V1.fake_client}
+  before(:each) {fake_client.reset!}
 
   it 'allows adding of exercises' do
     expect{fake_client.add_exercise}.to change{fake_client.exercises_array.count}.by(1)
@@ -10,7 +11,81 @@ RSpec.describe OpenStax::Exercises::V1::FakeClient do
 
   it 'allows searching of exercises by number' do
     fake_client.add_exercise(number: 42)
-    expect(fake_client.exercises(number: 42).count).to eq 1
+    fake_client.add_exercise(number: 36)
+
+    expect(fake_client.exercises(number: 42)).to eq(
+      [{
+        stimulus: "This is fake exercise 42.  <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span>",
+        questions: [
+          {
+            id: "1",
+            format: "short-answer",
+            stem: "What is the answer to this question?"
+          },
+          {
+            id: "2",
+            format: "multiple-choice",
+            stem: "Select the answer that makes the most sense.",
+            answers:[
+              {id: "3", content: "10 N"},
+              {id: "4", content: "1 N"}
+            ]
+          }
+        ]
+      }]
+    )
+  end
+
+  it 'allows searching of exercises by tag' do
+    fake_client.add_exercise(tags: ["billy"])
+    fake_client.add_exercise(tags: ["franky"])
+    fake_client.add_exercise(tags: ["billy"])
+
+    expect(fake_client.exercises(tag: "billy").count).to eq 2
+    expect(fake_client.exercises(tag: "franky").count).to eq 1
+    expect(fake_client.exercises(tag: "tommy").count).to eq 0
+
+    expect(fake_client.exercises(tag: "franky")).to eq(
+      [{
+        stimulus: "This is fake exercise 2.  <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span>",
+        questions: [
+          {
+            id: "5",
+            format: "short-answer",
+            stem: "What is the answer to this question?"
+          },
+          {
+            id: "6",
+            format: "multiple-choice",
+            stem: "Select the answer that makes the most sense.",
+            answers:[
+              {id: "7", content: "10 N"},
+              {id: "8", content: "1 N"}
+            ]
+          }
+        ]
+      }]
+    )
+
+    expect(fake_client.exercises(tag: "billy", number: 1).count).to eq 1
+  end
+
+  it 'allows searching of exercises by version' do
+    fake_client.add_exercise
+    fake_client.add_exercise
+    fake_client.add_exercise
+
+    expect(fake_client.exercises(version: 1).count).to eq 3
+  end
+
+  it 'allows searching of exercises by version and id' do
+    fake_client.add_exercise
+    fake_client.add_exercise
+    fake_client.add_exercise
+
+    expect(fake_client.exercises(id: "e1v1").count).to eq 1
+    expect(fake_client.exercises(id: "e2v1").count).to eq 1
+    expect(fake_client.exercises(id: "e4v1").count).to eq 0
   end
 
 end


### PR DESCRIPTION
@Dantemss here's the PR for providing you with exercise content.  From your import code, you call

    OpenStax::Exercises::V1.exercises(tags: ["ost-blah", "ost-blah2"])

and you get back ruby hashes containing exercise content that you could then shove into an `Exercise` object.  As you'll notice, there's a "real" and a "fake" implementation (the choice of which is made in a configuration call -- the actual business logic call to use the Exercises wrapper looks the same either way, like the above).  The "real" implementation (unimplemented) would actually make calls off to OX Exercises.  The "fake" implementation lets you add exercises from test code so that they have the tags / numbers you want. 