### PR TITLE
sprint 006 rake task and shell for sprint 6 routine

### DIFF
--- a/lib/sprint/006.rake
+++ b/lib/sprint/006.rake
@@ -1,0 +1,13 @@
+namespace :sprint do
+  desc 'Set up a user with a reading task with content from CNX and more real spaced practice'
+  task :'006', [:username] => [:environment] do |t, args|
+    args.with_defaults(username: SecureRandom.hex(4))
+    result = Sprint006::Main.call(username_or_user: args.username)
+
+    if result.errors.none?
+      puts "Created a user with username '#{args.username}' with the sprint scenario"
+    else
+      result.errors.each{|error| puts "Error: " + Lev::ErrorTranslator.translate(error)}
+    end
+  end
+end

--- a/lib/sprint/sprint_006/main.rb
+++ b/lib/sprint/sprint_006/main.rb
@@ -1,0 +1,29 @@
+module Sprint006
+  class Main
+
+    lev_routine
+
+    uses_routine OpenStax::Accounts::Dev::CreateAccount, 
+                 as: :create_account,
+                 translations: { outputs: {type: :verbatim} }
+
+  protected
+
+    def exec(username_or_user:, opens_at: Time.now)
+
+      if username_or_user.is_a? String
+        run(:create_account, username: username_or_user)
+        user = UserMapper.account_to_user(outputs[:account])
+      else
+        user = username_or_user
+      end
+
+      ##########
+      # Do all the sprint 6 setup, e.g. importing books, adding fake exercises
+      # to OpenStax::Exercises::V1.fake_client matching the tags from the books
+      # call the assistant to create an ireading, etc etc.
+
+    end
+
+  end
+end

--- a/spec/sprints/006/request.rb
+++ b/spec/sprints/006/request.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Sprint 6 API", type: :request, :api => true, :version => :v1 do
+
+  let!(:application)     { FactoryGirl.create :doorkeeper_application }
+  let!(:jimmy)           { FactoryGirl.create :user }
+  let!(:jimmy_token)     { FactoryGirl.create :doorkeeper_access_token, 
+                                              application: application, 
+                                              resource_owner_id: jimmy.id }
+
+  it "ponders life" do
+    # put some smoke tests here, see sprint 003
+  end
+
+end
+
+
+

--- a/spec/sprints/006/sprint_006.rb
+++ b/spec/sprints/006/sprint_006.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Sprint006, :type => :routine do
+
+  let!(:application)     { FactoryGirl.create :doorkeeper_application }
+  let!(:jimmy)           { FactoryGirl.create :user }
+  let!(:jimmy_token)     { FactoryGirl.create :doorkeeper_access_token, 
+                                              application: application, 
+                                              resource_owner_id: jimmy.id }
+
+  it "doesn't catch on fire" do
+    result = Sprint006::Main.call("frank")
+  end
+
+end
+
+
+


### PR DESCRIPTION
@Dantemss you can fill in this `Sprint006` routine with all the setup you need (calls to `ImportBook` etc).  This PR just gets you the boilerplate.

```
rake db:drop
rake db:migrate
rake sprint:006
rails server
```

Go to http://localhost:3001, sign in as the sole user (printed out in the sprint:006 run above).