### PR TITLE
use local tutor-js files

### DIFF
--- a/app/views/webview/index.html.erb
+++ b/app/views/webview/index.html.erb
@@ -1,3 +1,3 @@
 <script type='text/javascript' defer>var path = '<%= @path %>', name = '<%= @name %>';</script>
-<script type='text/javascript' src='//openstax.github.io/tutor-js/bundle.js' defer></script>
-<link rel='stylesheet' href='//openstax.github.io/tutor-js/tutor.css' />
+<script type='text/javascript' src='http://localhost:8000/dist/tutor.js' defer></script>
+<link rel='stylesheet' href='http://localhost:8000/dist/tutor.css' />

--- a/spec/views/webview/index.html.erb_spec.rb
+++ b/spec/views/webview/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "webview/index", :type => :view do
     render
 
     expect(rendered).to include("<script type='text/javascript' defer>var path = '#{@path}', name = '#{@name}';</script>")
-    expect(rendered).to include("<script type='text/javascript' src='//openstax.github.io/tutor-js/bundle.js' defer></script>")
-    expect(rendered).to include("<link rel='stylesheet' href='//openstax.github.io/tutor-js/tutor.css' />")
+    expect(rendered).to include("<script type='text/javascript' src='http://localhost:8000/dist/tutor.js' defer></script>")
+    expect(rendered).to include("<link rel='stylesheet' href='http://localhost:8000/dist/tutor.css' />")
   end
 end


### PR DESCRIPTION
This is mostly for testers like greg.

Instead of relying on the now-stale github.io files, use ones started by running `gulp serve` in tutor-js (install instructions in the README)