### PR TITLE
added missing call to #reset!

### DIFF
--- a/lib/tasks/sprint/sprint_006/main.rb
+++ b/lib/tasks/sprint/sprint_006/main.rb
@@ -33,6 +33,8 @@ module Sprint006
         config.supported_api_versions = ['v1']
       end
 
+      OpenStax::Exchange.reset!
+
       if username_or_user.is_a? String
         run(:create_account, username: username_or_user)
         user = UserMapper.account_to_user(outputs[:account])


### PR DESCRIPTION
A call to `#reset!` is required after configuration changes to `OpenStax::Exchange` to ensure the creation of a new client object with the updated config.