### PR TITLE
Add Spec for JSON format of TaskSearchRepresenter, TaskedExerciseRepresenter

### DIFF
--- a/spec/representers/api/v1/task_search_representer_spec.rb
+++ b/spec/representers/api/v1/task_search_representer_spec.rb
@@ -1,5 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::TaskSearchRepresenter, :type => :representer do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  context "a user" do
+
+    let(:user)    { FactoryGirl.create(:user) }
+    let(:outputs) { SearchTasks.call(q: "user_id:#{user.id}").outputs   }
+    let(:default_task)   { FactoryGirl.create(:task) }
+    let(:representation) { Api::V1::TaskSearchRepresenter.new(outputs).as_json }
+
+    it "generates a JSON representation of their tasks" do
+
+      5.times{ FactoryGirl.create(:tasking, taskee: user) }
+
+      expect(representation).to include(
+        "total_count" => 5,
+        "items" => a_collection_including(
+          a_hash_including(
+            "id"           => a_value_within(1).of(5),
+            "task_plan_id" => a_value_within(1).of(5),
+            "title"        => a_string_matching(default_task.title),
+            "is_shared"    => false
+          )
+        )
+      )
+
+    end
+
+  end
+
 end

--- a/spec/representers/api/v1/task_search_representer_spec.rb
+++ b/spec/representers/api/v1/task_search_representer_spec.rb
@@ -9,20 +9,20 @@ RSpec.describe Api::V1::TaskSearchRepresenter, :type => :representer do
     let(:default_task)   { FactoryGirl.create(:task) }
     let(:representation) { Api::V1::TaskSearchRepresenter.new(outputs).as_json }
 
-    it "generates a JSON representation of their tasks" do
-
-      5.times{ FactoryGirl.create(:tasking, taskee: user) }
+    it "represents a generates a JSON representation of their tasks" do
+      task_count = rand(5..10)
+      task_count.times{ FactoryGirl.create(:tasking, taskee: user) }
 
       expect(representation).to include(
-        "total_count" => 5,
-        "items" => a_collection_including(
-          a_hash_including(
-            "id"           => a_value_within(1).of(5),
-            "task_plan_id" => a_value_within(1).of(5),
-            "title"        => a_string_matching(default_task.title),
-            "is_shared"    => false
-          )
-        )
+        "total_count" => task_count,
+        "items" => outputs[:items].map{ | item |
+          json = item.as_json.slice('id', 'title', 'task_plan_id', 'is_shared', 'steps')
+          json['opens_at']  = DateTimeUtilities.to_api_s(item.opens_at)
+          json['due_at']    = DateTimeUtilities.to_api_s(item.due_at)
+          json['is_shared'] = item.is_shared
+          json['steps']     = item.task_steps.as_json
+          json
+        }
       )
 
     end

--- a/spec/representers/api/v1/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasked_exercise_representer_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::TaskedExerciseRepresenter, :type => :representer do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  let(:exercise_content) { OpenStax::Exercises::V1.fake_client.new_exercise_hash }
+  let(:tasked_exercise) {
+    FactoryGirl.create(:tasked_exercise, content: exercise_content.to_json)
+  }
+  let(:representation) { Api::V1::TaskedExerciseRepresenter.new(tasked_exercise).as_json }
+
+  it "represents a tasked exercise" do
+    expect(representation).to include(
+      "id"           => tasked_exercise.id,
+      "type"         => "exercise",
+      "is_completed" => false,
+      "content_url"  => tasked_exercise.url,
+      "content"      => exercise_content.deep_stringify_keys
+    )
+  end
+
 end


### PR DESCRIPTION
Submitting this for feedback early in case I'm not on the correct track for what should be tested here.

Should the spec be testing additional features of the Representer that I'm not aware of? My thoughts were that since were testing a Representer, the primary thing we need to ensure is well-formed JSON in the the format that the client expects to see.  I also took a peek at the spec for the TaskedReadingRepresenter and that was all it did as well.  

The other thing that needs specs is the due_at and opens_at keys.  Since those are timestamp attributes, I need to control the time that the factory is ran at and then compare against that.  I don't see Timecop or any similar gems being used, is there anything and I've just missed it?  Or perhaps I should just stub Time.now ?

I'm also not super familiar with rspec.  I've used it a bit but it's quite possible that I'm not writing this in the best fashion.  Opinions are quite welcome if it should be written differently.

Currently working on the TaskedExerciseRepresenter and will add it to this shortly.