### PR TITLE
Fixes test order dependency due to Exercises FakeClient

### DIFF
--- a/app/external/openstax/exercises/v1.rb
+++ b/app/external/openstax/exercises/v1.rb
@@ -29,23 +29,26 @@ module OpenStax::Exercises::V1
 
   # Accessor for the fake client, which has some extra fake methods on it
   def self.fake_client
-    FakeClient.instance
+    @fake_client ||= FakeClient.instance
+  end
+
+  def self.real_client
+    @real_client ||= RealClient.new(configuration)
   end
 
   def self.use_real_client
-    @use_fake_client = false
+    @client = real_client
   end
 
   def self.use_fake_client
-    @use_fake_client = true
+    @client = fake_client
   end
 
   private
 
   def self.client
     begin
-      @client ||= @use_fake_client ? fake_client : \
-                                     RealClient.new(configuration)
+      @client ||= real_client
     rescue StandardError => error
       raise ClientError.new("initialization failure", error)
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,5 +45,8 @@ Rails.application.configure do
   # Don't try to connect to Exchange
   OpenStax::Exchange.use_fake_client
   OpenStax::Exchange.reset!
+
+  # Don't try to connect to Exercises
+  OpenStax::Exercises::V1.use_fake_client
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,4 +79,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Don't try to connect to Exercises
+  OpenStax::Exercises::V1.use_fake_client
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,7 @@ Rails.application.configure do
   # Don't try to connect to Exchange
   OpenStax::Exchange.use_fake_client
   OpenStax::Exchange.reset!
+
+  # Don't try to connect to Exercises
+  OpenStax::Exercises::V1.use_fake_client
 end


### PR DESCRIPTION
This PR adds a call to `use_fake_client` in ALL environments and defaults the Exercises client to the `RealClient`.