### PR TITLE
Move Content::GetPage to Content::Api::GetPage

### DIFF
--- a/app/assistants/i_reading_assistant.rb
+++ b/app/assistants/i_reading_assistant.rb
@@ -114,7 +114,7 @@ class IReadingAssistant
     task_step_attributes = []
 
     task_plan.settings['page_ids'].each do |page_id|
-      page = Content::GetPage.call(page_id: page_id).outputs.page
+      page = Content::Api::GetPage.call(page_id: page_id).outputs.page
       doc = Nokogiri::HTML(page.content || '')
 
       # Extract Key Terms

--- a/app/subsystems/content/api/get_page.rb
+++ b/app/subsystems/content/api/get_page.rb
@@ -1,4 +1,4 @@
-class Content::GetPage
+class Content::Api::GetPage
 
   lev_routine
 


### PR DESCRIPTION
This way it will conform to the SubSystem's Api naming
convention and work with the autoloader