### PR TITLE
mitigate effects of vcr and webmock gems on http requests in specs that do not use them

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Don't error out when trying to connect to external sites
+  WebMock.allow_net_connect!
+
   # Don't try to connect to Exchange
   OpenStax::Exchange.use_fake_client
   OpenStax::Exchange.reset!

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -4,6 +4,7 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
   c.configure_rspec_metadata!
+  c.allow_http_connections_when_no_cassette = true
 end
 
 VCR_OPTS = {


### PR DESCRIPTION
At some fairly recent point in the past, the behavior of network connectivity inside specs changed, even when those specs don't use or care about `webmock` or `vcr`.  This introduced an order dependency between specs, with those following any spec that used `webmock` or `vcr` failing.

This PR allows specs to access the network as long as they don't have any `vcr` cassettes, which I believe fixes the problem while still preserving desired behavior. 