### PR TITLE
made task step and task plan routes shallow

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     end
 
     resources :tasks, only: [:show] do
-      resources :steps, controller: :task_steps, only: [:show, :update] do
+      resources :steps, controller: :task_steps, shallow: true, only: [:show, :update] do
         put 'completed', on: :member
       end
     end
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
     resources :courses, only: [] do
       get 'readings', on: :member
       get 'plans', on: :member
-      resources :task_plans, path: '/plans', except: :index do
+      resources :task_plans, path: '/plans', shallow: true, except: [:index, :edit] do
         post 'publish', on: :member
       end
     end

--- a/spec/requests/api/v1/exercise_update_progression_spec.rb
+++ b/spec/requests/api/v1/exercise_update_progression_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Exercise update progression", type: :request, :api => true, :ver
   let!(:tasked) { FactoryGirl.create(:tasked_exercise, 
                                      :with_tasking, tasked_to: user_1) }
 
-  let!(:step_route_base) { "/api/tasks/#{tasked.task_step.task.id}/steps/#{tasked.task_step.id}" }
+  let!(:step_route_base) { "/api/steps/#{tasked.task_step.id}" }
 
   it "only shows feedback and correct answer id after completed" do
 

--- a/spec/routing/api/v1/task_steps_controller_routing_spec.rb
+++ b/spec/routing/api/v1/task_steps_controller_routing_spec.rb
@@ -4,11 +4,11 @@ describe Api::V1::TaskStepsController, :type => :routing, :api => true, :version
 
   describe "/api/tasks/:task_id/steps/:id" do
     it "routes to #show" do
-      expect(get '/api/tasks/42/steps/23').to route_to('api/v1/task_steps#show', format: 'json', task_id: "42", id: "23")
+      expect(get '/api/steps/23').to route_to('api/v1/task_steps#show', format: 'json', id: "23")
     end
 
     it "routes to #completed" do
-      expect(put '/api/tasks/42/steps/23/completed').to route_to('api/v1/task_steps#completed', format: 'json', task_id: "42", id: "23")
+      expect(put '/api/steps/23/completed').to route_to('api/v1/task_steps#completed', format: 'json', id: "23")
     end
   end
 


### PR DESCRIPTION
This makes task step and task plan routes shallow, i.e. takes away the unnecessary part before `/blah/:id` at the end.

Before the routes in question looked like:

```
PUT     /api/tasks/:task_id/steps/:id/completed   
GET     /api/tasks/:task_id/steps/:id             
PATCH   /api/tasks/:task_id/steps/:id             
PUT     /api/tasks/:task_id/steps/:id             
POST    /api/courses/:course_id/plans/:id/publish 
GET     /api/courses/:course_id/plans/:id         
PATCH   /api/courses/:course_id/plans/:id         
PUT     /api/courses/:course_id/plans/:id         
DELETE  /api/courses/:course_id/plans/:id         
```

Now these look like:

```
PUT     /api/steps/:id/completed                  
GET     /api/steps/:id                            
PATCH   /api/steps/:id                            
PUT     /api/steps/:id                            
POST    /api/plans/:id/publish                    
GET     /api/plans/:id                            
PATCH   /api/plans/:id                            
PUT     /api/plans/:id                            
DELETE  /api/plans/:id                            
```