### PR TITLE
add /courses/123/tasks endpoint

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -40,4 +40,20 @@ class Api::V1::CoursesController < Api::V1::ApiController
     respond_with out, represent_with: Api::V1::TaskPlanSearchRepresenter
   end
 
+  api :GET, '/courses/:course_id/tasks', 'Gets all course tasks assigned to the role holder making the request'
+  description <<-EOS 
+    As a temporary patch to make this route available, this route currently returns exactly the same
+    thing as /api/user/tasks.  Once the backend does more work to make routes role-aware, we'll update
+    this endpoint to actually do what the description says.
+    #{json_schema(Api::V1::TaskSearchRepresenter, include: :readable)}
+  EOS
+  def tasks
+    # TODO actually make this URL role-aware and return the tasks for the role 
+    # in the specified course; for now this is just returning what /api/user/tasks 
+    # returns and is ignore 
+    OSU::AccessPolicy.require_action_allowed!(:read_tasks, current_api_user, current_human_user)
+    outputs = SearchTasks.call(q: "user_id:#{current_human_user.id}").outputs
+    respond_with outputs, represent_with: Api::V1::TaskSearchRepresenter
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     resources :courses, only: [] do
       get 'readings', on: :member
       get 'plans', on: :member
+      get 'tasks', on: :member
       resources :task_plans, path: '/plans', shallow: true, except: [:index, :edit] do
         post 'publish', on: :member
       end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -81,4 +81,19 @@ RSpec.describe Api::V1::CoursesController, :type => :controller, :api => true, :
     end
   end
 
+  describe "tasks" do
+    it "temporarily mirrors /api/user/tasks" do
+      api_get :tasks, user_1_token, parameters: {id: course.id}
+      expect(response.code).to eq('200')
+      expect(response.body).to eq({
+        total_count: 0,
+        items: []
+      }.to_json)
+    end
+
+    it "returns tasks for a role holder in a certain course" do
+      skip "skipped until implement the real /api/courses/123/tasks endpoint with role awareness"
+    end
+  end
+
 end


### PR DESCRIPTION
Adds a `/api/courses/123/tasks` endpoint.  For the time being (and for the convenience of the frontend), this endpoint returns exactly what `/api/user/tasks` returns.  Once the backend gets its role infrastructure in better shape, we'll update this endpoint to actually return tasks for a certain course (and for a certain role).

@Dantemss please review

/cc @philschatz