### PR TITLE
Video step

### DIFF
--- a/app/assistants/i_reading_assistant.rb
+++ b/app/assistants/i_reading_assistant.rb
@@ -60,6 +60,13 @@ class IReadingAssistant
 
             TaskedExercise.new(task_step: step, url: exercise.url,
                                title: exercise.title, content: exercise.content)
+          when OpenStax::Cnx::V1::Fragment::Video
+            raise "Video url not found for Video in Page #{page.id}" \
+              if fragment.url.blank?
+
+            TaskedVideo.new(task_step: step, url: page.url,
+                            title: fragment.title, content: fragment.to_html,
+                            video_url: fragment.url)
           else
             TaskedReading.new(task_step: step, url: page.url,
                               title: fragment.title, content: fragment.to_html)

--- a/app/external/openstax/cnx/v1/fragment/video.rb
+++ b/app/external/openstax/cnx/v1/fragment/video.rb
@@ -1,0 +1,12 @@
+module OpenStax::Cnx::V1::Fragment
+  class Video < Text
+
+    # CSS to find the video link
+    VIDEO_LINK_CSS = '.os-embed'
+
+    def url
+      @url ||= node.at_css(VIDEO_LINK_CSS).try(:attr, :href)
+    end
+
+  end
+end

--- a/app/external/openstax/cnx/v1/page.rb
+++ b/app/external/openstax/cnx/v1/page.rb
@@ -127,11 +127,15 @@ module OpenStax::Cnx::V1
         splitting_fragments = []
         # Figure out what we just split on, testing in priority order
         if split.matches?(ASSESSED_FEATURE_CSS)
-          # Assessed Feature = Text + Exercise
+          # Assessed Feature = Video + Exercise or Text + Exercise
           exercise = split.at_css(EXERCISE_CSS)
           recursive_compact(exercise, split)
 
-          splitting_fragments << Fragment::Text.new(node: split)
+          if split.matches?(VIDEO_CSS)
+            splitting_fragments << Fragment::Video.new(node: split)
+          else
+            splitting_fragments << Fragment::Text.new(node: split)
+          end
           splitting_fragments << Fragment::Exercise.new(node: exercise)
         elsif split.matches?(FEATURE_CSS)
           # Text Feature
@@ -141,9 +145,6 @@ module OpenStax::Cnx::V1
           splitting_fragments << Fragment::Exercise.new(node: split)
         elsif split.matches?(INTERACTIVE_CSS)
           # Interactive
-          splitting_fragments << Fragment::Text.new(node: split) # Placeholder
-        elsif split.matches?(VIDEO_CSS)
-          # Video
           splitting_fragments << Fragment::Text.new(node: split) # Placeholder
         end
 

--- a/app/models/tasked_video.rb
+++ b/app/models/tasked_video.rb
@@ -1,0 +1,6 @@
+class TaskedVideo < ActiveRecord::Base
+  acts_as_tasked
+
+  validates :url, presence: true
+  validates :content, presence: true
+end

--- a/app/representers/api/v1/tasked_video_representer.rb
+++ b/app/representers/api/v1/tasked_video_representer.rb
@@ -1,0 +1,13 @@
+module Api::V1
+  class TaskedVideoRepresenter < TaskedReadingRepresenter
+
+    property :video_url,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The video URL"
+             }
+  end
+end

--- a/db/migrate/20150319110230_create_tasked_videos.rb
+++ b/db/migrate/20150319110230_create_tasked_videos.rb
@@ -1,0 +1,12 @@
+class CreateTaskedVideos < ActiveRecord::Migration
+  def change
+    create_table :tasked_videos do |t|
+      t.string :url, null: false
+      t.text :content, null: false
+      t.string :title
+      t.string :video_url
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150313193101) do
+ActiveRecord::Schema.define(version: 20150319110230) do
 
   create_table "administrators", force: :cascade do |t|
     t.integer  "user_id",    null: false
@@ -412,6 +412,15 @@ ActiveRecord::Schema.define(version: 20150313193101) do
     t.string   "url",        null: false
     t.text     "content",    null: false
     t.string   "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "tasked_videos", force: :cascade do |t|
+    t.string   "url",        null: false
+    t.text     "content",    null: false
+    t.string   "title"
+    t.string   "video_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/cassettes/IReadingAssistant/_Newton_s_First_Law_of_Motion_Inertia_/is_split_into_different_task_steps.yml
+++ b/spec/cassettes/IReadingAssistant/_Newton_s_First_Law_of_Motion_Inertia_/is_split_into_different_task_steps.yml
@@ -1,0 +1,2463 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain
+      Location:
+      - "/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4"
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (pass - status > 300, not content)
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 14:13:34 GMT
+      X-Varnish:
+      - '173000177'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Varnish-Age:
+      - '0'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:30 GMT
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (override - archive contents)
+      X-Factor-Ttl:
+      - 'ttl: 604800.000'
+      Content-Length:
+      - '38216'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 14:13:35 GMT
+      X-Varnish:
+      - 173000179 170915691
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - HIT
+      X-Varnish-Age:
+      - '231038'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"googleAnalytics": null, "version": "4", "submitlog": "imported from
+        staging3", "abstract": null, "revised": "2015-03-16T16:00:23Z", "roles": null,
+        "keywords": [], "id": "61445f78-00e2-45ae-8e2c-461b17d9b4fd", "title": "Newton''s
+        First Law of Motion: Inertia", "mediaType": "application/vnd.org.cnx.module",
+        "content": "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head xmlns:c=\"http://cnx.rice.edu/cnxml\"
+        xmlns:md=\"http://cnx.rice.edu/mdml\"><title>Newton''s First Law of Motion:
+        Inertia</title><meta name=\"created-time\" content=\"2015/03/11 13:32:11 -0500\"/><meta
+        name=\"revised-time\" content=\"2015/03/16 11:00:23.682 GMT-5\"/><meta name=\"author\"
+        content=\"AlinaManager\"/><meta name=\"acl-list\" content=\"AlinaManager\"/><meta
+        name=\"licensor\" content=\"AlinaManager\"/><meta name=\"license\" content=\"http://creativecommons.org/licenses/by/4.0/\"/><meta
+        name=\"subject\" content=\"Mathematics and Statistics\"/></head>\n\n<body
+        xmlns:c=\"http://cnx.rice.edu/cnxml\" xmlns:md=\"http://cnx.rice.edu/mdml\"
+        xmlns:qml=\"http://cnx.rice.edu/qml/1.0\" xmlns:mod=\"http://cnx.rice.edu/#moduleIds\"
+        xmlns:bib=\"http://bibtexml.sf.net/\" xmlns:data=\"http://dev.w3.org/html5/spec/#custom\"><div
+        data-type=\"document-title\">Newton''s First Law of Motion: Inertia</div>\n  <section
+        data-depth=\"1\" id=\"fs-idp17120160\" class=\"learning-objectives\"><h1 data-type=\"title\">Section
+        Learning Objectives</h1><p id=\"eip-795\">By the end of this section you will
+        be able to: <span data-type=\"list\" data-list-type=\"bulleted\" id=\"eip-idp58500736\"><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-teks-112-39-c-4d\"> Describe Newton''s first law and friction <math
+        xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math></span><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-teks-112-39-c-4d\"> Discuss the relationship between mass and inertia</span></span></p></section>\n\n<div
+        data-type=\"note\" id=\"eip-887\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\"><p id=\"eip-idm12575088\">The Learning Objectives in this section
+        will help your students master the following TEKS: (4) Science concepts. The
+        student knows and applies the laws governing motion in a variety of situations.
+        The student is expected to: \n<span data-type=\"list\" data-list-type=\"bulleted\"
+        id=\"fs-idp60294944\">\n<span data-type=\"item\" class=\"ost-standards-def
+        ost-standards-teks\"><span class=\"ost-standards-name\">(4D)</span><span class=\"ost-standards-discard\">:</span><span
+        class=\"ost-standards-description ost-tag-teks-112-39-c-4d\">calculate the
+        effect of forces on objects, including the law of inertia, the relationship
+        between force and acceleration, and the nature of force pairs between objects</span></span></span></p></div>\n\n<table
+        id=\"eip-850\" summary=\"--\" class=\"key-terms ost-reading-discard\"><caption><span
+        data-type=\"title\">Section Key Terms</span></caption><tbody>\n  <tr>\n    <td>friction</td>\n    <td>inertia</td>\n    <td>law
+        of inertia</td>\n  </tr>\n  <tr>\n    <td>mass</td>\n    <td>Newton''s first
+        law of motion</td>\n    <td>system</td>\n  </tr>\n</tbody></table><div data-type=\"note\"
+        id=\"eip-456\" class=\"os-teacher\" data-label=\"Teacher Edition\"><p id=\"eip-idm59591792\">Before
+        students begin this section, it is useful to review the concepts of force,
+        external force, net external force, and addition of forces.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> <span
+        class=\"level-above\">[AL]</span> Ask students to speculate what happens to
+        objects when they are set in motion. Do they remain in motion or stop after
+        some time? Why?</p><div data-type=\"note\" id=\"eip-idm108977584\" class=\"tip
+        misconception\" data-label=\"Misconception Alert\">\nStudents may believe
+        that objects that are in motion tend to slow down and stop. Explain the concept
+        of friction. Talk about objects in outer space, where there is no atmosphere
+        and no gravity. Ask students to describe the motion of such objects.</div></div>\n\n<section
+        data-depth=\"1\" id=\"eip-201\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><h1
+        data-type=\"title\">Newton''s First Law and Friction</h1><p id=\"eip-708\"><span
+        data-type=\"term\">Newton''s first law of motion</span> states that:</p><ol
+        id=\"eip-idp55249424\"><li>A body at rest tends to stay at rest <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        (<a href=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm\">http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm</a>)</li>\n<li>A
+        body in motion tends to remain in motion at constant velocity unless acted
+        on by a net external force (recall that &#8220;constant velocity&#8221; means
+        in a straight line and at constant speed). <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </li>\n</ol>\n\n<section data-depth=\"2\" id=\"eip-241\"><h2 data-type=\"title\">Newton''s
+        1<sup>st</sup> Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><div data-type=\"note\" id=\"eip-659\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n<p id=\"eip-idm30448560\"><span class=\"level-below\">[BL]</span>\n<span
+        class=\"level-on\">[OL]</span>\n<span class=\"level-above\">[AL]</span> Discuss
+        examples of Newton&#8217;s First Law seen in everyday life. <div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Talk about different pairs of surfaces and
+        how each exhibits different levels of friction. Ask students to give examples
+        of smooth and rough surfaces. Ask them where friction may be useful and where
+        it may be undesirable. <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Ask students to give different examples
+        of systems where multiple forces occur. Draw free-body diagrams for these.
+        Include the force of friction. Emphasize the direction of the force of friction.</p></div>\n\n<p
+        id=\"eip-545\">At first glance, this law may seem to contradict your everyday
+        experience. You have probably noticed that a moving object will usually slow
+        down and stop unless some effort is made to keep it moving. The key to understanding
+        why, for example, a sliding box slows down (seemingly on its own) is that
+        a net external force acts on it to make it slow down. Without this net external
+        force, the box would continue to slide at a constant velocity (as stated in
+        Newton&#8217;s first law of motion). What force acts on the box to slow it
+        down? It is called <span data-type=\"term\">friction</span>. Friction is an
+        external force that acts opposite to the direction of motion (see <a href=\"#eip-idm20864848\"
+        class=\"autogenerated-content\">[link]</a>). Think of it as a resistance to
+        motion that slows things down.</p><p id=\"eip-66\">Friction:</p>\n\n<ol id=\"eip-idp86047488\"
+        data-number-style=\"arabic\"><li>Goes in the opposite direction<span data-type=\"media\"
+        id=\"eip-idm63937136\" data-alt=\"Alt text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></li>\n<li>Causes
+        an object to slow down <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a></li></ol></section>\n\n<section
+        data-depth=\"2\" id=\"eip-495\"><h2 data-type=\"title\">Newton''s 1<sup>st</sup>
+        Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><p id=\"eip-370\">Consider an air hockey table. When the air is turned
+        off, the puck slides only a short distance before friction slows it to a stop.
+        However, when the air is turned on, it lifts the puck slightly so that the
+        puck experiences very little friction as it moves over the surface. With friction
+        almost eliminated, the puck glides along with very little change in speed.
+        On a frictionless surface, the puck would experience no net external force
+        (ignoring air resistance, which is also a form of friction). Additionally,
+        if we know enough about friction, we can accurately predict how quickly objects
+        will slow down.</p>\n\n<p id=\"eip-114\">Now let&#8217;s think about another
+        example. A man pushes a box across a floor at constant velocity by applying
+        a force of +50 N (the positive sign indicates by convention that the direction
+        of motion is to the right). What is the force of friction that opposes the
+        motion? The force of friction must be &#8722;50 N. Why? According to Newton&#8217;s
+        first law of motion, any object moving at constant velocity has no net external
+        force acting upon it, which means that the sum of the forces acting on the
+        object must be zero. The mathematical way to say that no net external force
+        acts on an object is <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        , or <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        . So if the man applies +50 N of force, then the force of friction must be
+        &#8722;50 N for the two forces to add up to zero (i.e., &#8220;cancel&#8221;
+        each other). Whenever you encounter the phrase &#8220;at constant velocity,&#8221;
+        Newton&#8217;s first law tells you that the net external force is zero.</p><figure
+        id=\"eip-idm83000688\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>For
+        a box sliding across a floor, friction acts in the direction opposite to the
+        velocity.</figcaption><span data-type=\"media\" id=\"eip-idm83879248\" data-alt=\"Alt
+        text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure><p id=\"eip-985\">The
+        force of friction depends on two things: the coefficient of friction and the
+        normal force. The coefficient of friction is a constant that depends on the
+        nature of the surfaces in contact with one another. The normal force is the
+        force exerted by a surface that pushes on an object in response to gravity
+        pulling the object down. In equation form, the force of friction is <div data-type=\"equation\"
+        id=\"eip-idp12074176\" class=\"unnumbered\" data-label=\"\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"block\"><semantics><mrow><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></annotation-xml></semantics></math></div>where
+        &#956; is the coefficient of friction and N is the normal force. The coefficient
+        of friction is discussed in more detail in the next chapter and the normal
+        force is discussed in more detail in section four of this chapter.\n</p><p
+        id=\"eip-89\">Recall from section one that a net external force acts from
+        outside on the object of interest. A more precise definition is that it acts
+        on the <span data-type=\"term\">system</span> of interest. A system is one
+        or more objects that you choose to study. It is important to define the system
+        at the beginning of a problem to figure out which forces are external and
+        need to be considered and which are internal and can be ignored.</p><p id=\"eip-826\">For
+        example, in <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        (a), two children push a third child in a wagon at constant velocity. The
+        system of interest is the wagon plus the small child shown in part b of the
+        figure. The two children behind the wagon exert external forces on this system
+        (<em data-effect=\"italics\">F</em><sub>1</sub>, <em data-effect=\"italics\">F</em><sub>2</sub>).
+        Friction <em data-effect=\"italics\">f</em> acting at the axles of the wheels
+        and at the surface where the wheels touch the ground is another external force
+        acting on the system. Two more external forces act on the system: the weight
+        <em data-effect=\"italics\">W</em> of the system pulling down and the normal
+        force <em data-effect=\"italics\">N</em> of the ground pushing up. Notice
+        that the wagon is not accelerating vertically, so Newton&#8217;s first law
+        tells us that the normal force balances the weight. Because the wagon is moving
+        forward at constant velocity, then the force of friction must have the same
+        strength as the sum of the forces applied by the two children.</p><figure
+        id=\"eip-idm20864848\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>(a)
+        The wagon and rider form a &#8220;system&#8221; that is acted on by external
+        forces. (b)The two children pushing the wagon and child provide two external
+        forces. Friction acting at the wheel axles and on the surface of the tires
+        where they touch the ground provides an external force that acts against the
+        direction of motion. The weight <em data-effect=\"italics\">W</em> and the
+        normal force <em data-effect=\"italics\">N</em> from the ground are two more
+        external forces acting on the system. All external forces are represented
+        in the figure by arrows. All of the external forces acting on the system add
+        together, but because the wagon moves at a constant velocity, all the forces
+        must add up to zero.</figcaption><span data-type=\"media\" id=\"eip-idp5554688\"
+        data-alt=\"Alt text\"><img src=\"/resources/8c943f2ce4ca3d9a0a429e8a3d3f3c00/Figure_04_02_wagon.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></section></section>\n\n<section
+        data-depth=\"1\" id=\"eip-304\" class=\"ost-tag-lo-k12phys-ch04-s02-lo02\"><h1
+        data-type=\"title\">Mass and Inertia</h1>\n\n<div data-type=\"note\" id=\"eip-715\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"eip-idm26334000\"><span
+        class=\"level-below\">[BL]</span> Review Newton&#8217;s First Law. Explain
+        that the property of objects to maintain their state of motion is called inertia.
+        <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>
+        <span class=\"level-above\">[AL]</span> Take two similar carts or trolleys
+        with wheels. Place a heavy weight in one of them. Ask students which cart
+        would require more force to change its state of motion. Ask students which
+        would stay in motion longer if you were to set them in motion. Based on this
+        discussion, have students speculate what inertia may depend on.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> Explain
+        the concepts of mass and weight. Explain that these terms may be used interchangeably
+        in everyday life but have different meanings in science.</p></div>\n\n<p id=\"eip-613\"><span
+        data-type=\"term\">Inertia</span> is the tendency for an object at rest to
+        remain at rest or for a moving object to remain in motion in a straight line
+        with constant speed. This key property of objects was first described by Galileo.
+        Later, Newton incorporated the concept of inertia into his first law, which
+        is often referred to as the <span data-type=\"term\">law of inertia</span>.</p><p
+        id=\"eip-36\">As we know from experience, some objects have more inertia than
+        others. For example, changing the motion of a large truck is more difficult
+        than changing the motion of a toy truck. In fact, the inertia of an object
+        is proportional to the mass of the object. <span data-type=\"term\">Mass</span>
+        is a measure of the amount of matter (or &#8220;stuff&#8221;) in something.
+        The quantity or amount of matter in an object is determined by the number
+        and type of atoms it contains. Unlike weight (which changes if the gravitational
+        force changes), mass does not depend on gravity. The mass of an object is
+        the same on Earth, in orbit, or on the surface of the Moon. In practice, it
+        is very difficult to count and identify all of the atoms and molecules in
+        an object, so mass is usually not determined this way. Instead, the mass of
+        an object is determined by comparing it with the standard kilogram. Mass is
+        therefore expressed in kilograms.</p>\n\n<div data-type=\"note\" id=\"eip-idm961296\"
+        class=\"tip tips-for-success\" data-label=\"Tips for Success\">In everyday
+        language, people often use the terms weight and mass interchangeably&#8212;but
+        this is not correct. Weight is actually a force (we cover this in more detail
+        in section three).</div>\n\n<div data-type=\"note\" id=\"eip-231\" class=\"ost-assessed-feature
+        ost-video ost-tag-lo-k12phys-ch04-s02-lo02 watch-physics\" data-label=\"Watch
+        Physics\"><div data-type=\"title\">Newton&#8217;s first law of motion</div>
+        \n<p id=\"eip-idp1646512\">This <a href=\"https://www.khanacademy.org/science/physics/forces-newtons-laws/newtons-laws-of-motion/v/newton-s-1st-law-of-motion\"
+        class=\"os-embed\">video</a> contrasts the way we thought about motion and
+        force in the time before Galileo&#8217;s concept of inertia and <span data-type=\"term\">Newton&#8217;s
+        first law of motion</span> with the way we understand force and motion now.
+        Refer to <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        as you watch.\n</p>\n\n<ol id=\"eip-idp19850304\"><li>Galileo&#8217;s concepts<ol
+        id=\"eip-idp10164288\" data-number-style=\"lower-alpha\"><li>Things just come
+        to a stop</li><li>Forces don&#8217;t act against objects</li></ol></li><li>Newton&#8217;s
+        concepts<ol id=\"eip-idp5872736\" data-number-style=\"lower-alpha\"><li>Objects
+        will continue at the same speed if no opposing force</li><li>Weight is a force
+        acting against an object.</li></ol></li></ol>\n\n <div data-type=\"exercise\"
+        id=\"eip-idp413824\" class=\"os-exercise grasp-check\"><div data-type=\"problem\"
+        id=\"eip-idm76540272\">\n    <p id=\"eip-idm99866096\"><a href=\"#ost/api/ex/k12phys-ch04-ex033\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div></div><div data-type=\"note\"
+        id=\"eip-837\" class=\"os-teacher\" data-label=\"Teacher Edition\">Answer:
+        Friction</div></div>\n\n<div data-type=\"note\" id=\"fs-idm38320288\" class=\"ost-assessed-feature
+        ost-interactive virtual-physics ost-tag-lo-k12phys-ch04-s02-lo02\" data-label=\"Virtual
+        Physics\"><div data-type=\"title\">Forces and Motion: Basics</div>\n\n<p id=\"fs-idp34383024\">In
+        this simulation, you will first explore net force by placing blue people on
+        the left side of a tug of war rope and red people on the right side of the
+        rope (by clicking people and dragging them with your mouse). Experiment with
+        changing the number and size of people on each side to see how it affects
+        the outcome of the match and the net force. Hit the Go! button to start the
+        match, and the &#8220;reset all&#8221; button to start over.</p><ol id=\"fs-idp48496992\"
+        data-number-style=\"lower-alpha\"><li>The side with the most force wins</li><li>The
+        bigger the difference in the force, the easier it is for one side to win.</li><li>When
+        force is equal, no one wins.</li></ol><p id=\"fs-idp52126304\">Next, click
+        on the Friction tab. Try selecting different objects for the person to push.
+        Slide the applied force button to the right to apply force to the right and
+        to the left to apply force to the left. The force will continue to be applied
+        as long as you hold the button down. See the arrow representing friction change
+        in magnitude and direction depending on how much force you apply. Try increasing
+        or decreasing the friction force to see how this affects the motion.</p>\n<div
+        data-type=\"media\" id=\"fs-idp5640912\" class=\"os-embed\" data-alt=\" \">
+        <iframe width=\"960\" height=\"785\" src=\"http://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/\"/></div>\n\n  <div
+        data-type=\"exercise\" id=\"fs-idm56919408\" class=\"os-exercise grasp-check\"><div
+        data-type=\"problem\" id=\"fs-idm68103760\"><p id=\"fs-idm17001808\"><a href=\"#ost/api/ex/k12phys-ch04-ex034\"
+        class=\"autogenerated-content\">[link]</a>\n<div data-type=\"note\" id=\"fs-idm79914448\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p id=\"fs-idm91425440\"><span
+        data-type=\"term\">[Grasp Check]</span>\nAnswer: After the person stops pushing
+        the box, no force is applied to the right, but the friction force remains,
+        which acts to the left. Therefore, the net force acts to the left.</p>\n\n</div>\n\n  </p></div></div></div></section>\n<section
+        data-depth=\"1\" id=\"eip-305\" class=\"summary ost-reading-discard\"><h1
+        data-type=\"title\">Section Summary</h1><p id=\"eip-idm44169728\"><span data-type=\"list\"
+        data-list-type=\"bulleted\" id=\"eip-idm85549552\"><span data-type=\"item\">Newton&#8217;s
+        first law states that a body at rest remains at rest or, if moving, remains
+        in motion in a straight line at a constant speed unless acted on by a net
+        external force. This is also known as the law of inertia.</span>\n<span data-type=\"item\">Inertia
+        is the tendency of an object at rest to remain at rest or, if moving, to remain
+        in motion at constant velocity. Inertia is related to an object&#8217;s mass.</span>\n<span
+        data-type=\"item\">Friction is a force that opposes motion and causes an object
+        or system to slow down.</span>\n<span data-type=\"item\">Mass is the quantity
+        of matter in a substance.</span></span></p></section>\n\n<section data-depth=\"1\"
+        id=\"eip-836\" class=\"key-equations ost-reading-discard\"><h1 data-type=\"title\">Key
+        Equations</h1><table id=\"eip-812\" summary=\"--\"><tbody>\n  <tr>\n    <td>Newton''s
+        first law</td>\n  <td><math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow>\n
+        <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow></annotation-xml></semantics></math>where<math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow></annotation-xml></semantics></math>is a constant</td>\n  </tr>\n  <tr>\n    <td>Newton''s
+        sixth law</td>\n   \n<td><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow></annotation-xml></semantics></math>\n</td>\n  </tr>\n</tbody></table></section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm71187456\" class=\"practice-concepts ost-reading-discard\"><h1
+        data-type=\"title\">Check Your Understanding</h1>\n<div data-type=\"exercise\"
+        id=\"fs-idm20483824\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idp37354336\">\n      <p id=\"fs-idp35901760\"><a href=\"#ost/api/ex/k12phys-ch04-ex035\"
+        class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm51782000\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm30958336\">\n      <p id=\"fs-idm53218240\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex036\" class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n<div
+        data-type=\"exercise\" id=\"eip-idp1259600\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp22780016\"><p id=\"eip-idp10991472\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex037\" class=\"autogenerated-content\">[link]</a></p></div></div>\n<div
+        data-type=\"exercise\" id=\"eip-idp10062848\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp32885104\"><p id=\"eip-idp3387376\"><a href=\"#ost/api/ex/k12phys-ch04-ex038\"
+        class=\"autogenerated-content\">[link]</a></p></div></div></section>\n\n<div
+        data-type=\"note\" id=\"fs-idm112711040\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp9350960\">1. A body at rest tends to remain at
+        rest, and a body in motion tends to remain in motion at a constant velocity
+        unless acted on by a net external force.</p>\n<p id=\"fs-idm68577104\">2.
+        The object experiences a frictional force exerted by the surface, which opposes
+        its motion.</p>\n<p id=\"fs-idm65948736\">3. Inertia is an object&#8217;s
+        tendency to remain at rest or, if moving, to remain in motion at a constant
+        velocity. Inertia may also be described as the tendency of objects to maintain
+        their state of motion.</p>\n<p id=\"fs-idm56412736\">4. Mass is the quantity
+        of substance contained in matter. It depends on the number and type of atoms
+        in the matter.</p>\n</div>\n\n\n<div data-type=\"note\" id=\"fs-idm98755648\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"fs-idm111298272\">1.
+        <em data-effect=\"italics\">F</em><sub>net</sub> = 0</p><p id=\"fs-idm7398128\">2.
+        Friction is an external force that opposes the direction of motion of system.</p>\n<p
+        id=\"fs-idm91191728\">3. The quality of the surface&#8212;whether it is smooth
+        or rough</p>\n<p id=\"fs-idm85688352\">4. There is negligible friction between
+        the ice and the skater.</p>\n<p id=\"fs-idm130369856\">5. The inertia of an
+        object is proportional to its mass.</p>\n<p id=\"fs-idm102647072\">6. A system
+        is one or more objects that we wish to study.</p>\n<p id=\"fs-idm127557760\">7.
+        Mass is the quantity of matter contained in an object. Weight is the force
+        exerted by gravity on the object.</p>\n<p id=\"fs-idm23970880\">8. Mass is
+        measured in kilograms. Weight, being a force, is measured in newtons. However,
+        since mass cannot be determined by counting the number of atoms in an object,
+        it is derived from an object&#8217;s weight. Since the force of gravity is
+        almost constant on earth, the mass of an object is often given as the object&#8217;s
+        weight.</p>\n</div>\n\n\n\n<section data-depth=\"1\" id=\"fs-idm56025888\"
+        class=\"ost-reading-discard chapter-review concept\"><h1 data-type=\"title\">Concept
+        Items</h1><div data-type=\"exercise\" id=\"fs-idm65070096\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"fs-idp2435696\">\n      <p id=\"fs-idm60009600\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex047\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div><div
+        data-type=\"exercise\" id=\"fs-idm36770368\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm46629456\">\n      <p id=\"fs-idm27882848\"><a href=\"#ost/api/ex/k12phys-ch04-ex048\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n</section>\n\n\n\n<section
+        data-depth=\"1\" id=\"fs-idp15971072\" class=\"ost-reading-discard chapter-review
+        critical-thinking\"><h1 data-type=\"title\">Critical Thinking Items</h1><div
+        data-type=\"exercise\" id=\"fs-idp69697408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp55256064\">\n      <p id=\"fs-idp47204912\"><a href=\"#ost/api/ex/k12phys-ch04-ex053\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idp19674432\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp88556720\">\n      <p id=\"fs-idp38044752\"><a href=\"#ost/api/ex/k12phys-ch04-ex054\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idp48658432\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp12698432\">1. Less than (F1 + F2). The net force
+        will include a component of friction which will act in the direction opposite
+        to F1 and F2 and cancel part of these forces.</p>\n<p id=\"fs-idm10442672\">2.
+        Yes</p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idp5033136\" class=\"ost-reading-discard
+        test-prep multiple-choice\"><h1 data-type=\"title\">Test Prep Multiple Choice</h1><div
+        data-type=\"exercise\" id=\"fs-idp2931856\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm2415664\">\n      <p id=\"fs-idm1515712\"><a href=\"#ost/api/ex/k12phys-ch04-ex059\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm84911568\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm24438496\">\n      <p id=\"fs-idm95346960\"><a href=\"#ost/api/ex/k12phys-ch04-ex060\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idm15918336\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp42241296\">1. a) external </p>\n<p id=\"fs-idp63672752\">2.
+        b) law of inertia </p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idm53317184\"
+        class=\"ost-reading-discard test-prep short-answer\"><h1 data-type=\"title\">Test
+        Prep Short Answer</h1><div data-type=\"exercise\" id=\"fs-idm70263744\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm36001280\">\n      <p id=\"fs-idm58066816\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex061\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm79253408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm86468464\">\n      <p id=\"fs-idm52047952\"><a href=\"#ost/api/ex/k12phys-ch04-ex062\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp13927648\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp79608864\">\n      <p id=\"eip-idp64692080\"><a href=\"#ost/api/ex/k12phys-ch04-ex063\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp116624608\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp60936864\">\n      <p id=\"eip-idp34200800\"><a href=\"#ost/api/ex/k12phys-ch04-ex064\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp16574176\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp25075952\">\n<figure id=\"fs-idp45771152\"><figcaption>Arrow pointing
+        right, labeled F and smaller arrow pointing right labeled f</figcaption><span
+        data-type=\"media\" id=\"fs-idp66161920\" data-alt=\"Alt text\"><img src=\"/resources/79879c1d01fccc75a43f8d273fe59ac7/Figure_04_02_force_img.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></p>\n<p
+        id=\"fs-idp6971456\">2. The mass of the first object is less than that of
+        the second.</p>\n<p id=\"fs-idp24341232\">3. You could give each box a push
+        by applying the same amount of force. Whichever box accelerates faster is
+        lighter and so must be the empty box.</p>\n<p id=\"fs-idp23864352\">4. Yes</p>\n</div>\n</section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm72523760\" class=\"ost-reading-discard test-prep
+        extended-response\"><h1 data-type=\"title\">Test Prep Extended Response</h1><div
+        data-type=\"exercise\" id=\"fs-idm96811744\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm79488864\">\n      <p id=\"fs-idm116137648\"><a href=\"#ost/api/ex/k12phys-ch04-ex065\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idm37073488\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm35798256\">\n      <p id=\"fs-idm28998864\"><a href=\"#ost/api/ex/k12phys-ch04-ex066\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp64139392\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp50449808\">1. Not necessarily; if both are thrown at different
+        angles, they will travel different distances.</p>\n<p id=\"fs-idp47745568\">2.
+        The person is no longer applying force when the box is sliding freely. The
+        box is moving because of its own inertia. The only force acting on it is the
+        force of friction which acts from right to left. Thus, the direction of the
+        net external force is to the left.</p>\n</div>\n\n</section>\n<div data-type=\"glossary\"><h2>Glossary</h2>\n<div
+        data-type=\"definition\" id=\"fs-idp38390880\"><span data-type=\"term\">friction</span><div
+        data-type=\"meaning\" id=\"fs-idp69363104\">an external force that acts in
+        the direction opposite to the direction of motion</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp32901536\"><span data-type=\"term\">inertia</span><div data-type=\"meaning\"
+        id=\"fs-idp2280640\">the tendency of an object at rest to remain at rest or
+        for a moving object to remain in motion in a straight line and at constant
+        speed&#8212;MATH</div></div>\n<div data-type=\"definition\" id=\"fs-idp22688960\"><span
+        data-type=\"term\">law of inertia</span><div data-type=\"meaning\" id=\"fs-idp26210592\">Newton&#8217;s
+        first law of motion: a body at rest remains at rest or, if in motion, remains
+        in motion at a constant speed in a straight line unless acted on by a net
+        external force; also known as the law of inertia</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp76765280\"><span data-type=\"term\">mass</span><div data-type=\"meaning\"
+        id=\"fs-idp90674960\">the quantity of matter in a substance; measured in kilograms</div></div>\n<div
+        data-type=\"definition\" id=\"fs-idp42413872\"><span data-type=\"term\">Newton''s
+        first law of motion</span><div data-type=\"meaning\" id=\"fs-idp33729328\">a
+        body at rest remains at rest or, if in motion, remains in motion at a constant
+        speed in a straight line unless acted on by a net external force; also known
+        as the law of inertia</div></div>\n<div data-type=\"definition\" id=\"fs-idp59393232\"><span
+        data-type=\"term\">system</span><div data-type=\"meaning\" id=\"fs-idp77789136\">one
+        or more objects of interest for which only the forces acting on them from
+        the outside are considered but not the forces acting between them or inside
+        of them</div></div>\n</div></body>\n\n</html>", "subjects": ["Mathematics
+        and Statistics"], "legacy_id": "m53227", "parentId": null, "stateid": 1, "parentTitle":
+        null, "maintainers": [{"website": "", "surname": "Slavik", "suffix": "", "firstname":
+        "Alina", "title": "", "othername": "", "email": "alinams@rice.edu", "fullname":
+        "Alina Slavik", "id": "AlinaManager"}], "authors": [{"website": "", "surname":
+        "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername": "",
+        "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "parentVersion": "", "legacy_version": "1.4", "licensors": [{"website": "",
+        "surname": "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername":
+        "", "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "license": {"url": "http://creativecommons.org/licenses/by/4.0/", "code":
+        "by", "version": "4.0", "name": "Creative Commons Attribution License"}, "language":
+        "en", "created": "2015-03-11T18:32:11Z", "doctype": "", "buyLink": null, "submitter":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}, "parentAuthors": [], "history": [{"changes": "imported
+        from staging3", "version": "4", "revised": "2015-03-16T16:00:23Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "switched sim link; added width and height
+        attribute", "version": "3", "revised": "2015-03-11T21:28:30Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "retitled module", "version": "2", "revised":
+        "2015-03-11T18:40:21Z", "publisher": {"website": "", "surname": "Slavik",
+        "suffix": "", "firstname": "Alina", "title": "", "othername": "", "email":
+        "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}}, {"changes":
+        "imported module", "version": "1", "revised": "2015-03-11T18:36:37Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:31 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-s02-lo01,k12phys-ch04-s02-lo02
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:42 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-s02-lo01%2Ck12phys-ch04-s02-lo02
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:32 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-s02-lo01,k12phys-ch04-s02-lo02
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"b6f1642ab4935be83a3b69dfdef775ed"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=VXBHM3J1MlNKVDFnclRSOWZuTERMTmpKcHhuWlVHekNPdFFNR3J3Y1dpRnRxWStSdURGZkdUVkExM3VsNHpFdjcxMTRRVFpRSzI3N0hFWU5tTndzcUE9PS0taWhVaDNETzVIQ0g4aDdTMGpDbDdKZz09--25b4d372cb927a97eb367310e91740d361bd67cc;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 19a6b528-5bca-4749-8ede-b6e2b615b433
+      X-Runtime:
+      - '0.818269'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbF9jb3VudCI6MzIsIml0ZW1zIjpbeyJ1aWQiOiIzMUAxIiwibnVt
+        YmVyIjozMSwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0IjoiMjAxNS0wMy0x
+        MFQxOTo0OToxOC4zMTdaIiwiZWRpdG9ycyI6W10sImF1dGhvcnMiOlt7InVz
+        ZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVzZXJfaWQiOjJ9
+        XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltdLCJ0YWdzIjpb
+        InByYWN0aWNlLWNvbmNlcHRzIiwiaW5ib29rLXllcyIsImRvazEiLCJ0aW1l
+        LXNob3J0IiwiZGlzcGxheS1mcmVlLXJlc3BvbnNlIiwiZGlzcGxheS1yZWMt
+        c2Vuc2l0aXZlIiwiazEycGh5cy1jaDA0LXMwMi1sbzAxIiwiazEycGh5cy1j
+        aDA0LWV4MDMxIl0sInN0aW11bHVzX2h0bWwiOiIiLCJxdWVzdGlvbnMiOlt7
+        ImlkIjoxMDksInN0aW11bHVzX2h0bWwiOiIiLCJzdGVtX2h0bWwiOiJXaGF0
+        IGRvZXMgTmV3dG9u4oCZcyBGaXJzdCBMYXcgc3RhdGU/IiwiYW5zd2VycyI6
+        W3siaWQiOjM5MiwiY29udGVudF9odG1sIjoiVGhlIHJhdGUgb2YgY2hhbmdl
+        IG9mIG1vbWVudHVtIG9mIGEgYm9keSBpcyBpbnZlcnNlbHkgcHJvcG9ydGlv
+        bmFsIHRvIHRoZSBleHRlcm5hbCBmb3JjZSBhcHBsaWVkIG9uIHRoZSBib2R5
+        IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiQXJlIHlv
+        dSBzdXJlIHRoYXQgcmF0ZSBvZiBjaGFuZ2Ugb2YgbW9tZW50dW0gb2YgYSBi
+        b2R5IGlzIGludmVyc2VseSBwcm9wb3J0aW9uYWwgdG8gdGhlIGV4dGVybmFs
+        IGZvcmNlIGFwcGxpZWQgb24gdGhlIGJvZHk/In0seyJpZCI6MzkxLCJjb250
+        ZW50X2h0bWwiOiJUaGUgcmF0ZSBvZiBjaGFuZ2Ugb2YgbW9tZW50dW0gb2Yg
+        YSBib2R5IGlzIGRpcmVjdGx5IHByb3BvcnRpb25hbCB0byB0aGUgZXh0ZXJu
+        YWwgZm9yY2UgYXBwbGllZCBvbiB0aGUgYm9keSIsImNvcnJlY3RuZXNzIjoi
+        MC4wIiwiZmVlZGJhY2tfaHRtbCI6IklzbuKAmXQgaXQgdGhlIHNlY29uZCBs
+        YXcgb2YgbW90aW9uPyBDYW4geW91IHJlY2FsbCBhbGwgdGhlIHRocmVlIGxh
+        d3Mgb2YgbW90aW9uIGdpdmVuIGJ5IE5ld3Rvbj8ifSx7ImlkIjozOTAsImNv
+        bnRlbnRfaHRtbCI6IkEgYm9keSBhdCByZXN0IHRlbmRzIHRvIHJlbWFpbiBh
+        dCByZXN0LCBhbmQgYSBib2R5IGluIG1vdGlvbiB0ZW5kcyB0byByZW1haW4g
+        aW4gbW90aW9uIGF0IGEgY29uc3RhbnQgdmVsb2NpdHkgdW5sZXNzIGFjdGVk
+        IHVwb24gYnkgYSBuZXQgZXh0ZXJuYWwgZm9yY2UiLCJjb3JyZWN0bmVzcyI6
+        IjEuMCIsImZlZWRiYWNrX2h0bWwiOiJDb3JyZWN0ISBOZXd0b27igJlzIGZp
+        cnN0IGxhdyBzdGF0ZXMgdGhhdCBhIGJvZHkgYXQgcmVzdCB0ZW5kcyB0byBy
+        ZW1haW4gYXQgcmVzdCwgYW5kIGEgYm9keSBpbiBtb3Rpb24gdGVuZHMgdG8g
+        cmVtYWluIGluIG1vdGlvbiBhdCBhIGNvbnN0YW50IHZlbG9jaXR5IHVubGVz
+        cyBhY3RlZCB1cG9uIGJ5IGEgbmV0IGV4dGVybmFsIGZvcmNlLiJ9LHsiaWQi
+        OjM4OSwiY29udGVudF9odG1sIjoiQSBib2R5IGF0IHJlc3QgdGVuZHMgdG8g
+        cmVtYWluIGF0IHJlc3QsIGFuZCBhIGJvZHkgaW4gbW90aW9uIHRlbmRzIHRv
+        IHJlbWFpbiBpbiBtb3Rpb24gYXQgYSBjb25zdGFudCBhY2NlbGVyYXRpb24g
+        dW5sZXNzIGFjdGVkIHVwb24gYnkgYSBuZXQgZXh0ZXJuYWwgZm9yY2UiLCJj
+        b3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJEbyB5b3UgdGhp
+        bmsgYWNjZWxlcmF0ZWQgbW90aW9uIGlzIGRpZmZlcmVudCBmcm9tIHRoZSBt
+        b3Rpb24gd2hlcmUgYSBuZXQgZXh0ZXJuYWwgZm9yY2UgaXMgYWN0aW5nIG9u
+        IHRoZSBvYmplY3Q/In1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlw
+        bGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpb
+        XX1dfSx7InVpZCI6IjMyQDEiLCJudW1iZXIiOjMyLCJ2ZXJzaW9uIjoxLCJw
+        dWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4LjMzMloiLCJlZGl0
+        b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRf
+        aG9sZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJh
+        dHRhY2htZW50cyI6W10sInRhZ3MiOlsicHJhY3RpY2UtY29uY2VwdHMiLCJp
+        bmJvb2steWVzIiwidGltZS1zaG9ydCIsImRpc3BsYXktZnJlZS1yZXNwb25z
+        ZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsImRvazIiLCJrMTJwaHlzLWNo
+        MDQtczAyLWxvMDEiLCJrMTJwaHlzLWNoMDQtZXgwMzIiXSwic3RpbXVsdXNf
+        aHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjExMCwic3RpbXVsdXNfaHRt
+        bCI6IiIsInN0ZW1faHRtbCI6IkFjY29yZGluZyB0byBOZXd0b27igJlzIEZp
+        cnN0IExhdywgYSBib2R5IGluIG1vdGlvbiB0ZW5kcyB0byByZW1haW4gaW4g
+        bW90aW9uIGF0IGNvbnN0YW50IHZlbG9jaXR5LiBIb3dldmVyLCB3aGVuIHlv
+        dSBzbGlkZSBhbiBvYmplY3QgYWNyb3NzIGEgc3VyZmFjZSwgdGhlIG9iamVj
+        dCBldmVudHVhbGx5IHNsb3dzIGRvd24gYW5kIHN0b3BzLiBXaHk/IiwiYW5z
+        d2VycyI6W3siaWQiOjM5NiwiY29udGVudF9odG1sIjoiVGhlIG9iamVjdCBl
+        eHBlcmllbmNlcyBhIHBzZXVkbyBmb3JjZSBvZiB0aGUgYm9keSBpbiBtb3Rp
+        b24sIHdoaWNoIG9wcG9zZXMgaXRzIG1vdGlvbiIsImNvcnJlY3RuZXNzIjoi
+        MC4wIiwiZmVlZGJhY2tfaHRtbCI6IklzIGl0IGNvcnJlY3QgdG8gc2F5IHRo
+        YXQgYSBwc2V1ZG8gZm9yY2UgY2FuIGJyaW5nIGNoYW5nZSBpbiBtb3Rpb24g
+        b2YgdGhlIGJvZHk/In0seyJpZCI6Mzk1LCJjb250ZW50X2h0bWwiOiJUaGUg
+        b2JqZWN0IGV4cGVyaWVuY2VzIGFuIGludGVybmFsIGZvcmNlIGV4ZXJ0ZWQg
+        YnkgdGhlIGJvZHkgaXRzZWxmLCB3aGljaCBvcHBvc2VzIGl0cyBtb3Rpb24i
+        LCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJBcmUgeW91
+        IHN1cmUgdGhhdCBpbnRlcm5hbCBmb3JjZXMgY2FuIG9wcG9zZSB0aGUgbW90
+        aW9uIG9mIHRoZSBib2R5PyBDYW4geW91IHJlY2FsbCBOZXd0b27igJlzIHNl
+        Y29uZCBsYXcgb2YgbW90aW9uPyJ9LHsiaWQiOjM5NCwiY29udGVudF9odG1s
+        IjoiVGhlIG9iamVjdCBleHBlcmllbmNlcyB0aGUgZ3Jhdml0YXRpb25hbCBm
+        b3JjZSBleGVydGVkIGJ5IHRoZSBFYXJ0aCwgd2hpY2ggb3Bwb3NlcyBpdHMg
+        bW90aW9uIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoi
+        RG8geW91IHRoaW5rIHRoZSBncmF2aXRhdGlvbmFsIGZvcmNlIHdoaWNoIGFj
+        dHMgcGVycGVuZGljdWxhciB0byB0aGUgbW90aW9uIG9mIHRoZSBib2R5IHdp
+        bGwgb3Bwb3NlIGl0cyBtb3Rpb24/In0seyJpZCI6MzkzLCJjb250ZW50X2h0
+        bWwiOiJUaGUgb2JqZWN0IGV4cGVyaWVuY2VzIGEgZnJpY3Rpb25hbCBmb3Jj
+        ZSBleGVydGVkIGJ5IHRoZSBzdXJmYWNlLCB3aGljaCBvcHBvc2VzIGl0cyBt
+        b3Rpb24iLCJjb3JyZWN0bmVzcyI6IjEuMCIsImZlZWRiYWNrX2h0bWwiOiJD
+        b3JyZWN0ISBUaGUgb2JqZWN0IGV4cGVyaWVuY2VzIGEgZnJpY3Rpb25hbCBm
+        b3JjZSBleGVydGVkIGJ5IHRoZSBzdXJmYWNlLCB3aGljaCBvcHBvc2VzIGl0
+        cyBtb3Rpb24uIn1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUt
+        Y2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1d
+        fSx7InVpZCI6IjMzQDEiLCJudW1iZXIiOjMzLCJ2ZXJzaW9uIjoxLCJwdWJs
+        aXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4LjM0N1oiLCJlZGl0b3Jz
+        IjpbXSwiYXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9s
+        ZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRh
+        Y2htZW50cyI6W10sInRhZ3MiOlsicHJhY3RpY2UtY29uY2VwdHMiLCJkb2sx
+        IiwidGltZS1zaG9ydCIsImRpc3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3Bs
+        YXktcmVjLXNlbnNpdGl2ZSIsInR1dG9yLW9ubHkiLCJrMTJwaHlzLWNoMDQt
+        czAyLWxvMDEiLCJrMTJwaHlzLWNoMDQtZXgwMzMiXSwic3RpbXVsdXNfaHRt
+        bCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjExMSwic3RpbXVsdXNfaHRtbCI6
+        IiIsInN0ZW1faHRtbCI6IkhvdyBkbyB5b3UgZXhwcmVzcyBtYXRoZW1hdGlj
+        YWxseSB0aGF0IG5vIGV4dGVybmFsIGZvcmNlIGlzIGFjdGluZyBvbiBhIGJv
+        ZHk/IiwiYW5zd2VycyI6W3siaWQiOjQwMCwiY29udGVudF9odG1sIjoiPHNw
+        YW4gZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSA9IFxcaW5mdHlcIj5NYXRo
+        PC9zcGFuPiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6
+        IkFyZSB5b3Ugc3VyZSB0aGF0IDxzcGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0
+        e25ldH0gPSBcXGluZnR5XCI+TWF0aDwvc3Bhbj4gZXhwcmVzc2VzIG1hdGhl
+        bWF0aWNhbGx5IHRoYXQgbm8gZXh0ZXJuYWwgZm9yY2UgaXMgYWN0aW5nIG9u
+        IGEgYm9keT8ifSx7ImlkIjozOTksImNvbnRlbnRfaHRtbCI6IjxzcGFuIGRh
+        dGEtbWF0aD1cIkZfXFx0ZXh0e25ldH0gPSAxXCI+TWF0aDwvc3Bhbj4iLCJj
+        b3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJJcyBpdCBjb3Jy
+        ZWN0IHRvIHNheSB0aGF0IDxzcGFuIGRhdGEtbWF0aD1cIlxcdGV4dHtGfV9c
+        XHRleHR7bmV0fSA9IDFcIj5NYXRoPC9zcGFuPiByZXByZXNlbnRzIG5vIGV4
+        dGVybmFsIGZvcmNlIGlzIGFjdGluZyBvbiBhIGJvZHk/IERvZXNu4oCZdCBp
+        dCB0ZWxsIHRoYXQgYSB1bml0IGZvcmNlIGlzIGFjdGluZyBpbiB0aGUgcG9z
+        aXRpdmUgZGlyZWN0aW9uPyJ9LHsiaWQiOjM5OCwiY29udGVudF9odG1sIjoi
+        PHNwYW4gZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSA9IDBcIj5NYXRoPC9z
+        cGFuPiIsImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNv
+        cnJlY3QhIDxzcGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25ldH0gPSAwXCI+
+        TWF0aDwvc3Bhbj4gbWF0aGVtYXRpY2FsbHkgbWVhbnMgdGhhdCBubyBleHRl
+        cm5hbCBmb3JjZSBpcyBhY3Rpbmcgb24gYSBib2R5LiJ9LHsiaWQiOjM5Nywi
+        Y29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0
+        fSA9IHstMX1cIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNzIjoiMC4wIiwi
+        ZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayA8c3BhbiBkYXRhLW1hdGg9
+        XCJGX1xcdGV4dHtuZXR9ID0gey0xfVwiPk1hdGg8L3NwYW4+IG1lYW5zIHRo
+        YXQgbm8gZXh0ZXJuYWwgZm9yY2UgaXMgYWN0aW5nIG9uIGEgYm9keT8gRG9l
+        c27igJl0IGl0IHRlbGwgdGhhdCBhIHVuaXQgZm9yY2UgaXMgYWN0aW5nIGlu
+        IHRoZSBuZWdhdGl2ZSBkaXJlY3Rpb24/In1dLCJoaW50cyI6W10sImZvcm1h
+        dHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21i
+        b19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjM0QDEiLCJudW1iZXIiOjM0LCJ2
+        ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4
+        LjM2M1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNlcl9pZCI6MX1d
+        LCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVk
+        X2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsicHJhY3RpY2Ut
+        Y29uY2VwdHMiLCJkb2sxIiwidGltZS1zaG9ydCIsImRpc3BsYXktZnJlZS1y
+        ZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsInR1dG9yLW9ubHki
+        LCJrMTJwaHlzLWNoMDQtczAyLWxvMDEiLCJrMTJwaHlzLWNoMDQtZXgwMzQi
+        XSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjExMiwi
+        c3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IldoYXQgaXMgZnJpY3Rp
+        b24/IiwiYW5zd2VycyI6W3siaWQiOjQwNCwiY29udGVudF9odG1sIjoiRnJp
+        Y3Rpb24gaXMgYW4gZXh0ZXJuYWwgZm9yY2UgdGhhdCBhY2NlbGVyYXRlcyBt
+        b3Rpb24gb2YgdGhlIGJvZHkiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRi
+        YWNrX2h0bWwiOiJZZXMsIGZyaWN0aW9uIGlzIGFuIGV4dGVybmFsIGZvcmNl
+        IGJ1dCBkbyB5b3UgdGhpbmsgaXQgYWNjZWxlcmF0ZXMgbW90aW9uIG9mIHRo
+        ZSBib2R5PyBDYW4geW91IHRoaW5rIGhvdyBhIGJvZHkgY29tZXMgdG8gcmVz
+        dD8ifSx7ImlkIjo0MDMsImNvbnRlbnRfaHRtbCI6IkZyaWN0aW9uIGlzIGFu
+        IGV4dGVybmFsIGZvcmNlIHRoYXQgZGVjZWxlcmF0ZXMgbW90aW9uIG9mIHRo
+        ZSBib2R5IiwiY29ycmVjdG5lc3MiOiIxLjAiLCJmZWVkYmFja19odG1sIjoi
+        Q29ycmVjdCEgRnJpY3Rpb24gaXMgYW4gZXh0ZXJuYWwgZm9yY2UgdGhhdCBv
+        cHBvc2VzIHRoZSBtb3Rpb24gb2YgdGhlIGJvZHkuIn0seyJpZCI6NDAyLCJj
+        b250ZW50X2h0bWwiOiJGcmljdGlvbiBpcyBhbiBpbnRlcm5hbCBmb3JjZSB0
+        aGF0IGFjY2VsZXJhdGVzIG1vdGlvbiBvZiB0aGUgYm9keSIsImNvcnJlY3Ru
+        ZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkFyZSB5b3Ugc3VyZSB0aGF0
+        IGZyaWN0aW9uIGlzIGFuIGludGVybmFsIGZvcmNlIHRoYXQgYWNjZWxlcmF0
+        ZXMgbW90aW9uIG9mIHRoZSBib2R5PyBIYXZlIHlvdSBnb3QgdGhlIGRlZmlu
+        aXRpb24gY29ycmVjdGx5PyJ9LHsiaWQiOjQwMSwiY29udGVudF9odG1sIjoi
+        RnJpY3Rpb24gaXMgYW4gaW50ZXJuYWwgZm9yY2UgdGhhdCBkZWNlbGVyYXRl
+        cyBtb3Rpb24gb2YgdGhlIGJvZHkiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZl
+        ZWRiYWNrX2h0bWwiOiJJdCBpcyBjb3JyZWN0IHRoYXQgZnJpY3Rpb24gZGVj
+        ZWxlcmF0ZXMgbW90aW9uIG9mIHRoZSBib2R5IGJ1dCBkbyB5b3UgdGhpbmsg
+        aXQgaXMgYW4gaW50ZXJuYWwgZm9yY2U/IENhbiB5b3UgZGlmZmVyZW50aWF0
+        ZSBiZXR3ZWVuIGludGVybmFsIGFuZCBleHRlcm5hbCBmb3JjZXM/In1dLCJo
+        aW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1y
+        ZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjM1QDEi
+        LCJudW1iZXIiOjM1LCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1
+        LTAzLTEwVDE5OjQ5OjE4LjM3OFoiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6
+        W3sidXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9p
+        ZCI6Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRh
+        Z3MiOlsicHJhY3RpY2UtY29uY2VwdHMiLCJ0aW1lLXNob3J0IiwiZGlzcGxh
+        eS1mcmVlLXJlc3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwiZG9r
+        MiIsInR1dG9yLW9ubHkiLCJrMTJwaHlzLWNoMDQtczAyLWxvMDEiLCJrMTJw
+        aHlzLWNoMDQtZXgwMzUiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9u
+        cyI6W3siaWQiOjExMywic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6
+        Ik5hbWUgb25lIHRoaW5nIHRoYXQgdGhlIGZyaWN0aW9uIGJldHdlZW4gdHdv
+        IHN1cmZhY2VzIG1heSBkZXBlbmQgb24uIiwiYW5zd2VycyI6W3siaWQiOjQw
+        OCwiY29udGVudF9odG1sIjoiUm91Z2huZXNzIG9mIHRoZSBzdXJmYWNlcyIs
+        ImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3Qh
+        IEZyaWN0aW9uIGJldHdlZW4gdHdvIHN1cmZhY2VzIGRlcGVuZHMgb24gdGhl
+        IHF1YWxpdHkgb2YgdGhlIHN1cmZhY2UsIHRoYXQgaXMsIG9uIGl0cyBzbW9v
+        dGhuZXNzIG9yIHJvdWdobmVzcy4ifSx7ImlkIjo0MDcsImNvbnRlbnRfaHRt
+        bCI6IkJyZWFkdGggb2YgdGhlIHN1cmZhY2VzIiwiY29ycmVjdG5lc3MiOiIw
+        LjAiLCJmZWVkYmFja19odG1sIjoiSXMgaXQgY29ycmVjdCB0byBzYXkgdGhh
+        dCBmcmljdGlvbiBkZXBlbmRzIG9uIHRoZSBicmVhZHRoIG9mIHRoZSBzdXJm
+        YWNlPyBDYW4geW91IHJlY2FsbCBkZWZpbml0aW9uIG9mIGZyaWN0aW9uIGFu
+        ZCB0aGUgZmFjdG9ycyBvbiB3aGljaCBpdCBpcyBkZXBlbmRlbnQ/In0seyJp
+        ZCI6NDA2LCJjb250ZW50X2h0bWwiOiJMZW5ndGggb2YgdGhlIHN1cmZhY2Vz
+        IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiQXJlIHlv
+        dSBzdXJlIHRoYXQgZnJpY3Rpb24gZGVwZW5kcyBvbiB0aGUgZGltZW5zaW9u
+        IG9mIHRoZSBzdXJmYWNlcz8gRG8geW91IHRoaW5rIGZyaWN0aW9uIGRlcGVu
+        ZHMgb24gdGhlIGxlbmd0aCBvZiB0aGUgc3VyZmFjZT8ifSx7ImlkIjo0MDUs
+        ImNvbnRlbnRfaHRtbCI6IkNvbXBvc2l0aW9uIG9mIHRoZSBzdXJmYWNlcyIs
+        ImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0
+        aGluayBmcmljdGlvbiBpcyBhIHBoeXNpY2FsIHF1YW50aXR5IHdoaWNoIGRl
+        cGVuZHMgb24gdGhlIGNvbXBvc2l0aW9uIG9mIHRoZSBzdXJmYWNlcz8gQ2Fu
+        IHlvdSByZWNhbGwgZGVmaW5pdGlvbiBvZiBmcmljdGlvbj8ifV0sImhpbnRz
+        IjpbXSwiZm9ybWF0cyI6WyJtdWx0aXBsZS1jaG9pY2UiLCJmcmVlLXJlc3Bv
+        bnNlIl0sImNvbWJvX2Nob2ljZXMiOltdfV19LHsidWlkIjoiMzZAMSIsIm51
+        bWJlciI6MzYsInZlcnNpb24iOjEsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDMt
+        MTBUMTk6NDk6MTguMzkzWiIsImVkaXRvcnMiOltdLCJhdXRob3JzIjpbeyJ1
+        c2VyX2lkIjoxfV0sImNvcHlyaWdodF9ob2xkZXJzIjpbeyJ1c2VyX2lkIjoy
+        fV0sImRlcml2ZWRfZnJvbSI6W10sImF0dGFjaG1lbnRzIjpbXSwidGFncyI6
+        WyJwcmFjdGljZS1jb25jZXB0cyIsInRpbWUtc2hvcnQiLCJkaXNwbGF5LWZy
+        ZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1zZW5zaXRpdmUiLCJkb2syIiwi
+        dHV0b3Itb25seSIsImsxMnBoeXMtY2gwNC1zMDItbG8wMSIsImsxMnBoeXMt
+        Y2gwNC1leDAzNiJdLCJzdGltdWx1c19odG1sIjoiIiwicXVlc3Rpb25zIjpb
+        eyJpZCI6MTE0LCJzdGltdWx1c19odG1sIjoiIiwic3RlbV9odG1sIjoiV2h5
+        IGRvZXMgYSBwdWNrIHNsaWRlIG1vcmUgc21vb3RobHkgb24gYW4gYWlyLWhv
+        Y2tleSB0YWJsZSB3aGVuIHRoZSBhaXIgaXMgdHVybmVkIG9uPyIsImFuc3dl
+        cnMiOlt7ImlkIjo0MTIsImNvbnRlbnRfaHRtbCI6Ikl0IGluY3JlYXNlcyB0
+        aGUgZ3Jhdml0YXRpb25hbCBmb3JjZSBiZXR3ZWVuIHRoZSBwdWNrIGFuZCB0
+        aGUgdGFibGUiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwi
+        OiJJcyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0IGFpciB3aWxsIGhhdmUgYW55
+        IGVmZmVjdCBvbiB0aGUgZ3Jhdml0YXRpb25hbCBmb3JjZT8gQWxzbywgZG8g
+        eW91IHRoaW5rIGl0IHdpbGwgYmUgdGhlIHJpZ2h0IGZhY3RvciB0byBiZSBj
+        b25zaWRlcmVkIHdoZW4gbW90aW9uIGJldHdlZW4gdHdvIHN1cmZhY2VzIGlz
+        IGRlc2NyaWJlZD8ifSx7ImlkIjo0MTEsImNvbnRlbnRfaHRtbCI6Ikl0IHJl
+        ZHVjZXMgdGhlIGdyYXZpdGF0aW9uYWwgZm9yY2UgYmV0d2VlbiB0aGUgcHVj
+        ayBhbmQgdGhlIHRhYmxlIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFj
+        a19odG1sIjoiQXJlIHlvdSBzdXJlIHRoYXQgYWlyIHdpbGwgaGF2ZSBhbnkg
+        ZWZmZWN0IG9uIHRoZSBncmF2aXRhdGlvbmFsIGZvcmNlPyBBbHNvLCBpcyBp
+        dCB0aGUgY29ycmVjdCBmYWN0b3IgdG8gY29uc2lkZXIgd2hlbiBtb3Rpb24g
+        YmV0d2VlbiB0d28gc3VyZmFjZXMgaXMgY29uc2lkZXJlZD8ifSx7ImlkIjo0
+        MTAsImNvbnRlbnRfaHRtbCI6Ikl0IGluY3JlYXNlcyB0aGUgZnJpY3Rpb24g
+        YmV0d2VlbiB0aGUgcHVjayBhbmQgdGhlIHRhYmxlIiwiY29ycmVjdG5lc3Mi
+        OiIwLjAiLCJmZWVkYmFja19odG1sIjoiRG8geW91IHRoaW5rIGlmIHRoZSBm
+        cmljdGlvbiBiZXR3ZWVuIHRoZSBwdWNrIGFuZCB0aGUgdGFibGUgaXMgaW5j
+        cmVhc2VkLCB0aGUgcHVjayB3aWxsIHNsaWRlIG1vcmUgc21vb3RobHk/IENh
+        biB5b3UgcmVjYWxsIHRoZSBkZWZpbml0aW9uIG9mIGZyaWN0aW9uPyJ9LHsi
+        aWQiOjQwOSwiY29udGVudF9odG1sIjoiSXQgcmVkdWNlcyB0aGUgZnJpY3Rp
+        b24gYmV0d2VlbiB0aGUgcHVjayBhbmQgdGhlIHRhYmxlIiwiY29ycmVjdG5l
+        c3MiOiIxLjAiLCJmZWVkYmFja19odG1sIjoiQ29ycmVjdCEgVGhlIGFpciBy
+        ZWR1Y2VzIHRoZSBmcmljdGlvbiBiZXR3ZWVuIHRoZSBwdWNrIGFuZCB0aGUg
+        dGFibGUifV0sImhpbnRzIjpbXSwiZm9ybWF0cyI6WyJtdWx0aXBsZS1jaG9p
+        Y2UiLCJmcmVlLXJlc3BvbnNlIl0sImNvbWJvX2Nob2ljZXMiOltdfV19LHsi
+        dWlkIjoiMzdAMSIsIm51bWJlciI6MzcsInZlcnNpb24iOjEsInB1Ymxpc2hl
+        ZF9hdCI6IjIwMTUtMDMtMTBUMTk6NDk6MTguNDA4WiIsImVkaXRvcnMiOltd
+        LCJhdXRob3JzIjpbeyJ1c2VyX2lkIjoxfV0sImNvcHlyaWdodF9ob2xkZXJz
+        IjpbeyJ1c2VyX2lkIjoyfV0sImRlcml2ZWRfZnJvbSI6W10sImF0dGFjaG1l
+        bnRzIjpbXSwidGFncyI6WyJpbmJvb2steWVzIiwidGltZS1zaG9ydCIsImRp
+        c3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIs
+        ImRvazIiLCJjaGFwdGVyLXJldmlldy1jb25jZXB0IiwiazEycGh5cy1jaDA0
+        LXMwMi1sbzAxIiwiazEycGh5cy1jaDA0LWV4MDM3Il0sInN0aW11bHVzX2h0
+        bWwiOiIiLCJxdWVzdGlvbnMiOlt7ImlkIjoxMTUsInN0aW11bHVzX2h0bWwi
+        OiIiLCJzdGVtX2h0bWwiOiJBIGJhbGwgcm9sbHMgYWxvbmcgdGhlIGdyb3Vu
+        ZCBtb3ZpbmcgZnJvbSBOb3J0aCB0byBTb3V0aC4gV2hhdCBkaXJlY3Rpb24g
+        aXMgdGhlIGZyaWN0aW9uYWwgZm9yY2UgdGhhdCBhY3RzIG9uIHRoZSBiYWxs
+        PyIsImFuc3dlcnMiOlt7ImlkIjo0MTYsImNvbnRlbnRfaHRtbCI6IkVhc3Qg
+        dG8gd2VzdCIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6
+        IkFyZSB5b3Ugc3VyZSB0aGF0IGZyaWN0aW9uYWwgZm9yY2UgYWN0cyBpbiB0
+        aGUgZGlyZWN0aW9uIHBlcnBlbmRpY3VsYXIgdG8gdGhlIGRpcmVjdGlvbiBv
+        ZiBtb3Rpb24gb2YgdGhlIG9iamVjdD8gQ2FuIHlvdSByZWNhbGwgdGhlIGZ1
+        bmN0aW9uIG9mIGZyaWN0aW9uYWwgZm9yY2U/IFdoYXQgaXMgaXRzIHB1cnBv
+        c2U/In0seyJpZCI6NDE1LCJjb250ZW50X2h0bWwiOiJXZXN0IHRvIGVhc3Qi
+        LCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJJcyBpdCBj
+        b3JyZWN0IHRvIHNheSB0aGF0IGZyaWN0aW9uYWwgZm9yY2UgYWN0cyBpbiB0
+        aGUgZGlyZWN0aW9uIHBlcnBlbmRpY3VsYXIgdG8gdGhlIGRpcmVjdGlvbiBv
+        ZiBtb3Rpb24/In0seyJpZCI6NDE0LCJjb250ZW50X2h0bWwiOiJTb3V0aCB0
+        byBub3J0aCIsImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6
+        IkNvcnJlY3QhIEZyaWN0aW9uYWwgZm9yY2UgYWN0cyBpbiBhIGRpcmVjdGlv
+        biB0byBvcHBvc2UgdGhlIGNoYW5nZSBpbiBtb3Rpb24gb2YgdGhlIGJvZHku
+        In0seyJpZCI6NDEzLCJjb250ZW50X2h0bWwiOiJOb3J0aCB0byBzb3V0aCIs
+        ImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0
+        aGluayBmcmljdGlvbmFsIGZvcmNlIGFjdHMgaW4gdGhlIGRpcmVjdGlvbiBv
+        ZiBtb3Rpb24/IENhbiB5b3UgcmVjYWxsIHdoYXQgdGhlIGZ1bmN0aW9uIG9m
+        IGZyaWN0aW9uYWwgZm9yY2UgaXM/In1dLCJoaW50cyI6W10sImZvcm1hdHMi
+        OlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19j
+        aG9pY2VzIjpbXX1dfSx7InVpZCI6IjM4QDEiLCJudW1iZXIiOjM4LCJ2ZXJz
+        aW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4LjQy
+        N1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJj
+        b3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zy
+        b20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsidGltZS1zaG9ydCIs
+        ImRpc3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2
+        ZSIsImRvazIiLCJ0dXRvci1vbmx5IiwiY2hhcHRlci1yZXZpZXctY29uY2Vw
+        dCIsImsxMnBoeXMtY2gwNC1zMDItbG8wMSIsImsxMnBoeXMtY2gwNC1leDAz
+        OCJdLCJzdGltdWx1c19odG1sIjoiIiwicXVlc3Rpb25zIjpbeyJpZCI6MTE2
+        LCJzdGltdWx1c19odG1sIjoiIiwic3RlbV9odG1sIjoiQSBib3dsaW5nIGxh
+        bmUgaXMgYW4gZXhhbXBsZSB3aGVyZSBhIHNtb290aCBzdXJmYWNlIHdpdGgg
+        bGVzcyBmcmljdGlvbiBpcyBkZXNpcmFibGUgc28gdGhhdCB0aGUgYmFsbCBj
+        YW4gc2xpZGUgc21vb3RobHkuIEdpdmUgYW5vdGhlciBleGFtcGxlIHdoZXJl
+        IGEgc3VyZmFjZSB3aXRoIGxlc3MgZnJpY3Rpb24gaXMgZGVzaXJhYmxlLiIs
+        ImFuc3dlcnMiOlt7ImlkIjo0MjAsImNvbnRlbnRfaHRtbCI6IkpvZ2dpbmcg
+        dHJhY2siLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJD
+        YW4geW91IHdhbGsgZWFzaWx5IG9uIGEgc2xpcHBpbmcgc3VyZmFjZT8gRG8g
+        eW91IHRoaW5rIGl0IGlzIHJlcXVpcmVkIHRvIGhhdmUgbGVzcyBmcmljdGlv
+        biBvbiBhIGpvZ2dpbmcgdHJhY2s/In0seyJpZCI6NDE5LCJjb250ZW50X2h0
+        bWwiOiJJY2UgaG9ja2V5IHN0YWRpdW0iLCJjb3JyZWN0bmVzcyI6IjEuMCIs
+        ImZlZWRiYWNrX2h0bWwiOiJDb3JyZWN0ISBJdCBpcyByZXF1aXJlZCB0byBo
+        YXZlIGxlc3MgZnJpY3Rpb24gb24gdGhlIGljZSBob2NrZXkgaWNlIHN1cmZh
+        Y2UgYXMgaXQgd2lsbCBoZWxwIHB1Y2sgdG8gc2xpZGUgZWFzaWx5IG9uIHRo
+        ZSBjb3VydC4ifSx7ImlkIjo0MTgsImNvbnRlbnRfaHRtbCI6IlNwcmludCBy
+        YWNlIHRyYWNrIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1s
+        IjoiQXJlIHlvdSBzdXJlIHRoYXQgaXQgaXMgcmVxdWlyZWQgdG8gaGF2ZSBs
+        ZXNzIGZyaWN0aW9uIGluIGEgc3ByaW50IHJhY2UgdHJhY2s/IENhbiB5b3Ug
+        cnVuIGluIGEgc2xpcHBpbmcgc3VyZmFjZT8ifSx7ImlkIjo0MTcsImNvbnRl
+        bnRfaHRtbCI6IlRlbm5pcyBjb3VydCIsImNvcnJlY3RuZXNzIjoiMC4wIiwi
+        ZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayBpdCBpcyByZXF1aXJlZCB0
+        byBoYXZlIGxlc3MgZnJpY3Rpb24gaW4gYSB0ZW5uaXMgY291cnQ/IENhbiB5
+        b3UgdGhpbmsgd2hhdCB3aWxsIGhhcHBlbiBpZiB0aGUgZnJpY3Rpb24gb2Yg
+        dGhlIHRlbm5pcyBjb3VydCBpcyBsZXNzPyJ9XSwiaGludHMiOltdLCJmb3Jt
+        YXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZyZWUtcmVzcG9uc2UiXSwiY29t
+        Ym9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiIzOUAxIiwibnVtYmVyIjozOSwi
+        dmVyc2lvbiI6MSwicHVibGlzaGVkX2F0IjoiMjAxNS0wMy0xMFQxOTo0OTox
+        OC40NDJaIiwiZWRpdG9ycyI6W10sImF1dGhvcnMiOlt7InVzZXJfaWQiOjF9
+        XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVzZXJfaWQiOjJ9XSwiZGVyaXZl
+        ZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltdLCJ0YWdzIjpbInRpbWUtc2hv
+        cnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1zZW5z
+        aXRpdmUiLCJkb2syIiwidHV0b3Itb25seSIsImNoYXB0ZXItcmV2aWV3LWNv
+        bmNlcHQiLCJrMTJwaHlzLWNoMDQtczAyLWxvMDEiLCJrMTJwaHlzLWNoMDQt
+        ZXgwMzkiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQi
+        OjExNywic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IldoaWNoIGZv
+        cmNlcyBhZmZlY3QgdGhlIG1vdGlvbiBvZiBhIHN5c3RlbT8iLCJhbnN3ZXJz
+        IjpbeyJpZCI6NDI0LCJjb250ZW50X2h0bWwiOiJOZWl0aGVyIGludGVybmFs
+        IG5vciBleHRlcm5hbCBmb3JjZSIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVl
+        ZGJhY2tfaHRtbCI6IlllcywgaW50ZXJuYWwgZm9yY2UgY2Fubm90IGFmZmVj
+        dCB0aGUgbW90aW9uIG9mIHRoZSBvYmplY3QgYnV0IHdoYXQgYWJvdXQgZXh0
+        ZXJuYWwgZm9yY2VzPyBEbyB5b3UgdGhpbmsgaXQgY2FuIG5vdCBhZmZlY3Qg
+        bW90aW9uIG9mIGFuIG9iamVjdD8ifSx7ImlkIjo0MjMsImNvbnRlbnRfaHRt
+        bCI6IkJvdGggaW50ZXJuYWwgYW5kIGV4dGVybmFsIGZvcmNlcyIsImNvcnJl
+        Y3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6Ikl0IGlzIGNvcnJlY3Qg
+        dGhhdCBleHRlcm5hbCBmb3JjZXMgY2FuIGFmZmVjdCB0aGUgbW90aW9uIG9m
+        IGFuIG9iamVjdCBidXQgd2hhdCBhYm91dCBpbnRlcm5hbCBmb3JjZXM/IERv
+        IHlvdSB0aGluayBhIGZvcmNlIG9yaWdpbmF0aW5nIGluc2lkZSBhbiBvYmpl
+        Y3QgY2FuIGFmZmVjdCBpdHMgbW90aW9uPyJ9LHsiaWQiOjQyMiwiY29udGVu
+        dF9odG1sIjoiRXh0ZXJuYWwgZm9yY2VzIiwiY29ycmVjdG5lc3MiOiIxLjAi
+        LCJmZWVkYmFja19odG1sIjoiQ29ycmVjdCEgRXh0ZXJuYWwgZm9yY2VzIGFm
+        ZmVjdCB0aGUgbW90aW9uIG9mIGFuIG9iamVjdC4ifSx7ImlkIjo0MjEsImNv
+        bnRlbnRfaHRtbCI6IkludGVybmFsIGZvcmNlcyIsImNvcnJlY3RuZXNzIjoi
+        MC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayBhbiBpbnRlcm5h
+        bCBmb3JjZSBjYW4gYWZmZWN0IHRoZSBtb3Rpb24gb2YgdGhlIG9iamVjdD8g
+        Q2FuIHlvdSB0aGluayBhYm91dCB0aGUgZmFjdG9ycyB3aGljaCBjYW4gYnJp
+        bmcgYWJvdXQgY2hhbmdlIGluIHRoZSBtb3Rpb24gb2YgdGhlIG9iamVjdD8i
+        fV0sImhpbnRzIjpbXSwiZm9ybWF0cyI6WyJtdWx0aXBsZS1jaG9pY2UiLCJm
+        cmVlLXJlc3BvbnNlIl0sImNvbWJvX2Nob2ljZXMiOltdfV19LHsidWlkIjoi
+        NDBAMSIsIm51bWJlciI6NDAsInZlcnNpb24iOjEsInB1Ymxpc2hlZF9hdCI6
+        IjIwMTUtMDMtMTBUMTk6NDk6MTguNDU3WiIsImVkaXRvcnMiOltdLCJhdXRo
+        b3JzIjpbeyJ1c2VyX2lkIjoxfV0sImNvcHlyaWdodF9ob2xkZXJzIjpbeyJ1
+        c2VyX2lkIjoyfV0sImRlcml2ZWRfZnJvbSI6W10sImF0dGFjaG1lbnRzIjpb
+        XSwidGFncyI6WyJpbmJvb2steWVzIiwiZGlzcGxheS1mcmVlLXJlc3BvbnNl
+        IiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwiY2hhcHRlci1yZXZpZXctY29u
+        Y2VwdCIsImRvazMiLCJ0aW1lLW1lZGl1bSIsImsxMnBoeXMtY2gwNC1zMDIt
+        bG8wMSIsImsxMnBoeXMtY2gwNC1leDA0MCJdLCJzdGltdWx1c19odG1sIjoi
+        IiwicXVlc3Rpb25zIjpbeyJpZCI6MTE4LCJzdGltdWx1c19odG1sIjoiIiwi
+        c3RlbV9odG1sIjoiVHdvIHBlb3BsZSBwdXNoIGEgY2FydCBvbiBhIGhvcml6
+        b250YWwgc3VyZmFjZSBieSBhcHBseWluZyBmb3JjZXMgPHNwYW4gZGF0YS1t
+        YXRoPVwiRl8xXCI+TWF0aDwvc3Bhbj4gYW5kIDxzcGFuIGRhdGEtbWF0aD1c
+        IkZfMlwiPk1hdGg8L3NwYW4+IGluIHRoZSBzYW1lIGRpcmVjdGlvbi4gSXMg
+        dGhlIG5ldCBmb3JjZSBhY3Rpbmcgb24gdGhlIGNhcnQgPHNwYW4gZGF0YS1t
+        YXRoPVwiRl9cXHRleHR7bmV0fVwiPk1hdGg8L3NwYW4+IGVxdWFsIHRvLCBn
+        cmVhdGVyIHRoYW4sIG9yIGxlc3MgdGhhbiA8c3BhbiBkYXRhLW1hdGg9XCJG
+        XzEgKyBGXzJcIj5NYXRoPC9zcGFuPj8gV2h5PyIsImFuc3dlcnMiOlt7Imlk
+        Ijo0MjgsImNvbnRlbnRfaHRtbCI6IjxzcGFuIGRhdGEtbWF0aD1cIkZfXFx0
+        ZXh0e25ldH0gPSBGXzEgKyBGXzJcIj5NYXRoPC9zcGFuPiBiZWNhdXNlIHRo
+        ZSBuZXQgZm9yY2Ugd2lsbCBpbmNsdWRlIHRoZSBjb21wb25lbnQgb2YgZnJp
+        Y3Rpb25hbCBmb3JjZS4iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNr
+        X2h0bWwiOiJZZXMsIG5ldCBmb3JjZSB3aWxsIGluY2x1ZGUgdGhlIGNvbXBv
+        bmVudCBvZiBmcmljdGlvbmFsIGZvcmNlIGJ1dCBkbyB5b3UgdGhpbmsgPHNw
+        YW4gZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSA9IEZfMSArIEZfMlwiPk1h
+        dGg8L3NwYW4+PyJ9LHsiaWQiOjQyNywiY29udGVudF9odG1sIjoiPHNwYW4g
+        ZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSAmbHQ7IEZfMSArIEZfMlwiPk1h
+        dGg8L3NwYW4+IGJlY2F1c2UgdGhlIG5ldCBmb3JjZSB3aWxsIGluY2x1ZGUg
+        dGhlIGNvbXBvbmVudCBvZiBmcmljdGlvbmFsIGZvcmNlLiIsImNvcnJlY3Ru
+        ZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIDxzcGFuIGRh
+        dGEtbWF0aD1cIkZfXFx0ZXh0e25ldH1cIj5NYXRoPC9zcGFuPiBpcyBzbWFs
+        bGVyIHRoYW4gPHNwYW4gZGF0YS1tYXRoPVwiRl8xICsgRl8yXCI+TWF0aDwv
+        c3Bhbj4uIFRoZSBuZXQgZm9yY2Ugd2lsbCBpbmNsdWRlIGEgY29tcG9uZW50
+        IG9mIGZyaWN0aW9uIHdoaWNoIHdpbGwgYWN0IGluIHRoZSBkaXJlY3Rpb24g
+        b3Bwb3NpdGUgdG8gPHNwYW4gZGF0YS1tYXRoPVwiRl8xXCI+TWF0aDwvc3Bh
+        bj4gYW5kIDxzcGFuIGRhdGEtbWF0aD1cIkZfMlwiPk1hdGg8L3NwYW4+LCBh
+        bmQgaGVuY2UgY2FuY2VsIG91dCBwYXJ0IG9mIHRoZXNlIGZvcmNlcy4ifSx7
+        ImlkIjo0MjYsImNvbnRlbnRfaHRtbCI6IjxzcGFuIGRhdGEtbWF0aD1cIkZf
+        XFx0ZXh0e25ldH0gPSBGXzEgKyBGXzJcIj5NYXRoPC9zcGFuPiBiZWNhdXNl
+        IHRoZSBuZXQgZm9yY2Ugd2lsbCBub3QgaW5jbHVkZSB0aGUgY29tcG9uZW50
+        IG9mIGZyaWN0aW9uYWwgZm9yY2UuIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJm
+        ZWVkYmFja19odG1sIjoiRG8geW91IHRoaW5rIHdoZW4gYSBjYXJ0IGlzIG1v
+        dmluZyBvbiBhIGhvcml6b250YWwgc3VyZmFjZSB3aWxsIG5vdCBleHBlcmll
+        bmNlIGFueSBmcmljdGlvbmFsIGZvcmNlPyJ9LHsiaWQiOjQyNSwiY29udGVu
+        dF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSAmbHQ7
+        IEZfMSArIEZfMlwiPk1hdGg8L3NwYW4+IGJlY2F1c2UgdGhlIG5ldCBmb3Jj
+        ZSB3aWxsIG5vdCBpbmNsdWRlIHRoZSBjb21wb25lbnQgb2YgZnJpY3Rpb25h
+        bCBmb3JjZS4iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwi
+        OiJJcyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0IHRoZSBuZXQgZm9yY2Ugd2ls
+        bCBub3QgaW5jbHVkZSB0aGUgY29tcG9uZW50IG9mIGZyaWN0aW9uYWwgZm9y
+        Y2U/IENhbiB5b3UgZXhwbGFpbiB0aGUgaW5lcXVhbGl0eSBvY2N1cnJpbmcg
+        aW4gdGhlIG1hdGhlbWF0aWNhbCBleHByZXNzaW9ucyB3aXRob3V0IGNvbnNp
+        ZGVyaW5nIHRoZSBmcmljdGlvbmFsIGZvcmNlPyJ9XSwiaGludHMiOltdLCJm
+        b3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZyZWUtcmVzcG9uc2UiXSwi
+        Y29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiI0MUAxIiwibnVtYmVyIjo0
+        MSwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0IjoiMjAxNS0wMy0xMFQxOTo0
+        OToxOC40NzJaIiwiZWRpdG9ycyI6W10sImF1dGhvcnMiOlt7InVzZXJfaWQi
+        OjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVzZXJfaWQiOjJ9XSwiZGVy
+        aXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltdLCJ0YWdzIjpbImRpc3Bs
+        YXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsInR1
+        dG9yLW9ubHkiLCJjaGFwdGVyLXJldmlldy1jb25jZXB0IiwiZG9rMyIsInRp
+        bWUtbWVkaXVtIiwiazEycGh5cy1jaDA0LXMwMi1sbzAxIiwiazEycGh5cy1j
+        aDA0LWV4MDQxIl0sInN0aW11bHVzX2h0bWwiOiIiLCJxdWVzdGlvbnMiOlt7
+        ImlkIjoxMTksInN0aW11bHVzX2h0bWwiOiIiLCJzdGVtX2h0bWwiOiJXaGVu
+        IGEgcm9ja2V0IGlzIGxhdW5jaGVkIGludG8gc3BhY2UgYW5kIGVzY2FwZXMg
+        dGhlIGVhcnRo4oCZcyBhdG1vc3BoZXJlLiBBZnRlciBlc2NhcGluZyBpdCBj
+        b250aW51ZXMgdG8gdHJhdmVsIGluIGEgc3RyYWlnaHQgbGluZSB1bnRpbCBp
+        dCBpcyBhY3RlZCB1cG9uIGJ5IGFub3RoZXIgZm9yY2Ugc3VjaCBhcyBpdHMg
+        b3duIHRocnVzdCBvciBhbm90aGVyIHBsYW5ldOKAmXMgZ3Jhdml0eS4iLCJh
+        bnN3ZXJzIjpbeyJpZCI6NDMwLCJjb250ZW50X2h0bWwiOiIwIiwiY29ycmVj
+        dG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiRG8geW91IHRoaW5rIGlu
+        IGFic2VuY2Ugb2YgYW4gZXh0ZXJuYWwgZm9yY2UgdGhlIHJvY2tldCB3aWxs
+        IHRha2UgYSBwYXRoIG90aGVyIHRoYW4gYSBzdHJhaWdodCBsaW5lPyBDYW4g
+        eW91IHJlY2FsbCBOZXd0b27igJlzIGZpcnN0IGxhdyBvZiBtb3Rpb24/In0s
+        eyJpZCI6NDI5LCJjb250ZW50X2h0bWwiOiIxIiwiY29ycmVjdG5lc3MiOiIx
+        LjAiLCJmZWVkYmFja19odG1sIjoiQ29ycmVjdCEgVGhlIHN0YXRlIG9mIG1v
+        dGlvbiByZW1haW5zIHVuY2hhbmdlZCB1bnRpbCBhbmQgdW5sZXNzIHRoZSBy
+        b2NrZXQgZXhwZXJpZW5jZXMgYW4gZXh0ZXJuYWwgZm9yY2UuIn1dLCJoaW50
+        cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNw
+        b25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjQyQDEiLCJu
+        dW1iZXIiOjQyLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAz
+        LTEwVDE5OjQ5OjE4LjQ4OFoiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3si
+        dXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6
+        Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3Mi
+        OlsiZGlzcGxheS1mcmVlLXJlc3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0
+        aXZlIiwidHV0b3Itb25seSIsImNoYXB0ZXItcmV2aWV3LWNvbmNlcHQiLCJ0
+        aW1lLW1lZGl1bSIsImRvazQiLCJrMTJwaHlzLWNoMDQtczAyLWxvMDEiLCJr
+        MTJwaHlzLWNoMDQtZXgwNDIiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0
+        aW9ucyI6W3siaWQiOjEyMCwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRt
+        bCI6IkEgcGVyc29uIHJvbGxzIGEgYmFsbCBvbiB0aGUgZmxvb3IgZnJvbSBX
+        ZXN0IHRvIEVhc3QgYnkgYXBwbHlpbmcgYSBmb3JjZSA8c3BhbiBkYXRhLW1h
+        dGg9XCJGXzFcIj5NYXRoPC9zcGFuPi4gVGhlIGZyaWN0aW9uYWwgZm9yY2Ug
+        dGhhdCBvcHBvc2VzIHRoZSBtb3Rpb24gb2YgdGhpcyBiYWxsIGlzIDxzcGFu
+        IGRhdGEtbWF0aD1cImZcIj5NYXRoPC9zcGFuPi4gV2hhdCBpcyB0aGUgbWFn
+        bml0dWRlIGFuZCBkaXJlY3Rpb24gb2YgdGhlIGFkZGl0aW9uYWwgZm9yY2Ug
+        dGhhdCBzaG91bGQgYmUgYXBwbGllZCB0byB0aGUgYmFsbCB0byBrZWVwIGl0
+        IG1vdmluZyBhdCB0aGUgc2FtZSB2ZWxvY2l0eT8iLCJhbnN3ZXJzIjpbeyJp
+        ZCI6NDM0LCJjb250ZW50X2h0bWwiOiI8c3BhbiBkYXRhLW1hdGg9XCJGXzEg
+        LSBmXCI+TWF0aDwvc3Bhbj4gaW4gdGhlIGRpcmVjdGlvbiBmcm9tIEVhc3Qg
+        dG8gV2VzdCIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6
+        IklzbuKAmXQgdGhpcyBnb2luZyB0byByZWR1Y2UgdGhlIHZlbG9jaXR5IG9m
+        IHRoZSBib2R5PyBDYW4geW91IHRoaW5rIG9mIGhvdyB5b3Ugd2lsbCBtYWlu
+        dGFpbiB0aGUgc2FtZSB2ZWxvY2l0eT8ifSx7ImlkIjo0MzMsImNvbnRlbnRf
+        aHRtbCI6IjxzcGFuIGRhdGEtbWF0aD1cIkZfMSAtIGZcIj5NYXRoPC9zcGFu
+        PiBpbiB0aGUgZGlyZWN0aW9uIGZyb20gV2VzdCB0byBFYXN0IiwiY29ycmVj
+        dG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiRG9u4oCZdCB5b3UgdGhp
+        bmsgd2l0aCB0aGlzIG11Y2ggb2YgZm9yY2UgdGhlIGJvZHkgd2lsbCBzdGFy
+        dCBhY2NlbGVyYXRpbmc/IENhbiB5b3UgdGhpbmsgd2h5PyJ9LHsiaWQiOjQz
+        MiwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiZlwiPk1hdGg8
+        L3NwYW4+IGluIHRoZSBkaXJlY3Rpb24gZnJvbSBFYXN0IHRvIFdlc3QiLCJj
+        b3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJJdCBpcyBjb3Jy
+        ZWN0IHRoYXQgbWFnbml0dWRlIG9mIHRoZSBmb3JjZSB3aGljaCBpcyByZXF1
+        aXJlZCB0byBrZWVwIGJhbGwgbW92aW5nIHdpdGggdGhlIHNhbWUgdmVsb2Np
+        dHkgaXMgPHNwYW4gZGF0YS1tYXRoPVwiZlwiPk1hdGg8L3NwYW4+IGJ1dCB3
+        aGF0IGFib3V0IHRoZSBkaXJlY3Rpb24/IERvIHlvdSB0aGluayB5b3Ugd2ls
+        bCBhcHBseSB0aGUgZm9yY2UgaW4gdGhlIGRpcmVjdGlvbiBvZiBmcmljdGlv
+        bmFsIGZvcmNlPyJ9LHsiaWQiOjQzMSwiY29udGVudF9odG1sIjoiPHNwYW4g
+        ZGF0YS1tYXRoPVwiZlwiPk1hdGg8L3NwYW4+IGluIHRoZSBkaXJlY3Rpb24g
+        ZnJvbSBXZXN0IHRvIEVhc3QiLCJjb3JyZWN0bmVzcyI6IjEuMCIsImZlZWRi
+        YWNrX2h0bWwiOiJDb3JyZWN0ISBUbyBrZWVwIHRoZSBiYWxsIG1vdmluZyB3
+        aXRoIHRoZSBzYW1lIHZlbG9jaXR5IGFuIGFkZGl0aW9uYWwgZm9yY2Ugb2Yg
+        bWFnbml0dWRlIDxzcGFuIGRhdGEtbWF0aD1cImZcIj5NYXRoPC9zcGFuPiBp
+        cyB0byBiZSBhcHBsaWVkIGZyb20gV2VzdCB0byBFYXN0LiBUaGUgYmFsbCB0
+        cmF2ZWxzIGZyb20gV2VzdCB0byBFYXN0IHdpdGggYSBmb3JjZSBvZiA8c3Bh
+        biBkYXRhLW1hdGg9XCJGXzEgLSBmXCI+TWF0aDwvc3Bhbj4uIFRoZSBhZGRp
+        dGlvbmFsIGZvcmNlIHRoYXQgc2hvdWxkIGJlIGFwcGxpZWQgdG8ga2VlcCB0
+        aGUgYmFsbCBtb3Zpbmcgd2l0aCB0aGUgc2FtZSB2ZWxvY2l0eSwgc2hvdWxk
+        IGJlIGp1c3QgZW5vdWdoIHRvIG92ZXJjb21lIHRoZSBlZmZlY3Qgb2YgZnJp
+        Y3Rpb24uIEZyaWN0aW9uLCBpbiB0aGlzIGNhc2UsIGFjdHMgZnJvbSBFYXN0
+        IHRvIFdlc3QuIEhlbmNlLCB0aGUgYWRkaXRpb25hbCBmb3JjZSBzaG91bGQg
+        YmUgZnJvbSBXZXN0IHRvIEVhc3QsIHdpdGggdGhlIG1hZ25pdHVkZSA8c3Bh
+        biBkYXRhLW1hdGg9XCJmXCI+TWF0aDwvc3Bhbj4uIn1dLCJoaW50cyI6W10s
+        ImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJd
+        LCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjQzQDEiLCJudW1iZXIi
+        OjQzLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5
+        OjQ5OjE4LjUwM1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNlcl9p
+        ZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJk
+        ZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsiaW5i
+        b29rLXllcyIsImRvazEiLCJ0aW1lLXNob3J0IiwiZGlzcGxheS1mcmVlLXJl
+        c3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwidGVzdC1wcmVwLW11
+        bHRpcGxlLWNob2ljZSIsImsxMnBoeXMtY2gwNC1zMDItbG8wMSIsImsxMnBo
+        eXMtY2gwNC1leDA0MyJdLCJzdGltdWx1c19odG1sIjoiIiwicXVlc3Rpb25z
+        IjpbeyJpZCI6MTIxLCJzdGltdWx1c19odG1sIjoiIiwic3RlbV9odG1sIjoi
+        V2hhdCBraW5kIG9mIGZvcmNlIGlzIGZyaWN0aW9uPyIsImFuc3dlcnMiOlt7
+        ImlkIjo0MzcsImNvbnRlbnRfaHRtbCI6Ik5ldCBmb3JjZSIsImNvcnJlY3Ru
+        ZXNzIjoiMC4wIn0seyJpZCI6NDM2LCJjb250ZW50X2h0bWwiOiJJbnRlcm5h
+        bCIsImNvcnJlY3RuZXNzIjoiMC4wIn0seyJpZCI6NDM1LCJjb250ZW50X2h0
+        bWwiOiJFeHRlcm5hbCIsImNvcnJlY3RuZXNzIjoiMS4wIn1dLCJoaW50cyI6
+        W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25z
+        ZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjQ0QDEiLCJudW1i
+        ZXIiOjQ0LCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEw
+        VDE5OjQ5OjE4LjUxOVoiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNl
+        cl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1d
+        LCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsi
+        aW5ib29rLXllcyIsInRpbWUtc2hvcnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9u
+        c2UiLCJkaXNwbGF5LXJlYy1zZW5zaXRpdmUiLCJkb2syIiwidGVzdC1wcmVw
+        LXNob3J0LWFuc3dlciIsImsxMnBoeXMtY2gwNC1zMDItbG8wMSIsImsxMnBo
+        eXMtY2gwNC1leDA0NCJdLCJzdGltdWx1c19odG1sIjoiIiwicXVlc3Rpb25z
+        IjpbeyJpZCI6MTIyLCJzdGltdWx1c19odG1sIjoiIiwic3RlbV9odG1sIjoi
+        QSBib2R5IHdpdGggbWFzcyA8c3BhbiBkYXRhLW1hdGg9XCJtXCI+TWF0aDwv
+        c3Bhbj4gaXMgcHVzaGVkIGFsb25nIGEgaG9yaXpvbnRhbCBzdXJmYWNlIGJ5
+        IGEgZm9yY2UgPHNwYW4gZGF0YS1tYXRoPVwiRlwiPk1hdGg8L3NwYW4+IGFu
+        ZCBvcHBvc2VkIGJ5IGEgZnJpY3Rpb25hbCBmb3JjZSA8c3BhbiBkYXRhLW1h
+        dGg9XCJmXCI+TWF0aDwvc3Bhbj4uIERyYXcgYSBmcmVlIGJvZHkgZGlhZ3Jh
+        bSB0byByZXByZXNlbnQgdGhpcyBzaXR1YXRpb24uIiwiYW5zd2VycyI6W3si
+        aWQiOjQ0MSwiY29udGVudF9odG1sIjoiQW4gYXJyb3cgcG9pbnRpbmcgcmln
+        aHQsIGxhYmVsZWQgRiBhbmQgc21hbGxlciBhcnJvdyBwb2ludGluZyBkb3du
+        IGxhYmVsZWQgZiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRt
+        bCI6IklzIGl0IGNvcnJlY3QgdG8gc2F5IHRoYXQgZnJpY3Rpb25hbCBmb3Jj
+        ZSB3aGljaCBvcHBvc2VzIHRoZSBtb3Rpb24gb2YgdGhlIGJvZHkgYWN0cyBp
+        biB0aGUgZGlyZWN0aW9uIHBlcnBlbmRpY3VsYXIgdG8gdGhlIGFwcGxpZWQg
+        Zm9yY2U/In0seyJpZCI6NDQwLCJjb250ZW50X2h0bWwiOiJBbiBhcnJvdyBw
+        b2ludGluZyByaWdodCwgbGFiZWxlZCBGIGFuZCBzbWFsbGVyIGFycm93IHBv
+        aW50aW5nIHVwIGxhYmVsZWQgZiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVl
+        ZGJhY2tfaHRtbCI6IkFyZSB5b3Ugc3VyZSB0aGF0IGZyaWN0aW9uYWwgZm9y
+        Y2UgYWN0cyBpbiB0aGUgZGlyZWN0aW9uIHBlcnBlbmRpY3VsYXIgdG8gdGhl
+        IGRpcmVjdGlvbiBvZiBhcHBsaWVkIGV4dGVybmFsIGZvcmNlPyBIYXZlIHlv
+        dSB1bmRlcnN0b29kIGNvbmNlcHQgb2YgZnJpY3Rpb25hbCBmb3JjZSBjb3Jy
+        ZWN0bHk/In0seyJpZCI6NDM5LCJjb250ZW50X2h0bWwiOiJBbiBhcnJvdyBw
+        b2ludGluZyByaWdodCwgbGFiZWxlZCBGIGFuZCBzbWFsbGVyIGFycm93IHBv
+        aW50aW5nIHJpZ2h0IGxhYmVsZWQgZiIsImNvcnJlY3RuZXNzIjoiMC4wIiwi
+        ZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayBmcmljdGlvbmFsIGZvcmNl
+        IGFjdHMgaW4gdGhlIGRpcmVjdGlvbiBvZiBhcHBsaWVkIGV4dGVybmFsIGZv
+        cmNlPyBDYW4geW91IHJlY2FsbCBkZWZpbml0aW9uIG9mIGZyaWN0aW9uYWwg
+        Zm9yY2U/In0seyJpZCI6NDM4LCJjb250ZW50X2h0bWwiOiJBbiBhcnJvdyBw
+        b2ludGluZyByaWdodCwgbGFiZWxlZCA8c3BhbiBkYXRhLW1hdGg9XCJGXCI+
+        TWF0aDwvc3Bhbj4gYW5kIHNtYWxsZXIgYXJyb3cgcG9pbnRpbmcgbGVmdCBs
+        YWJlbGVkIDxzcGFuIGRhdGEtbWF0aD1cImZcIj5NYXRoPC9zcGFuPiIsImNv
+        cnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIEZy
+        aWN0aW9uYWwgZm9yY2UgYWN0cyBpbiB0aGUgZGlyZWN0aW9uIG9wcG9zaXRl
+        IHRvIHRoZSBkaXJlY3Rpb24gb2YgdGhlIGFwcGxpZWQgZXh0ZXJuYWwgZm9y
+        Y2UifV0sImhpbnRzIjpbXSwiZm9ybWF0cyI6WyJtdWx0aXBsZS1jaG9pY2Ui
+        LCJmcmVlLXJlc3BvbnNlIl0sImNvbWJvX2Nob2ljZXMiOltdfV19LHsidWlk
+        IjoiNDVAMSIsIm51bWJlciI6NDUsInZlcnNpb24iOjEsInB1Ymxpc2hlZF9h
+        dCI6IjIwMTUtMDMtMTBUMTk6NDk6MTguNTM0WiIsImVkaXRvcnMiOltdLCJh
+        dXRob3JzIjpbeyJ1c2VyX2lkIjoxfV0sImNvcHlyaWdodF9ob2xkZXJzIjpb
+        eyJ1c2VyX2lkIjoyfV0sImRlcml2ZWRfZnJvbSI6W10sImF0dGFjaG1lbnRz
+        IjpbXSwidGFncyI6WyJpbmJvb2steWVzIiwidGltZS1zaG9ydCIsImRpc3Bs
+        YXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsImRv
+        azIiLCJ0ZXN0LXByZXAtc2hvcnQtYW5zd2VyIiwiazEycGh5cy1jaDA0LXMw
+        Mi1sbzAxIiwiazEycGh5cy1jaDA0LWV4MDQ1Il0sInN0aW11bHVzX2h0bWwi
+        OiIiLCJxdWVzdGlvbnMiOlt7ImlkIjoxMjMsInN0aW11bHVzX2h0bWwiOiIi
+        LCJzdGVtX2h0bWwiOiJUd28gb2JqZWN0cyByZXN0IG9uIGEgdW5pZm9ybSBz
+        dXJmYWNlLiBBIHBlcnNvbiBwdXNoZXMgYXQgYm90aCB3aXRoIGVxdWFsIGFt
+        b3VudHMgb2YgZm9yY2UuIElmIHRoZSBmaXJzdCBvYmplY3Qgc3RhcnRzIHRv
+        IG1vdmUgZmFzdGVyIHRoYW4gdGhlIHNlY29uZCwgd2hhdCBjYW4gYmUgc2Fp
+        ZCBhYm91dCB0aGVpciBtYXNzZXM/IiwiYW5zd2VycyI6W3siaWQiOjQ0NSwi
+        Y29udGVudF9odG1sIjoiTm8gaW5mZXJlbmNlIGNhbiBiZSBtYWRlIGFzIG1h
+        c3MgYW5kIGZvcmNlIGFyZSBub3QgcmVsYXRlZCB0byBlYWNoIG90aGVyIiwi
+        Y29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiSXMgaXQgY29y
+        cmVjdCB0byBzYXkgdGhhdCBubyBpbmZlcmVuY2UgY2FuIGJlIG1hZGU/IEhh
+        dmUgeW91IGNvbnNpZGVyZWQgTmV3dG9u4oCZcyBmaXJzdCBsYXcgb2YgbW90
+        aW9uPyBDYW4geW91IGFuc3dlciBpdCB1c2luZyBkZWZpbml0aW9uIG9mIGlu
+        ZXJ0aWE/In0seyJpZCI6NDQ0LCJjb250ZW50X2h0bWwiOiJNYXNzIG9mIHRo
+        ZSBmaXJzdCBvYmplY3QgaXMgZ3JlYXRlciB0aGFuIHRoYXQgb2YgdGhlIHNl
+        Y29uZCBvYmplY3QiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0
+        bWwiOiJIYXZlIHlvdSBjb25zaWRlcmVkIGluZXJ0aWEgb2YgYm90aCB0aGUg
+        b2JqZWN0cz8gRG8geW91IHRoaW5rIGEgaGVhdmllciBvYmplY3Qgd2lsbCBt
+        b3ZlIGZhc3RlciB0aGFuIHRoZSBsaWdodGVyIGlmIHNhbWUgYW1vdW50IG9m
+        IGZvcmNlIGlzIGFwcGxpZWQ/In0seyJpZCI6NDQzLCJjb250ZW50X2h0bWwi
+        OiJNYXNzIG9mIHRoZSBmaXJzdCBvYmplY3QgaXMgZXF1YWwgdG8gdGhlIG1h
+        c3Mgb2YgdGhlIHNlY29uZCBvYmplY3QiLCJjb3JyZWN0bmVzcyI6IjAuMCIs
+        ImZlZWRiYWNrX2h0bWwiOiJBcmUgeW91IHN1cmUgdGhhdCBib3RoIHRoZSBv
+        YmplY3RzIHdpbGwgaGF2ZSBzYW1lIG1hc3M/IEhhdmUgeW91IGNvbnNpZGVy
+        ZWQgdGhlIGZhY3QgdGhhdCBvbmUgaXMgbW92aW5nIGZhc3RlciB0aGFuIHRo
+        ZSBvdGhlciB3aGVuIHRoZSBzYW1lIGFtb3VudCBvZiBmb3JjZSBpcyBiZWlu
+        ZyBhcHBsaWVkIG9uIHRoZW0/In0seyJpZCI6NDQyLCJjb250ZW50X2h0bWwi
+        OiJNYXNzIG9mIHRoZSBmaXJzdCBvYmplY3QgaXMgbGVzcyB0aGFuIHRoYXQg
+        b2YgdGhlIHNlY29uZCBvYmplY3QiLCJjb3JyZWN0bmVzcyI6IjEuMCIsImZl
+        ZWRiYWNrX2h0bWwiOiJDb3JyZWN0ISBTaW5jZSB0aGUgc2FtZSBhbW91bnQg
+        b2YgZm9yY2UgaXMgYXBwbGllZCBvbiB0aGUgb2JqZWN0cywgb2JqZWN0IHdp
+        dGggbGVzcyBtYXNzIHdpbGwgbW92ZSBmYXN0ZXIgdGhhbiB0aGUgb3RoZXIg
+        b2JqZWN0LiJ9XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNo
+        b2ljZSIsImZyZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0s
+        eyJ1aWQiOiI0NkAxIiwibnVtYmVyIjo0NiwidmVyc2lvbiI6MSwicHVibGlz
+        aGVkX2F0IjoiMjAxNS0wMy0xMFQxOTo0OToxOC41NTBaIiwiZWRpdG9ycyI6
+        W10sImF1dGhvcnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRl
+        cnMiOlt7InVzZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNo
+        bWVudHMiOltdLCJ0YWdzIjpbImluYm9vay15ZXMiLCJkaXNwbGF5LWZyZWUt
+        cmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1zZW5zaXRpdmUiLCJkb2szIiwidGlt
+        ZS1tZWRpdW0iLCJ0ZXN0LXByZXAtZXh0ZW5kZWQtcmVzcG9uc2UiLCJrMTJw
+        aHlzLWNoMDQtczAyLWxvMDEiLCJrMTJwaHlzLWNoMDQtZXgwNDYiXSwic3Rp
+        bXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjEyNCwic3RpbXVs
+        dXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IlR3byBwZW9wbGUgYXBwbHkgdGhl
+        IHNhbWUgZm9yY2UgdG8gdGhyb3cgdHdvIGlkZW50aWNhbCBiYWxscyBpbiB0
+        aGUgYWlyLiBXaWxsIHRoZSBiYWxscyBuZWNlc3NhcmlseSB0cmF2ZWwgdGhl
+        IHNhbWUgZGlzdGFuY2U/IFdoeSBvciB3aHkgbm90PyIsImFuc3dlcnMiOlt7
+        ImlkIjo0NDksImNvbnRlbnRfaHRtbCI6IlllcywgdGhlIGJhbGxzIHdpbGwg
+        bmVjZXNzYXJpbHkgdHJhdmVsIHRoZSBzYW1lIGRpc3RhbmNlIGFzIHRoZSBh
+        bmdsZSBhdCB3aGljaCB0aGV5IGFyZSB0aHJvd24gbWF5IGRpZmZlciIsImNv
+        cnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkFyZSB5b3Ugc3Vy
+        ZSB0aGF0IHRoZSB0d28gYmFsbHMgd2lsbCB0cmF2ZWwgdGhlIHNhbWUgZGlz
+        dGFuY2UgaWYgdGhleSBhcmUgdGhyb3duIGF0IGRpZmZlcmVudCBhbmdsZXM/
+        In0seyJpZCI6NDQ4LCJjb250ZW50X2h0bWwiOiJZZXMsIHRoZSBiYWxscyB3
+        aWxsIG5lY2Vzc2FyaWx5IHRyYXZlbCB0aGUgc2FtZSBkaXN0YW5jZSBhcyB0
+        aGUgZ3Jhdml0YXRpb25hbCBmb3JjZSBhY3Rpbmcgb24gdGhlbSBpcyBzYW1l
+        IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiQ2FuIHlv
+        dSB0aGluayB3aGF0IHdpbGwgaGFwcGVuIGlmIHRoZSBiYWxscyBhcmUgdGhy
+        b3duIGF0IGRpZmZlcmVudCBhbmdsZXM/IERvIHlvdSB0aGluayBib3RoIGJh
+        bGxzIHdpbGwgdHJhdmVsIHRoZSBzYW1lIGRpc3RhbmNlcz8ifSx7ImlkIjo0
+        NDcsImNvbnRlbnRfaHRtbCI6Ik5vLCB0aGUgYmFsbHMgd2lsbCBub3QgbmVj
+        ZXNzYXJpbHkgdHJhdmVsIHRoZSBzYW1lIGRpc3RhbmNlIGFzIHRoZSBhbmds
+        ZSBhdCB3aGljaCB0aGV5IGFyZSB0aHJvd24gbWF5IGRpZmZlciIsImNvcnJl
+        Y3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIFRoZSB0
+        cmFqZWN0b3J5IG9mIHRoZSB0d28gYmFsbHMgd2lsbCBiZSBkaWZmZXJlbnQg
+        aWYgdGhleSBhcmUgdGhyb3duIGF0IGRpZmZlcmVudCBhbmdsZXMgd2l0aCB0
+        aGUgc2FtZSBmb3JjZS4ifSx7ImlkIjo0NDYsImNvbnRlbnRfaHRtbCI6Ik5v
+        LCB0aGUgYmFsbHMgd2lsbCBub3QgbmVjZXNzYXJpbHkgdHJhdmVsIHRoZSBz
+        YW1lIGRpc3RhbmNlIGFzIHRoZSBncmF2aXRhdGlvbmFsIGZvcmNlIGFjdGlu
+        ZyBvbiB0aGVtIGFyZSBkaWZmZXJlbnQiLCJjb3JyZWN0bmVzcyI6IjAuMCIs
+        ImZlZWRiYWNrX2h0bWwiOiJEbyB5b3UgdGhpbmsgZ3Jhdml0eSBpcyBub24t
+        dW5pZm9ybSBvbiB0aGUgc3VyZmFjZSBvZiB0aGUgZWFydGggd2hlcmUgdGhl
+        c2UgYmFsbHMgYXJlIGJlaW5nIHRocm93bj8ifV0sImhpbnRzIjpbXSwiZm9y
+        bWF0cyI6WyJtdWx0aXBsZS1jaG9pY2UiLCJmcmVlLXJlc3BvbnNlIl0sImNv
+        bWJvX2Nob2ljZXMiOltdfV19LHsidWlkIjoiNDdAMSIsIm51bWJlciI6NDcs
+        InZlcnNpb24iOjEsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDMtMTBUMTk6NDk6
+        MTguNTY1WiIsImVkaXRvcnMiOltdLCJhdXRob3JzIjpbeyJ1c2VyX2lkIjox
+        fV0sImNvcHlyaWdodF9ob2xkZXJzIjpbeyJ1c2VyX2lkIjoyfV0sImRlcml2
+        ZWRfZnJvbSI6W10sImF0dGFjaG1lbnRzIjpbXSwidGFncyI6WyJwcmFjdGlj
+        ZS1jb25jZXB0cyIsImluYm9vay15ZXMiLCJkb2sxIiwidGltZS1zaG9ydCIs
+        ImRpc3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2
+        ZSIsImsxMnBoeXMtY2gwNC1zMDItbG8wMiIsImsxMnBoeXMtY2gwNC1leDA0
+        NyJdLCJzdGltdWx1c19odG1sIjoiIiwicXVlc3Rpb25zIjpbeyJpZCI6MTI1
+        LCJzdGltdWx1c19odG1sIjoiIiwic3RlbV9odG1sIjoiV2hhdCBpcyBpbmVy
+        dGlhPyIsImFuc3dlcnMiOlt7ImlkIjo0NTMsImNvbnRlbnRfaHRtbCI6Iklu
+        ZXJ0aWEgaXMgYW4gb2JqZWN04oCZcyB0ZW5kZW5jeSB0byByZW1haW4gYXQg
+        cmVzdCBvciBpbiBtb3Rpb24uIiwiY29ycmVjdG5lc3MiOiIxLjAiLCJmZWVk
+        YmFja19odG1sIjoiQ29ycmVjdCEgSW5lcnRpYSBpcyBhbiBvYmplY3TigJlz
+        IHRlbmRlbmN5IHRvIHJlbWFpbiBhdCByZXN0IG9yLCBpZiBtb3ZpbmcsIHRv
+        IHJlbWFpbiBpbiBtb3Rpb24gYXQgYSBjb25zdGFudCB2ZWxvY2l0eS4gSW5l
+        cnRpYSBtYXkgYWxzbyBiZSBkZXNjcmliZWQgYXMgdGhlIHRlbmRlbmN5IG9m
+        IG9iamVjdHMgdG8gbWFpbnRhaW4gdGhlaXIgc3RhdGUgb2YgbW90aW9uLiJ9
+        LHsiaWQiOjQ1MiwiY29udGVudF9odG1sIjoiSW5lcnRpYSBpcyBhbiBvYmpl
+        Y3TigJlzIHRlbmRlbmN5IHRvIHJlbWFpbiBpbiBtb3Rpb24iLCJjb3JyZWN0
+        bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJZZXMsIGluZXJ0aWEgb2Yg
+        YW4gb2JqZWN0IGlzIGl0cyB0ZW5kZW5jeSB0byBtYWludGFpbiBpdHMgc3Rh
+        dGUgb2YgbW90aW9uIHVubGVzcyBhY3RlZCB1cG9uIGJ5IGFuIGV4dGVybmFs
+        IGZvcmNlIGJ1dCB3aGF0IGFib3V0IHRoZSBjYXNlIHdoZW4gaXQgaXMgaW4g
+        dGhlIHN0YXRlIG9mIHJlc3Q/In0seyJpZCI6NDUxLCJjb250ZW50X2h0bWwi
+        OiJJbmVydGlhIGlzIGFuIG9iamVjdOKAmXMgdGVuZGVuY3kgdG8gcmVtYWlu
+        IGF0IHJlc3QiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwi
+        OiJJdCBpcyBjb3JyZWN0IHRoYXQgaW5lcnRpYSBvZiBhbiBvYmplY3QgaXMg
+        aXRzIHRlbmRlbmN5IHRvIHJlbWFpbiBhdCByZXN0IHVubGVzcyBhY3RlZCB1
+        cG9uIGJ5IGFuIGV4dGVybmFsIGZvcmNlIGJ1dCB3aGF0IGFib3V0IHRoZSBj
+        YXNlIHdoZW4gaXQgaXMgaW4gdGhlIHN0YXRlIG9mIG1vdGlvbj8ifSx7Imlk
+        Ijo0NTAsImNvbnRlbnRfaHRtbCI6IkluZXJ0aWEgaXMgYW4gb2JqZWN04oCZ
+        cyB0ZW5kZW5jeSB0byBtYWludGFpbiBpdHMgbWFzcyIsImNvcnJlY3RuZXNz
+        IjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayBpbmVydGlh
+        IG9mIGFuIG9iamVjdCBpcyByZWxhdGVkIHRvIGl0cyBtYXNzPyBEb2VzIGl0
+        IG5vdCByZWxhdGUgdG8gdGhlIG1vdGlvbiBvZiB0aGUgb2JqZWN0PyJ9XSwi
+        aGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZyZWUt
+        cmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiI0OEAx
+        IiwibnVtYmVyIjo0OCwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0IjoiMjAx
+        NS0wMy0xMFQxOTo0OToxOC41ODBaIiwiZWRpdG9ycyI6W10sImF1dGhvcnMi
+        Olt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVzZXJf
+        aWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltdLCJ0
+        YWdzIjpbInByYWN0aWNlLWNvbmNlcHRzIiwiaW5ib29rLXllcyIsInRpbWUt
+        c2hvcnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1z
+        ZW5zaXRpdmUiLCJkb2syIiwiazEycGh5cy1jaDA0LXMwMi1sbzAyIiwiazEy
+        cGh5cy1jaDA0LWV4MDQ4Il0sInN0aW11bHVzX2h0bWwiOiIiLCJxdWVzdGlv
+        bnMiOlt7ImlkIjoxMjYsInN0aW11bHVzX2h0bWwiOiIiLCJzdGVtX2h0bWwi
+        OiJXaGF0IGlzIG1hc3M/IFdoYXQgZG9lcyBpdCBkZXBlbmQgb24/IiwiYW5z
+        d2VycyI6W3siaWQiOjQ1NywiY29udGVudF9odG1sIjoiTWFzcyBpcyB0aGUg
+        cXVhbnRpdHkgb2Ygc3Vic3RhbmNlIGNvbnRhaW5lZCBpbiBhbiBvYmplY3Qg
+        YW5kIGl0IGRlcGVuZHMgb24gdGhlIG51bWJlciBhbmQgdHlwZSBvZiBhdG9t
+        cyBhbmQgbW9sZWN1bGVzIGluIHRoZSBvYmplY3QuIiwiY29ycmVjdG5lc3Mi
+        OiIxLjAiLCJmZWVkYmFja19odG1sIjoiQ29ycmVjdCEgTWFzcyBpcyB0aGUg
+        cXVhbnRpdHkgb2Ygc3Vic3RhbmNlIGNvbnRhaW5lZCBpbiBhbiBvYmplY3Qu
+        IEl0IGRlcGVuZHMgb24gdGhlIG51bWJlciBhbmQgdHlwZSBvZiBhdG9tcyBh
+        bmQgbW9sZWN1bGVzIGluIHRoZSBvYmplY3QuIn0seyJpZCI6NDU2LCJjb250
+        ZW50X2h0bWwiOiJNYXNzIGlzIHRoZSBxdWFudGl0eSBvZiBzdWJzdGFuY2Ug
+        Y29udGFpbmVkIGluIGFuIG9iamVjdCBhbmQgaXQgZGVwZW5kcyBvbiB0aGUg
+        Z3Jhdml0YXRpb25hbCBmb3JjZSBhY3Rpbmcgb24gdGhlIG9iamVjdCIsImNv
+        cnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6Ikl0IGlzIGNvcnJl
+        Y3QgdGhhdCBtYXNzIGlzIHRoZSBxdWFudGl0eSBvZiBzdWJzdGFuY2UgY29u
+        dGFpbmVkIGluIGFuIG9iamVjdCBidXQgZG9lcyBpdCBkZXBlbmRzIG9uIGdy
+        YXZpdGF0aW9uYWwgZm9yY2U/In0seyJpZCI6NDU1LCJjb250ZW50X2h0bWwi
+        OiJNYXNzIGlzIHRoZSB3ZWlnaHQgb2YgYW4gb2JqZWN0IGFuZCBpdCBkZXBl
+        bmRzIG9uIHRoZSBudW1iZXIgYW5kIHR5cGUgb2YgYXRvbXMgYW5kIG1vbGVj
+        dWxlcyBpbiB0aGUgb2JqZWN0IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVk
+        YmFja19odG1sIjoiRG8geW91IHRoaW5rIG1hc3MgYW5kIHdlaWdodCByZXBy
+        ZXNlbnQgdGhlIHNhbWUgcGh5c2ljYWwgcXVhbnRpdHk/IENhbiB5b3UgZGlm
+        ZmVyZW50aWF0ZSBiZXR3ZWVuIG1hc3MgYW5kIHdlaWdodCBvZiBhbiBvYmpl
+        Y3Q/In0seyJpZCI6NDU0LCJjb250ZW50X2h0bWwiOiJNYXNzIGlzIHRoZSB3
+        ZWlnaHQgb2YgYW4gb2JqZWN0IGFuZCBpdCBkZXBlbmRzIG9uIHRoZSBncmF2
+        aXRhdGlvbmFsIGZvcmNlIGFjdGluZyBvbiB0aGUgb2JqZWN0IiwiY29ycmVj
+        dG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiSXMgaXQgY29ycmVjdCB0
+        byBzYXkgdGhhdCBtYXNzIGFuZCB3ZWlnaHQgYXJlIHRoZSBzYW1lIHBoeXNp
+        Y2FsIHF1YW50aXRpZXM/IEFsc28sIGRvIHlvdSB0aGluayBtYXNzIG9mIGFu
+        IG9iamVjdCBpcyBkZXBlbmRlbnQgb24gdGhlIGdyYXZpdGF0aW9uYWwgZm9y
+        Y2U/In1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNl
+        IiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVp
+        ZCI6IjQ5QDEiLCJudW1iZXIiOjQ5LCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRf
+        YXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4LjU5OFoiLCJlZGl0b3JzIjpbXSwi
+        YXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6
+        W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50
+        cyI6W10sInRhZ3MiOlsicHJhY3RpY2UtY29uY2VwdHMiLCJkb2sxIiwidGlt
+        ZS1zaG9ydCIsImRpc3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVj
+        LXNlbnNpdGl2ZSIsInR1dG9yLW9ubHkiLCJrMTJwaHlzLWNoMDQtczAyLWxv
+        MDIiLCJrMTJwaHlzLWNoMDQtZXgwNDkiXSwic3RpbXVsdXNfaHRtbCI6IiIs
+        InF1ZXN0aW9ucyI6W3siaWQiOjEyNywic3RpbXVsdXNfaHRtbCI6IiIsInN0
+        ZW1faHRtbCI6IldoYXQgaXMgdGhlIGluZXJ0aWEgb2YgYW4gb2JqZWN0IHBy
+        b3BvcnRpb25hbCB0bz8iLCJhbnN3ZXJzIjpbeyJpZCI6NDYxLCJjb250ZW50
+        X2h0bWwiOiJUZW1wZXJhdHVyZSIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVl
+        ZGJhY2tfaHRtbCI6IklzIGl0IGNvcnJlY3QgdG8gc2F5IHRoYXQgaW5lcnRp
+        YSB3aGljaCBpcyB0aGUgc3RhdGUgb2YgYSBib2R5IGlzIGRlcGVuZGVudCBv
+        biB0aGUgdGVtcGVyYXR1cmUgb2YgdGhlIGJvZHk/IENhbiB5b3UgcmVjYWxs
+        IGRlZmluaXRpb24gb2YgaW5lcnRpYSBhbmQgTmV3dG9u4oCZcyBmaXJzdCBs
+        YXcgb2YgbW90aW9uPyJ9LHsiaWQiOjQ2MCwiY29udGVudF9odG1sIjoiU2hh
+        cGUiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJBcmUg
+        eW91IHN1cmUgdGhhdCBpbmVydGlhIGRlcGVuZHMgb24gdGhlIHNoYXBlIG9m
+        IHRoZSBvYmplY3Q/IENhbiB5b3UgcmVjYWxsIGRlZmluaXRpb24gb2YgaW5l
+        cnRpYT8ifSx7ImlkIjo0NTksImNvbnRlbnRfaHRtbCI6IlZvbHVtZSIsImNv
+        cnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGlu
+        ayB0aGF0IHRoZSBpbmVydGlhIG9mIGFuIG9iamVjdCBkZXBlbmRzIG9uIHRo
+        ZSB2b2x1bWUgb2YgdGhlIG9iamVjdD8gRG9lcyBpdCBkZXBlbmQgb24gdGhl
+        IGRpbWVuc2lvbiBvZiB0aGUgb2JqZWN0PyBDYW4geW91IHJlY2FsbCB0aGUg
+        ZGVmaW5pdGlvbiBvZiBpbmVydGlhPyJ9LHsiaWQiOjQ1OCwiY29udGVudF9o
+        dG1sIjoiTWFzcyIsImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRt
+        bCI6IkNvcnJlY3QhIEluZXJ0aWEgZGVwZW5kcyBvbiB0aGUgbWFzcyBvZiB0
+        aGUgYm9keS4gSW5lcnRpYSBpcyBhbiBvYmplY3TigJlzIHRlbmRlbmN5IHRv
+        IHJlbWFpbiBhdCByZXN0IG9yLCBpZiBtb3ZpbmcsIHRvIHJlbWFpbiBpbiBt
+        b3Rpb24gYXQgYSBjb25zdGFudCB2ZWxvY2l0eS4gSW5lcnRpYSBtYXkgYWxz
+        byBiZSBkZXNjcmliZWQgYXMgdGhlIHRlbmRlbmN5IG9mIG9iamVjdHMgdG8g
+        bWFpbnRhaW4gdGhlaXIgc3RhdGUgb2YgbW90aW9uIn1dLCJoaW50cyI6W10s
+        ImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJd
+        LCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjUwQDEiLCJudW1iZXIi
+        OjUwLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5
+        OjQ5OjE4LjYxM1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNlcl9p
+        ZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJk
+        ZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsicHJh
+        Y3RpY2UtY29uY2VwdHMiLCJkb2sxIiwidGltZS1zaG9ydCIsImRpc3BsYXkt
+        ZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsInR1dG9y
+        LW9ubHkiLCJrMTJwaHlzLWNoMDQtczAyLWxvMDIiLCJrMTJwaHlzLWNoMDQt
+        ZXgwNTAiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQi
+        OjEyOCwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkluIHRoZSBj
+        b250ZXh0IG9mIE5ld3RvbuKAmXMgRmlyc3QgbGF3LCBhIHN5c3RlbSBpcyBv
+        bmUgb3IgbW9yZSBvYmplY3QgdGhhdCB3ZSB3aXNoIHRvIHN0dWR5IiwiYW5z
+        d2VycyI6W3siaWQiOjQ2MywiY29udGVudF9odG1sIjoiMCIsImNvcnJlY3Ru
+        ZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayBhIHN5
+        c3RlbSBpcyBkaWZmZXJlbnQgZnJvbSBhIHN1YmplY3Qgd2hpY2ggaXMgdW5k
+        ZXIgaW52ZXN0aWdhdGlvbj8gQ2FuIHlvdSBkaWZmZXJlbnRpYXRlIGJldHdl
+        ZW4gYSBzeXN0ZW0gYW5kIGl0cyBzdXJyb3VuZGluZz8ifSx7ImlkIjo0NjIs
+        ImNvbnRlbnRfaHRtbCI6IjEiLCJjb3JyZWN0bmVzcyI6IjEuMCIsImZlZWRi
+        YWNrX2h0bWwiOiJDb3JyZWN0ISBBIHN5c3RlbSBpcyBvbmUgb3IgbW9yZSBv
+        YmplY3QgdGhhdCBpcyB1bmRlciBpbnZlc3RpZ2F0aW9uLiJ9XSwiaGludHMi
+        OltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZyZWUtcmVzcG9u
+        c2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiI1MUAxIiwibnVt
+        YmVyIjo1MSwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0IjoiMjAxNS0wMy0x
+        MFQxOTo0OToxOC42NDBaIiwiZWRpdG9ycyI6W10sImF1dGhvcnMiOlt7InVz
+        ZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVzZXJfaWQiOjJ9
+        XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltdLCJ0YWdzIjpb
+        InByYWN0aWNlLWNvbmNlcHRzIiwidGltZS1zaG9ydCIsImRpc3BsYXktZnJl
+        ZS1yZXNwb25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsImRvazIiLCJ0
+        dXRvci1vbmx5IiwiazEycGh5cy1jaDA0LXMwMi1sbzAyIiwiazEycGh5cy1j
+        aDA0LWV4MDUxIl0sInN0aW11bHVzX2h0bWwiOiIiLCJxdWVzdGlvbnMiOlt7
+        ImlkIjoxMjksInN0aW11bHVzX2h0bWwiOiIiLCJzdGVtX2h0bWwiOiJXaGF0
+        IGlzIHRoZSBkaWZmZXJlbmNlIGJldHdlZW4gbWFzcyBhbmQgd2VpZ2h0PyIs
+        ImFuc3dlcnMiOlt7ImlkIjo0NjcsImNvbnRlbnRfaHRtbCI6IkJvdGggdGhl
+        IG1hc3MgYW5kIHRoZSB3ZWlnaHQgYXJlIHRoZSBxdWFudGl0eSBvZiB0aGUg
+        bWF0dGVyIGNvbnRhaW5lZCBpbiBhbiBvYmplY3QuIiwiY29ycmVjdG5lc3Mi
+        OiIwLjAiLCJmZWVkYmFja19odG1sIjoiSXQgaXMgY29ycmVjdCB0aGF0IG1h
+        c3MgaXMgYW1vdW50IG9mIG1hdHRlciBjb250YWluZWQgaW4gYW4gb2JqZWN0
+        IGJ1dCB3aGF0IGFib3V0IHdlaWdodD8gRG8geW91IHRoaW5rIHRoYXQgbWFz
+        cyBhbmQgd2VpZ2h0IGFyZSB0aGUgc2FtZSBwaHlzaWNhbCBxdWFudGl0eT8i
+        fSx7ImlkIjo0NjYsImNvbnRlbnRfaHRtbCI6IkJvdGggdGhlIG1hc3MgYW5k
+        IHRoZSB3ZWlnaHQgYXJlIHRoZSBmb3JjZSBleGVydGVkIGJ5IGdyYXZpdHkg
+        b24gYW4gb2JqZWN0IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19o
+        dG1sIjoiRG8geW91IHRoaW5rIHRoYXQgbWFzcyBhbmQgd2VpZ2h0IGFyZSB0
+        aGUgc2FtZSBwaHlzaWNhbCBxdWFudGl0eT8gQ2FuIHlvdSByZWNhbGwgdGhl
+        IGRlZmluaXRpb24gb2YgbWFzcyBvZiBhbiBvYmplY3Q/In0seyJpZCI6NDY1
+        LCJjb250ZW50X2h0bWwiOiJNYXNzIGlzIHRoZSBxdWFudGl0eSBvZiBtYXR0
+        ZXIgY29udGFpbmVkIGluIGFuIG9iamVjdCBhbmQgd2VpZ2h0IGlzIHRoZSBm
+        b3JjZSBleGVydGVkIGJ5IHRoZSBncmF2aXR5IG9uIHRoZSBvYmplY3QiLCJj
+        b3JyZWN0bmVzcyI6IjEuMCIsImZlZWRiYWNrX2h0bWwiOiJDb3JyZWN0ISBN
+        YXNzIGlzIHRoZSBxdWFudGl0eSBvZiBtYXR0ZXIgY29udGFpbmVkIGluIGFu
+        IG9iamVjdCBhbmQgd2VpZ2h0IGlzIHRoZSBmb3JjZSBleGVydGVkIGJ5IGdy
+        YXZpdHkgb24gdGhlIG9iamVjdCJ9LHsiaWQiOjQ2NCwiY29udGVudF9odG1s
+        IjoiTWFzcyBpcyB0aGUgZm9yY2UgZXhlcnRlZCBieSBncmF2aXR5IG9uIGFu
+        IG9iamVjdCBhbmQgd2VpZ2h0IGlzIHRoZSBxdWFudGl0eSBvZiBtYXR0ZXIg
+        Y29udGFpbmVkIGluIHRoZSBvYmplY3QiLCJjb3JyZWN0bmVzcyI6IjAuMCIs
+        ImZlZWRiYWNrX2h0bWwiOiJIYXZlIHlvdSBjb25zaWRlcmVkIHRoZSBkZWZp
+        bml0aW9uIG9mIG1hc3MgYW5kIHdlaWdodCBjb3JyZWN0bHk/In1dLCJoaW50
+        cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNw
+        b25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVpZCI6IjUyQDEiLCJu
+        dW1iZXIiOjUyLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAz
+        LTEwVDE5OjQ5OjE4LjY1NVoiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3si
+        dXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6
+        Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3Mi
+        OlsicHJhY3RpY2UtY29uY2VwdHMiLCJ0aW1lLXNob3J0IiwiZGlzcGxheS1m
+        cmVlLXJlc3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwiZG9rMiIs
+        InR1dG9yLW9ubHkiLCJrMTJwaHlzLWNoMDQtczAyLWxvMDIiLCJrMTJwaHlz
+        LWNoMDQtZXgwNTIiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6
+        W3siaWQiOjEzMCwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkRl
+        dGVybWluaW5nIG1hc3Mgb2YgYW4gb2JqZWN0IGJ5IGNvdW50aW5nIHRoZSBu
+        dW1iZXIgb2YgYXRvbXMgYW5kIG1vbGVjdWxlcyBpbiBpdCBpcyBhbiBpbXBv
+        c3NpYmxlIHRhc2suIFRoZXJlZm9yZSwgdGhlIG1hc3Mgb2YgYW4gb2JqZWN0
+        IGlzIG9mdGVuIGdpdmVuIGJ5IHRoZSBvYmplY3TigJlzIHdlaWdodCBhcyB0
+        aGUgZm9yY2Ugb2YgZ3Jhdml0eSBpcyBhbG1vc3QgY29uc3RhbnQsIHRoYXQg
+        aXMsIHVuaWZvcm0gb24gdGhlIHN1cmZhY2Ugb2YgZWFydGguIiwiYW5zd2Vy
+        cyI6W3siaWQiOjQ2OSwiY29udGVudF9odG1sIjoiMCIsImNvcnJlY3RuZXNz
+        IjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayB5b3Ugd2ls
+        bCBiZSBhYmxlIHRvIGRldGVybWluZSBtYXNzIG9mIGFuIG9iamVjdCBieSBj
+        b3VudGluZyBudW1lcm91cyBudW1iZXIgb2YgYXRvbXMgYW5kIG1vbGVjdWxl
+        cyBjb21wb3NpbmcgaXQ/IElzIHRoaXMgbWV0aG9kIHBvc3NpYmxlPyJ9LHsi
+        aWQiOjQ2OCwiY29udGVudF9odG1sIjoiMSIsImNvcnJlY3RuZXNzIjoiMS4w
+        IiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIE1hc3MgaXMgbWVhc3VyZWQg
+        aW4ga2lsb2dyYW1zLiBXZWlnaHQsIGJlaW5nIGEgZm9yY2UsIGlzIG1lYXN1
+        cmVkIGluIE5ld3Rvbi4gSG93ZXZlciwgc2luY2UgbWFzcyBjYW5ub3QgYmUg
+        ZGV0ZXJtaW5lZCBieSBjb3VudGluZyB0aGUgbnVtYmVyIG9mIGF0b21zIGFu
+        ZCBtb2xlY3VsZXMgaW4gaXQsIGl0IGlzIGRlcml2ZWQgZnJvbSBhbiBvYmpl
+        Y3TigJlzIHdlaWdodC4gU2luY2UgdGhlIGZvcmNlIG9mIGdyYXZpdHkgaXMg
+        YWxtb3N0IGNvbnN0YW50IG9uIGVhcnRoLCB0aGUgbWFzcyBvZiBhbiBvYmpl
+        Y3QgaXMgb2Z0ZW4gZ2l2ZW4gYnkgdGhlIG9iamVjdOKAmXMgd2VpZ2h0LiJ9
+        XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZy
+        ZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiI1
+        M0AxIiwibnVtYmVyIjo1MywidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0Ijoi
+        MjAxNS0wMy0xMFQxOTo0OToxOC42NzBaIiwiZWRpdG9ycyI6W10sImF1dGhv
+        cnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVz
+        ZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltd
+        LCJ0YWdzIjpbImluYm9vay15ZXMiLCJ0aW1lLXNob3J0IiwiZGlzcGxheS1m
+        cmVlLXJlc3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwiZG9rMiIs
+        ImNoYXB0ZXItcmV2aWV3LWNvbmNlcHQiLCJrMTJwaHlzLWNoMDQtczAyLWxv
+        MDIiLCJrMTJwaHlzLWNoMDQtZXgwNTMiXSwic3RpbXVsdXNfaHRtbCI6IiIs
+        InF1ZXN0aW9ucyI6W3siaWQiOjEzMSwic3RpbXVsdXNfaHRtbCI6IiIsInN0
+        ZW1faHRtbCI6IlRoZSB0aXJlcyB5b3UgY2hvb3NlIHRvIGRyaXZlIG92ZXIg
+        aWN5IHJvYWRzIHdpbGwgY3JlYXRlIG1vcmUgZnJpY3Rpb24gd2l0aCB0aGUg
+        cm9hZCB0aGFuIHlvdXIgc3VtbWVyIHRpcmVzLiBHaXZlIGFub3RoZXIgZXhh
+        bXBsZSB3aGVyZSBtb3JlIGZyaWN0aW9uIGlzIGRlc2lyYWJsZS4iLCJhbnN3
+        ZXJzIjpbeyJpZCI6NDczLCJjb250ZW50X2h0bWwiOiJKb2dnaW5nIHRyYWNr
+        IiwiY29ycmVjdG5lc3MiOiIxLjAiLCJmZWVkYmFja19odG1sIjoiQ29ycmVj
+        dCEgQSBqb2dnaW5nIHRyYWNrIGlzIHJlcXVpcmVkIHRvIGhhdmUgbW9yZSBm
+        cmljdGlvbiBhcyBpdCBwcmV2ZW50cyB0aGUgcnVubmVyIGZyb20gc2xpcHBp
+        bmcuIn0seyJpZCI6NDcyLCJjb250ZW50X2h0bWwiOiJJY2Ugc2thdGluZyBy
+        aW5rIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiSGF2
+        ZSB5b3UgY29uc2lkZXJlZCB0aGUgZmFjdCB0aGF0IGljZSBza2F0aW5nIHJl
+        cXVpcmVzIGEgcGVyc29uIHRvIHNsaWRlIHNtb290aGx5IG92ZXIgdGhlIGlj
+        ZT8gQ2FuIHlvdSB0aGluayB3aGF0IHdpbGwgaGFwcGVuIGlmIHRoZSBmcmlj
+        dGlvbiBvZiB0aGUgc3VyZmFjZSBpcyBpbmNyZWFzZWQ/In0seyJpZCI6NDcx
+        LCJjb250ZW50X2h0bWwiOiJBaXIgaG9ja2V5IHRhYmxlIiwiY29ycmVjdG5l
+        c3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiQXJlIHlvdSBzdXJlIHRoYXQg
+        eW91IHdpbGwgYmUgcmVxdWlyaW5nIG1vcmUgZnJpY3Rpb24gaW4gdGhlIGdh
+        bWUgb2YgYWlyIGhvY2tleT8gQ2FuIHlvdSB0aGluayB3aGF0IHdpbGwgaGFw
+        cGVuIHRvIHRoZSBtb3Rpb24gb2YgdGhlIHB1Y2sgaWYgdGhlIGZyaWN0aW9u
+        IGlzIGluY3JlYXNlZD8ifSx7ImlkIjo0NzAsImNvbnRlbnRfaHRtbCI6Iklj
+        ZSBob2NrZXkgc3RhZGl1bSIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJh
+        Y2tfaHRtbCI6IkRvIHlvdSB0aGluayB5b3Ugd2lsbCByZXF1aXJlIG1vcmUg
+        ZnJpY3Rpb24gaW4gdGhlIGdhbWUgb2YgSWNlIGhvY2tleT8gRG8geW91IG5v
+        dCB0aGluayB0aGF0IHRoZSBwdWNrIHdpbGwgbW92ZSBzbW9vdGhseSBvbiBp
+        Y2U/In1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNl
+        IiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfSx7InVp
+        ZCI6IjU0QDEiLCJudW1iZXIiOjU0LCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRf
+        YXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4LjY4NVoiLCJlZGl0b3JzIjpbXSwi
+        YXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6
+        W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50
+        cyI6W10sInRhZ3MiOlsidGltZS1zaG9ydCIsImRpc3BsYXktZnJlZS1yZXNw
+        b25zZSIsImRpc3BsYXktcmVjLXNlbnNpdGl2ZSIsImRvazIiLCJ0dXRvci1v
+        bmx5IiwiY2hhcHRlci1yZXZpZXctY29uY2VwdCIsImsxMnBoeXMtY2gwNC1z
+        MDItbG8wMiIsImsxMnBoeXMtY2gwNC1leDA1NCJdLCJzdGltdWx1c19odG1s
+        IjoiIiwicXVlc3Rpb25zIjpbeyJpZCI6MTMyLCJzdGltdWx1c19odG1sIjoi
+        Iiwic3RlbV9odG1sIjoiQSBib2R5IGhhcyBhIHdlaWdodCBvZiAzMCB1bml0
+        cyBvbiBlYXJ0aC4gQ29tcGFyZWQgd2l0aCBpdHMgd2VpZ2h0IG9uIGVhcnRo
+        LCB3aWxsIGl0IHdlaWdoIG1vcmUsIGxlc3MsIG9yIHRoZSBzYW1lIG9uIHRo
+        ZSBtb29uPyIsImFuc3dlcnMiOlt7ImlkIjo0NzcsImNvbnRlbnRfaHRtbCI6
+        Ilplcm8iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJJ
+        cyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0IGEgbWFzcyB3aWxsIGhhdmUgemVy
+        byB3ZWlnaHQgb24gYW55IHN1cmZhY2Ugd2hpY2ggZXhoaWJpdHMgcHJvcGVy
+        dHkgb2YgZ3Jhdml0eT8ifSx7ImlkIjo0NzYsImNvbnRlbnRfaHRtbCI6IlNh
+        bWUiLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwiOiJBcmUg
+        eW91IHN1cmUgdGhhdCB0aGUgdmFsdWUgb2YgZ3Jhdml0eSBvbiB0aGUgZWFy
+        dGggYW5kIG9uIHRoZSBtb29uIGlzIHNhbWU/In0seyJpZCI6NDc1LCJjb250
+        ZW50X2h0bWwiOiJNb3JlIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFj
+        a19odG1sIjoiRG8geW91IHRoaW5rIGdyYXZpdHkgb2YgdGhlIG1vb24gaXMg
+        Z3JlYXRlciB0aGFuIHRoZSBlYXJ0aD8ifSx7ImlkIjo0NzQsImNvbnRlbnRf
+        aHRtbCI6Ikxlc3MiLCJjb3JyZWN0bmVzcyI6IjEuMCIsImZlZWRiYWNrX2h0
+        bWwiOiJDb3JyZWN0ISBUaGUgYm9keSB3aWxsIHdlaWdoIGxlc3Mgb24gbW9v
+        biBhcyBpdHMgZ3Jhdml0eSBpcyBsZXNzIHRoYW4gdGhhdCBvZiBlYXJ0aCJ9
+        XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZy
+        ZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiI1
+        NUAxIiwibnVtYmVyIjo1NSwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0Ijoi
+        MjAxNS0wMy0xMFQxOTo0OToxOC43MDBaIiwiZWRpdG9ycyI6W10sImF1dGhv
+        cnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVz
+        ZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltd
+        LCJ0YWdzIjpbInRpbWUtc2hvcnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9uc2Ui
+        LCJkaXNwbGF5LXJlYy1zZW5zaXRpdmUiLCJkb2syIiwidHV0b3Itb25seSIs
+        ImNoYXB0ZXItcmV2aWV3LWNvbmNlcHQiLCJrMTJwaHlzLWNoMDQtczAyLWxv
+        MDIiLCJrMTJwaHlzLWNoMDQtZXgwNTUiXSwic3RpbXVsdXNfaHRtbCI6IiIs
+        InF1ZXN0aW9ucyI6W3siaWQiOjEzMywic3RpbXVsdXNfaHRtbCI6IiIsInN0
+        ZW1faHRtbCI6IkEgYm9keSBoYXMgYSBtYXNzIG9mIDMwIGtnIG9uIGVhcnRo
+        LiBXaWxsIGl0cyBtYXNzIGJlIG1vcmUsIGxlc3MsIG9yIHRoZSBzYW1lIG9u
+        IHRoZSBtb29uPyIsImFuc3dlcnMiOlt7ImlkIjo0ODEsImNvbnRlbnRfaHRt
+        bCI6Ilplcm8iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwi
+        OiJJcyBpdCBwb3NzaWJsZSB0byBoYXZlIGFuIG9iamVjdCB3aXRob3V0IG1h
+        c3M/In0seyJpZCI6NDgwLCJjb250ZW50X2h0bWwiOiJTYW1lIiwiY29ycmVj
+        dG5lc3MiOiIxLjAiLCJmZWVkYmFja19odG1sIjoiQ29ycmVjdCEgTWFzcyBv
+        ZiB0aGUgYm9keSB3aWxsIHJlbWFpbiBzYW1lIG9uIGJvdGggc3VyZmFjZXMu
+        In0seyJpZCI6NDc5LCJjb250ZW50X2h0bWwiOiJNb3JlIiwiY29ycmVjdG5l
+        c3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiQXJlIHlvdSBzdXJlIHRoYXQg
+        Z3Jhdml0eSBhZmZlY3RzIG1hc3Mgb2YgdGhlIGJvZHk/IEhhdmUgeW91IGNv
+        bnNpZGVyZWQgdGhlIGZhY3QgdGhhdCBtYXNzIGlzIGFuIGludHJpbnNpYyBw
+        cm9wZXJ0eSBvZiBhbiBvYmplY3Q/In0seyJpZCI6NDc4LCJjb250ZW50X2h0
+        bWwiOiJMZXNzIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1s
+        IjoiRG8geW91IHRoaW5rIGdyYXZpdHkgYWZmZWN0cyBtYXNzIG9mIHRoZSBi
+        b2R5PyJ9XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2lj
+        ZSIsImZyZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1
+        aWQiOiI1NkAxIiwibnVtYmVyIjo1NiwidmVyc2lvbiI6MSwicHVibGlzaGVk
+        X2F0IjoiMjAxNS0wMy0xMFQxOTo0OToxOC43MTVaIiwiZWRpdG9ycyI6W10s
+        ImF1dGhvcnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMi
+        Olt7InVzZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVu
+        dHMiOltdLCJ0YWdzIjpbImluYm9vay15ZXMiLCJkaXNwbGF5LWZyZWUtcmVz
+        cG9uc2UiLCJkaXNwbGF5LXJlYy1zZW5zaXRpdmUiLCJjaGFwdGVyLXJldmll
+        dy1jb25jZXB0IiwiZG9rMyIsInRpbWUtbWVkaXVtIiwiazEycGh5cy1jaDA0
+        LXMwMi1sbzAyIiwiazEycGh5cy1jaDA0LWV4MDU2Il0sInN0aW11bHVzX2h0
+        bWwiOiIiLCJxdWVzdGlvbnMiOlt7ImlkIjoxMzQsInN0aW11bHVzX2h0bWwi
+        OiIiLCJzdGVtX2h0bWwiOiJBIGJvb2sgcGxhY2VkIG9uIGEgYmFsYW5jZSBp
+        cyBiYWxhbmNlZCBieSBhIHN0YW5kYXJkIDEga2cgaXJvbiB3ZWlnaHQgcGxh
+        Y2VkIG9uIHRoZSBvcHBvc2l0ZSBzaWRlcyBvZiB0aGUgYmFsYW5jZS4gV2hl
+        biBhbGwgdGhlc2Ugb2JqZWN0cyBhcmUgdGFrZW4gdG8gbW9vbiBhbmQgYSBz
+        aW1pbGFyIGV4ZXJjaXNlIGlzIHBlcmZvcm1lZCwgdGhlIGJhbGFuY2UgaXMg
+        c3RpbGwgYmFsYW5jZWQgYmVjYXVzZSBhdCBtb29u4oCZcyBzdXJmYWNlIGdy
+        YXZpdHkgaXMgdW5pZm9ybSBhcyBpdCBpcyBvbiB0aGUgZWFydGggc3VyZmFj
+        ZS4iLCJhbnN3ZXJzIjpbeyJpZCI6NDgzLCJjb250ZW50X2h0bWwiOiIwIiwi
+        Y29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiRG8geW91IHRo
+        aW5rIGdyYXZpdHkgaXMgbm9uLXVuaWZvcm0gb24gbW9vbuKAmXMgc3VyZmFj
+        ZT8ifSx7ImlkIjo0ODIsImNvbnRlbnRfaHRtbCI6IjEiLCJjb3JyZWN0bmVz
+        cyI6IjEuMCIsImZlZWRiYWNrX2h0bWwiOiJDb3JyZWN0ISBUaGUgYmFsYW5j
+        ZSBkb2VzIG5vdCBjaGFuZ2UgYmVjYXVzZSBncmF2aXR5IGlzIHVuaWZvcm0g
+        b24gYm90aCB0aGUgc3VyZmFjZXMuIn1dLCJoaW50cyI6W10sImZvcm1hdHMi
+        OlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19j
+        aG9pY2VzIjpbXX1dfSx7InVpZCI6IjU3QDEiLCJudW1iZXIiOjU3LCJ2ZXJz
+        aW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4Ljcz
+        MFoiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJj
+        b3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zy
+        b20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsiZGlzcGxheS1mcmVl
+        LXJlc3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwidHV0b3Itb25s
+        eSIsImNoYXB0ZXItcmV2aWV3LWNvbmNlcHQiLCJkb2szIiwidGltZS1tZWRp
+        dW0iLCJrMTJwaHlzLWNoMDQtczAyLWxvMDIiLCJrMTJwaHlzLWNoMDQtZXgw
+        NTciXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjEz
+        NSwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkEgMjAwIGtnIGNh
+        ciB0cmF2ZWxzIGF0IDYwIGttL2ggYW5kIGEgYmlrZSBvZiBtYXNzIG9mIDYw
+        IGtnIGlzIHRyYXZlbGxpbmcgb24gdGhlIHNhbWUgcm9hZCBhdCAxMCBrbS9o
+        LiBXaGljaCBzeXN0ZW0gaGFzIG1vcmUgaW5lcnRpYT8gV2h5PyIsImFuc3dl
+        cnMiOlt7ImlkIjo0ODcsImNvbnRlbnRfaHRtbCI6IlRoZSBiaWtlIGhhcyBt
+        b3JlIGluZXJ0aWEgYXMgaXRzIG1hc3MgaXMgbGVzc2VyIHRoYW4gdGhlIGNh
+        ciIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlv
+        dSB0aGluayBpbmVydGlhIGlzIGdyZWF0ZXIgZm9yIG9iamVjdHMgd2l0aCBs
+        ZXNzZXIgbWFzcz8ifSx7ImlkIjo0ODYsImNvbnRlbnRfaHRtbCI6IlRoZSBj
+        YXIgaGFzIG1vcmUgaW5lcnRpYSBhcyBpdHMgbWFzcyBpcyBsZXNzZXIgdGhh
+        biB0aGUgYmlrZSIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRt
+        bCI6Ikl0IGlzIGNvcnJlY3QgdGhhdCB0aGUgY2FyIGhhcyBtb3JlIGluZXJ0
+        aWEgYnV0IGRvIHlvdSB0aGluayBsZXNzZXIgbWFzcyBwb3NzZXNzZXMgbW9y
+        ZSBpbmVydGlhPyJ9LHsiaWQiOjQ4NSwiY29udGVudF9odG1sIjoiVGhlIGJp
+        a2UgaGFzIG1vcmUgaW5lcnRpYSBhcyBpdHMgbWFzcyBpcyBncmVhdGVyIHRo
+        YW4gdGhlIGNhciIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRt
+        bCI6IkFyZSB5b3Ugc3VyZSB0aGUgYmlrZSBoYXMgbW9yZSBtYXNzIHRoYW4g
+        dGhlIGNhcj8ifSx7ImlkIjo0ODQsImNvbnRlbnRfaHRtbCI6IkNhciBoYXMg
+        bW9yZSBpbmVydGlhIGFzIGl0cyBtYXNzIGlzIGdyZWF0ZXIgdGhhbiB0aGUg
+        YmlrZSIsImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNv
+        cnJlY3QhIFRoZSBjYXIgaGFzIG1vcmUgaW5lcnRpYSwgc2luY2UgaW5lcnRp
+        YSBpcyBncmVhdGVyIGZvciBvYmplY3RzIHdpdGggZ3JlYXRlciBtYXNzLiJ9
+        XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIsImZy
+        ZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQiOiI1
+        OEAxIiwibnVtYmVyIjo1OCwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0Ijoi
+        MjAxNS0wMy0xMFQxOTo0OToxOC43NDVaIiwiZWRpdG9ycyI6W10sImF1dGhv
+        cnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7InVz
+        ZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMiOltd
+        LCJ0YWdzIjpbImRpc3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVj
+        LXNlbnNpdGl2ZSIsInR1dG9yLW9ubHkiLCJjaGFwdGVyLXJldmlldy1jb25j
+        ZXB0IiwidGltZS1tZWRpdW0iLCJkb2s0IiwiazEycGh5cy1jaDA0LXMwMi1s
+        bzAyIiwiazEycGh5cy1jaDA0LWV4MDU4Il0sInN0aW11bHVzX2h0bWwiOiIi
+        LCJxdWVzdGlvbnMiOlt7ImlkIjoxMzYsInN0aW11bHVzX2h0bWwiOiIiLCJz
+        dGVtX2h0bWwiOiJBIDI1IGtnIG9iamVjdCBtb3ZlcyBmcm9tIGxlZnQgdG8g
+        cmlnaHQgYXQgYSBzcGVlZCBvZiAzMCBrbS9oLiBXaGF0IG5ldCBmb3JjZSBp
+        cyByZXF1aXJlZCB0byBrZWVwIHRoaXMgb2JqZWN0IGluIG1vdGlvbj8iLCJh
+        bnN3ZXJzIjpbeyJpZCI6NDkxLCJjb250ZW50X2h0bWwiOiI3NTAgTmV3dG9u
+        IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19odG1sIjoiSGF2ZSB5
+        b3UgY29uc2lkZXJlZCBOZXd0b27igJlzIGZpcnN0IGxhdyBvZiBtb3Rpb24/
+        IERvIHlvdSB0aGluayBhbiBleHRyYSBmb3JjZSBpcyByZXF1aXJlZCB0byBr
+        ZWVwIHRoZSBib2R5IGluIG1vdGlvbj8ifSx7ImlkIjo0OTAsImNvbnRlbnRf
+        aHRtbCI6IjMwIE5ld3RvbiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJh
+        Y2tfaHRtbCI6IkFyZSB5b3Ugc3VyZSB0aGF0IHlvdSB3aWxsIHJlcXVpcmUg
+        YW4gZXh0cmEgZm9yY2UgZXF1aXZhbGVudCB0byB0aGUgdmVsb2NpdHkgb2Yg
+        dGhlIG9iamVjdCB0byBrZWVwIGl0IGluIG1vdGlvbj8gSGF2ZSBjb25zaWRl
+        cmVkIE5ld3RvbuKAmXMgZmlyc3QgbGF3IG9mIG1vdGlvbj8ifSx7ImlkIjo0
+        ODksImNvbnRlbnRfaHRtbCI6IjI1IE5ld3RvbiIsImNvcnJlY3RuZXNzIjoi
+        MC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlvdSB0aGluayBhbiBleHRyYSBm
+        b3JjZSBlcXVpdmFsZW50IHRvIG1hc3MgaXMgcmVxdWlyZWQgdG8ga2VlcCBh
+        IGJvZHkgaW4gbW90aW9uPyBDYW4geW91IHJlY2FsbCBOZXd0b27igJlzIGZp
+        cnN0IGxhdyBvZiBtb3Rpb24/In0seyJpZCI6NDg4LCJjb250ZW50X2h0bWwi
+        OiIwIE5ld3RvbiIsImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJhY2tfaHRt
+        bCI6IkNvcnJlY3QhIEFjY29yZGluZyB0byBOZXd0b27igJlzIGZpcnN0IGxh
+        dyBvZiBtb3Rpb24gdGhlIHN0YXRlIG9mIHJlc3Qgb3IgdW5pZm9ybSBtb3Rp
+        b24gZG9lcyBub3QgY2hhbmdlIHVubGVzcyBhY3RlZCB1cG9uIGJ5IGFuIGV4
+        dGVybmFsIGZvcmNlLiBUaGVyZWZvcmUsIHRoZSBib2R5IHdpbGwga2VlcCBt
+        b3Zpbmcgd2l0aCB2ZWxvY2l0eSAzMCBrbS9oIHdpdGhvdXQgYW55IGV4dGVy
+        bmFsIGZvcmNlLiJ9XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxl
+        LWNob2ljZSIsImZyZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119
+        XX0seyJ1aWQiOiI1OUAxIiwibnVtYmVyIjo1OSwidmVyc2lvbiI6MSwicHVi
+        bGlzaGVkX2F0IjoiMjAxNS0wMy0xMFQxOTo0OToxOC43NjBaIiwiZWRpdG9y
+        cyI6W10sImF1dGhvcnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hv
+        bGRlcnMiOlt7InVzZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0
+        YWNobWVudHMiOltdLCJ0YWdzIjpbImluYm9vay15ZXMiLCJkb2sxIiwidGlt
+        ZS1zaG9ydCIsImRpc3BsYXktZnJlZS1yZXNwb25zZSIsImRpc3BsYXktcmVj
+        LXNlbnNpdGl2ZSIsInRlc3QtcHJlcC1tdWx0aXBsZS1jaG9pY2UiLCJrMTJw
+        aHlzLWNoMDQtczAyLWxvMDIiLCJrMTJwaHlzLWNoMDQtZXgwNTkiXSwic3Rp
+        bXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjEzNywic3RpbXVs
+        dXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IldoYXQgaXMgYW5vdGhlciBuYW1l
+        IGZvciBOZXd0b27igJlzIEZpcnN0IExhdz8iLCJhbnN3ZXJzIjpbeyJpZCI6
+        NDk0LCJjb250ZW50X2h0bWwiOiJMYXcgb2YgZnJpY3Rpb24iLCJjb3JyZWN0
+        bmVzcyI6IjAuMCJ9LHsiaWQiOjQ5MywiY29udGVudF9odG1sIjoiTGF3IG9m
+        IGluZXJ0aWEiLCJjb3JyZWN0bmVzcyI6IjEuMCJ9LHsiaWQiOjQ5MiwiY29u
+        dGVudF9odG1sIjoiTGF3IG9mIGluZmluaXRlIG1vdGlvbiIsImNvcnJlY3Ru
+        ZXNzIjoiMC4wIn1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUt
+        Y2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1d
+        fSx7InVpZCI6IjYwQDEiLCJudW1iZXIiOjYwLCJ2ZXJzaW9uIjoxLCJwdWJs
+        aXNoZWRfYXQiOiIyMDE1LTAzLTEwVDE5OjQ5OjE4Ljc3NloiLCJlZGl0b3Jz
+        IjpbXSwiYXV0aG9ycyI6W3sidXNlcl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9s
+        ZGVycyI6W3sidXNlcl9pZCI6Mn1dLCJkZXJpdmVkX2Zyb20iOltdLCJhdHRh
+        Y2htZW50cyI6W10sInRhZ3MiOlsiaW5ib29rLXllcyIsInRpbWUtc2hvcnQi
+        LCJkaXNwbGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1zZW5zaXRp
+        dmUiLCJkb2syIiwidGVzdC1wcmVwLXNob3J0LWFuc3dlciIsImsxMnBoeXMt
+        Y2gwNC1zMDItbG8wMiIsImsxMnBoeXMtY2gwNC1leDA2MCJdLCJzdGltdWx1
+        c19odG1sIjoiIiwicXVlc3Rpb25zIjpbeyJpZCI6MTM4LCJzdGltdWx1c19o
+        dG1sIjoiIiwic3RlbV9odG1sIjoiVHdvIHNpbWlsYXIgYm94ZXMgcmVzdCBv
+        biBhIHRhYmxlLiBPbmUgaXMgZW1wdHkgYW5kIHRoZSBvdGhlciBpcyBmaWxs
+        ZWQgd2l0aCBwZWJibGVzLiBXaXRob3V0IG9wZW5pbmcgb3IgbGlmdGluZyBl
+        aXRoZXIsIGhvdyBjYW4geW91IHRlbGwgd2hpY2ggYm94IGlzIGZ1bGw/IFdo
+        eT8iLCJhbnN3ZXJzIjpbeyJpZCI6NDk4LCJjb250ZW50X2h0bWwiOiJCeSBh
+        cHBseWluZyBleHRlcm5hbCBmb3JjZS4gV2hpY2hldmVyIGJveCBhY2NlbGVy
+        YXRlcyBmYXN0ZXIgaXMgaGVhdmllciBhbmQgc28gdGhlIG90aGVyIGJveCBt
+        dXN0IGJlIGVtcHR5IiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVkYmFja19o
+        dG1sIjoiRG8geW91IHRoaW5rIGhlYXZpZXIgYm94IHdpbGwgbW92ZSBmYXN0
+        ZXIgdGhhbiB0aGUgbGlnaHRlciBib3ggaWYgdGhlIHNhbWUgYW1vdW50IG9m
+        IGV4dGVybmFsIGZvcmNlIGlzIGFwcGxpZWQ/IFRyeSBhbmQgcmVhc29uIGl0
+        IHRocm91Z2ggaW5lcnRpYSBvZiBhbiBvYmplY3QuIn0seyJpZCI6NDk3LCJj
+        b250ZW50X2h0bWwiOiJCeSBhcHBseWluZyBleHRlcm5hbCBmb3JjZS4gV2hp
+        Y2hldmVyIGJveCBhY2NlbGVyYXRlcyBmYXN0ZXIgaXMgbGlnaHRlciBhbmQg
+        c28gbXVzdCBiZSBlbXB0eSIsImNvcnJlY3RuZXNzIjoiMS4wIiwiZmVlZGJh
+        Y2tfaHRtbCI6IkNvcnJlY3QhIFlvdSBjb3VsZCBnaXZlIGVhY2ggYm94IGEg
+        cHVzaCBieSBhcHBseWluZyB0aGUgc2FtZSBhbW91bnQgb2YgZm9yY2UuIFdo
+        aWNoZXZlciBib3ggYWNjZWxlcmF0ZXMgZmFzdGVyIGlzIGxpZ2h0ZXI7IHNv
+        IGl0IG11c3QgYmUgdGhlIGVtcHR5IGJveC4ifSx7ImlkIjo0OTYsImNvbnRl
+        bnRfaHRtbCI6IkJ5IGFwcGx5aW5nIGludGVybmFsIGZvcmNlLiBXaGljaGV2
+        ZXIgYm94IGFjY2VsZXJhdGVzIGZhc3RlciBpcyBoZWF2aWVyIGFuZCBzbyB0
+        aGUgb3RoZXIgYm94IG11c3QgYmUgZW1wdHkiLCJjb3JyZWN0bmVzcyI6IjAu
+        MCIsImZlZWRiYWNrX2h0bWwiOiJJcyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0
+        IGFuIGV4dGVybmFsIGZvcmNlIGNhbiBiZSBhcHBsaWVkIG9uIGFuIG9iamVj
+        dCBmcm9tIG91dHNpZGU/IEFsc28sIGRvIHlvdSB0aGluayBoZWF2aWVyIGJv
+        eCB3aWxsIG1vdmUgZmFzdGVyIHRoYW4gdGhlIGxpZ2h0ZXIgYm94IGlmIHRo
+        ZSBzYW1lIGFtb3VudCBvZiBmb3JjZSBpcyBhcHBsaWVkPyBDYW4geW91IHJl
+        Y2FsbCBkZWZpbml0aW9uIG9mIGluZXJ0aWE/In0seyJpZCI6NDk1LCJjb250
+        ZW50X2h0bWwiOiJCeSBhcHBseWluZyBpbnRlcm5hbCBmb3JjZS4gV2hpY2hl
+        dmVyIGJveCBhY2NlbGVyYXRlcyBmYXN0ZXIgaXMgbGlnaHRlciBhbmQgc28g
+        bXVzdCBiZSBlbXB0eSIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tf
+        aHRtbCI6IkNhbiB5b3UgYXBwbHkgaW50ZXJuYWwgZm9yY2Ugb24gYW4gb2Jq
+        ZWN0IGZyb20gb3V0c2lkZSBvZiB0aGUgc3lzdGVtPyBDYW4geW91IGRpZmZl
+        cmVudGlhdGUgYmV0d2VlbiBpbnRlcm5hbCBhbmQgZXh0ZXJuYWwgZm9yY2Vz
+        PyJ9XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11bHRpcGxlLWNob2ljZSIs
+        ImZyZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNlcyI6W119XX0seyJ1aWQi
+        OiI2MUAxIiwibnVtYmVyIjo2MSwidmVyc2lvbiI6MSwicHVibGlzaGVkX2F0
+        IjoiMjAxNS0wMy0xMFQxOTo0OToxOC43OTJaIiwiZWRpdG9ycyI6W10sImF1
+        dGhvcnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJpZ2h0X2hvbGRlcnMiOlt7
+        InVzZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpbXSwiYXR0YWNobWVudHMi
+        OltdLCJ0YWdzIjpbImluYm9vay15ZXMiLCJ0aW1lLXNob3J0IiwiZGlzcGxh
+        eS1mcmVlLXJlc3BvbnNlIiwiZGlzcGxheS1yZWMtc2Vuc2l0aXZlIiwiZG9r
+        MiIsInRlc3QtcHJlcC1zaG9ydC1hbnN3ZXIiLCJrMTJwaHlzLWNoMDQtczAy
+        LWxvMDIiLCJrMTJwaHlzLWNoMDQtZXgwNjEiXSwic3RpbXVsdXNfaHRtbCI6
+        IiIsInF1ZXN0aW9ucyI6W3siaWQiOjEzOSwic3RpbXVsdXNfaHRtbCI6IiIs
+        InN0ZW1faHRtbCI6IkFuIGV4dGVybmFsIGZvcmNlIGlzIHJlcXVpcmVkIHRv
+        IHNldCBhIHN0YXRpb25hcnkgb2JqZWN0IGluIG1vdGlvbiBpbiBhbiBvdXRl
+        ciBzcGFjZSBhd2F5IGZyb20gYWxsIGdyYXZpdGF0aW9uYWwgaW5mbHVlbmNl
+        cyBhbmQgZnJpY3Rpb25hbCBpbmZsdWVuY2VzIGNhdXNlZCBieSBhdG1vc3Bo
+        ZXJlIiwiYW5zd2VycyI6W3siaWQiOjUwMCwiY29udGVudF9odG1sIjoiMCIs
+        ImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkFyZSB5b3Ug
+        c3VyZSB0aGF0IHRoZSBvYmplY3Qgd2lsbCBjaGFuZ2UgaXRzIHN0YXRlIG9m
+        IHJlc3Qgd2l0aG91dCB0aGUgaW5mbHVlbmNlIGFuIGV4dGVybmFsIGZvcmNl
+        PyBDYW4geW91IHJlY2FsbCBOZXd0b27igJlzIGZpcnN0IGxhdyBvZiBtb3Rp
+        b24/In0seyJpZCI6NDk5LCJjb250ZW50X2h0bWwiOiIxIiwiY29ycmVjdG5l
+        c3MiOiIxLjAiLCJmZWVkYmFja19odG1sIjoiQ29ycmVjdCEgQWNjb3JkaW5n
+        IHRvIE5ld3RvbuKAmXMgZmlyc3QgbGF3IG9mIG1vdGlvbiBhbiBleHRlcm5h
+        bCBmb3JjZSBpcyByZXF1aXJlZCB0byBjaGFuZ2UgdGhlIHN0YXRlIG9mIHJl
+        c3Qgb2YgYW4gb2JqZWN0LiJ9XSwiaGludHMiOltdLCJmb3JtYXRzIjpbIm11
+        bHRpcGxlLWNob2ljZSIsImZyZWUtcmVzcG9uc2UiXSwiY29tYm9fY2hvaWNl
+        cyI6W119XX0seyJ1aWQiOiI2MkAxIiwibnVtYmVyIjo2MiwidmVyc2lvbiI6
+        MSwicHVibGlzaGVkX2F0IjoiMjAxNS0wMy0xMFQxOTo0OToxOC44MDdaIiwi
+        ZWRpdG9ycyI6W10sImF1dGhvcnMiOlt7InVzZXJfaWQiOjF9XSwiY29weXJp
+        Z2h0X2hvbGRlcnMiOlt7InVzZXJfaWQiOjJ9XSwiZGVyaXZlZF9mcm9tIjpb
+        XSwiYXR0YWNobWVudHMiOltdLCJ0YWdzIjpbImluYm9vay15ZXMiLCJkaXNw
+        bGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1zZW5zaXRpdmUiLCJk
+        b2szIiwidGltZS1tZWRpdW0iLCJ0ZXN0LXByZXAtZXh0ZW5kZWQtcmVzcG9u
+        c2UiLCJrMTJwaHlzLWNoMDQtczAyLWxvMDIiLCJrMTJwaHlzLWNoMDQtZXgw
+        NjIiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3siaWQiOjE0
+        MCwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkEgcGVyc29uIHB1
+        c2hlcyBhIGJveCBmcm9tIGxlZnQgdG8gcmlnaHQgYW5kIHRoZW4gbGV0cyBp
+        dCBzbGlkZSBmcmVlbHkgYWNyb3NzIHRoZSBmbG9vci4gVGhlIGJveCBzbG93
+        cyBkb3duIGFzIGl0IHNsaWRlcyBhY3Jvc3MgdGhlIGZsb29yLiBXaGVuIHRo
+        ZSBib3ggaXMgc2xpZGluZyBmcmVlbHksIGluIHdoYXQgZGlyZWN0aW9uIGlz
+        IHRoZSBuZXQgZm9yY2U/IFdoeT8iLCJhbnN3ZXJzIjpbeyJpZCI6NTA0LCJj
+        b250ZW50X2h0bWwiOiJUaGUgbmV0IGZvcmNlIGlzIGFjdGluZyBpbiB0aGUg
+        ZG93bndhcmQgZGlyZWN0aW9uIiwiY29ycmVjdG5lc3MiOiIwLjAiLCJmZWVk
+        YmFja19odG1sIjoiQXJlIHlvdSBzdXJlIHRoYXQgbmV0IGZvcmNlIGlzIGFj
+        dGluZyBpbiB0aGUgZG93bndhcmQgZGlyZWN0aW9uPyBIYXZlIHlvdSBjb25z
+        aWRlcmVkIHRoZSBmYWN0IHRoYXQgdGhlIGJveCBpcyBzbGlkaW5nIGluIHRo
+        ZSBob3Jpem9udGFsIGRpcmVjdGlvbj8gRG8geW91IHRoaW5rIHRoYXRmb3Ig
+        YSBib3ggd2hpY2ggaGFzIG5ldCBtb3Rpb24gaW4gdGhlIGhvcml6b250YWwg
+        ZGlyZWN0aW9uIHdpbGwgaGF2ZSBuZXQgZm9yY2UgaW4gdGhlIGRpcmVjdGlv
+        biBwZXJwZW5kaWN1bGFyIHRvIGl0PyJ9LHsiaWQiOjUwMywiY29udGVudF9o
+        dG1sIjoiVGhlIG5ldCBmb3JjZSBpcyBhY3RpbmcgaW4gdGhlIHVwd2FyZCBk
+        aXJlY3Rpb24iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZlZWRiYWNrX2h0bWwi
+        OiJEbyB5b3UgdGhpbmsgd2hlbiB0aGUgYm94IGlzIHNsaWRpbmcgZnJlZWx5
+        IGluIHRoZSBob3Jpem9udGFsIGRpcmVjdGlvbiB0aGVuIGl0IHdpbGwgaGF2
+        ZSBuZXQgZm9yY2UgaW4gdGhlIGRpcmVjdGlvbiBwZXJwZW5kaWN1bGFyIHRv
+        IGl0PyBDYW4geW91IGRyYXcgYSBmcmVlLWJvZHkgZGlhZ3JhbSBmb3IgdGhp
+        cyBzeXN0ZW0/In0seyJpZCI6NTAyLCJjb250ZW50X2h0bWwiOiJUaGUgbmV0
+        IGZvcmNlIGlzIGFjdGluZyBpbiB0aGUgZGlyZWN0aW9uIHJpZ2h0IHRvIGxl
+        ZnQiLCJjb3JyZWN0bmVzcyI6IjEuMCIsImZlZWRiYWNrX2h0bWwiOiJDb3Jy
+        ZWN0ISBUaGUgcGVyc29uIGlzIG5vIGxvbmdlciBhcHBseWluZyBmb3JjZSB3
+        aGVuIHRoZSBib3ggaXMgc2xpZGluZyBmcmVlbHkuIFRoZSBib3ggaXMgbW92
+        aW5nIGJlY2F1c2Ugb2YgaXRzIG93biBpbmVydGlhLiBUaGUgb25seSBmb3Jj
+        ZSBhY3Rpbmcgb24gaXQgaXMgdGhlIGZvcmNlIG9mIGZyaWN0aW9uIHdoaWNo
+        IGFjdHMgZnJvbSByaWdodCB0byBsZWZ0LiBUaHVzLCB0aGUgZGlyZWN0aW9u
+        IG9mIHRoZSBuZXQgZm9yY2UgaXMgdG8gdGhlIGxlZnQuIn0seyJpZCI6NTAx
+        LCJjb250ZW50X2h0bWwiOiJUaGUgbmV0IGZvcmNlIGlzIGFjdGluZyBpbiB0
+        aGUgZGlyZWN0aW9uIGxlZnQgdG8gcmlnaHQiLCJjb3JyZWN0bmVzcyI6IjAu
+        MCIsImZlZWRiYWNrX2h0bWwiOiJIYXZlIHlvdSBjb25zaWRlcmVkIHRoZSBm
+        YWN0IHRoYXQgdGhlIGJveCBpcyBzbGlkaW5nIGZyZWVseT8gQ2FuIHlvdSBm
+        aWd1cmUgb3V0IHdoaWNoIGZvcmNlIGlzIGFjdGluZyBvbiB0aGUgYm94IHdo
+        ZW4gaXQgaXMgc2xpZGluZyBmcmVlbHk/In1dLCJoaW50cyI6W10sImZvcm1h
+        dHMiOlsibXVsdGlwbGUtY2hvaWNlIiwiZnJlZS1yZXNwb25zZSJdLCJjb21i
+        b19jaG9pY2VzIjpbXX1dfV19
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:34 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex033
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:46 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-ex033
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:35 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex033
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"e44a72e37cd0e7c819b33498c7344771"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=WnJ5cHQ5MmtiNG40dlNwVlNoaWxKMDVoa0hqaEhicTNubVhsYWMyN0lCb0V4S1NLUWJtVHovWmVDREY2YU1pNVdMdUhvV2NjS1NxM21mSG1IUG1DeVE9PS0tUkQvRGVCLzNDUExmNW90cTIrWG5TUT09--4440038f3621cf56b88fa7298143dd49e2aa3d21;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 5d3bdc1c-7590-4c70-a836-3657c0c91888
+      X-Runtime:
+      - '0.065554'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbF9jb3VudCI6MSwiaXRlbXMiOlt7InVpZCI6IjMzQDEiLCJudW1i
+        ZXIiOjMzLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEw
+        VDE5OjQ5OjE4LjM0N1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNl
+        cl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1d
+        LCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsi
+        azEycGh5cy1jaDA0LXMwMi1sbzAxIiwiazEycGh5cy1jaDA0LWV4MDMzIiwi
+        cHJhY3RpY2UtY29uY2VwdHMiLCJ0dXRvci1vbmx5IiwiZG9rMSIsInRpbWUt
+        c2hvcnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1z
+        ZW5zaXRpdmUiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3si
+        aWQiOjExMSwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkhvdyBk
+        byB5b3UgZXhwcmVzcyBtYXRoZW1hdGljYWxseSB0aGF0IG5vIGV4dGVybmFs
+        IGZvcmNlIGlzIGFjdGluZyBvbiBhIGJvZHk/IiwiYW5zd2VycyI6W3siaWQi
+        OjQwMCwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9cXHRl
+        eHR7bmV0fSA9IFxcaW5mdHlcIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNz
+        IjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkFyZSB5b3Ugc3VyZSB0aGF0IDxz
+        cGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25ldH0gPSBcXGluZnR5XCI+TWF0
+        aDwvc3Bhbj4gZXhwcmVzc2VzIG1hdGhlbWF0aWNhbGx5IHRoYXQgbm8gZXh0
+        ZXJuYWwgZm9yY2UgaXMgYWN0aW5nIG9uIGEgYm9keT8ifSx7ImlkIjozOTks
+        ImNvbnRlbnRfaHRtbCI6IjxzcGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25l
+        dH0gPSAxXCI+TWF0aDwvc3Bhbj4iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZl
+        ZWRiYWNrX2h0bWwiOiJJcyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0IDxzcGFu
+        IGRhdGEtbWF0aD1cIlxcdGV4dHtGfV9cXHRleHR7bmV0fSA9IDFcIj5NYXRo
+        PC9zcGFuPiByZXByZXNlbnRzIG5vIGV4dGVybmFsIGZvcmNlIGlzIGFjdGlu
+        ZyBvbiBhIGJvZHk/IERvZXNu4oCZdCBpdCB0ZWxsIHRoYXQgYSB1bml0IGZv
+        cmNlIGlzIGFjdGluZyBpbiB0aGUgcG9zaXRpdmUgZGlyZWN0aW9uPyJ9LHsi
+        aWQiOjM5OCwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9c
+        XHRleHR7bmV0fSA9IDBcIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNzIjoi
+        MS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIDxzcGFuIGRhdGEtbWF0
+        aD1cIkZfXFx0ZXh0e25ldH0gPSAwXCI+TWF0aDwvc3Bhbj4gbWF0aGVtYXRp
+        Y2FsbHkgbWVhbnMgdGhhdCBubyBleHRlcm5hbCBmb3JjZSBpcyBhY3Rpbmcg
+        b24gYSBib2R5LiJ9LHsiaWQiOjM5NywiY29udGVudF9odG1sIjoiPHNwYW4g
+        ZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSA9IHstMX1cIj5NYXRoPC9zcGFu
+        PiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlv
+        dSB0aGluayA8c3BhbiBkYXRhLW1hdGg9XCJGX1xcdGV4dHtuZXR9ID0gey0x
+        fVwiPk1hdGg8L3NwYW4+IG1lYW5zIHRoYXQgbm8gZXh0ZXJuYWwgZm9yY2Ug
+        aXMgYWN0aW5nIG9uIGEgYm9keT8gRG9lc27igJl0IGl0IHRlbGwgdGhhdCBh
+        IHVuaXQgZm9yY2UgaXMgYWN0aW5nIGluIHRoZSBuZWdhdGl2ZSBkaXJlY3Rp
+        b24/In1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNl
+        IiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfV19
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:36 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:47 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-ex034
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:37 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"1edc9876248d860d4b4caef904652123"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=dUpJRmFUcW9WdVNLZUNIVzRLUGN6SlhWZC9aeGVDbHgrTGJKNWVYb0FDVklmSmlBekNuaTdGc09RN2FMbmhWZUNrOUc2djNxeElwMmwwRXNtMDg1SkE9PS0tc29JdTBaTC9LZFdCdUVPNlpocVBnUT09--b4fb42bdff90640cc75e503a0c573a68b86f963c;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 964ae7f1-944b-4566-88b3-ce479fe3cded
+      X-Runtime:
+      - '0.042914'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: UTF-8
+      string: '{"total_count":1,"items":[{"uid":"34@1","number":34,"version":1,"published_at":"2015-03-10T19:49:18.363Z","editors":[],"authors":[{"user_id":1}],"copyright_holders":[{"user_id":2}],"derived_from":[],"attachments":[],"tags":["k12phys-ch04-s02-lo01","k12phys-ch04-ex034","practice-concepts","tutor-only","dok1","time-short","display-free-response","display-rec-sensitive"],"stimulus_html":"","questions":[{"id":112,"stimulus_html":"","stem_html":"What
+        is friction?","answers":[{"id":404,"content_html":"Friction is an external
+        force that accelerates motion of the body","correctness":"0.0","feedback_html":"Yes,
+        friction is an external force but do you think it accelerates motion of the
+        body? Can you think how a body comes to rest?"},{"id":403,"content_html":"Friction
+        is an external force that decelerates motion of the body","correctness":"1.0","feedback_html":"Correct!
+        Friction is an external force that opposes the motion of the body."},{"id":402,"content_html":"Friction
+        is an internal force that accelerates motion of the body","correctness":"0.0","feedback_html":"Are
+        you sure that friction is an internal force that accelerates motion of the
+        body? Have you got the definition correctly?"},{"id":401,"content_html":"Friction
+        is an internal force that decelerates motion of the body","correctness":"0.0","feedback_html":"It
+        is correct that friction decelerates motion of the body but do you think it
+        is an internal force? Can you differentiate between internal and external
+        forces?"}],"hints":[],"formats":["multiple-choice","free-response"],"combo_choices":[]}]}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:38 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex033
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:49 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-ex033
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:39 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex033
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"e44a72e37cd0e7c819b33498c7344771"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=M0pCZHhzSWc4aWZ6cEk4QzRLM2lFbysyK1Y5aEptRlRKZjU4QnA2SUkvcnRaam4xNGNFR0ovNTVTNk5sQUdsdFVSdzlWM1Z2YktKYUhQUU5UbmpYWFE9PS0ta2tPeWlkcjZiQ2Q5dmp1dkFPQW5Wdz09--45c37685541873b48520c899e8736c2871bd94a4;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 7ec20796-8d00-4f87-8172-8f1353ed6211
+      X-Runtime:
+      - '0.044491'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbF9jb3VudCI6MSwiaXRlbXMiOlt7InVpZCI6IjMzQDEiLCJudW1i
+        ZXIiOjMzLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEw
+        VDE5OjQ5OjE4LjM0N1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNl
+        cl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1d
+        LCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsi
+        azEycGh5cy1jaDA0LXMwMi1sbzAxIiwiazEycGh5cy1jaDA0LWV4MDMzIiwi
+        cHJhY3RpY2UtY29uY2VwdHMiLCJ0dXRvci1vbmx5IiwiZG9rMSIsInRpbWUt
+        c2hvcnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1z
+        ZW5zaXRpdmUiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3si
+        aWQiOjExMSwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkhvdyBk
+        byB5b3UgZXhwcmVzcyBtYXRoZW1hdGljYWxseSB0aGF0IG5vIGV4dGVybmFs
+        IGZvcmNlIGlzIGFjdGluZyBvbiBhIGJvZHk/IiwiYW5zd2VycyI6W3siaWQi
+        OjQwMCwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9cXHRl
+        eHR7bmV0fSA9IFxcaW5mdHlcIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNz
+        IjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkFyZSB5b3Ugc3VyZSB0aGF0IDxz
+        cGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25ldH0gPSBcXGluZnR5XCI+TWF0
+        aDwvc3Bhbj4gZXhwcmVzc2VzIG1hdGhlbWF0aWNhbGx5IHRoYXQgbm8gZXh0
+        ZXJuYWwgZm9yY2UgaXMgYWN0aW5nIG9uIGEgYm9keT8ifSx7ImlkIjozOTks
+        ImNvbnRlbnRfaHRtbCI6IjxzcGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25l
+        dH0gPSAxXCI+TWF0aDwvc3Bhbj4iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZl
+        ZWRiYWNrX2h0bWwiOiJJcyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0IDxzcGFu
+        IGRhdGEtbWF0aD1cIlxcdGV4dHtGfV9cXHRleHR7bmV0fSA9IDFcIj5NYXRo
+        PC9zcGFuPiByZXByZXNlbnRzIG5vIGV4dGVybmFsIGZvcmNlIGlzIGFjdGlu
+        ZyBvbiBhIGJvZHk/IERvZXNu4oCZdCBpdCB0ZWxsIHRoYXQgYSB1bml0IGZv
+        cmNlIGlzIGFjdGluZyBpbiB0aGUgcG9zaXRpdmUgZGlyZWN0aW9uPyJ9LHsi
+        aWQiOjM5OCwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9c
+        XHRleHR7bmV0fSA9IDBcIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNzIjoi
+        MS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIDxzcGFuIGRhdGEtbWF0
+        aD1cIkZfXFx0ZXh0e25ldH0gPSAwXCI+TWF0aDwvc3Bhbj4gbWF0aGVtYXRp
+        Y2FsbHkgbWVhbnMgdGhhdCBubyBleHRlcm5hbCBmb3JjZSBpcyBhY3Rpbmcg
+        b24gYSBib2R5LiJ9LHsiaWQiOjM5NywiY29udGVudF9odG1sIjoiPHNwYW4g
+        ZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSA9IHstMX1cIj5NYXRoPC9zcGFu
+        PiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlv
+        dSB0aGluayA8c3BhbiBkYXRhLW1hdGg9XCJGX1xcdGV4dHtuZXR9ID0gey0x
+        fVwiPk1hdGg8L3NwYW4+IG1lYW5zIHRoYXQgbm8gZXh0ZXJuYWwgZm9yY2Ug
+        aXMgYWN0aW5nIG9uIGEgYm9keT8gRG9lc27igJl0IGl0IHRlbGwgdGhhdCBh
+        IHVuaXQgZm9yY2UgaXMgYWN0aW5nIGluIHRoZSBuZWdhdGl2ZSBkaXJlY3Rp
+        b24/In1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNl
+        IiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfV19
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:40 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:50 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-ex034
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:40 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"1edc9876248d860d4b4caef904652123"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=MUxLSFRFdWJGcEZsWW82V3JTd3JFdFZGN0Y5NVFlRGlXTXlSZ2liNm83TTJIYUxSZFdZNVlhQ1laMkl1TjRPZXNqc09MYzA5d0VSVHBzNWNieFVLY0E9PS0tRGJmdkFZUUhVVGpnNmJ6ODVuR1BzQT09--d0f5b6c4d1742623c54a2ef6f3f70dfabd84ebf6;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 9867445b-ce30-4201-ae0e-279dd5d9c103
+      X-Runtime:
+      - '0.042441'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: UTF-8
+      string: '{"total_count":1,"items":[{"uid":"34@1","number":34,"version":1,"published_at":"2015-03-10T19:49:18.363Z","editors":[],"authors":[{"user_id":1}],"copyright_holders":[{"user_id":2}],"derived_from":[],"attachments":[],"tags":["k12phys-ch04-s02-lo01","k12phys-ch04-ex034","practice-concepts","tutor-only","dok1","time-short","display-free-response","display-rec-sensitive"],"stimulus_html":"","questions":[{"id":112,"stimulus_html":"","stem_html":"What
+        is friction?","answers":[{"id":404,"content_html":"Friction is an external
+        force that accelerates motion of the body","correctness":"0.0","feedback_html":"Yes,
+        friction is an external force but do you think it accelerates motion of the
+        body? Can you think how a body comes to rest?"},{"id":403,"content_html":"Friction
+        is an external force that decelerates motion of the body","correctness":"1.0","feedback_html":"Correct!
+        Friction is an external force that opposes the motion of the body."},{"id":402,"content_html":"Friction
+        is an internal force that accelerates motion of the body","correctness":"0.0","feedback_html":"Are
+        you sure that friction is an internal force that accelerates motion of the
+        body? Have you got the definition correctly?"},{"id":401,"content_html":"Friction
+        is an internal force that decelerates motion of the body","correctness":"0.0","feedback_html":"It
+        is correct that friction decelerates motion of the body but do you think it
+        is an internal force? Can you differentiate between internal and external
+        forces?"}],"hints":[],"formats":["multiple-choice","free-response"],"combo_choices":[]}]}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:41 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex033
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:52 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-ex033
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:41 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex033
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"e44a72e37cd0e7c819b33498c7344771"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=S3B4NVJZTlNBUE5OSDh5ZlpJQUhXZG5EL2FzckhUVkhnSXU1L0w2Zkx6cExoOWhEKytzUy80Um9Kak1vNmwrTHhxNk4xUFppdEhYWXFCbUQrYXEwM2c9PS0tWlRiY29YWnp2Y21jQU5mb3locjhGUT09--25dbc40c85223556f617bebfdddf1af70397eb23;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 811f63c6-eccc-41d9-b3d4-d0f920b6f2fc
+      X-Runtime:
+      - '0.044163'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbF9jb3VudCI6MSwiaXRlbXMiOlt7InVpZCI6IjMzQDEiLCJudW1i
+        ZXIiOjMzLCJ2ZXJzaW9uIjoxLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTAzLTEw
+        VDE5OjQ5OjE4LjM0N1oiLCJlZGl0b3JzIjpbXSwiYXV0aG9ycyI6W3sidXNl
+        cl9pZCI6MX1dLCJjb3B5cmlnaHRfaG9sZGVycyI6W3sidXNlcl9pZCI6Mn1d
+        LCJkZXJpdmVkX2Zyb20iOltdLCJhdHRhY2htZW50cyI6W10sInRhZ3MiOlsi
+        azEycGh5cy1jaDA0LXMwMi1sbzAxIiwiazEycGh5cy1jaDA0LWV4MDMzIiwi
+        cHJhY3RpY2UtY29uY2VwdHMiLCJ0dXRvci1vbmx5IiwiZG9rMSIsInRpbWUt
+        c2hvcnQiLCJkaXNwbGF5LWZyZWUtcmVzcG9uc2UiLCJkaXNwbGF5LXJlYy1z
+        ZW5zaXRpdmUiXSwic3RpbXVsdXNfaHRtbCI6IiIsInF1ZXN0aW9ucyI6W3si
+        aWQiOjExMSwic3RpbXVsdXNfaHRtbCI6IiIsInN0ZW1faHRtbCI6IkhvdyBk
+        byB5b3UgZXhwcmVzcyBtYXRoZW1hdGljYWxseSB0aGF0IG5vIGV4dGVybmFs
+        IGZvcmNlIGlzIGFjdGluZyBvbiBhIGJvZHk/IiwiYW5zd2VycyI6W3siaWQi
+        OjQwMCwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9cXHRl
+        eHR7bmV0fSA9IFxcaW5mdHlcIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNz
+        IjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkFyZSB5b3Ugc3VyZSB0aGF0IDxz
+        cGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25ldH0gPSBcXGluZnR5XCI+TWF0
+        aDwvc3Bhbj4gZXhwcmVzc2VzIG1hdGhlbWF0aWNhbGx5IHRoYXQgbm8gZXh0
+        ZXJuYWwgZm9yY2UgaXMgYWN0aW5nIG9uIGEgYm9keT8ifSx7ImlkIjozOTks
+        ImNvbnRlbnRfaHRtbCI6IjxzcGFuIGRhdGEtbWF0aD1cIkZfXFx0ZXh0e25l
+        dH0gPSAxXCI+TWF0aDwvc3Bhbj4iLCJjb3JyZWN0bmVzcyI6IjAuMCIsImZl
+        ZWRiYWNrX2h0bWwiOiJJcyBpdCBjb3JyZWN0IHRvIHNheSB0aGF0IDxzcGFu
+        IGRhdGEtbWF0aD1cIlxcdGV4dHtGfV9cXHRleHR7bmV0fSA9IDFcIj5NYXRo
+        PC9zcGFuPiByZXByZXNlbnRzIG5vIGV4dGVybmFsIGZvcmNlIGlzIGFjdGlu
+        ZyBvbiBhIGJvZHk/IERvZXNu4oCZdCBpdCB0ZWxsIHRoYXQgYSB1bml0IGZv
+        cmNlIGlzIGFjdGluZyBpbiB0aGUgcG9zaXRpdmUgZGlyZWN0aW9uPyJ9LHsi
+        aWQiOjM5OCwiY29udGVudF9odG1sIjoiPHNwYW4gZGF0YS1tYXRoPVwiRl9c
+        XHRleHR7bmV0fSA9IDBcIj5NYXRoPC9zcGFuPiIsImNvcnJlY3RuZXNzIjoi
+        MS4wIiwiZmVlZGJhY2tfaHRtbCI6IkNvcnJlY3QhIDxzcGFuIGRhdGEtbWF0
+        aD1cIkZfXFx0ZXh0e25ldH0gPSAwXCI+TWF0aDwvc3Bhbj4gbWF0aGVtYXRp
+        Y2FsbHkgbWVhbnMgdGhhdCBubyBleHRlcm5hbCBmb3JjZSBpcyBhY3Rpbmcg
+        b24gYSBib2R5LiJ9LHsiaWQiOjM5NywiY29udGVudF9odG1sIjoiPHNwYW4g
+        ZGF0YS1tYXRoPVwiRl9cXHRleHR7bmV0fSA9IHstMX1cIj5NYXRoPC9zcGFu
+        PiIsImNvcnJlY3RuZXNzIjoiMC4wIiwiZmVlZGJhY2tfaHRtbCI6IkRvIHlv
+        dSB0aGluayA8c3BhbiBkYXRhLW1hdGg9XCJGX1xcdGV4dHtuZXR9ID0gey0x
+        fVwiPk1hdGg8L3NwYW4+IG1lYW5zIHRoYXQgbm8gZXh0ZXJuYWwgZm9yY2Ug
+        aXMgYWN0aW5nIG9uIGEgYm9keT8gRG9lc27igJl0IGl0IHRlbGwgdGhhdCBh
+        IHVuaXQgZm9yY2UgaXMgYWN0aW5nIGluIHRoZSBuZWdhdGl2ZSBkaXJlY3Rp
+        b24/In1dLCJoaW50cyI6W10sImZvcm1hdHMiOlsibXVsdGlwbGUtY2hvaWNl
+        IiwiZnJlZS1yZXNwb25zZSJdLCJjb21ib19jaG9pY2VzIjpbXX1dfV19
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:42 GMT
+- request:
+    method: get
+    uri: http://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:53 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Location:
+      - https://exercises-dev1.openstax.org/api/exercises?q=tag%3Ak12phys-ch04-ex034
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx/1.4.6
+        (Ubuntu)</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:43 GMT
+- request:
+    method: get
+    uri: https://exercises-dev1.openstax.org/api/exercises?q=tag:k12phys-ch04-ex034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/vnd.openstax.v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 19 Mar 2015 14:13:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"1edc9876248d860d4b4caef904652123"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _exercises_session=cExnVHBMNWlZMTZqRFlla0RhL3lUZ3pxdmlScDkvRVl2d08xemVEdmttMlJnZ1pmK205VTlmbnd3MGN0akd2Q0puVWVYbm5FOTczZDJqc0pHbkpaNmc9PS0tR1daOHdRSU1WbUlmdDk0QTMxb1RTdz09--e703f91cecc141dc00eeabab3d3a5677dc775be6;
+        path=/; HttpOnly
+      X-Request-Id:
+      - b4101c40-e5d1-4217-82a2-4a912f84a6bd
+      X-Runtime:
+      - '0.047009'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+    body:
+      encoding: UTF-8
+      string: '{"total_count":1,"items":[{"uid":"34@1","number":34,"version":1,"published_at":"2015-03-10T19:49:18.363Z","editors":[],"authors":[{"user_id":1}],"copyright_holders":[{"user_id":2}],"derived_from":[],"attachments":[],"tags":["k12phys-ch04-s02-lo01","k12phys-ch04-ex034","practice-concepts","tutor-only","dok1","time-short","display-free-response","display-rec-sensitive"],"stimulus_html":"","questions":[{"id":112,"stimulus_html":"","stem_html":"What
+        is friction?","answers":[{"id":404,"content_html":"Friction is an external
+        force that accelerates motion of the body","correctness":"0.0","feedback_html":"Yes,
+        friction is an external force but do you think it accelerates motion of the
+        body? Can you think how a body comes to rest?"},{"id":403,"content_html":"Friction
+        is an external force that decelerates motion of the body","correctness":"1.0","feedback_html":"Correct!
+        Friction is an external force that opposes the motion of the body."},{"id":402,"content_html":"Friction
+        is an internal force that accelerates motion of the body","correctness":"0.0","feedback_html":"Are
+        you sure that friction is an internal force that accelerates motion of the
+        body? Have you got the definition correctly?"},{"id":401,"content_html":"Friction
+        is an internal force that decelerates motion of the body","correctness":"0.0","feedback_html":"It
+        is correct that friction decelerates motion of the body but do you think it
+        is an internal force? Can you differentiate between internal and external
+        forces?"}],"hints":[],"formats":["multiple-choice","free-response"],"combo_choices":[]}]}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 14:13:44 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/OpenStax_Cnx_V1_Fragment_Video/can_retrieve_the_fragment_s_title.yml
+++ b/spec/cassettes/OpenStax_Cnx_V1_Fragment_Video/can_retrieve_the_fragment_s_title.yml
@@ -1,0 +1,558 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain
+      Location:
+      - "/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4"
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (pass - status > 300, not content)
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 10:32:41 GMT
+      X-Varnish:
+      - '172894874'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Varnish-Age:
+      - '0'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 10:32:38 GMT
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (override - archive contents)
+      X-Factor-Ttl:
+      - 'ttl: 604800.000'
+      Content-Length:
+      - '38216'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 10:32:42 GMT
+      X-Varnish:
+      - 172894875 170915691
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - HIT
+      X-Varnish-Age:
+      - '217785'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"googleAnalytics": null, "version": "4", "submitlog": "imported from
+        staging3", "abstract": null, "revised": "2015-03-16T16:00:23Z", "roles": null,
+        "keywords": [], "id": "61445f78-00e2-45ae-8e2c-461b17d9b4fd", "title": "Newton''s
+        First Law of Motion: Inertia", "mediaType": "application/vnd.org.cnx.module",
+        "content": "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head xmlns:c=\"http://cnx.rice.edu/cnxml\"
+        xmlns:md=\"http://cnx.rice.edu/mdml\"><title>Newton''s First Law of Motion:
+        Inertia</title><meta name=\"created-time\" content=\"2015/03/11 13:32:11 -0500\"/><meta
+        name=\"revised-time\" content=\"2015/03/16 11:00:23.682 GMT-5\"/><meta name=\"author\"
+        content=\"AlinaManager\"/><meta name=\"acl-list\" content=\"AlinaManager\"/><meta
+        name=\"licensor\" content=\"AlinaManager\"/><meta name=\"license\" content=\"http://creativecommons.org/licenses/by/4.0/\"/><meta
+        name=\"subject\" content=\"Mathematics and Statistics\"/></head>\n\n<body
+        xmlns:c=\"http://cnx.rice.edu/cnxml\" xmlns:md=\"http://cnx.rice.edu/mdml\"
+        xmlns:qml=\"http://cnx.rice.edu/qml/1.0\" xmlns:mod=\"http://cnx.rice.edu/#moduleIds\"
+        xmlns:bib=\"http://bibtexml.sf.net/\" xmlns:data=\"http://dev.w3.org/html5/spec/#custom\"><div
+        data-type=\"document-title\">Newton''s First Law of Motion: Inertia</div>\n  <section
+        data-depth=\"1\" id=\"fs-idp17120160\" class=\"learning-objectives\"><h1 data-type=\"title\">Section
+        Learning Objectives</h1><p id=\"eip-795\">By the end of this section you will
+        be able to: <span data-type=\"list\" data-list-type=\"bulleted\" id=\"eip-idp58500736\"><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-teks-112-39-c-4d\"> Describe Newton''s first law and friction <math
+        xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math></span><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-teks-112-39-c-4d\"> Discuss the relationship between mass and inertia</span></span></p></section>\n\n<div
+        data-type=\"note\" id=\"eip-887\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\"><p id=\"eip-idm12575088\">The Learning Objectives in this section
+        will help your students master the following TEKS: (4) Science concepts. The
+        student knows and applies the laws governing motion in a variety of situations.
+        The student is expected to: \n<span data-type=\"list\" data-list-type=\"bulleted\"
+        id=\"fs-idp60294944\">\n<span data-type=\"item\" class=\"ost-standards-def
+        ost-standards-teks\"><span class=\"ost-standards-name\">(4D)</span><span class=\"ost-standards-discard\">:</span><span
+        class=\"ost-standards-description ost-tag-teks-112-39-c-4d\">calculate the
+        effect of forces on objects, including the law of inertia, the relationship
+        between force and acceleration, and the nature of force pairs between objects</span></span></span></p></div>\n\n<table
+        id=\"eip-850\" summary=\"--\" class=\"key-terms ost-reading-discard\"><caption><span
+        data-type=\"title\">Section Key Terms</span></caption><tbody>\n  <tr>\n    <td>friction</td>\n    <td>inertia</td>\n    <td>law
+        of inertia</td>\n  </tr>\n  <tr>\n    <td>mass</td>\n    <td>Newton''s first
+        law of motion</td>\n    <td>system</td>\n  </tr>\n</tbody></table><div data-type=\"note\"
+        id=\"eip-456\" class=\"os-teacher\" data-label=\"Teacher Edition\"><p id=\"eip-idm59591792\">Before
+        students begin this section, it is useful to review the concepts of force,
+        external force, net external force, and addition of forces.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> <span
+        class=\"level-above\">[AL]</span> Ask students to speculate what happens to
+        objects when they are set in motion. Do they remain in motion or stop after
+        some time? Why?</p><div data-type=\"note\" id=\"eip-idm108977584\" class=\"tip
+        misconception\" data-label=\"Misconception Alert\">\nStudents may believe
+        that objects that are in motion tend to slow down and stop. Explain the concept
+        of friction. Talk about objects in outer space, where there is no atmosphere
+        and no gravity. Ask students to describe the motion of such objects.</div></div>\n\n<section
+        data-depth=\"1\" id=\"eip-201\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><h1
+        data-type=\"title\">Newton''s First Law and Friction</h1><p id=\"eip-708\"><span
+        data-type=\"term\">Newton''s first law of motion</span> states that:</p><ol
+        id=\"eip-idp55249424\"><li>A body at rest tends to stay at rest <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        (<a href=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm\">http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm</a>)</li>\n<li>A
+        body in motion tends to remain in motion at constant velocity unless acted
+        on by a net external force (recall that &#8220;constant velocity&#8221; means
+        in a straight line and at constant speed). <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </li>\n</ol>\n\n<section data-depth=\"2\" id=\"eip-241\"><h2 data-type=\"title\">Newton''s
+        1<sup>st</sup> Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><div data-type=\"note\" id=\"eip-659\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n<p id=\"eip-idm30448560\"><span class=\"level-below\">[BL]</span>\n<span
+        class=\"level-on\">[OL]</span>\n<span class=\"level-above\">[AL]</span> Discuss
+        examples of Newton&#8217;s First Law seen in everyday life. <div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Talk about different pairs of surfaces and
+        how each exhibits different levels of friction. Ask students to give examples
+        of smooth and rough surfaces. Ask them where friction may be useful and where
+        it may be undesirable. <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Ask students to give different examples
+        of systems where multiple forces occur. Draw free-body diagrams for these.
+        Include the force of friction. Emphasize the direction of the force of friction.</p></div>\n\n<p
+        id=\"eip-545\">At first glance, this law may seem to contradict your everyday
+        experience. You have probably noticed that a moving object will usually slow
+        down and stop unless some effort is made to keep it moving. The key to understanding
+        why, for example, a sliding box slows down (seemingly on its own) is that
+        a net external force acts on it to make it slow down. Without this net external
+        force, the box would continue to slide at a constant velocity (as stated in
+        Newton&#8217;s first law of motion). What force acts on the box to slow it
+        down? It is called <span data-type=\"term\">friction</span>. Friction is an
+        external force that acts opposite to the direction of motion (see <a href=\"#eip-idm20864848\"
+        class=\"autogenerated-content\">[link]</a>). Think of it as a resistance to
+        motion that slows things down.</p><p id=\"eip-66\">Friction:</p>\n\n<ol id=\"eip-idp86047488\"
+        data-number-style=\"arabic\"><li>Goes in the opposite direction<span data-type=\"media\"
+        id=\"eip-idm63937136\" data-alt=\"Alt text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></li>\n<li>Causes
+        an object to slow down <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a></li></ol></section>\n\n<section
+        data-depth=\"2\" id=\"eip-495\"><h2 data-type=\"title\">Newton''s 1<sup>st</sup>
+        Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><p id=\"eip-370\">Consider an air hockey table. When the air is turned
+        off, the puck slides only a short distance before friction slows it to a stop.
+        However, when the air is turned on, it lifts the puck slightly so that the
+        puck experiences very little friction as it moves over the surface. With friction
+        almost eliminated, the puck glides along with very little change in speed.
+        On a frictionless surface, the puck would experience no net external force
+        (ignoring air resistance, which is also a form of friction). Additionally,
+        if we know enough about friction, we can accurately predict how quickly objects
+        will slow down.</p>\n\n<p id=\"eip-114\">Now let&#8217;s think about another
+        example. A man pushes a box across a floor at constant velocity by applying
+        a force of +50 N (the positive sign indicates by convention that the direction
+        of motion is to the right). What is the force of friction that opposes the
+        motion? The force of friction must be &#8722;50 N. Why? According to Newton&#8217;s
+        first law of motion, any object moving at constant velocity has no net external
+        force acting upon it, which means that the sum of the forces acting on the
+        object must be zero. The mathematical way to say that no net external force
+        acts on an object is <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        , or <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        . So if the man applies +50 N of force, then the force of friction must be
+        &#8722;50 N for the two forces to add up to zero (i.e., &#8220;cancel&#8221;
+        each other). Whenever you encounter the phrase &#8220;at constant velocity,&#8221;
+        Newton&#8217;s first law tells you that the net external force is zero.</p><figure
+        id=\"eip-idm83000688\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>For
+        a box sliding across a floor, friction acts in the direction opposite to the
+        velocity.</figcaption><span data-type=\"media\" id=\"eip-idm83879248\" data-alt=\"Alt
+        text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure><p id=\"eip-985\">The
+        force of friction depends on two things: the coefficient of friction and the
+        normal force. The coefficient of friction is a constant that depends on the
+        nature of the surfaces in contact with one another. The normal force is the
+        force exerted by a surface that pushes on an object in response to gravity
+        pulling the object down. In equation form, the force of friction is <div data-type=\"equation\"
+        id=\"eip-idp12074176\" class=\"unnumbered\" data-label=\"\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"block\"><semantics><mrow><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></annotation-xml></semantics></math></div>where
+        &#956; is the coefficient of friction and N is the normal force. The coefficient
+        of friction is discussed in more detail in the next chapter and the normal
+        force is discussed in more detail in section four of this chapter.\n</p><p
+        id=\"eip-89\">Recall from section one that a net external force acts from
+        outside on the object of interest. A more precise definition is that it acts
+        on the <span data-type=\"term\">system</span> of interest. A system is one
+        or more objects that you choose to study. It is important to define the system
+        at the beginning of a problem to figure out which forces are external and
+        need to be considered and which are internal and can be ignored.</p><p id=\"eip-826\">For
+        example, in <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        (a), two children push a third child in a wagon at constant velocity. The
+        system of interest is the wagon plus the small child shown in part b of the
+        figure. The two children behind the wagon exert external forces on this system
+        (<em data-effect=\"italics\">F</em><sub>1</sub>, <em data-effect=\"italics\">F</em><sub>2</sub>).
+        Friction <em data-effect=\"italics\">f</em> acting at the axles of the wheels
+        and at the surface where the wheels touch the ground is another external force
+        acting on the system. Two more external forces act on the system: the weight
+        <em data-effect=\"italics\">W</em> of the system pulling down and the normal
+        force <em data-effect=\"italics\">N</em> of the ground pushing up. Notice
+        that the wagon is not accelerating vertically, so Newton&#8217;s first law
+        tells us that the normal force balances the weight. Because the wagon is moving
+        forward at constant velocity, then the force of friction must have the same
+        strength as the sum of the forces applied by the two children.</p><figure
+        id=\"eip-idm20864848\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>(a)
+        The wagon and rider form a &#8220;system&#8221; that is acted on by external
+        forces. (b)The two children pushing the wagon and child provide two external
+        forces. Friction acting at the wheel axles and on the surface of the tires
+        where they touch the ground provides an external force that acts against the
+        direction of motion. The weight <em data-effect=\"italics\">W</em> and the
+        normal force <em data-effect=\"italics\">N</em> from the ground are two more
+        external forces acting on the system. All external forces are represented
+        in the figure by arrows. All of the external forces acting on the system add
+        together, but because the wagon moves at a constant velocity, all the forces
+        must add up to zero.</figcaption><span data-type=\"media\" id=\"eip-idp5554688\"
+        data-alt=\"Alt text\"><img src=\"/resources/8c943f2ce4ca3d9a0a429e8a3d3f3c00/Figure_04_02_wagon.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></section></section>\n\n<section
+        data-depth=\"1\" id=\"eip-304\" class=\"ost-tag-lo-k12phys-ch04-s02-lo02\"><h1
+        data-type=\"title\">Mass and Inertia</h1>\n\n<div data-type=\"note\" id=\"eip-715\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"eip-idm26334000\"><span
+        class=\"level-below\">[BL]</span> Review Newton&#8217;s First Law. Explain
+        that the property of objects to maintain their state of motion is called inertia.
+        <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>
+        <span class=\"level-above\">[AL]</span> Take two similar carts or trolleys
+        with wheels. Place a heavy weight in one of them. Ask students which cart
+        would require more force to change its state of motion. Ask students which
+        would stay in motion longer if you were to set them in motion. Based on this
+        discussion, have students speculate what inertia may depend on.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> Explain
+        the concepts of mass and weight. Explain that these terms may be used interchangeably
+        in everyday life but have different meanings in science.</p></div>\n\n<p id=\"eip-613\"><span
+        data-type=\"term\">Inertia</span> is the tendency for an object at rest to
+        remain at rest or for a moving object to remain in motion in a straight line
+        with constant speed. This key property of objects was first described by Galileo.
+        Later, Newton incorporated the concept of inertia into his first law, which
+        is often referred to as the <span data-type=\"term\">law of inertia</span>.</p><p
+        id=\"eip-36\">As we know from experience, some objects have more inertia than
+        others. For example, changing the motion of a large truck is more difficult
+        than changing the motion of a toy truck. In fact, the inertia of an object
+        is proportional to the mass of the object. <span data-type=\"term\">Mass</span>
+        is a measure of the amount of matter (or &#8220;stuff&#8221;) in something.
+        The quantity or amount of matter in an object is determined by the number
+        and type of atoms it contains. Unlike weight (which changes if the gravitational
+        force changes), mass does not depend on gravity. The mass of an object is
+        the same on Earth, in orbit, or on the surface of the Moon. In practice, it
+        is very difficult to count and identify all of the atoms and molecules in
+        an object, so mass is usually not determined this way. Instead, the mass of
+        an object is determined by comparing it with the standard kilogram. Mass is
+        therefore expressed in kilograms.</p>\n\n<div data-type=\"note\" id=\"eip-idm961296\"
+        class=\"tip tips-for-success\" data-label=\"Tips for Success\">In everyday
+        language, people often use the terms weight and mass interchangeably&#8212;but
+        this is not correct. Weight is actually a force (we cover this in more detail
+        in section three).</div>\n\n<div data-type=\"note\" id=\"eip-231\" class=\"ost-assessed-feature
+        ost-video ost-tag-lo-k12phys-ch04-s02-lo02 watch-physics\" data-label=\"Watch
+        Physics\"><div data-type=\"title\">Newton&#8217;s first law of motion</div>
+        \n<p id=\"eip-idp1646512\">This <a href=\"https://www.khanacademy.org/science/physics/forces-newtons-laws/newtons-laws-of-motion/v/newton-s-1st-law-of-motion\"
+        class=\"os-embed\">video</a> contrasts the way we thought about motion and
+        force in the time before Galileo&#8217;s concept of inertia and <span data-type=\"term\">Newton&#8217;s
+        first law of motion</span> with the way we understand force and motion now.
+        Refer to <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        as you watch.\n</p>\n\n<ol id=\"eip-idp19850304\"><li>Galileo&#8217;s concepts<ol
+        id=\"eip-idp10164288\" data-number-style=\"lower-alpha\"><li>Things just come
+        to a stop</li><li>Forces don&#8217;t act against objects</li></ol></li><li>Newton&#8217;s
+        concepts<ol id=\"eip-idp5872736\" data-number-style=\"lower-alpha\"><li>Objects
+        will continue at the same speed if no opposing force</li><li>Weight is a force
+        acting against an object.</li></ol></li></ol>\n\n <div data-type=\"exercise\"
+        id=\"eip-idp413824\" class=\"os-exercise grasp-check\"><div data-type=\"problem\"
+        id=\"eip-idm76540272\">\n    <p id=\"eip-idm99866096\"><a href=\"#ost/api/ex/k12phys-ch04-ex033\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div></div><div data-type=\"note\"
+        id=\"eip-837\" class=\"os-teacher\" data-label=\"Teacher Edition\">Answer:
+        Friction</div></div>\n\n<div data-type=\"note\" id=\"fs-idm38320288\" class=\"ost-assessed-feature
+        ost-interactive virtual-physics ost-tag-lo-k12phys-ch04-s02-lo02\" data-label=\"Virtual
+        Physics\"><div data-type=\"title\">Forces and Motion: Basics</div>\n\n<p id=\"fs-idp34383024\">In
+        this simulation, you will first explore net force by placing blue people on
+        the left side of a tug of war rope and red people on the right side of the
+        rope (by clicking people and dragging them with your mouse). Experiment with
+        changing the number and size of people on each side to see how it affects
+        the outcome of the match and the net force. Hit the Go! button to start the
+        match, and the &#8220;reset all&#8221; button to start over.</p><ol id=\"fs-idp48496992\"
+        data-number-style=\"lower-alpha\"><li>The side with the most force wins</li><li>The
+        bigger the difference in the force, the easier it is for one side to win.</li><li>When
+        force is equal, no one wins.</li></ol><p id=\"fs-idp52126304\">Next, click
+        on the Friction tab. Try selecting different objects for the person to push.
+        Slide the applied force button to the right to apply force to the right and
+        to the left to apply force to the left. The force will continue to be applied
+        as long as you hold the button down. See the arrow representing friction change
+        in magnitude and direction depending on how much force you apply. Try increasing
+        or decreasing the friction force to see how this affects the motion.</p>\n<div
+        data-type=\"media\" id=\"fs-idp5640912\" class=\"os-embed\" data-alt=\" \">
+        <iframe width=\"960\" height=\"785\" src=\"http://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/\"/></div>\n\n  <div
+        data-type=\"exercise\" id=\"fs-idm56919408\" class=\"os-exercise grasp-check\"><div
+        data-type=\"problem\" id=\"fs-idm68103760\"><p id=\"fs-idm17001808\"><a href=\"#ost/api/ex/k12phys-ch04-ex034\"
+        class=\"autogenerated-content\">[link]</a>\n<div data-type=\"note\" id=\"fs-idm79914448\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p id=\"fs-idm91425440\"><span
+        data-type=\"term\">[Grasp Check]</span>\nAnswer: After the person stops pushing
+        the box, no force is applied to the right, but the friction force remains,
+        which acts to the left. Therefore, the net force acts to the left.</p>\n\n</div>\n\n  </p></div></div></div></section>\n<section
+        data-depth=\"1\" id=\"eip-305\" class=\"summary ost-reading-discard\"><h1
+        data-type=\"title\">Section Summary</h1><p id=\"eip-idm44169728\"><span data-type=\"list\"
+        data-list-type=\"bulleted\" id=\"eip-idm85549552\"><span data-type=\"item\">Newton&#8217;s
+        first law states that a body at rest remains at rest or, if moving, remains
+        in motion in a straight line at a constant speed unless acted on by a net
+        external force. This is also known as the law of inertia.</span>\n<span data-type=\"item\">Inertia
+        is the tendency of an object at rest to remain at rest or, if moving, to remain
+        in motion at constant velocity. Inertia is related to an object&#8217;s mass.</span>\n<span
+        data-type=\"item\">Friction is a force that opposes motion and causes an object
+        or system to slow down.</span>\n<span data-type=\"item\">Mass is the quantity
+        of matter in a substance.</span></span></p></section>\n\n<section data-depth=\"1\"
+        id=\"eip-836\" class=\"key-equations ost-reading-discard\"><h1 data-type=\"title\">Key
+        Equations</h1><table id=\"eip-812\" summary=\"--\"><tbody>\n  <tr>\n    <td>Newton''s
+        first law</td>\n  <td><math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow>\n
+        <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow></annotation-xml></semantics></math>where<math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow></annotation-xml></semantics></math>is a constant</td>\n  </tr>\n  <tr>\n    <td>Newton''s
+        sixth law</td>\n   \n<td><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow></annotation-xml></semantics></math>\n</td>\n  </tr>\n</tbody></table></section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm71187456\" class=\"practice-concepts ost-reading-discard\"><h1
+        data-type=\"title\">Check Your Understanding</h1>\n<div data-type=\"exercise\"
+        id=\"fs-idm20483824\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idp37354336\">\n      <p id=\"fs-idp35901760\"><a href=\"#ost/api/ex/k12phys-ch04-ex035\"
+        class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm51782000\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm30958336\">\n      <p id=\"fs-idm53218240\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex036\" class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n<div
+        data-type=\"exercise\" id=\"eip-idp1259600\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp22780016\"><p id=\"eip-idp10991472\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex037\" class=\"autogenerated-content\">[link]</a></p></div></div>\n<div
+        data-type=\"exercise\" id=\"eip-idp10062848\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp32885104\"><p id=\"eip-idp3387376\"><a href=\"#ost/api/ex/k12phys-ch04-ex038\"
+        class=\"autogenerated-content\">[link]</a></p></div></div></section>\n\n<div
+        data-type=\"note\" id=\"fs-idm112711040\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp9350960\">1. A body at rest tends to remain at
+        rest, and a body in motion tends to remain in motion at a constant velocity
+        unless acted on by a net external force.</p>\n<p id=\"fs-idm68577104\">2.
+        The object experiences a frictional force exerted by the surface, which opposes
+        its motion.</p>\n<p id=\"fs-idm65948736\">3. Inertia is an object&#8217;s
+        tendency to remain at rest or, if moving, to remain in motion at a constant
+        velocity. Inertia may also be described as the tendency of objects to maintain
+        their state of motion.</p>\n<p id=\"fs-idm56412736\">4. Mass is the quantity
+        of substance contained in matter. It depends on the number and type of atoms
+        in the matter.</p>\n</div>\n\n\n<div data-type=\"note\" id=\"fs-idm98755648\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"fs-idm111298272\">1.
+        <em data-effect=\"italics\">F</em><sub>net</sub> = 0</p><p id=\"fs-idm7398128\">2.
+        Friction is an external force that opposes the direction of motion of system.</p>\n<p
+        id=\"fs-idm91191728\">3. The quality of the surface&#8212;whether it is smooth
+        or rough</p>\n<p id=\"fs-idm85688352\">4. There is negligible friction between
+        the ice and the skater.</p>\n<p id=\"fs-idm130369856\">5. The inertia of an
+        object is proportional to its mass.</p>\n<p id=\"fs-idm102647072\">6. A system
+        is one or more objects that we wish to study.</p>\n<p id=\"fs-idm127557760\">7.
+        Mass is the quantity of matter contained in an object. Weight is the force
+        exerted by gravity on the object.</p>\n<p id=\"fs-idm23970880\">8. Mass is
+        measured in kilograms. Weight, being a force, is measured in newtons. However,
+        since mass cannot be determined by counting the number of atoms in an object,
+        it is derived from an object&#8217;s weight. Since the force of gravity is
+        almost constant on earth, the mass of an object is often given as the object&#8217;s
+        weight.</p>\n</div>\n\n\n\n<section data-depth=\"1\" id=\"fs-idm56025888\"
+        class=\"ost-reading-discard chapter-review concept\"><h1 data-type=\"title\">Concept
+        Items</h1><div data-type=\"exercise\" id=\"fs-idm65070096\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"fs-idp2435696\">\n      <p id=\"fs-idm60009600\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex047\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div><div
+        data-type=\"exercise\" id=\"fs-idm36770368\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm46629456\">\n      <p id=\"fs-idm27882848\"><a href=\"#ost/api/ex/k12phys-ch04-ex048\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n</section>\n\n\n\n<section
+        data-depth=\"1\" id=\"fs-idp15971072\" class=\"ost-reading-discard chapter-review
+        critical-thinking\"><h1 data-type=\"title\">Critical Thinking Items</h1><div
+        data-type=\"exercise\" id=\"fs-idp69697408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp55256064\">\n      <p id=\"fs-idp47204912\"><a href=\"#ost/api/ex/k12phys-ch04-ex053\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idp19674432\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp88556720\">\n      <p id=\"fs-idp38044752\"><a href=\"#ost/api/ex/k12phys-ch04-ex054\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idp48658432\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp12698432\">1. Less than (F1 + F2). The net force
+        will include a component of friction which will act in the direction opposite
+        to F1 and F2 and cancel part of these forces.</p>\n<p id=\"fs-idm10442672\">2.
+        Yes</p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idp5033136\" class=\"ost-reading-discard
+        test-prep multiple-choice\"><h1 data-type=\"title\">Test Prep Multiple Choice</h1><div
+        data-type=\"exercise\" id=\"fs-idp2931856\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm2415664\">\n      <p id=\"fs-idm1515712\"><a href=\"#ost/api/ex/k12phys-ch04-ex059\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm84911568\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm24438496\">\n      <p id=\"fs-idm95346960\"><a href=\"#ost/api/ex/k12phys-ch04-ex060\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idm15918336\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp42241296\">1. a) external </p>\n<p id=\"fs-idp63672752\">2.
+        b) law of inertia </p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idm53317184\"
+        class=\"ost-reading-discard test-prep short-answer\"><h1 data-type=\"title\">Test
+        Prep Short Answer</h1><div data-type=\"exercise\" id=\"fs-idm70263744\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm36001280\">\n      <p id=\"fs-idm58066816\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex061\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm79253408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm86468464\">\n      <p id=\"fs-idm52047952\"><a href=\"#ost/api/ex/k12phys-ch04-ex062\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp13927648\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp79608864\">\n      <p id=\"eip-idp64692080\"><a href=\"#ost/api/ex/k12phys-ch04-ex063\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp116624608\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp60936864\">\n      <p id=\"eip-idp34200800\"><a href=\"#ost/api/ex/k12phys-ch04-ex064\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp16574176\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp25075952\">\n<figure id=\"fs-idp45771152\"><figcaption>Arrow pointing
+        right, labeled F and smaller arrow pointing right labeled f</figcaption><span
+        data-type=\"media\" id=\"fs-idp66161920\" data-alt=\"Alt text\"><img src=\"/resources/79879c1d01fccc75a43f8d273fe59ac7/Figure_04_02_force_img.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></p>\n<p
+        id=\"fs-idp6971456\">2. The mass of the first object is less than that of
+        the second.</p>\n<p id=\"fs-idp24341232\">3. You could give each box a push
+        by applying the same amount of force. Whichever box accelerates faster is
+        lighter and so must be the empty box.</p>\n<p id=\"fs-idp23864352\">4. Yes</p>\n</div>\n</section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm72523760\" class=\"ost-reading-discard test-prep
+        extended-response\"><h1 data-type=\"title\">Test Prep Extended Response</h1><div
+        data-type=\"exercise\" id=\"fs-idm96811744\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm79488864\">\n      <p id=\"fs-idm116137648\"><a href=\"#ost/api/ex/k12phys-ch04-ex065\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idm37073488\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm35798256\">\n      <p id=\"fs-idm28998864\"><a href=\"#ost/api/ex/k12phys-ch04-ex066\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp64139392\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp50449808\">1. Not necessarily; if both are thrown at different
+        angles, they will travel different distances.</p>\n<p id=\"fs-idp47745568\">2.
+        The person is no longer applying force when the box is sliding freely. The
+        box is moving because of its own inertia. The only force acting on it is the
+        force of friction which acts from right to left. Thus, the direction of the
+        net external force is to the left.</p>\n</div>\n\n</section>\n<div data-type=\"glossary\"><h2>Glossary</h2>\n<div
+        data-type=\"definition\" id=\"fs-idp38390880\"><span data-type=\"term\">friction</span><div
+        data-type=\"meaning\" id=\"fs-idp69363104\">an external force that acts in
+        the direction opposite to the direction of motion</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp32901536\"><span data-type=\"term\">inertia</span><div data-type=\"meaning\"
+        id=\"fs-idp2280640\">the tendency of an object at rest to remain at rest or
+        for a moving object to remain in motion in a straight line and at constant
+        speed&#8212;MATH</div></div>\n<div data-type=\"definition\" id=\"fs-idp22688960\"><span
+        data-type=\"term\">law of inertia</span><div data-type=\"meaning\" id=\"fs-idp26210592\">Newton&#8217;s
+        first law of motion: a body at rest remains at rest or, if in motion, remains
+        in motion at a constant speed in a straight line unless acted on by a net
+        external force; also known as the law of inertia</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp76765280\"><span data-type=\"term\">mass</span><div data-type=\"meaning\"
+        id=\"fs-idp90674960\">the quantity of matter in a substance; measured in kilograms</div></div>\n<div
+        data-type=\"definition\" id=\"fs-idp42413872\"><span data-type=\"term\">Newton''s
+        first law of motion</span><div data-type=\"meaning\" id=\"fs-idp33729328\">a
+        body at rest remains at rest or, if in motion, remains in motion at a constant
+        speed in a straight line unless acted on by a net external force; also known
+        as the law of inertia</div></div>\n<div data-type=\"definition\" id=\"fs-idp59393232\"><span
+        data-type=\"term\">system</span><div data-type=\"meaning\" id=\"fs-idp77789136\">one
+        or more objects of interest for which only the forces acting on them from
+        the outside are considered but not the forces acting between them or inside
+        of them</div></div>\n</div></body>\n\n</html>", "subjects": ["Mathematics
+        and Statistics"], "legacy_id": "m53227", "parentId": null, "stateid": 1, "parentTitle":
+        null, "maintainers": [{"website": "", "surname": "Slavik", "suffix": "", "firstname":
+        "Alina", "title": "", "othername": "", "email": "alinams@rice.edu", "fullname":
+        "Alina Slavik", "id": "AlinaManager"}], "authors": [{"website": "", "surname":
+        "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername": "",
+        "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "parentVersion": "", "legacy_version": "1.4", "licensors": [{"website": "",
+        "surname": "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername":
+        "", "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "license": {"url": "http://creativecommons.org/licenses/by/4.0/", "code":
+        "by", "version": "4.0", "name": "Creative Commons Attribution License"}, "language":
+        "en", "created": "2015-03-11T18:32:11Z", "doctype": "", "buyLink": null, "submitter":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}, "parentAuthors": [], "history": [{"changes": "imported
+        from staging3", "version": "4", "revised": "2015-03-16T16:00:23Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "switched sim link; added width and height
+        attribute", "version": "3", "revised": "2015-03-11T21:28:30Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "retitled module", "version": "2", "revised":
+        "2015-03-11T18:40:21Z", "publisher": {"website": "", "surname": "Slavik",
+        "suffix": "", "firstname": "Alina", "title": "", "othername": "", "email":
+        "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}}, {"changes":
+        "imported module", "version": "1", "revised": "2015-03-11T18:36:37Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 10:32:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/OpenStax_Cnx_V1_Fragment_Video/can_retrieve_the_fragment_s_video_url.yml
+++ b/spec/cassettes/OpenStax_Cnx_V1_Fragment_Video/can_retrieve_the_fragment_s_video_url.yml
@@ -1,0 +1,558 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain
+      Location:
+      - "/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4"
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (pass - status > 300, not content)
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 10:32:42 GMT
+      X-Varnish:
+      - '172894880'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Varnish-Age:
+      - '0'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 10:32:39 GMT
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (override - archive contents)
+      X-Factor-Ttl:
+      - 'ttl: 604800.000'
+      Content-Length:
+      - '38216'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 10:32:43 GMT
+      X-Varnish:
+      - 172894882 170915691
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - HIT
+      X-Varnish-Age:
+      - '217786'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"googleAnalytics": null, "version": "4", "submitlog": "imported from
+        staging3", "abstract": null, "revised": "2015-03-16T16:00:23Z", "roles": null,
+        "keywords": [], "id": "61445f78-00e2-45ae-8e2c-461b17d9b4fd", "title": "Newton''s
+        First Law of Motion: Inertia", "mediaType": "application/vnd.org.cnx.module",
+        "content": "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head xmlns:c=\"http://cnx.rice.edu/cnxml\"
+        xmlns:md=\"http://cnx.rice.edu/mdml\"><title>Newton''s First Law of Motion:
+        Inertia</title><meta name=\"created-time\" content=\"2015/03/11 13:32:11 -0500\"/><meta
+        name=\"revised-time\" content=\"2015/03/16 11:00:23.682 GMT-5\"/><meta name=\"author\"
+        content=\"AlinaManager\"/><meta name=\"acl-list\" content=\"AlinaManager\"/><meta
+        name=\"licensor\" content=\"AlinaManager\"/><meta name=\"license\" content=\"http://creativecommons.org/licenses/by/4.0/\"/><meta
+        name=\"subject\" content=\"Mathematics and Statistics\"/></head>\n\n<body
+        xmlns:c=\"http://cnx.rice.edu/cnxml\" xmlns:md=\"http://cnx.rice.edu/mdml\"
+        xmlns:qml=\"http://cnx.rice.edu/qml/1.0\" xmlns:mod=\"http://cnx.rice.edu/#moduleIds\"
+        xmlns:bib=\"http://bibtexml.sf.net/\" xmlns:data=\"http://dev.w3.org/html5/spec/#custom\"><div
+        data-type=\"document-title\">Newton''s First Law of Motion: Inertia</div>\n  <section
+        data-depth=\"1\" id=\"fs-idp17120160\" class=\"learning-objectives\"><h1 data-type=\"title\">Section
+        Learning Objectives</h1><p id=\"eip-795\">By the end of this section you will
+        be able to: <span data-type=\"list\" data-list-type=\"bulleted\" id=\"eip-idp58500736\"><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-teks-112-39-c-4d\"> Describe Newton''s first law and friction <math
+        xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math></span><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-teks-112-39-c-4d\"> Discuss the relationship between mass and inertia</span></span></p></section>\n\n<div
+        data-type=\"note\" id=\"eip-887\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\"><p id=\"eip-idm12575088\">The Learning Objectives in this section
+        will help your students master the following TEKS: (4) Science concepts. The
+        student knows and applies the laws governing motion in a variety of situations.
+        The student is expected to: \n<span data-type=\"list\" data-list-type=\"bulleted\"
+        id=\"fs-idp60294944\">\n<span data-type=\"item\" class=\"ost-standards-def
+        ost-standards-teks\"><span class=\"ost-standards-name\">(4D)</span><span class=\"ost-standards-discard\">:</span><span
+        class=\"ost-standards-description ost-tag-teks-112-39-c-4d\">calculate the
+        effect of forces on objects, including the law of inertia, the relationship
+        between force and acceleration, and the nature of force pairs between objects</span></span></span></p></div>\n\n<table
+        id=\"eip-850\" summary=\"--\" class=\"key-terms ost-reading-discard\"><caption><span
+        data-type=\"title\">Section Key Terms</span></caption><tbody>\n  <tr>\n    <td>friction</td>\n    <td>inertia</td>\n    <td>law
+        of inertia</td>\n  </tr>\n  <tr>\n    <td>mass</td>\n    <td>Newton''s first
+        law of motion</td>\n    <td>system</td>\n  </tr>\n</tbody></table><div data-type=\"note\"
+        id=\"eip-456\" class=\"os-teacher\" data-label=\"Teacher Edition\"><p id=\"eip-idm59591792\">Before
+        students begin this section, it is useful to review the concepts of force,
+        external force, net external force, and addition of forces.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> <span
+        class=\"level-above\">[AL]</span> Ask students to speculate what happens to
+        objects when they are set in motion. Do they remain in motion or stop after
+        some time? Why?</p><div data-type=\"note\" id=\"eip-idm108977584\" class=\"tip
+        misconception\" data-label=\"Misconception Alert\">\nStudents may believe
+        that objects that are in motion tend to slow down and stop. Explain the concept
+        of friction. Talk about objects in outer space, where there is no atmosphere
+        and no gravity. Ask students to describe the motion of such objects.</div></div>\n\n<section
+        data-depth=\"1\" id=\"eip-201\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><h1
+        data-type=\"title\">Newton''s First Law and Friction</h1><p id=\"eip-708\"><span
+        data-type=\"term\">Newton''s first law of motion</span> states that:</p><ol
+        id=\"eip-idp55249424\"><li>A body at rest tends to stay at rest <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        (<a href=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm\">http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm</a>)</li>\n<li>A
+        body in motion tends to remain in motion at constant velocity unless acted
+        on by a net external force (recall that &#8220;constant velocity&#8221; means
+        in a straight line and at constant speed). <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </li>\n</ol>\n\n<section data-depth=\"2\" id=\"eip-241\"><h2 data-type=\"title\">Newton''s
+        1<sup>st</sup> Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><div data-type=\"note\" id=\"eip-659\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n<p id=\"eip-idm30448560\"><span class=\"level-below\">[BL]</span>\n<span
+        class=\"level-on\">[OL]</span>\n<span class=\"level-above\">[AL]</span> Discuss
+        examples of Newton&#8217;s First Law seen in everyday life. <div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Talk about different pairs of surfaces and
+        how each exhibits different levels of friction. Ask students to give examples
+        of smooth and rough surfaces. Ask them where friction may be useful and where
+        it may be undesirable. <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Ask students to give different examples
+        of systems where multiple forces occur. Draw free-body diagrams for these.
+        Include the force of friction. Emphasize the direction of the force of friction.</p></div>\n\n<p
+        id=\"eip-545\">At first glance, this law may seem to contradict your everyday
+        experience. You have probably noticed that a moving object will usually slow
+        down and stop unless some effort is made to keep it moving. The key to understanding
+        why, for example, a sliding box slows down (seemingly on its own) is that
+        a net external force acts on it to make it slow down. Without this net external
+        force, the box would continue to slide at a constant velocity (as stated in
+        Newton&#8217;s first law of motion). What force acts on the box to slow it
+        down? It is called <span data-type=\"term\">friction</span>. Friction is an
+        external force that acts opposite to the direction of motion (see <a href=\"#eip-idm20864848\"
+        class=\"autogenerated-content\">[link]</a>). Think of it as a resistance to
+        motion that slows things down.</p><p id=\"eip-66\">Friction:</p>\n\n<ol id=\"eip-idp86047488\"
+        data-number-style=\"arabic\"><li>Goes in the opposite direction<span data-type=\"media\"
+        id=\"eip-idm63937136\" data-alt=\"Alt text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></li>\n<li>Causes
+        an object to slow down <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a></li></ol></section>\n\n<section
+        data-depth=\"2\" id=\"eip-495\"><h2 data-type=\"title\">Newton''s 1<sup>st</sup>
+        Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><p id=\"eip-370\">Consider an air hockey table. When the air is turned
+        off, the puck slides only a short distance before friction slows it to a stop.
+        However, when the air is turned on, it lifts the puck slightly so that the
+        puck experiences very little friction as it moves over the surface. With friction
+        almost eliminated, the puck glides along with very little change in speed.
+        On a frictionless surface, the puck would experience no net external force
+        (ignoring air resistance, which is also a form of friction). Additionally,
+        if we know enough about friction, we can accurately predict how quickly objects
+        will slow down.</p>\n\n<p id=\"eip-114\">Now let&#8217;s think about another
+        example. A man pushes a box across a floor at constant velocity by applying
+        a force of +50 N (the positive sign indicates by convention that the direction
+        of motion is to the right). What is the force of friction that opposes the
+        motion? The force of friction must be &#8722;50 N. Why? According to Newton&#8217;s
+        first law of motion, any object moving at constant velocity has no net external
+        force acting upon it, which means that the sum of the forces acting on the
+        object must be zero. The mathematical way to say that no net external force
+        acts on an object is <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        , or <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        . So if the man applies +50 N of force, then the force of friction must be
+        &#8722;50 N for the two forces to add up to zero (i.e., &#8220;cancel&#8221;
+        each other). Whenever you encounter the phrase &#8220;at constant velocity,&#8221;
+        Newton&#8217;s first law tells you that the net external force is zero.</p><figure
+        id=\"eip-idm83000688\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>For
+        a box sliding across a floor, friction acts in the direction opposite to the
+        velocity.</figcaption><span data-type=\"media\" id=\"eip-idm83879248\" data-alt=\"Alt
+        text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure><p id=\"eip-985\">The
+        force of friction depends on two things: the coefficient of friction and the
+        normal force. The coefficient of friction is a constant that depends on the
+        nature of the surfaces in contact with one another. The normal force is the
+        force exerted by a surface that pushes on an object in response to gravity
+        pulling the object down. In equation form, the force of friction is <div data-type=\"equation\"
+        id=\"eip-idp12074176\" class=\"unnumbered\" data-label=\"\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"block\"><semantics><mrow><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></annotation-xml></semantics></math></div>where
+        &#956; is the coefficient of friction and N is the normal force. The coefficient
+        of friction is discussed in more detail in the next chapter and the normal
+        force is discussed in more detail in section four of this chapter.\n</p><p
+        id=\"eip-89\">Recall from section one that a net external force acts from
+        outside on the object of interest. A more precise definition is that it acts
+        on the <span data-type=\"term\">system</span> of interest. A system is one
+        or more objects that you choose to study. It is important to define the system
+        at the beginning of a problem to figure out which forces are external and
+        need to be considered and which are internal and can be ignored.</p><p id=\"eip-826\">For
+        example, in <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        (a), two children push a third child in a wagon at constant velocity. The
+        system of interest is the wagon plus the small child shown in part b of the
+        figure. The two children behind the wagon exert external forces on this system
+        (<em data-effect=\"italics\">F</em><sub>1</sub>, <em data-effect=\"italics\">F</em><sub>2</sub>).
+        Friction <em data-effect=\"italics\">f</em> acting at the axles of the wheels
+        and at the surface where the wheels touch the ground is another external force
+        acting on the system. Two more external forces act on the system: the weight
+        <em data-effect=\"italics\">W</em> of the system pulling down and the normal
+        force <em data-effect=\"italics\">N</em> of the ground pushing up. Notice
+        that the wagon is not accelerating vertically, so Newton&#8217;s first law
+        tells us that the normal force balances the weight. Because the wagon is moving
+        forward at constant velocity, then the force of friction must have the same
+        strength as the sum of the forces applied by the two children.</p><figure
+        id=\"eip-idm20864848\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>(a)
+        The wagon and rider form a &#8220;system&#8221; that is acted on by external
+        forces. (b)The two children pushing the wagon and child provide two external
+        forces. Friction acting at the wheel axles and on the surface of the tires
+        where they touch the ground provides an external force that acts against the
+        direction of motion. The weight <em data-effect=\"italics\">W</em> and the
+        normal force <em data-effect=\"italics\">N</em> from the ground are two more
+        external forces acting on the system. All external forces are represented
+        in the figure by arrows. All of the external forces acting on the system add
+        together, but because the wagon moves at a constant velocity, all the forces
+        must add up to zero.</figcaption><span data-type=\"media\" id=\"eip-idp5554688\"
+        data-alt=\"Alt text\"><img src=\"/resources/8c943f2ce4ca3d9a0a429e8a3d3f3c00/Figure_04_02_wagon.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></section></section>\n\n<section
+        data-depth=\"1\" id=\"eip-304\" class=\"ost-tag-lo-k12phys-ch04-s02-lo02\"><h1
+        data-type=\"title\">Mass and Inertia</h1>\n\n<div data-type=\"note\" id=\"eip-715\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"eip-idm26334000\"><span
+        class=\"level-below\">[BL]</span> Review Newton&#8217;s First Law. Explain
+        that the property of objects to maintain their state of motion is called inertia.
+        <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>
+        <span class=\"level-above\">[AL]</span> Take two similar carts or trolleys
+        with wheels. Place a heavy weight in one of them. Ask students which cart
+        would require more force to change its state of motion. Ask students which
+        would stay in motion longer if you were to set them in motion. Based on this
+        discussion, have students speculate what inertia may depend on.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> Explain
+        the concepts of mass and weight. Explain that these terms may be used interchangeably
+        in everyday life but have different meanings in science.</p></div>\n\n<p id=\"eip-613\"><span
+        data-type=\"term\">Inertia</span> is the tendency for an object at rest to
+        remain at rest or for a moving object to remain in motion in a straight line
+        with constant speed. This key property of objects was first described by Galileo.
+        Later, Newton incorporated the concept of inertia into his first law, which
+        is often referred to as the <span data-type=\"term\">law of inertia</span>.</p><p
+        id=\"eip-36\">As we know from experience, some objects have more inertia than
+        others. For example, changing the motion of a large truck is more difficult
+        than changing the motion of a toy truck. In fact, the inertia of an object
+        is proportional to the mass of the object. <span data-type=\"term\">Mass</span>
+        is a measure of the amount of matter (or &#8220;stuff&#8221;) in something.
+        The quantity or amount of matter in an object is determined by the number
+        and type of atoms it contains. Unlike weight (which changes if the gravitational
+        force changes), mass does not depend on gravity. The mass of an object is
+        the same on Earth, in orbit, or on the surface of the Moon. In practice, it
+        is very difficult to count and identify all of the atoms and molecules in
+        an object, so mass is usually not determined this way. Instead, the mass of
+        an object is determined by comparing it with the standard kilogram. Mass is
+        therefore expressed in kilograms.</p>\n\n<div data-type=\"note\" id=\"eip-idm961296\"
+        class=\"tip tips-for-success\" data-label=\"Tips for Success\">In everyday
+        language, people often use the terms weight and mass interchangeably&#8212;but
+        this is not correct. Weight is actually a force (we cover this in more detail
+        in section three).</div>\n\n<div data-type=\"note\" id=\"eip-231\" class=\"ost-assessed-feature
+        ost-video ost-tag-lo-k12phys-ch04-s02-lo02 watch-physics\" data-label=\"Watch
+        Physics\"><div data-type=\"title\">Newton&#8217;s first law of motion</div>
+        \n<p id=\"eip-idp1646512\">This <a href=\"https://www.khanacademy.org/science/physics/forces-newtons-laws/newtons-laws-of-motion/v/newton-s-1st-law-of-motion\"
+        class=\"os-embed\">video</a> contrasts the way we thought about motion and
+        force in the time before Galileo&#8217;s concept of inertia and <span data-type=\"term\">Newton&#8217;s
+        first law of motion</span> with the way we understand force and motion now.
+        Refer to <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        as you watch.\n</p>\n\n<ol id=\"eip-idp19850304\"><li>Galileo&#8217;s concepts<ol
+        id=\"eip-idp10164288\" data-number-style=\"lower-alpha\"><li>Things just come
+        to a stop</li><li>Forces don&#8217;t act against objects</li></ol></li><li>Newton&#8217;s
+        concepts<ol id=\"eip-idp5872736\" data-number-style=\"lower-alpha\"><li>Objects
+        will continue at the same speed if no opposing force</li><li>Weight is a force
+        acting against an object.</li></ol></li></ol>\n\n <div data-type=\"exercise\"
+        id=\"eip-idp413824\" class=\"os-exercise grasp-check\"><div data-type=\"problem\"
+        id=\"eip-idm76540272\">\n    <p id=\"eip-idm99866096\"><a href=\"#ost/api/ex/k12phys-ch04-ex033\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div></div><div data-type=\"note\"
+        id=\"eip-837\" class=\"os-teacher\" data-label=\"Teacher Edition\">Answer:
+        Friction</div></div>\n\n<div data-type=\"note\" id=\"fs-idm38320288\" class=\"ost-assessed-feature
+        ost-interactive virtual-physics ost-tag-lo-k12phys-ch04-s02-lo02\" data-label=\"Virtual
+        Physics\"><div data-type=\"title\">Forces and Motion: Basics</div>\n\n<p id=\"fs-idp34383024\">In
+        this simulation, you will first explore net force by placing blue people on
+        the left side of a tug of war rope and red people on the right side of the
+        rope (by clicking people and dragging them with your mouse). Experiment with
+        changing the number and size of people on each side to see how it affects
+        the outcome of the match and the net force. Hit the Go! button to start the
+        match, and the &#8220;reset all&#8221; button to start over.</p><ol id=\"fs-idp48496992\"
+        data-number-style=\"lower-alpha\"><li>The side with the most force wins</li><li>The
+        bigger the difference in the force, the easier it is for one side to win.</li><li>When
+        force is equal, no one wins.</li></ol><p id=\"fs-idp52126304\">Next, click
+        on the Friction tab. Try selecting different objects for the person to push.
+        Slide the applied force button to the right to apply force to the right and
+        to the left to apply force to the left. The force will continue to be applied
+        as long as you hold the button down. See the arrow representing friction change
+        in magnitude and direction depending on how much force you apply. Try increasing
+        or decreasing the friction force to see how this affects the motion.</p>\n<div
+        data-type=\"media\" id=\"fs-idp5640912\" class=\"os-embed\" data-alt=\" \">
+        <iframe width=\"960\" height=\"785\" src=\"http://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/\"/></div>\n\n  <div
+        data-type=\"exercise\" id=\"fs-idm56919408\" class=\"os-exercise grasp-check\"><div
+        data-type=\"problem\" id=\"fs-idm68103760\"><p id=\"fs-idm17001808\"><a href=\"#ost/api/ex/k12phys-ch04-ex034\"
+        class=\"autogenerated-content\">[link]</a>\n<div data-type=\"note\" id=\"fs-idm79914448\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p id=\"fs-idm91425440\"><span
+        data-type=\"term\">[Grasp Check]</span>\nAnswer: After the person stops pushing
+        the box, no force is applied to the right, but the friction force remains,
+        which acts to the left. Therefore, the net force acts to the left.</p>\n\n</div>\n\n  </p></div></div></div></section>\n<section
+        data-depth=\"1\" id=\"eip-305\" class=\"summary ost-reading-discard\"><h1
+        data-type=\"title\">Section Summary</h1><p id=\"eip-idm44169728\"><span data-type=\"list\"
+        data-list-type=\"bulleted\" id=\"eip-idm85549552\"><span data-type=\"item\">Newton&#8217;s
+        first law states that a body at rest remains at rest or, if moving, remains
+        in motion in a straight line at a constant speed unless acted on by a net
+        external force. This is also known as the law of inertia.</span>\n<span data-type=\"item\">Inertia
+        is the tendency of an object at rest to remain at rest or, if moving, to remain
+        in motion at constant velocity. Inertia is related to an object&#8217;s mass.</span>\n<span
+        data-type=\"item\">Friction is a force that opposes motion and causes an object
+        or system to slow down.</span>\n<span data-type=\"item\">Mass is the quantity
+        of matter in a substance.</span></span></p></section>\n\n<section data-depth=\"1\"
+        id=\"eip-836\" class=\"key-equations ost-reading-discard\"><h1 data-type=\"title\">Key
+        Equations</h1><table id=\"eip-812\" summary=\"--\"><tbody>\n  <tr>\n    <td>Newton''s
+        first law</td>\n  <td><math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow>\n
+        <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow></annotation-xml></semantics></math>where<math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow></annotation-xml></semantics></math>is a constant</td>\n  </tr>\n  <tr>\n    <td>Newton''s
+        sixth law</td>\n   \n<td><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow></annotation-xml></semantics></math>\n</td>\n  </tr>\n</tbody></table></section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm71187456\" class=\"practice-concepts ost-reading-discard\"><h1
+        data-type=\"title\">Check Your Understanding</h1>\n<div data-type=\"exercise\"
+        id=\"fs-idm20483824\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idp37354336\">\n      <p id=\"fs-idp35901760\"><a href=\"#ost/api/ex/k12phys-ch04-ex035\"
+        class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm51782000\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm30958336\">\n      <p id=\"fs-idm53218240\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex036\" class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n<div
+        data-type=\"exercise\" id=\"eip-idp1259600\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp22780016\"><p id=\"eip-idp10991472\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex037\" class=\"autogenerated-content\">[link]</a></p></div></div>\n<div
+        data-type=\"exercise\" id=\"eip-idp10062848\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp32885104\"><p id=\"eip-idp3387376\"><a href=\"#ost/api/ex/k12phys-ch04-ex038\"
+        class=\"autogenerated-content\">[link]</a></p></div></div></section>\n\n<div
+        data-type=\"note\" id=\"fs-idm112711040\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp9350960\">1. A body at rest tends to remain at
+        rest, and a body in motion tends to remain in motion at a constant velocity
+        unless acted on by a net external force.</p>\n<p id=\"fs-idm68577104\">2.
+        The object experiences a frictional force exerted by the surface, which opposes
+        its motion.</p>\n<p id=\"fs-idm65948736\">3. Inertia is an object&#8217;s
+        tendency to remain at rest or, if moving, to remain in motion at a constant
+        velocity. Inertia may also be described as the tendency of objects to maintain
+        their state of motion.</p>\n<p id=\"fs-idm56412736\">4. Mass is the quantity
+        of substance contained in matter. It depends on the number and type of atoms
+        in the matter.</p>\n</div>\n\n\n<div data-type=\"note\" id=\"fs-idm98755648\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"fs-idm111298272\">1.
+        <em data-effect=\"italics\">F</em><sub>net</sub> = 0</p><p id=\"fs-idm7398128\">2.
+        Friction is an external force that opposes the direction of motion of system.</p>\n<p
+        id=\"fs-idm91191728\">3. The quality of the surface&#8212;whether it is smooth
+        or rough</p>\n<p id=\"fs-idm85688352\">4. There is negligible friction between
+        the ice and the skater.</p>\n<p id=\"fs-idm130369856\">5. The inertia of an
+        object is proportional to its mass.</p>\n<p id=\"fs-idm102647072\">6. A system
+        is one or more objects that we wish to study.</p>\n<p id=\"fs-idm127557760\">7.
+        Mass is the quantity of matter contained in an object. Weight is the force
+        exerted by gravity on the object.</p>\n<p id=\"fs-idm23970880\">8. Mass is
+        measured in kilograms. Weight, being a force, is measured in newtons. However,
+        since mass cannot be determined by counting the number of atoms in an object,
+        it is derived from an object&#8217;s weight. Since the force of gravity is
+        almost constant on earth, the mass of an object is often given as the object&#8217;s
+        weight.</p>\n</div>\n\n\n\n<section data-depth=\"1\" id=\"fs-idm56025888\"
+        class=\"ost-reading-discard chapter-review concept\"><h1 data-type=\"title\">Concept
+        Items</h1><div data-type=\"exercise\" id=\"fs-idm65070096\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"fs-idp2435696\">\n      <p id=\"fs-idm60009600\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex047\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div><div
+        data-type=\"exercise\" id=\"fs-idm36770368\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm46629456\">\n      <p id=\"fs-idm27882848\"><a href=\"#ost/api/ex/k12phys-ch04-ex048\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n</section>\n\n\n\n<section
+        data-depth=\"1\" id=\"fs-idp15971072\" class=\"ost-reading-discard chapter-review
+        critical-thinking\"><h1 data-type=\"title\">Critical Thinking Items</h1><div
+        data-type=\"exercise\" id=\"fs-idp69697408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp55256064\">\n      <p id=\"fs-idp47204912\"><a href=\"#ost/api/ex/k12phys-ch04-ex053\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idp19674432\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp88556720\">\n      <p id=\"fs-idp38044752\"><a href=\"#ost/api/ex/k12phys-ch04-ex054\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idp48658432\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp12698432\">1. Less than (F1 + F2). The net force
+        will include a component of friction which will act in the direction opposite
+        to F1 and F2 and cancel part of these forces.</p>\n<p id=\"fs-idm10442672\">2.
+        Yes</p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idp5033136\" class=\"ost-reading-discard
+        test-prep multiple-choice\"><h1 data-type=\"title\">Test Prep Multiple Choice</h1><div
+        data-type=\"exercise\" id=\"fs-idp2931856\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm2415664\">\n      <p id=\"fs-idm1515712\"><a href=\"#ost/api/ex/k12phys-ch04-ex059\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm84911568\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm24438496\">\n      <p id=\"fs-idm95346960\"><a href=\"#ost/api/ex/k12phys-ch04-ex060\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idm15918336\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp42241296\">1. a) external </p>\n<p id=\"fs-idp63672752\">2.
+        b) law of inertia </p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idm53317184\"
+        class=\"ost-reading-discard test-prep short-answer\"><h1 data-type=\"title\">Test
+        Prep Short Answer</h1><div data-type=\"exercise\" id=\"fs-idm70263744\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm36001280\">\n      <p id=\"fs-idm58066816\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex061\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm79253408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm86468464\">\n      <p id=\"fs-idm52047952\"><a href=\"#ost/api/ex/k12phys-ch04-ex062\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp13927648\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp79608864\">\n      <p id=\"eip-idp64692080\"><a href=\"#ost/api/ex/k12phys-ch04-ex063\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp116624608\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp60936864\">\n      <p id=\"eip-idp34200800\"><a href=\"#ost/api/ex/k12phys-ch04-ex064\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp16574176\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp25075952\">\n<figure id=\"fs-idp45771152\"><figcaption>Arrow pointing
+        right, labeled F and smaller arrow pointing right labeled f</figcaption><span
+        data-type=\"media\" id=\"fs-idp66161920\" data-alt=\"Alt text\"><img src=\"/resources/79879c1d01fccc75a43f8d273fe59ac7/Figure_04_02_force_img.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></p>\n<p
+        id=\"fs-idp6971456\">2. The mass of the first object is less than that of
+        the second.</p>\n<p id=\"fs-idp24341232\">3. You could give each box a push
+        by applying the same amount of force. Whichever box accelerates faster is
+        lighter and so must be the empty box.</p>\n<p id=\"fs-idp23864352\">4. Yes</p>\n</div>\n</section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm72523760\" class=\"ost-reading-discard test-prep
+        extended-response\"><h1 data-type=\"title\">Test Prep Extended Response</h1><div
+        data-type=\"exercise\" id=\"fs-idm96811744\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm79488864\">\n      <p id=\"fs-idm116137648\"><a href=\"#ost/api/ex/k12phys-ch04-ex065\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idm37073488\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm35798256\">\n      <p id=\"fs-idm28998864\"><a href=\"#ost/api/ex/k12phys-ch04-ex066\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp64139392\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp50449808\">1. Not necessarily; if both are thrown at different
+        angles, they will travel different distances.</p>\n<p id=\"fs-idp47745568\">2.
+        The person is no longer applying force when the box is sliding freely. The
+        box is moving because of its own inertia. The only force acting on it is the
+        force of friction which acts from right to left. Thus, the direction of the
+        net external force is to the left.</p>\n</div>\n\n</section>\n<div data-type=\"glossary\"><h2>Glossary</h2>\n<div
+        data-type=\"definition\" id=\"fs-idp38390880\"><span data-type=\"term\">friction</span><div
+        data-type=\"meaning\" id=\"fs-idp69363104\">an external force that acts in
+        the direction opposite to the direction of motion</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp32901536\"><span data-type=\"term\">inertia</span><div data-type=\"meaning\"
+        id=\"fs-idp2280640\">the tendency of an object at rest to remain at rest or
+        for a moving object to remain in motion in a straight line and at constant
+        speed&#8212;MATH</div></div>\n<div data-type=\"definition\" id=\"fs-idp22688960\"><span
+        data-type=\"term\">law of inertia</span><div data-type=\"meaning\" id=\"fs-idp26210592\">Newton&#8217;s
+        first law of motion: a body at rest remains at rest or, if in motion, remains
+        in motion at a constant speed in a straight line unless acted on by a net
+        external force; also known as the law of inertia</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp76765280\"><span data-type=\"term\">mass</span><div data-type=\"meaning\"
+        id=\"fs-idp90674960\">the quantity of matter in a substance; measured in kilograms</div></div>\n<div
+        data-type=\"definition\" id=\"fs-idp42413872\"><span data-type=\"term\">Newton''s
+        first law of motion</span><div data-type=\"meaning\" id=\"fs-idp33729328\">a
+        body at rest remains at rest or, if in motion, remains in motion at a constant
+        speed in a straight line unless acted on by a net external force; also known
+        as the law of inertia</div></div>\n<div data-type=\"definition\" id=\"fs-idp59393232\"><span
+        data-type=\"term\">system</span><div data-type=\"meaning\" id=\"fs-idp77789136\">one
+        or more objects of interest for which only the forces acting on them from
+        the outside are considered but not the forces acting between them or inside
+        of them</div></div>\n</div></body>\n\n</html>", "subjects": ["Mathematics
+        and Statistics"], "legacy_id": "m53227", "parentId": null, "stateid": 1, "parentTitle":
+        null, "maintainers": [{"website": "", "surname": "Slavik", "suffix": "", "firstname":
+        "Alina", "title": "", "othername": "", "email": "alinams@rice.edu", "fullname":
+        "Alina Slavik", "id": "AlinaManager"}], "authors": [{"website": "", "surname":
+        "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername": "",
+        "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "parentVersion": "", "legacy_version": "1.4", "licensors": [{"website": "",
+        "surname": "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername":
+        "", "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "license": {"url": "http://creativecommons.org/licenses/by/4.0/", "code":
+        "by", "version": "4.0", "name": "Creative Commons Attribution License"}, "language":
+        "en", "created": "2015-03-11T18:32:11Z", "doctype": "", "buyLink": null, "submitter":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}, "parentAuthors": [], "history": [{"changes": "imported
+        from staging3", "version": "4", "revised": "2015-03-16T16:00:23Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "switched sim link; added width and height
+        attribute", "version": "3", "revised": "2015-03-11T21:28:30Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "retitled module", "version": "2", "revised":
+        "2015-03-11T18:40:21Z", "publisher": {"website": "", "surname": "Slavik",
+        "suffix": "", "firstname": "Alina", "title": "", "othername": "", "email":
+        "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}}, {"changes":
+        "imported module", "version": "1", "revised": "2015-03-11T18:36:37Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 10:32:39 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/OpenStax_Cnx_V1_Fragment_Video/provides_info_about_the_video_fragment.yml
+++ b/spec/cassettes/OpenStax_Cnx_V1_Fragment_Video/provides_info_about_the_video_fragment.yml
@@ -1,0 +1,558 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain
+      Location:
+      - "/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4"
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (pass - status > 300, not content)
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 10:32:41 GMT
+      X-Varnish:
+      - '172894868'
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - MISS
+      X-Varnish-Age:
+      - '0'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 10:32:37 GMT
+- request:
+    method: get
+    uri: http://archive.cnx.org/contents/61445f78-00e2-45ae-8e2c-461b17d9b4fd@4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Server:
+      - waitress
+      X-Varnish-Action:
+      - FETCH (override - archive contents)
+      X-Factor-Ttl:
+      - 'ttl: 604800.000'
+      Content-Length:
+      - '38216'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 19 Mar 2015 10:32:41 GMT
+      X-Varnish:
+      - 172894870 170915691
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Cache:
+      - HIT
+      X-Varnish-Age:
+      - '217784'
+      Age:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"googleAnalytics": null, "version": "4", "submitlog": "imported from
+        staging3", "abstract": null, "revised": "2015-03-16T16:00:23Z", "roles": null,
+        "keywords": [], "id": "61445f78-00e2-45ae-8e2c-461b17d9b4fd", "title": "Newton''s
+        First Law of Motion: Inertia", "mediaType": "application/vnd.org.cnx.module",
+        "content": "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head xmlns:c=\"http://cnx.rice.edu/cnxml\"
+        xmlns:md=\"http://cnx.rice.edu/mdml\"><title>Newton''s First Law of Motion:
+        Inertia</title><meta name=\"created-time\" content=\"2015/03/11 13:32:11 -0500\"/><meta
+        name=\"revised-time\" content=\"2015/03/16 11:00:23.682 GMT-5\"/><meta name=\"author\"
+        content=\"AlinaManager\"/><meta name=\"acl-list\" content=\"AlinaManager\"/><meta
+        name=\"licensor\" content=\"AlinaManager\"/><meta name=\"license\" content=\"http://creativecommons.org/licenses/by/4.0/\"/><meta
+        name=\"subject\" content=\"Mathematics and Statistics\"/></head>\n\n<body
+        xmlns:c=\"http://cnx.rice.edu/cnxml\" xmlns:md=\"http://cnx.rice.edu/mdml\"
+        xmlns:qml=\"http://cnx.rice.edu/qml/1.0\" xmlns:mod=\"http://cnx.rice.edu/#moduleIds\"
+        xmlns:bib=\"http://bibtexml.sf.net/\" xmlns:data=\"http://dev.w3.org/html5/spec/#custom\"><div
+        data-type=\"document-title\">Newton''s First Law of Motion: Inertia</div>\n  <section
+        data-depth=\"1\" id=\"fs-idp17120160\" class=\"learning-objectives\"><h1 data-type=\"title\">Section
+        Learning Objectives</h1><p id=\"eip-795\">By the end of this section you will
+        be able to: <span data-type=\"list\" data-list-type=\"bulleted\" id=\"eip-idp58500736\"><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-teks-112-39-c-4d\"> Describe Newton''s first law and friction <math
+        xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math></span><span
+        data-type=\"item\" class=\"ost-learning-objective-def ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-teks-112-39-c-4d\"> Discuss the relationship between mass and inertia</span></span></p></section>\n\n<div
+        data-type=\"note\" id=\"eip-887\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\"><p id=\"eip-idm12575088\">The Learning Objectives in this section
+        will help your students master the following TEKS: (4) Science concepts. The
+        student knows and applies the laws governing motion in a variety of situations.
+        The student is expected to: \n<span data-type=\"list\" data-list-type=\"bulleted\"
+        id=\"fs-idp60294944\">\n<span data-type=\"item\" class=\"ost-standards-def
+        ost-standards-teks\"><span class=\"ost-standards-name\">(4D)</span><span class=\"ost-standards-discard\">:</span><span
+        class=\"ost-standards-description ost-tag-teks-112-39-c-4d\">calculate the
+        effect of forces on objects, including the law of inertia, the relationship
+        between force and acceleration, and the nature of force pairs between objects</span></span></span></p></div>\n\n<table
+        id=\"eip-850\" summary=\"--\" class=\"key-terms ost-reading-discard\"><caption><span
+        data-type=\"title\">Section Key Terms</span></caption><tbody>\n  <tr>\n    <td>friction</td>\n    <td>inertia</td>\n    <td>law
+        of inertia</td>\n  </tr>\n  <tr>\n    <td>mass</td>\n    <td>Newton''s first
+        law of motion</td>\n    <td>system</td>\n  </tr>\n</tbody></table><div data-type=\"note\"
+        id=\"eip-456\" class=\"os-teacher\" data-label=\"Teacher Edition\"><p id=\"eip-idm59591792\">Before
+        students begin this section, it is useful to review the concepts of force,
+        external force, net external force, and addition of forces.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> <span
+        class=\"level-above\">[AL]</span> Ask students to speculate what happens to
+        objects when they are set in motion. Do they remain in motion or stop after
+        some time? Why?</p><div data-type=\"note\" id=\"eip-idm108977584\" class=\"tip
+        misconception\" data-label=\"Misconception Alert\">\nStudents may believe
+        that objects that are in motion tend to slow down and stop. Explain the concept
+        of friction. Talk about objects in outer space, where there is no atmosphere
+        and no gravity. Ask students to describe the motion of such objects.</div></div>\n\n<section
+        data-depth=\"1\" id=\"eip-201\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><h1
+        data-type=\"title\">Newton''s First Law and Friction</h1><p id=\"eip-708\"><span
+        data-type=\"term\">Newton''s first law of motion</span> states that:</p><ol
+        id=\"eip-idp55249424\"><li>A body at rest tends to stay at rest <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        (<a href=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm\">http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/Final.htm</a>)</li>\n<li>A
+        body in motion tends to remain in motion at constant velocity unless acted
+        on by a net external force (recall that &#8220;constant velocity&#8221; means
+        in a straight line and at constant speed). <math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </li>\n</ol>\n\n<section data-depth=\"2\" id=\"eip-241\"><h2 data-type=\"title\">Newton''s
+        1<sup>st</sup> Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><div data-type=\"note\" id=\"eip-659\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n<p id=\"eip-idm30448560\"><span class=\"level-below\">[BL]</span>\n<span
+        class=\"level-on\">[OL]</span>\n<span class=\"level-above\">[AL]</span> Discuss
+        examples of Newton&#8217;s First Law seen in everyday life. <div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Talk about different pairs of surfaces and
+        how each exhibits different levels of friction. Ask students to give examples
+        of smooth and rough surfaces. Ask them where friction may be useful and where
+        it may be undesirable. <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>\n<span
+        class=\"level-above\">[AL]</span> Ask students to give different examples
+        of systems where multiple forces occur. Draw free-body diagrams for these.
+        Include the force of friction. Emphasize the direction of the force of friction.</p></div>\n\n<p
+        id=\"eip-545\">At first glance, this law may seem to contradict your everyday
+        experience. You have probably noticed that a moving object will usually slow
+        down and stop unless some effort is made to keep it moving. The key to understanding
+        why, for example, a sliding box slows down (seemingly on its own) is that
+        a net external force acts on it to make it slow down. Without this net external
+        force, the box would continue to slide at a constant velocity (as stated in
+        Newton&#8217;s first law of motion). What force acts on the box to slow it
+        down? It is called <span data-type=\"term\">friction</span>. Friction is an
+        external force that acts opposite to the direction of motion (see <a href=\"#eip-idm20864848\"
+        class=\"autogenerated-content\">[link]</a>). Think of it as a resistance to
+        motion that slows things down.</p><p id=\"eip-66\">Friction:</p>\n\n<ol id=\"eip-idp86047488\"
+        data-number-style=\"arabic\"><li>Goes in the opposite direction<span data-type=\"media\"
+        id=\"eip-idm63937136\" data-alt=\"Alt text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></li>\n<li>Causes
+        an object to slow down <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a></li></ol></section>\n\n<section
+        data-depth=\"2\" id=\"eip-495\"><h2 data-type=\"title\">Newton''s 1<sup>st</sup>
+        Law: <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        </h2><p id=\"eip-370\">Consider an air hockey table. When the air is turned
+        off, the puck slides only a short distance before friction slows it to a stop.
+        However, when the air is turned on, it lifts the puck slightly so that the
+        puck experiences very little friction as it moves over the surface. With friction
+        almost eliminated, the puck glides along with very little change in speed.
+        On a frictionless surface, the puck would experience no net external force
+        (ignoring air resistance, which is also a form of friction). Additionally,
+        if we know enough about friction, we can accurately predict how quickly objects
+        will slow down.</p>\n\n<p id=\"eip-114\">Now let&#8217;s think about another
+        example. A man pushes a box across a floor at constant velocity by applying
+        a force of +50 N (the positive sign indicates by convention that the direction
+        of motion is to the right). What is the force of friction that opposes the
+        motion? The force of friction must be &#8722;50 N. Why? According to Newton&#8217;s
+        first law of motion, any object moving at constant velocity has no net external
+        force acting upon it, which means that the sum of the forces acting on the
+        object must be zero. The mathematical way to say that no net external force
+        acts on an object is <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        , or <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow><mtext>MATH</mtext></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mtext>MATH</mtext></annotation-xml></semantics></math>
+        . So if the man applies +50 N of force, then the force of friction must be
+        &#8722;50 N for the two forces to add up to zero (i.e., &#8220;cancel&#8221;
+        each other). Whenever you encounter the phrase &#8220;at constant velocity,&#8221;
+        Newton&#8217;s first law tells you that the net external force is zero.</p><figure
+        id=\"eip-idm83000688\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>For
+        a box sliding across a floor, friction acts in the direction opposite to the
+        velocity.</figcaption><span data-type=\"media\" id=\"eip-idm83879248\" data-alt=\"Alt
+        text\"><img src=\"http://www.pa.uky.edu/~kwng/phy211/oldexam/Spring99EvenFinal/IMG00006.GIF\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure><p id=\"eip-985\">The
+        force of friction depends on two things: the coefficient of friction and the
+        normal force. The coefficient of friction is a constant that depends on the
+        nature of the surfaces in contact with one another. The normal force is the
+        force exerted by a surface that pushes on an object in response to gravity
+        pulling the object down. In equation form, the force of friction is <div data-type=\"equation\"
+        id=\"eip-idp12074176\" class=\"unnumbered\" data-label=\"\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"block\"><semantics><mrow><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></mrow><annotation-xml
+        encoding=\"MathML-Content\"><mrow><mi>f</mi><mo>=</mo><mi>&#956;</mi><mi>N</mi></mrow></annotation-xml></semantics></math></div>where
+        &#956; is the coefficient of friction and N is the normal force. The coefficient
+        of friction is discussed in more detail in the next chapter and the normal
+        force is discussed in more detail in section four of this chapter.\n</p><p
+        id=\"eip-89\">Recall from section one that a net external force acts from
+        outside on the object of interest. A more precise definition is that it acts
+        on the <span data-type=\"term\">system</span> of interest. A system is one
+        or more objects that you choose to study. It is important to define the system
+        at the beginning of a problem to figure out which forces are external and
+        need to be considered and which are internal and can be ignored.</p><p id=\"eip-826\">For
+        example, in <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        (a), two children push a third child in a wagon at constant velocity. The
+        system of interest is the wagon plus the small child shown in part b of the
+        figure. The two children behind the wagon exert external forces on this system
+        (<em data-effect=\"italics\">F</em><sub>1</sub>, <em data-effect=\"italics\">F</em><sub>2</sub>).
+        Friction <em data-effect=\"italics\">f</em> acting at the axles of the wheels
+        and at the surface where the wheels touch the ground is another external force
+        acting on the system. Two more external forces act on the system: the weight
+        <em data-effect=\"italics\">W</em> of the system pulling down and the normal
+        force <em data-effect=\"italics\">N</em> of the ground pushing up. Notice
+        that the wagon is not accelerating vertically, so Newton&#8217;s first law
+        tells us that the normal force balances the weight. Because the wagon is moving
+        forward at constant velocity, then the force of friction must have the same
+        strength as the sum of the forces applied by the two children.</p><figure
+        id=\"eip-idm20864848\" class=\"ost-tag-lo-k12phys-ch04-s02-lo01\"><figcaption>(a)
+        The wagon and rider form a &#8220;system&#8221; that is acted on by external
+        forces. (b)The two children pushing the wagon and child provide two external
+        forces. Friction acting at the wheel axles and on the surface of the tires
+        where they touch the ground provides an external force that acts against the
+        direction of motion. The weight <em data-effect=\"italics\">W</em> and the
+        normal force <em data-effect=\"italics\">N</em> from the ground are two more
+        external forces acting on the system. All external forces are represented
+        in the figure by arrows. All of the external forces acting on the system add
+        together, but because the wagon moves at a constant velocity, all the forces
+        must add up to zero.</figcaption><span data-type=\"media\" id=\"eip-idp5554688\"
+        data-alt=\"Alt text\"><img src=\"/resources/8c943f2ce4ca3d9a0a429e8a3d3f3c00/Figure_04_02_wagon.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></section></section>\n\n<section
+        data-depth=\"1\" id=\"eip-304\" class=\"ost-tag-lo-k12phys-ch04-s02-lo02\"><h1
+        data-type=\"title\">Mass and Inertia</h1>\n\n<div data-type=\"note\" id=\"eip-715\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"eip-idm26334000\"><span
+        class=\"level-below\">[BL]</span> Review Newton&#8217;s First Law. Explain
+        that the property of objects to maintain their state of motion is called inertia.
+        <div data-type=\"newline\"><br/></div>\n<span class=\"level-on\">[OL]</span>
+        <span class=\"level-above\">[AL]</span> Take two similar carts or trolleys
+        with wheels. Place a heavy weight in one of them. Ask students which cart
+        would require more force to change its state of motion. Ask students which
+        would stay in motion longer if you were to set them in motion. Based on this
+        discussion, have students speculate what inertia may depend on.<div data-type=\"newline\"><br/></div>\n<span
+        class=\"level-below\">[BL]</span> <span class=\"level-on\">[OL]</span> Explain
+        the concepts of mass and weight. Explain that these terms may be used interchangeably
+        in everyday life but have different meanings in science.</p></div>\n\n<p id=\"eip-613\"><span
+        data-type=\"term\">Inertia</span> is the tendency for an object at rest to
+        remain at rest or for a moving object to remain in motion in a straight line
+        with constant speed. This key property of objects was first described by Galileo.
+        Later, Newton incorporated the concept of inertia into his first law, which
+        is often referred to as the <span data-type=\"term\">law of inertia</span>.</p><p
+        id=\"eip-36\">As we know from experience, some objects have more inertia than
+        others. For example, changing the motion of a large truck is more difficult
+        than changing the motion of a toy truck. In fact, the inertia of an object
+        is proportional to the mass of the object. <span data-type=\"term\">Mass</span>
+        is a measure of the amount of matter (or &#8220;stuff&#8221;) in something.
+        The quantity or amount of matter in an object is determined by the number
+        and type of atoms it contains. Unlike weight (which changes if the gravitational
+        force changes), mass does not depend on gravity. The mass of an object is
+        the same on Earth, in orbit, or on the surface of the Moon. In practice, it
+        is very difficult to count and identify all of the atoms and molecules in
+        an object, so mass is usually not determined this way. Instead, the mass of
+        an object is determined by comparing it with the standard kilogram. Mass is
+        therefore expressed in kilograms.</p>\n\n<div data-type=\"note\" id=\"eip-idm961296\"
+        class=\"tip tips-for-success\" data-label=\"Tips for Success\">In everyday
+        language, people often use the terms weight and mass interchangeably&#8212;but
+        this is not correct. Weight is actually a force (we cover this in more detail
+        in section three).</div>\n\n<div data-type=\"note\" id=\"eip-231\" class=\"ost-assessed-feature
+        ost-video ost-tag-lo-k12phys-ch04-s02-lo02 watch-physics\" data-label=\"Watch
+        Physics\"><div data-type=\"title\">Newton&#8217;s first law of motion</div>
+        \n<p id=\"eip-idp1646512\">This <a href=\"https://www.khanacademy.org/science/physics/forces-newtons-laws/newtons-laws-of-motion/v/newton-s-1st-law-of-motion\"
+        class=\"os-embed\">video</a> contrasts the way we thought about motion and
+        force in the time before Galileo&#8217;s concept of inertia and <span data-type=\"term\">Newton&#8217;s
+        first law of motion</span> with the way we understand force and motion now.
+        Refer to <a href=\"#eip-idm20864848\" class=\"autogenerated-content\">[link]</a>
+        as you watch.\n</p>\n\n<ol id=\"eip-idp19850304\"><li>Galileo&#8217;s concepts<ol
+        id=\"eip-idp10164288\" data-number-style=\"lower-alpha\"><li>Things just come
+        to a stop</li><li>Forces don&#8217;t act against objects</li></ol></li><li>Newton&#8217;s
+        concepts<ol id=\"eip-idp5872736\" data-number-style=\"lower-alpha\"><li>Objects
+        will continue at the same speed if no opposing force</li><li>Weight is a force
+        acting against an object.</li></ol></li></ol>\n\n <div data-type=\"exercise\"
+        id=\"eip-idp413824\" class=\"os-exercise grasp-check\"><div data-type=\"problem\"
+        id=\"eip-idm76540272\">\n    <p id=\"eip-idm99866096\"><a href=\"#ost/api/ex/k12phys-ch04-ex033\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div></div><div data-type=\"note\"
+        id=\"eip-837\" class=\"os-teacher\" data-label=\"Teacher Edition\">Answer:
+        Friction</div></div>\n\n<div data-type=\"note\" id=\"fs-idm38320288\" class=\"ost-assessed-feature
+        ost-interactive virtual-physics ost-tag-lo-k12phys-ch04-s02-lo02\" data-label=\"Virtual
+        Physics\"><div data-type=\"title\">Forces and Motion: Basics</div>\n\n<p id=\"fs-idp34383024\">In
+        this simulation, you will first explore net force by placing blue people on
+        the left side of a tug of war rope and red people on the right side of the
+        rope (by clicking people and dragging them with your mouse). Experiment with
+        changing the number and size of people on each side to see how it affects
+        the outcome of the match and the net force. Hit the Go! button to start the
+        match, and the &#8220;reset all&#8221; button to start over.</p><ol id=\"fs-idp48496992\"
+        data-number-style=\"lower-alpha\"><li>The side with the most force wins</li><li>The
+        bigger the difference in the force, the easier it is for one side to win.</li><li>When
+        force is equal, no one wins.</li></ol><p id=\"fs-idp52126304\">Next, click
+        on the Friction tab. Try selecting different objects for the person to push.
+        Slide the applied force button to the right to apply force to the right and
+        to the left to apply force to the left. The force will continue to be applied
+        as long as you hold the button down. See the arrow representing friction change
+        in magnitude and direction depending on how much force you apply. Try increasing
+        or decreasing the friction force to see how this affects the motion.</p>\n<div
+        data-type=\"media\" id=\"fs-idp5640912\" class=\"os-embed\" data-alt=\" \">
+        <iframe width=\"960\" height=\"785\" src=\"http://archive.cnx.org/specials/e2ca52af-8c6b-450e-ac2f-9300b38e8739/moving-man/\"/></div>\n\n  <div
+        data-type=\"exercise\" id=\"fs-idm56919408\" class=\"os-exercise grasp-check\"><div
+        data-type=\"problem\" id=\"fs-idm68103760\"><p id=\"fs-idm17001808\"><a href=\"#ost/api/ex/k12phys-ch04-ex034\"
+        class=\"autogenerated-content\">[link]</a>\n<div data-type=\"note\" id=\"fs-idm79914448\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p id=\"fs-idm91425440\"><span
+        data-type=\"term\">[Grasp Check]</span>\nAnswer: After the person stops pushing
+        the box, no force is applied to the right, but the friction force remains,
+        which acts to the left. Therefore, the net force acts to the left.</p>\n\n</div>\n\n  </p></div></div></div></section>\n<section
+        data-depth=\"1\" id=\"eip-305\" class=\"summary ost-reading-discard\"><h1
+        data-type=\"title\">Section Summary</h1><p id=\"eip-idm44169728\"><span data-type=\"list\"
+        data-list-type=\"bulleted\" id=\"eip-idm85549552\"><span data-type=\"item\">Newton&#8217;s
+        first law states that a body at rest remains at rest or, if moving, remains
+        in motion in a straight line at a constant speed unless acted on by a net
+        external force. This is also known as the law of inertia.</span>\n<span data-type=\"item\">Inertia
+        is the tendency of an object at rest to remain at rest or, if moving, to remain
+        in motion at constant velocity. Inertia is related to an object&#8217;s mass.</span>\n<span
+        data-type=\"item\">Friction is a force that opposes motion and causes an object
+        or system to slow down.</span>\n<span data-type=\"item\">Mass is the quantity
+        of matter in a substance.</span></span></p></section>\n\n<section data-depth=\"1\"
+        id=\"eip-836\" class=\"key-equations ost-reading-discard\"><h1 data-type=\"title\">Key
+        Equations</h1><table id=\"eip-812\" summary=\"--\"><tbody>\n  <tr>\n    <td>Newton''s
+        first law</td>\n  <td><math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><semantics><mrow>\n
+        <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>c</mi><mo>,</mo>\n
+        </mrow></annotation-xml></semantics></math>where<math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mtext>&#8201;</mtext><mi>c</mi><mtext>&#8201;</mtext>\n
+        </mrow></annotation-xml></semantics></math>is a constant</td>\n  </tr>\n  <tr>\n    <td>Newton''s
+        sixth law</td>\n   \n<td><math xmlns=\"http://www.w3.org/1998/Math/MathML\"
+        display=\"inline\"><semantics><mrow>\n <mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow>\n</mrow><annotation-xml encoding=\"MathML-Content\"><mrow>\n  <mi>f</mi><mrow><mo>(</mo>\n   <mi>x</mi>\n  <mo>)</mo></mrow><mo>=</mo><mi>x</mi>\n
+        </mrow></annotation-xml></semantics></math>\n</td>\n  </tr>\n</tbody></table></section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm71187456\" class=\"practice-concepts ost-reading-discard\"><h1
+        data-type=\"title\">Check Your Understanding</h1>\n<div data-type=\"exercise\"
+        id=\"fs-idm20483824\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idp37354336\">\n      <p id=\"fs-idp35901760\"><a href=\"#ost/api/ex/k12phys-ch04-ex035\"
+        class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm51782000\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm30958336\">\n      <p id=\"fs-idm53218240\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex036\" class=\"autogenerated-content\">[link]</a></p>\n    </div>\n  </div>\n<div
+        data-type=\"exercise\" id=\"eip-idp1259600\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp22780016\"><p id=\"eip-idp10991472\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex037\" class=\"autogenerated-content\">[link]</a></p></div></div>\n<div
+        data-type=\"exercise\" id=\"eip-idp10062848\" class=\"os-exercise os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo02 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"eip-idp32885104\"><p id=\"eip-idp3387376\"><a href=\"#ost/api/ex/k12phys-ch04-ex038\"
+        class=\"autogenerated-content\">[link]</a></p></div></div></section>\n\n<div
+        data-type=\"note\" id=\"fs-idm112711040\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp9350960\">1. A body at rest tends to remain at
+        rest, and a body in motion tends to remain in motion at a constant velocity
+        unless acted on by a net external force.</p>\n<p id=\"fs-idm68577104\">2.
+        The object experiences a frictional force exerted by the surface, which opposes
+        its motion.</p>\n<p id=\"fs-idm65948736\">3. Inertia is an object&#8217;s
+        tendency to remain at rest or, if moving, to remain in motion at a constant
+        velocity. Inertia may also be described as the tendency of objects to maintain
+        their state of motion.</p>\n<p id=\"fs-idm56412736\">4. Mass is the quantity
+        of substance contained in matter. It depends on the number and type of atoms
+        in the matter.</p>\n</div>\n\n\n<div data-type=\"note\" id=\"fs-idm98755648\"
+        class=\"os-teacher\" data-label=\"Teacher Edition\">\n<p id=\"fs-idm111298272\">1.
+        <em data-effect=\"italics\">F</em><sub>net</sub> = 0</p><p id=\"fs-idm7398128\">2.
+        Friction is an external force that opposes the direction of motion of system.</p>\n<p
+        id=\"fs-idm91191728\">3. The quality of the surface&#8212;whether it is smooth
+        or rough</p>\n<p id=\"fs-idm85688352\">4. There is negligible friction between
+        the ice and the skater.</p>\n<p id=\"fs-idm130369856\">5. The inertia of an
+        object is proportional to its mass.</p>\n<p id=\"fs-idm102647072\">6. A system
+        is one or more objects that we wish to study.</p>\n<p id=\"fs-idm127557760\">7.
+        Mass is the quantity of matter contained in an object. Weight is the force
+        exerted by gravity on the object.</p>\n<p id=\"fs-idm23970880\">8. Mass is
+        measured in kilograms. Weight, being a force, is measured in newtons. However,
+        since mass cannot be determined by counting the number of atoms in an object,
+        it is derived from an object&#8217;s weight. Since the force of gravity is
+        almost constant on earth, the mass of an object is often given as the object&#8217;s
+        weight.</p>\n</div>\n\n\n\n<section data-depth=\"1\" id=\"fs-idm56025888\"
+        class=\"ost-reading-discard chapter-review concept\"><h1 data-type=\"title\">Concept
+        Items</h1><div data-type=\"exercise\" id=\"fs-idm65070096\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\"><div
+        data-type=\"problem\" id=\"fs-idp2435696\">\n      <p id=\"fs-idm60009600\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex047\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div><div
+        data-type=\"exercise\" id=\"fs-idm36770368\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm46629456\">\n      <p id=\"fs-idm27882848\"><a href=\"#ost/api/ex/k12phys-ch04-ex048\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n</section>\n\n\n\n<section
+        data-depth=\"1\" id=\"fs-idp15971072\" class=\"ost-reading-discard chapter-review
+        critical-thinking\"><h1 data-type=\"title\">Critical Thinking Items</h1><div
+        data-type=\"exercise\" id=\"fs-idp69697408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp55256064\">\n      <p id=\"fs-idp47204912\"><a href=\"#ost/api/ex/k12phys-ch04-ex053\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idp19674432\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idp88556720\">\n      <p id=\"fs-idp38044752\"><a href=\"#ost/api/ex/k12phys-ch04-ex054\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idp48658432\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp12698432\">1. Less than (F1 + F2). The net force
+        will include a component of friction which will act in the direction opposite
+        to F1 and F2 and cancel part of these forces.</p>\n<p id=\"fs-idm10442672\">2.
+        Yes</p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idp5033136\" class=\"ost-reading-discard
+        test-prep multiple-choice\"><h1 data-type=\"title\">Test Prep Multiple Choice</h1><div
+        data-type=\"exercise\" id=\"fs-idp2931856\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm2415664\">\n      <p id=\"fs-idm1515712\"><a href=\"#ost/api/ex/k12phys-ch04-ex059\"
+        class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm84911568\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-1 ost-tag-blooms-1 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm24438496\">\n      <p id=\"fs-idm95346960\"><a href=\"#ost/api/ex/k12phys-ch04-ex060\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n</section>\n\n<div
+        data-type=\"note\" id=\"fs-idm15918336\" class=\"os-teacher\" data-label=\"Teacher
+        Edition\">\n  <p id=\"fs-idp42241296\">1. a) external </p>\n<p id=\"fs-idp63672752\">2.
+        b) law of inertia </p>\n</div>\n\n<section data-depth=\"1\" id=\"fs-idm53317184\"
+        class=\"ost-reading-discard test-prep short-answer\"><h1 data-type=\"title\">Test
+        Prep Short Answer</h1><div data-type=\"exercise\" id=\"fs-idm70263744\" class=\"os-exercise
+        ost-tag-lo-k12phys-ch04-s02-lo01 ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div
+        data-type=\"problem\" id=\"fs-idm36001280\">\n      <p id=\"fs-idm58066816\"><a
+        href=\"#ost/api/ex/k12phys-ch04-ex061\" class=\"autogenerated-content\">[link]</a>\n    </p></div>\n  </div>\n  <div
+        data-type=\"exercise\" id=\"fs-idm79253408\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"fs-idm86468464\">\n      <p id=\"fs-idm52047952\"><a href=\"#ost/api/ex/k12phys-ch04-ex062\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp13927648\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp79608864\">\n      <p id=\"eip-idp64692080\"><a href=\"#ost/api/ex/k12phys-ch04-ex063\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n<div data-type=\"exercise\"
+        id=\"eip-idp116624608\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-2 ost-tag-blooms-3 ost-tag-time-short\">\n    <div data-type=\"problem\"
+        id=\"eip-idp60936864\">\n      <p id=\"eip-idp34200800\"><a href=\"#ost/api/ex/k12phys-ch04-ex064\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp16574176\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp25075952\">\n<figure id=\"fs-idp45771152\"><figcaption>Arrow pointing
+        right, labeled F and smaller arrow pointing right labeled f</figcaption><span
+        data-type=\"media\" id=\"fs-idp66161920\" data-alt=\"Alt text\"><img src=\"/resources/79879c1d01fccc75a43f8d273fe59ac7/Figure_04_02_force_img.png\"
+        data-media-type=\"image/jpeg\" alt=\"Alt text\"/></span></figure></p>\n<p
+        id=\"fs-idp6971456\">2. The mass of the first object is less than that of
+        the second.</p>\n<p id=\"fs-idp24341232\">3. You could give each box a push
+        by applying the same amount of force. Whichever box accelerates faster is
+        lighter and so must be the empty box.</p>\n<p id=\"fs-idp23864352\">4. Yes</p>\n</div>\n</section>\n\n<section
+        data-depth=\"1\" id=\"fs-idm72523760\" class=\"ost-reading-discard test-prep
+        extended-response\"><h1 data-type=\"title\">Test Prep Extended Response</h1><div
+        data-type=\"exercise\" id=\"fs-idm96811744\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo01
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm79488864\">\n      <p id=\"fs-idm116137648\"><a href=\"#ost/api/ex/k12phys-ch04-ex065\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n  <div data-type=\"exercise\"
+        id=\"fs-idm37073488\" class=\"os-exercise ost-tag-lo-k12phys-ch04-s02-lo02
+        ost-tag-dok-3 ost-tag-blooms-5 ost-tag-time-med\">\n    <div data-type=\"problem\"
+        id=\"fs-idm35798256\">\n      <p id=\"fs-idm28998864\"><a href=\"#ost/api/ex/k12phys-ch04-ex066\"
+        class=\"autogenerated-content\">[link]</a></p></div>\n  </div>\n\n<div data-type=\"note\"
+        id=\"fs-idp64139392\" class=\"os-teacher\" data-label=\"Teacher Edition\">\n  <p
+        id=\"fs-idp50449808\">1. Not necessarily; if both are thrown at different
+        angles, they will travel different distances.</p>\n<p id=\"fs-idp47745568\">2.
+        The person is no longer applying force when the box is sliding freely. The
+        box is moving because of its own inertia. The only force acting on it is the
+        force of friction which acts from right to left. Thus, the direction of the
+        net external force is to the left.</p>\n</div>\n\n</section>\n<div data-type=\"glossary\"><h2>Glossary</h2>\n<div
+        data-type=\"definition\" id=\"fs-idp38390880\"><span data-type=\"term\">friction</span><div
+        data-type=\"meaning\" id=\"fs-idp69363104\">an external force that acts in
+        the direction opposite to the direction of motion</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp32901536\"><span data-type=\"term\">inertia</span><div data-type=\"meaning\"
+        id=\"fs-idp2280640\">the tendency of an object at rest to remain at rest or
+        for a moving object to remain in motion in a straight line and at constant
+        speed&#8212;MATH</div></div>\n<div data-type=\"definition\" id=\"fs-idp22688960\"><span
+        data-type=\"term\">law of inertia</span><div data-type=\"meaning\" id=\"fs-idp26210592\">Newton&#8217;s
+        first law of motion: a body at rest remains at rest or, if in motion, remains
+        in motion at a constant speed in a straight line unless acted on by a net
+        external force; also known as the law of inertia</div></div>\n<div data-type=\"definition\"
+        id=\"fs-idp76765280\"><span data-type=\"term\">mass</span><div data-type=\"meaning\"
+        id=\"fs-idp90674960\">the quantity of matter in a substance; measured in kilograms</div></div>\n<div
+        data-type=\"definition\" id=\"fs-idp42413872\"><span data-type=\"term\">Newton''s
+        first law of motion</span><div data-type=\"meaning\" id=\"fs-idp33729328\">a
+        body at rest remains at rest or, if in motion, remains in motion at a constant
+        speed in a straight line unless acted on by a net external force; also known
+        as the law of inertia</div></div>\n<div data-type=\"definition\" id=\"fs-idp59393232\"><span
+        data-type=\"term\">system</span><div data-type=\"meaning\" id=\"fs-idp77789136\">one
+        or more objects of interest for which only the forces acting on them from
+        the outside are considered but not the forces acting between them or inside
+        of them</div></div>\n</div></body>\n\n</html>", "subjects": ["Mathematics
+        and Statistics"], "legacy_id": "m53227", "parentId": null, "stateid": 1, "parentTitle":
+        null, "maintainers": [{"website": "", "surname": "Slavik", "suffix": "", "firstname":
+        "Alina", "title": "", "othername": "", "email": "alinams@rice.edu", "fullname":
+        "Alina Slavik", "id": "AlinaManager"}], "authors": [{"website": "", "surname":
+        "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername": "",
+        "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "parentVersion": "", "legacy_version": "1.4", "licensors": [{"website": "",
+        "surname": "Slavik", "suffix": "", "firstname": "Alina", "title": "", "othername":
+        "", "email": "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}],
+        "license": {"url": "http://creativecommons.org/licenses/by/4.0/", "code":
+        "by", "version": "4.0", "name": "Creative Commons Attribution License"}, "language":
+        "en", "created": "2015-03-11T18:32:11Z", "doctype": "", "buyLink": null, "submitter":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}, "parentAuthors": [], "history": [{"changes": "imported
+        from staging3", "version": "4", "revised": "2015-03-16T16:00:23Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "switched sim link; added width and height
+        attribute", "version": "3", "revised": "2015-03-11T21:28:30Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}, {"changes": "retitled module", "version": "2", "revised":
+        "2015-03-11T18:40:21Z", "publisher": {"website": "", "surname": "Slavik",
+        "suffix": "", "firstname": "Alina", "title": "", "othername": "", "email":
+        "alinams@rice.edu", "fullname": "Alina Slavik", "id": "AlinaManager"}}, {"changes":
+        "imported module", "version": "1", "revised": "2015-03-11T18:36:37Z", "publisher":
+        {"website": "", "surname": "Slavik", "suffix": "", "firstname": "Alina", "title":
+        "", "othername": "", "email": "alinams@rice.edu", "fullname": "Alina Slavik",
+        "id": "AlinaManager"}}]}'
+    http_version: 
+  recorded_at: Thu, 19 Mar 2015 10:32:37 GMT
+recorded_with: VCR 2.9.3

--- a/spec/external/openstax/cnx/v1/fragment/video_spec.rb
+++ b/spec/external/openstax/cnx/v1/fragment/video_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'vcr_helper'
+
+RSpec.describe OpenStax::Cnx::V1::Fragment::Video, :type => :external,
+                                             :vcr => VCR_OPTS do
+  let!(:cnx_page_id) { '61445f78-00e2-45ae-8e2c-461b17d9b4fd' }
+  let!(:cnx_page) { OpenStax::Cnx::V1::Page.new(id: cnx_page_id) }
+  let!(:video_fragments) {
+    cnx_page.fragments.select do |f|
+      f.is_a? OpenStax::Cnx::V1::Fragment::Video
+    end
+  }
+  let!(:expected_titles) { ['Newton’s first law of motion'] }
+  let!(:expected_urls) { ['https://www.khanacademy.org/science/physics/forces-newtons-laws/newtons-laws-of-motion/v/newton-s-1st-law-of-motion'] }
+
+  it 'provides info about the video fragment' do
+    video_fragments.each do |fragment|
+      expect(fragment.node).not_to be_nil
+      expect(fragment.title).not_to be_nil
+      expect(fragment.to_html).not_to be_nil
+      expect(fragment.url).not_to be_nil
+    end
+  end
+
+  it "can retrieve the fragment's title" do
+    expect(video_fragments.collect { |f| f.title }).to eq expected_titles
+  end
+
+  it "can retrieve the fragment's video url" do
+    expect(video_fragments.collect { |f| f.url }).to eq expected_urls
+  end
+end

--- a/spec/external/openstax/cnx/v1/page_spec.rb
+++ b/spec/external/openstax/cnx/v1/page_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe OpenStax::Cnx::V1::Page, :type => :external, :vcr => VCR_OPTS do
                expected: {
                 los: ['k12phys-ch04-s02-lo01', 'k12phys-ch04-s02-lo02'],
                 fragment_classes: [OpenStax::Cnx::V1::Fragment::Text,
-                                   OpenStax::Cnx::V1::Fragment::Text,
+                                   OpenStax::Cnx::V1::Fragment::Video,
                                    OpenStax::Cnx::V1::Fragment::Exercise,
                                    OpenStax::Cnx::V1::Fragment::Text,
                                    OpenStax::Cnx::V1::Fragment::Exercise,
@@ -55,7 +55,7 @@ RSpec.describe OpenStax::Cnx::V1::Page, :type => :external, :vcr => VCR_OPTS do
                expected: {
                 los: ['k12phys-ch04-s02-lo01', 'k12phys-ch04-s02-lo02'],
                 fragment_classes: [OpenStax::Cnx::V1::Fragment::Text,
-                                   OpenStax::Cnx::V1::Fragment::Text,
+                                   OpenStax::Cnx::V1::Fragment::Video,
                                    OpenStax::Cnx::V1::Fragment::Exercise,
                                    OpenStax::Cnx::V1::Fragment::Text,
                                    OpenStax::Cnx::V1::Fragment::Exercise,

--- a/spec/factories/tasked_videos.rb
+++ b/spec/factories/tasked_videos.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :tasked_video do
+    transient do
+      skip_task false
+    end
+
+    task_step nil
+    url { Faker::Internet.url }
+    title { Faker::Lorem.sentence(3) }
+    content { Faker::Lorem.paragraph }
+    video_url { Faker::Internet.url }
+
+    after(:build) do |tasked_video, evaluator|
+      options = { tasked: tasked_video }
+      options[:task] = nil if evaluator.skip_task
+
+      tasked_video.task_step ||= FactoryGirl.build(:task_step, options)
+    end
+  end
+end

--- a/spec/representers/api/v1/tasked_video_representer_spec.rb
+++ b/spec/representers/api/v1/tasked_video_representer_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TaskedVideoRepresenter, :type => :representer do
+  it 'should represent a video' do
+    task_step = FactoryGirl.create(:tasked_video).task_step
+    json = Api::V1::TaskedVideoRepresenter.new(task_step.tasked).to_json
+
+    expect(JSON.parse(json)).to eq({
+      id: task_step.id,
+      type: 'video',
+      title: task_step.tasked.title,
+      is_completed: false,
+      content_url: task_step.tasked.url,
+      content_html: task_step.tasked.content,
+      video_url: task_step.tasked.video_url
+    }.stringify_keys)
+  end
+end


### PR DESCRIPTION
- Create video fragments from a cnx page
    
    In an assessed feature, there is either a video or some text plus an
    exercise.  Add a video fragment class that inherits from the text
    fragment class but with a url method that returns the url of the video
    from .ost-embed. Code assumes only one video in each fragment.

- Add tasked video model and representer