### PR TITLE
Fix sprint 007a task

### DIFF
--- a/app/assistants/i_reading_assistant.rb
+++ b/app/assistants/i_reading_assistant.rb
@@ -64,9 +64,8 @@ class IReadingAssistant
             raise "Video url not found for Video in Page #{page.id}" \
               if fragment.url.blank?
 
-            TaskedVideo.new(task_step: step, url: page.url,
-                            title: fragment.title, content: fragment.to_html,
-                            video_url: fragment.url)
+            TaskedVideo.new(task_step: step, url: fragment.url,
+                            title: fragment.title, content: fragment.to_html)
           else
             TaskedReading.new(task_step: step, url: page.url,
                               title: fragment.title, content: fragment.to_html)

--- a/app/external/openstax/cnx/v1/fragment/video.rb
+++ b/app/external/openstax/cnx/v1/fragment/video.rb
@@ -5,7 +5,13 @@ module OpenStax::Cnx::V1::Fragment
     VIDEO_LINK_CSS = '.os-embed'
 
     def url
-      @url ||= node.at_css(VIDEO_LINK_CSS).try(:attr, :href)
+      video = node.at_css(VIDEO_LINK_CSS)
+      @url ||= case
+      when video.try(:name) == 'a'
+        video.attr(:href)
+      when video.try(:attr, :'data-type') == 'media'
+        video.try(:xpath, 'iframe/@src')
+      end
     end
 
   end

--- a/app/external/openstax/cnx/v1/page.rb
+++ b/app/external/openstax/cnx/v1/page.rb
@@ -129,14 +129,15 @@ module OpenStax::Cnx::V1
         if split.matches?(ASSESSED_FEATURE_CSS)
           # Assessed Feature = Video + Exercise or Text + Exercise
           exercise = split.at_css(EXERCISE_CSS)
-          recursive_compact(exercise, split)
+          Rails.logger.warn { "An assessed feature should have an exercise but doesn't: #{url}" } if exercise.nil?
+          recursive_compact(exercise, split) unless exercise.nil?
 
           if split.matches?(VIDEO_CSS)
             splitting_fragments << Fragment::Video.new(node: split)
           else
             splitting_fragments << Fragment::Text.new(node: split)
           end
-          splitting_fragments << Fragment::Exercise.new(node: exercise)
+          splitting_fragments << Fragment::Exercise.new(node: exercise) unless exercise.nil?
         elsif split.matches?(FEATURE_CSS)
           # Text Feature
           splitting_fragments << Fragment::Text.new(node: split)

--- a/app/representers/api/v1/tasked_video_representer.rb
+++ b/app/representers/api/v1/tasked_video_representer.rb
@@ -1,13 +1,4 @@
 module Api::V1
   class TaskedVideoRepresenter < TaskedReadingRepresenter
-
-    property :video_url,
-             type: String,
-             writeable: false,
-             readable: true,
-             schema_info: {
-               required: false,
-               description: "The video URL"
-             }
   end
 end

--- a/db/migrate/20150319213309_remove_tasked_video_video_url.rb
+++ b/db/migrate/20150319213309_remove_tasked_video_video_url.rb
@@ -1,0 +1,5 @@
+class RemoveTaskedVideoVideoUrl < ActiveRecord::Migration
+  def change
+    remove_column :tasked_videos, :video_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150319110230) do
+ActiveRecord::Schema.define(version: 20150319213309) do
 
   create_table "administrators", force: :cascade do |t|
     t.integer  "user_id",    null: false
@@ -420,7 +420,6 @@ ActiveRecord::Schema.define(version: 20150319110230) do
     t.string   "url",        null: false
     t.text     "content",    null: false
     t.string   "title"
-    t.string   "video_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/tasked_videos.rb
+++ b/spec/factories/tasked_videos.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
     url { Faker::Internet.url }
     title { Faker::Lorem.sentence(3) }
     content { Faker::Lorem.paragraph }
-    video_url { Faker::Internet.url }
 
     after(:build) do |tasked_video, evaluator|
       options = { tasked: tasked_video }

--- a/spec/representers/api/v1/tasked_video_representer_spec.rb
+++ b/spec/representers/api/v1/tasked_video_representer_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Api::V1::TaskedVideoRepresenter, :type => :representer do
       is_completed: false,
       content_url: task_step.tasked.url,
       content_html: task_step.tasked.content,
-      video_url: task_step.tasked.video_url
     }.stringify_keys)
   end
 end


### PR DESCRIPTION
Fix html parsing to allow assessed feature without exercises

Running "rake sprint:007a" was giving the following error:

```
rake aborted!
NoMethodError: undefined method `parent' for nil:NilClass
/home/karen/tutor-server/lib/html_tree_operations.rb:7:in `recursive_compact'
/home/karen/tutor-server/app/external/openstax/cnx/v1/page.rb:132:in `fragments'
```

because we just added this page
http://cnx.org/contents/7db9aa72-f815-4c3b-9cb6-d50cf5318b58@4.5:2/Updated_Tutor_HS_Physics_Conte#fs-id1172194442505
which has an assessed feature with just a video without an exercise.

------

Also:
 - added code to parse the video url from iframe and
 - removed video_url from tasked_video.