### PR TITLE
Correct complete/partial complete counts

### DIFF
--- a/app/routines/calculate_i_reading_stats.rb
+++ b/app/routines/calculate_i_reading_stats.rb
@@ -61,17 +61,19 @@ class CalculateIReadingStats
   end
 
   def generate_course_stat_data
+    tasks = @plan.tasks.to_a
     {
 
-      total_count: @plan.tasks.count,
+      total_count: tasks.count,
 
-      complete_count: @plan.tasks.select{|task|
+      complete_count: tasks.count{|task|
         task.task_steps.all?{| ts | ts.completed? }
-      }.length,
+      },
 
-      partially_complete_count: @plan.tasks.select{|task|
-        task.task_steps.any?{| ts | ts.completed? }
-      }.length,
+      partially_complete_count: tasks.count{|task|
+        task.task_steps.any?{| ts | ts.completed? } &&
+          !task.task_steps.all?{| ts | ts.completed? }
+      },
 
       current_pages: task_plan_pages.map{|page|
         generate_page_stats(page)

--- a/lib/tasks/sprint/008.rake
+++ b/lib/tasks/sprint/008.rake
@@ -6,6 +6,7 @@ namespace :sprint do
 
     if result.errors.none?
       puts 'Added teacher, student, and teacher_and_student users. Added courses/1 and courses/2.'
+      puts "Added task_plan id #{result.outputs.stats_task_plan.id} with 30 students that have partially completed tasks"
     else
       result.errors.each{|error| puts "Error: " + Lev::ErrorTranslator.translate(error)}
     end

--- a/spec/routines/calculate_i_reading_stats_spec.rb
+++ b/spec/routines/calculate_i_reading_stats_spec.rb
@@ -16,7 +16,7 @@ describe CalculateIReadingStats do
   context "With an unworked plan" do
 
     it "is all zero for an unworked task_plan" do
-      expect(stats.course.total_count).to eq(8)
+      expect(stats.course.total_count).to eq(task_plan.tasks.length)
       expect(stats.course.complete_count).to eq(0)
       expect(stats.course.partially_complete_count).to eq(0)
 
@@ -44,13 +44,13 @@ describe CalculateIReadingStats do
       stats = CalculateIReadingStats.call(plan: task_plan.reload).outputs.stats
 
       expect(stats.course.complete_count).to eq(1)
-      expect(stats.course.partially_complete_count).to eq(1)
+      expect(stats.course.partially_complete_count).to eq(0)
 
       last_plan=task_plan.tasks.last
       MarkTaskStepCompleted.call(task_step: last_plan.task_steps.first)
       stats = CalculateIReadingStats.call(plan: task_plan.reload).outputs.stats
       expect(stats.course.complete_count).to eq(1)
-      expect(stats.course.partially_complete_count).to eq(2)
+      expect(stats.course.partially_complete_count).to eq(1)
     end
 
 
@@ -71,7 +71,9 @@ describe CalculateIReadingStats do
       stats = CalculateIReadingStats.call(plan: task_plan.reload).outputs.stats
       page = stats.course.current_pages.first
       expect(page['page']['title']).to eq('Force')
-      expect(page['student_count']).to eq(8)
+      expect(page['student_count']).to eq(number_of_students)
+      expect(page['correct_count']).to eq(1)
+      expect(page['incorrect_count']).to eq(0)
     end
 
   end


### PR DESCRIPTION
Turns out the stats were double counting the complete stats,
a task was being counted as partially_complete even if
it was completely complete.

Also sneak in a fix to the description on the rake
task that I mucked up last PR.