### PR TITLE
Add published_at field to task_plans

### DIFF
--- a/app/representers/api/v1/task_plan_representer.rb
+++ b/app/representers/api/v1/task_plan_representer.rb
@@ -23,6 +23,11 @@ module Api::V1
              readable: true,
              writeable: true
 
+    property :published_at,
+             type: String,
+             readable: true,
+             writeable: true
+
     property :due_at,
              type: String,
              readable: true,

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -38,6 +38,7 @@ class DistributeTasks
     # Call the assistant code to create and distribute Tasks
     outputs[:tasks] = assistant.distribute_tasks(task_plan: task_plan,
                                                  taskees: taskees)
+    task_plan.update_attributes(published_at: Time.now)
   end
 
 end

--- a/db/migrate/20140926165258_create_tasks_task_plans.rb
+++ b/db/migrate/20140926165258_create_tasks_task_plans.rb
@@ -8,7 +8,7 @@ class CreateTasksTaskPlans < ActiveRecord::Migration
       t.text :settings, null: false
       t.datetime :opens_at, null: false
       t.datetime :due_at
-
+      t.datetime :published_at
       t.timestamps null: false
 
       t.index [:owner_id, :owner_type]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -395,6 +395,7 @@ ActiveRecord::Schema.define(version: 20150325170729) do
     t.text     "settings",           null: false
     t.datetime "opens_at",           null: false
     t.datetime "due_at"
+    t.datetime "published_at"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
   end

--- a/lib/tasks/sprint/sprint_008/main.rb
+++ b/lib/tasks/sprint/sprint_008/main.rb
@@ -31,7 +31,7 @@ module Sprint008
       # Add the students to the courses
 
       Domain::AddUserAsCourseStudent[course: course1, user: student.entity_user]
-      student_role = Entity::Role.last
+      student_role = Entity::Models::Role.last
       Domain::AddUserAsCourseStudent[course: course2, user: teacher_and_student.entity_user]
 
       # Set up three reading tasks (will include try another)

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -161,6 +161,9 @@ describe Api::V1::TaskPlansController, :type => :controller,
                                                     id: task_plan.id} }
         .to change{ Tasks::Models::Task.count }.by(1)
       expect(response).to have_http_status(:success)
+      # need to reload the task_plan since publishing it will set the
+      # publish_at date and change the representation
+      expect(task_plan.reload.published_at).to be_within(1.second).of(Time.now)
       expect(response.body).to(
         eq(Api::V1::TaskPlanRepresenter.new(task_plan).to_json)
       )

--- a/spec/representers/api/v1/task_plan_representer_spec.rb
+++ b/spec/representers/api/v1/task_plan_representer_spec.rb
@@ -10,10 +10,17 @@ RSpec.describe Api::V1::TaskPlanRepresenter, :type => :representer do
   it "represents a task plan" do
     expect(representation).to include(
       "id" => task_plan.id,
-      "type" => task_plan.type,
+      "type" => task_plan.type
     )
     expect(representation["stats"]).to be_nil
   end
 
+  it "includes published_at when published" do
+      task_plan.update_attributes(published_at: Time.now)
+      representation = Api::V1::TaskPlanRepresenter.new(task_plan).as_json
+      expect(representation).to include(
+        "published_at" => DateTimeUtilities.to_api_s(task_plan.published_at)
+      )
+  end
 
 end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe DistributeTasks, :type => :routine do
   it 'validates the task_plan settings against the assistant schema' do
     task_plan = FactoryGirl.create :tasks_task_plan
 
-    expect(DistributeTasks.call(task_plan).errors).to be_empty
-
     allow(DummyAssistant).to receive(:schema).and_return(
       '{
         "type": "object",
@@ -26,6 +24,7 @@ RSpec.describe DistributeTasks, :type => :routine do
 
     result = DistributeTasks.call(task_plan)
     expect(result.errors.first.code).to eq :invalid_settings
+    expect(task_plan.published_at).to be_nil
     expect(result.outputs.tasks).to be_blank
   end
 
@@ -40,4 +39,11 @@ RSpec.describe DistributeTasks, :type => :routine do
     result = DistributeTasks.call(task_plan)
     expect(result.errors).to be_empty
   end
+
+  it "sets the published_at field when it distributes" do
+      task_plan = FactoryGirl.create :task_plan
+      DistributeTasks.call(task_plan)
+      expect(task_plan.reload.published_at).to be_within(1.second).of(Time.now)
+  end
+
 end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DistributeTasks, :type => :routine do
   end
 
   it "sets the published_at field when it distributes" do
-      task_plan = FactoryGirl.create :task_plan
+      task_plan = FactoryGirl.create :tasks_task_plan
       DistributeTasks.call(task_plan)
       expect(task_plan.reload.published_at).to be_within(1.second).of(Time.now)
   end


### PR DESCRIPTION
Adds the field to task_plans and updates it when the plan is distributed.