### PR TITLE
Send tasked_exercise answers to Exchange

### DIFF
--- a/app/routines/mark_task_step_completed.rb
+++ b/app/routines/mark_task_step_completed.rb
@@ -9,10 +9,8 @@ class MarkTaskStepCompleted
     task_step.save
     transfer_errors_from(task_step, {type: :verbatim}, true)
 
-    if task_step.tasked
-      task_step.tasked.try(:handle_task_step_completion!)
-      transfer_errors_from(task_step.tasked, {type: :verbatim}, true)
-    end
+    task_step.tasked.try(:handle_task_step_completion!)
+    transfer_errors_from(task_step.tasked, {type: :verbatim}, true)
 
     task = task_step.task
     task.handle_task_step_completion!

--- a/app/routines/mark_task_step_completed.rb
+++ b/app/routines/mark_task_step_completed.rb
@@ -9,6 +9,11 @@ class MarkTaskStepCompleted
     task_step.save
     transfer_errors_from(task_step, {type: :verbatim}, true)
 
+    if task_step.tasked
+      task_step.tasked.try(:handle_task_step_completion!)
+      transfer_errors_from(task_step.tasked, {type: :verbatim}, true)
+    end
+
     task = task_step.task
     task.handle_task_step_completion!
     transfer_errors_from(task, {type: :verbatim}, true)

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -1,6 +1,6 @@
 class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   sortable_belongs_to :task, on: :number, inverse_of: :task_steps
-  belongs_to :tasked, polymorphic: true, dependent: :destroy
+  belongs_to :tasked, polymorphic: true, dependent: :destroy, inverse_of: :task_step
 
   enum group_type: [:default_group, :core_group, :spaced_practice_group]
 

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -58,6 +58,17 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
     self.content = json_hash.to_json
   end
 
+  # submits the result to exchange
+  def handle_task_step_completion!
+    # Currently assuming only one question per tasked_exercise, see also correct_answer_id
+    question = wrapper.questions.first
+    # "trial" is set to only "0" for now.  When multiple
+    # attempts are supported, it will be incremented to indicate the attempt #
+    OpenStax::Exchange.record_multiple_choice_answer(
+      question['id'], url, '0', answer_id
+    )
+  end
+
   protected
 
   # Eventually this will be enforced by the exercise substeps

--- a/lib/acts_as_tasked.rb
+++ b/lib/acts_as_tasked.rb
@@ -7,7 +7,7 @@ module ActsAsTasked
   module ClassMethods
     def acts_as_tasked
       class_eval do
-        has_one :task_step, as: :tasked
+        has_one :task_step, as: :tasked, inverse_of: :tasked
 
         delegate :completed_at, :completed?, :complete,
                  to: :task_step, allow_nil: true

--- a/spec/routines/mark_task_step_completed_spec.rb
+++ b/spec/routines/mark_task_step_completed_spec.rb
@@ -26,15 +26,13 @@ RSpec.describe MarkTaskStepCompleted, :type => :routine do
   end
 
   it 'instructs the associated Task to handle completion-related activities' do
-    task = Tasks::Models::Task.new
-    task_step = Tasks::Models::TaskStep.new
+    task_step = tasked_reading.task_step
+    task = task_step.task
     expect(task_step).to receive(:complete)
     expect(task_step).to receive(:save)
     expect(task_step).to receive(:task).and_return(task)
     expect(task).to receive(:handle_task_step_completion!)
-
     result = MarkTaskStepCompleted.call(task_step: task_step)
-
     expect(result.errors).to be_empty
   end
 

--- a/spec/routines/mark_task_step_completed_spec.rb
+++ b/spec/routines/mark_task_step_completed_spec.rb
@@ -38,4 +38,10 @@ RSpec.describe MarkTaskStepCompleted, :type => :routine do
     expect(result.errors).to be_empty
   end
 
+  it 'instructs the associated Tasked to handle completion-related activities' do
+    expect(tasked_exercise).to receive(:handle_task_step_completion!)
+    result = MarkTaskStepCompleted.call(task_step: tasked_exercise.task_step)
+    expect(result.errors).to be_empty
+  end
+
 end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -71,4 +71,15 @@ RSpec.describe Tasks::Models::TaskedExercise, :type => :model do
     expect(tasked_exercise).not_to be_valid
     expect(tasked_exercise.reload).not_to be_valid
   end
+
+  it 'records answers in exchange when the task_step is completed' do
+    tasked_exercise.free_response = 'abc'
+    tasked_exercise.answer_id = tasked_exercise.answer_ids.first
+    question_id = tasked_exercise.wrapper.questions.first['id']
+    expect(OpenStax::Exchange).to receive(:record_multiple_choice_answer)
+                                   .with(question_id,
+                                         tasked_exercise.url,
+                                         "0", tasked_exercise.answer_ids.first)
+    tasked_exercise.handle_task_step_completion!
+  end
 end


### PR DESCRIPTION
This modifies the `MarkTaskStepCompleted` routine to call `handle_task_step_completion!` on the `tasked` association of `TaskStep`, just as it does to the `task` association.

TaskedExercise implements the method to submit the answer to Exchange using the `OpenStax::Exchange.record_multiple_choice_answer` method.

Note that TaskedExercise does not handle multiple questions, it only submits the first one.  That's what other code does in the file, so I assumed questions is an array for future expansion and not something that should be currently handled.


