### PR TITLE
Add "is_correct" to tasked_exercise representation

### DIFF
--- a/app/representers/api/v1/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasked_exercise_representer.rb
@@ -76,5 +76,15 @@ module Api::V1
                description: "Whether or not a recovery exercise is available"
              }
 
+    property :is_correct,
+             type: 'boolean',
+             writeable: false,
+             readable: true,
+             if: -> (*) { task_step.completed? },
+             getter: -> (*) { correct_answer_id == answer_id },
+             schema_info: {
+               description: "Whether or not the answer given by the student is correct"
+             }
+
   end
 end

--- a/spec/representers/api/v1/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasked_exercise_representer_spec.rb
@@ -26,4 +26,30 @@ RSpec.describe Api::V1::TaskedExerciseRepresenter, :type => :representer do
     )
   end
 
+
+  context "when complete" do
+    before do
+      tasked_exercise.free_response = 'Four score and seven years ago ...'
+      tasked_exercise.answer_id = tasked_exercise.answer_ids.first
+      tasked_exercise.save!
+      tasked_exercise.task_step.complete
+      tasked_exercise.task_step.save!
+    end
+
+    it "has additional fields" do
+      expect(representation).to include(
+        "id"                => tasked_exercise.id,
+        "type"              => "exercise",
+        "is_completed"      => true,
+        "content_url"       => tasked_exercise.url,
+        "correct_answer_id" =>tasked_exercise.correct_answer_id,
+        "answer_id"         =>tasked_exercise.answer_ids.first,
+        "free_response"     =>"Four score and seven years ago ...",
+        "has_recovery"      => false,
+        "is_correct"        => true
+      )
+    end
+
+  end
+
 end


### PR DESCRIPTION
FE requested this but I'm not sure how much it adds, correct_answer_id and answer_id were already present on the representation, so this really just saves them using a ===

