### PR TITLE
spaced practice - round 3

### DIFF
--- a/app/representers/api/v1/task_step_properties.rb
+++ b/app/representers/api/v1/task_step_properties.rb
@@ -41,7 +41,7 @@ module Api::V1
                             TaskedRepresenterMapper.models.collect{ |klass|
                               "'" + klass.name.demodulize.remove("Tasked")
                                          .underscore.downcase + "'"
-                            }.join(',')}"
+                            }.reject{|m| m == 'placeholder'}.join(',')}"
              }
 
     property :is_completed,

--- a/app/representers/api/v1/tasked_placeholder_representer.rb
+++ b/app/representers/api/v1/tasked_placeholder_representer.rb
@@ -3,5 +3,39 @@ module Api::V1
 
     include TaskStepProperties
 
+    ## overridden from TaskStepProperties
+    property :type,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: lambda { |*| 'exercise' },
+             schema_info: {
+               required: true,
+               description: "The type of this TaskStep, one of: #{
+                            TaskedRepresenterMapper.models.collect{ |klass|
+                              "'" + klass.name.demodulize.remove("Tasked")
+                                         .underscore.downcase + "'"
+                            }.reject{|m| m == 'placeholder'}.join(',')}"
+             }
+
+    property :url,
+             type: String,
+             writeable: false,
+             readable: true,
+             as: :content_url,
+             schema_info: {
+               required: false,
+               description: "The source URL for this Exercise"
+             }
+
+    property :content,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The Exercise's content without correctness and feedback info"
+             }
+
   end
 end

--- a/app/representers/api/v1/tasked_representer_mapper.rb
+++ b/app/representers/api/v1/tasked_representer_mapper.rb
@@ -33,6 +33,7 @@ module Api::V1
       @@map ||= {
         Tasks::Models::TaskedReading     => ->(*){TaskedReadingRepresenter},
         Tasks::Models::TaskedExercise    => ->(*){TaskedExerciseRepresenter},
+        Tasks::Models::TaskedPlaceholder => ->(*){TaskedPlaceholderRepresenter},
         Tasks::Models::TaskedVideo       => ->(*){TaskedVideoRepresenter},
         Tasks::Models::TaskedInteractive => ->(*){TaskedInteractiveRepresenter},
         Tasks::Models::TaskedPlaceholder => ->(*){TaskedPlaceholderRepresenter}

--- a/app/routines/mark_task_step_completed.rb
+++ b/app/routines/mark_task_step_completed.rb
@@ -13,7 +13,7 @@ class MarkTaskStepCompleted
     transfer_errors_from(task_step.tasked, {type: :verbatim}, true)
 
     task = task_step.task
-    task.handle_task_step_completion!
+    task.handle_task_step_completion!(completion_time: completion_time)
     transfer_errors_from(task, {type: :verbatim}, true)
   end
 

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -68,8 +68,8 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
     write_attribute(:spaced_practice_algorithm, YAML.dump(algorithm))
   end
 
-  def handle_task_step_completion!
-    spaced_practice_algorithm.call(event: :task_step_completion, task: self)
+  def handle_task_step_completion!(completion_time: Time.now)
+    spaced_practice_algorithm.call(event: :task_step_completion, task: self, current_time: completion_time)
   end
 
   protected

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -393,7 +393,7 @@ ActiveRecord::Schema.define(version: 20150406200833) do
     t.string   "title"
     t.string   "type",               null: false
     t.text     "settings",           null: false
-    t.datetime "opens_at",           null: false
+    t.datetime "opens_at"
     t.datetime "due_at"
     t.datetime "published_at"
     t.datetime "created_at",         null: false

--- a/lib/spaced_practice_algorithm_do_nothing.rb
+++ b/lib/spaced_practice_algorithm_do_nothing.rb
@@ -1,4 +1,4 @@
 class SpacedPracticeAlgorithmDoNothing
-  def call(event:, task:)
+  def call(event:, task:, current_time: Time.now)
   end
 end

--- a/lib/spaced_practice_algorithm_i_reading.rb
+++ b/lib/spaced_practice_algorithm_i_reading.rb
@@ -42,6 +42,9 @@ class SpacedPracticeAlgorithmIReading
     @k_ago_map.each do |k_ago, num_k_ago_exercises|
       break if k_ago >= maps.count
 
+      k_ago_task_title = maps[k_ago][:task].title
+      k_ago_task_los   = maps[k_ago][:los]
+
       candidate_exercises = (maps[k_ago][:content_exercises] - all_taskee_exercises).sort_by{|ex| ex.id}.take(10)
       #puts "candidate_exercises: #{candidate_exercises.collect{|ex| ex.id}.sort}"
 
@@ -67,6 +70,8 @@ class SpacedPracticeAlgorithmIReading
           content:   exercise.content,
           exercise:  chosen_exercise
         )
+        task_step.tasked.inject_debug_content(debug_content: "LOs: #{k_ago_task_los.inspect}<br>")
+        task_step.tasked.inject_debug_content(debug_content: "Task: #{k_ago_task_title}<br>")
         task_step.tasked.inject_debug_content(debug_content: 'SPE<br>')
         task_step.tasked.save!
         task_step.save!

--- a/lib/tasks/sprint/sprint_009/sp.rb
+++ b/lib/tasks/sprint/sprint_009/sp.rb
@@ -10,9 +10,9 @@ module Sprint009
       OpenStax::Exercises::V1.use_real_client
 
       puts "===== CREATING USERS ====="
-      student1 = FactoryGirl.create :user, username: 'in_order'
-      student2 = FactoryGirl.create :user, username: 'out_of_order'
-      student3 = FactoryGirl.create :user, username: 'skipped'
+      student1 = FactoryGirl.create :user, username: 'order_1_2_3_4'
+      student2 = FactoryGirl.create :user, username: 'order_2_1_4_3'
+      student3 = FactoryGirl.create :user, username: 'no_history'
 
       puts "===== CREATING COURSE ====="
       physics_course = Domain::CreateCourse[name: 'Physics']
@@ -71,7 +71,8 @@ module Sprint009
           taskees:   taskee_roles,
           assistant: assistant,
           opens_at:  task_dates[ii][:opens_at],
-          due_at:    task_dates[ii][:due_at]
+          due_at:    task_dates[ii][:due_at],
+          title:     "iReading #{ii+1}: #{page_data.title}"
         )
         tasks
       end
@@ -82,7 +83,7 @@ module Sprint009
 
       puts "===== CREATING USER HISTORIES ====="
 
-      # taskee1: in order
+      # taskee1: task completion order #1 #2 #3 #4
       reading_task_groups[0][0].core_task_steps.each_with_index do |task_step, ii|
         MarkTaskStepCompleted.call(task_step: task_step, completion_time: task_dates[0][:opens_at]+(10+ii).minutes)
       end
@@ -96,7 +97,7 @@ module Sprint009
         MarkTaskStepCompleted.call(task_step: task_step, completion_time: task_dates[3][:opens_at]+(10+ii).minutes)
       end
 
-      # taskee2: out of order
+      # taskee2: task completion order #2 #1 #4 #3
       reading_task_groups[1][1].core_task_steps.each_with_index do |task_step, ii|
         MarkTaskStepCompleted.call(task_step: task_step, completion_time: task_dates[0][:opens_at]+(10+ii).minutes)
       end
@@ -110,17 +111,19 @@ module Sprint009
         MarkTaskStepCompleted.call(task_step: task_step, completion_time: task_dates[3][:opens_at]+(10+ii).minutes)
       end
 
+      # taskee3: no task completion
     end
 
     private
 
-    def create_tasks(page_id:, taskees:, assistant:, opens_at: Time.now, due_at: opens_at+1.week)
+    def create_tasks(page_id:, taskees:, assistant:, opens_at: Time.now, due_at: opens_at+1.week, title: 'iReading')
       ## create TaskPlans for each Page with LOs
       task_plan = FactoryGirl.create(:tasks_task_plan,
         assistant: assistant,
-        opens_at: opens_at,
-        due_at:   due_at,
-        settings: { page_ids: [page_id] }
+        opens_at:  opens_at,
+        due_at:    due_at,
+        title:     title,
+        settings: { page_ids: [page_id] },
       )
 
       ## Add TaskingPlans for each Taskee to the TaskPlans

--- a/lib/tasks/sprint/sprint_009/sp.rb
+++ b/lib/tasks/sprint/sprint_009/sp.rb
@@ -58,10 +58,10 @@ module Sprint009
       ## assignment data
       base_time = Time.now
       task_dates = [
-        {opens_at: base_time +  1.day,  due_at: base_time +  8.days},
-        {opens_at: base_time +  4.days, due_at: base_time + 11.days},
-        {opens_at: base_time +  7.days, due_at: base_time + 14.days},
-        {opens_at: base_time + 10.days, due_at: base_time + 17.days}
+        {opens_at: base_time - 25.days, due_at: base_time - 15.days},
+        {opens_at: base_time - 20.days, due_at: base_time - 10.days},
+        {opens_at: base_time -  5.days, due_at: base_time +  5.days},
+        {opens_at: base_time + 10.days, due_at: base_time + 20.days}
       ]
 
       ## task = reading_task_groups[assignment_index][taskee_index]

--- a/spec/representers/api/v1/tasked_placeholder_representer_spec.rb
+++ b/spec/representers/api/v1/tasked_placeholder_representer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TaskedPlaceholderRepresenter, :type => :representer do
+
+  let(:tasked_placeholder) {
+    task_step = FactoryGirl.create(:tasks_task_step)
+    tasked_placeholder = Tasks::Models::TaskedPlaceholder.new
+    task_step.tasked = tasked_placeholder
+    task_step.save!
+    tasked_placeholder
+  }
+  let(:representation)     { Api::V1::TaskedPlaceholderRepresenter.new(tasked_placeholder).as_json }
+
+  it "represents a tasked placeholder" do
+    expect(representation).to include(
+      "id"           => tasked_placeholder.id,
+      "type"         => "exercise",  ## <-- not a typo
+      "is_completed" => false,
+      # "content_url"  => tasked_placeholder.url,
+      # "content"      => tasked_placeholder.content
+    )
+  end
+
+end


### PR DESCRIPTION
This PR:
* adds missing  `TaskedPlaceholderRepresenter` class to fix an exception; a page reload is still necessary after completing the 'core' task steps through the UI
* fixes a bug in how the `SpacedPracticeAlgorithmIReading` handles  `TaskStep` completion time
* has the SPA add more details debug content to `TaskedExercise`s it creates
* updates the sprint009 `sp.rb` script to:
** add task titles based on its number and associated page title
** update usernames to better indicate the order in which they completed tasks (if at all)
** update task open/due dates
