### PR TITLE
Remove the oauth stuff not needed in BigLearn real client

### DIFF
--- a/app/external/openstax/big_learn/v1/real_client.rb
+++ b/app/external/openstax/big_learn/v1/real_client.rb
@@ -3,8 +3,6 @@ class OpenStax::BigLearn::V1::RealClient
     @client_id = configuration.client_id
     @secret = configuration.secret
     @server_url = configuration.server_url
-    @oauth_client = OAuth2::Client.new(@client_id, @secret, site: @server_url)
-    @oauth_token = @oauth_client.client_credentials.get_token if @client_id
   end
 
   # TODO implement these methods when real API set; use HTTParty, e.g:


### PR DESCRIPTION
Quick PR to remove the oauth instantiation in biglearn real client