### PR TITLE
corrected SS has_blah association default foreign key

### DIFF
--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -4,7 +4,6 @@ class Content::Models::Exercise < Tutor::SubSystems::BaseModel
   has_many :exercise_tags, dependent: :destroy
 
   has_many :tasked_exercises, subsystem: :tasks,
-                              dependent: :destroy,
-                              foreign_key: :content_exercise_id
+                              dependent: :destroy
   protected :tasked_exercises
 end

--- a/app/subsystems/course_membership/models/entity_extensions.rb
+++ b/app/subsystems/course_membership/models/entity_extensions.rb
@@ -1,2 +1,2 @@
-Entity::Role.has_many :students, subsystem: :course_membership, foreign_key: 'entity_role_id'
-Entity::Role.has_many :teachers, subsystem: :course_membership, foreign_key: 'entity_role_id'
+Entity::Role.has_many :students, subsystem: :course_membership
+Entity::Role.has_many :teachers, subsystem: :course_membership

--- a/app/subsystems/tasks/models/entity_extensions.rb
+++ b/app/subsystems/tasks/models/entity_extensions.rb
@@ -1,2 +1,2 @@
-Entity::Task.has_many :taskings, subsystem: :tasks, foreign_key: :entity_task_id
-Entity::Task.has_one :task, subsystem: :tasks, foreign_key: :entity_task_id
+Entity::Task.has_many :taskings, subsystem: :tasks
+Entity::Task.has_one :task, subsystem: :tasks

--- a/lib/tutor/subsystems/association_extensions.rb
+++ b/lib/tutor/subsystems/association_extensions.rb
@@ -54,7 +54,7 @@ module Tutor::SubSystems
           options[:foreign_key] ||= "#{subsystem_name}_#{association_name.to_s.underscore}_id"
         else
           klass_name = self.name.demodulize.underscore
-          options[:foreign_key] ||= "#{subsystem_name}_#{klass_name}_id"
+          options[:foreign_key] ||= "#{my_subsystem_name}_#{klass_name}_id"
         end
         options
       end


### PR DESCRIPTION
@Dantemss and @nathanstitt -- we had some earlier discussion in another PR about has_many default foreign keys in SS's.  This fix changes the default to use the `my_subsystem_name` instead of `subsystem_name`, which I believe is correct (and gets rid of the need to specify foreign keys like we were doing).  Let me know what you think.