### PR TITLE
Strong ETag and If-Modified-Since

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'openstax_exchange'
 gem 'chronic'
 
 # API versioning and documentation
-gem 'openstax_api', '~> 5.2.2'
+gem 'openstax_api', '~> 5.3.0'
 gem 'apipie-rails'
 gem 'maruku'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     docile (1.1.5)
     domain_name (0.5.23)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (2.1.4)
+    doorkeeper (2.2.0)
       railties (>= 3.2)
     erubis (2.7.0)
     eventmachine (1.0.7)
@@ -248,7 +248,7 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_api (5.2.2)
+    openstax_api (5.3.0)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
       lev (>= 1.0.0)
@@ -497,7 +497,7 @@ DEPENDENCIES
   newrelic_rpm
   nifty-generators
   openstax_accounts (~> 5.0.1)
-  openstax_api (~> 5.2.2)
+  openstax_api (~> 5.3.0)
   openstax_exchange
   openstax_utilities (~> 4.2.0)
   pg

--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
   def show
     task_step = Tasks::Models::TaskStep.find(params[:id])
     tasked = task_step.tasked
-    standard_read(tasked, Api::V1::TaskedRepresenterMapper.representer_for(tasked))
+    standard_read(tasked, Api::V1::TaskedRepresenterMapper.representer_for(tasked), true)
   end
 
   api :PUT, '/steps/:step_id', 'Updates the specified TaskStep'

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::TasksController < Api::V1::ApiController
   #   #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
   # EOS
   def show
-    standard_read(Tasks::Models::Task.find(params[:id]), Api::V1::TaskRepresenter)
+    standard_read(Tasks::Models::Task.find(params[:id]), Api::V1::TaskRepresenter, true)
   end
 
 end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -1,6 +1,6 @@
 class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   sortable_belongs_to :task, on: :number, inverse_of: :task_steps, touch: true
-  belongs_to :tasked, polymorphic: true, dependent: :destroy, inverse_of: :task_step
+  belongs_to :tasked, polymorphic: true, dependent: :destroy, inverse_of: :task_step, touch: true
 
   enum group_type: [:default_group, :core_group, :spaced_practice_group]
 

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -1,5 +1,5 @@
 class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
-  sortable_belongs_to :task, on: :number, inverse_of: :task_steps
+  sortable_belongs_to :task, on: :number, inverse_of: :task_steps, touch: true
   belongs_to :tasked, polymorphic: true, dependent: :destroy, inverse_of: :task_step
 
   enum group_type: [:default_group, :core_group, :spaced_practice_group]

--- a/lib/acts_as_tasked.rb
+++ b/lib/acts_as_tasked.rb
@@ -9,6 +9,8 @@ module ActsAsTasked
       class_eval do
         has_one :task_step, as: :tasked, inverse_of: :tasked
 
+        after_save { task_step.touch if task_step.persisted? }
+
         delegate :completed_at, :completed?, :complete, to: :task_step, allow_nil: true
 
         def can_be_recovered?

--- a/lib/acts_as_tasked.rb
+++ b/lib/acts_as_tasked.rb
@@ -9,7 +9,7 @@ module ActsAsTasked
       class_eval do
         has_one :task_step, as: :tasked, inverse_of: :tasked
 
-        after_save { task_step.touch if task_step.persisted? }
+        after_update { task_step.try(:touch) if task_step.try(:persisted?) }
 
         delegate :completed_at, :completed?, :complete, to: :task_step, allow_nil: true
 

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -16,4 +16,9 @@ RSpec.describe Tasks::Models::TaskStep, :type => :model do
     expect(FactoryGirl.build(:tasks_task_step,
                              tasked: task_step.tasked)).not_to be_valid
   end
+
+  it "invalidates task's cache when updated" do
+    task_step.tasked = FactoryGirl.build :tasks_tasked_exercise, task_step: task_step
+    expect { task_step.save! }.to change{ task_step.task.cache_key }
+  end
 end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe Tasks::Models::TaskedExercise, :type => :model do
     expect(tasked_exercise.reload).not_to be_valid
   end
 
+  it "invalidates task's cache when updated" do
+    tasked_exercise.free_response = 'abc'
+    tasked_exercise.answer_id = tasked_exercise.answer_ids.first
+    expect { tasked_exercise.save! }.to change{ tasked_exercise.task_step.task.cache_key }
+  end
+
   it 'records answers in exchange when the task_step is completed' do
     exchange_identifier = 42
     allow(tasked_exercise).to receive(:identifier).and_return(exchange_identifier)


### PR DESCRIPTION
Support ETags (If-None-Match) and If-Modified-Since based on the updated_at timestamp  for Tasks and TaskSteps (GET only)