### PR TITLE
Better dashboard endpoint

### DIFF
--- a/app/controllers/api/v1/courses/dashboard.rb
+++ b/app/controllers/api/v1/courses/dashboard.rb
@@ -1,0 +1,58 @@
+class Api::V1::Courses::Dashboard
+  lev_routine
+
+  uses_routine GetCourseTaskPlans,
+               as: :get_plans,
+               translations: { outputs: { map: { items: :plans } } }
+  uses_routine ::Tasks::GetTasks,
+               as: :get_tasks
+  uses_routine GetCourse,
+               as: :get_course
+  uses_routine GetTeacherNames,
+               as: :get_teacher_names,
+               translations: { outputs: { scope: :course } }
+
+  protected
+
+  def exec(course:, role:)
+    role_type = get_role_type(course, role)
+
+    raise SecurityTransgression if role_type.nil?
+
+    load_tasks(role)
+    load_plans(course) if :teacher == role_type
+    load_course(course, role_type)
+    load_role(role, role_type)
+  end
+
+  def get_role_type(course, role)
+    if CourseMembership::IsCourseTeacher[course: course, roles: role]
+      :teacher
+    elsif CourseMembership::IsCourseStudent[course: course, roles: role]
+      :student
+    end
+  end
+
+  def load_tasks(role)
+    run(:get_tasks, roles: role)
+    entity_task_ids = outputs["[:get_tasks, :tasks]"].collect{|entity_task| entity_task.id}
+    outputs[:tasks] = Tasks::Models::Task.where{entity_task_id.in entity_task_ids}
+  end
+
+  def load_plans(course)
+    run(:get_plans, course: course)
+  end
+
+  def load_course(course, role_type)
+    run(:get_course_profile, course)
+    run(:get_teacher_names, course.id)
+  end
+
+  def load_role(role, role_type)
+    outputs.role = {
+      id: role.id,
+      type: role_type.to_s
+    }
+  end
+
+end

--- a/app/controllers/api/v1/courses/dashboard.rb
+++ b/app/controllers/api/v1/courses/dashboard.rb
@@ -9,8 +9,7 @@ class Api::V1::Courses::Dashboard
   uses_routine GetCourse,
                as: :get_course
   uses_routine GetTeacherNames,
-               as: :get_teacher_names,
-               translations: { outputs: { scope: :course } }
+               as: :get_teacher_names
 
   protected
 
@@ -44,8 +43,14 @@ class Api::V1::Courses::Dashboard
   end
 
   def load_course(course, role_type)
-    run(:get_course_profile, course)
+    run(:get_course, course.id)
     run(:get_teacher_names, course.id)
+
+    outputs[:course] = {
+      id: outputs["[:get_course, :course]"].course_id,
+      name: outputs["[:get_course, :course]"].name,
+      teacher_names: outputs["[:get_teacher_names, :teacher_names]"]
+    }
   end
 
   def load_role(role, role_type)

--- a/app/controllers/api/v1/courses/dashboard_representer.rb
+++ b/app/controllers/api/v1/courses/dashboard_representer.rb
@@ -72,7 +72,8 @@ module Api::V1::Courses
 
       property :correct_exercise_count,
                type: Integer,
-               readable: true
+               readable: true,
+               if: -> (*) { past_due? && completed? }
     end
 
     class Role < Roar::Decorator

--- a/app/controllers/api/v1/courses/dashboard_representer.rb
+++ b/app/controllers/api/v1/courses/dashboard_representer.rb
@@ -1,0 +1,130 @@
+module Api::V1::Courses
+
+  class DashboardRepresenter < ::Roar::Decorator
+
+    include ::Roar::JSON
+
+    class Base < Roar::Decorator
+      include Roar::JSON
+
+      property :id,
+               type: Integer,
+               readable: true
+
+      property :title,
+               type: String,
+               readable: true
+
+      property :opens_at,
+               type: DateTime,
+               readable: true
+
+      property :due_at,
+               type: DateTime,
+               readable: true
+
+    end
+
+    class Plan < Base
+
+      property :trouble,
+               type: :boolean,
+               readable: true,
+               getter: lambda{|*| rand(0..1)==0 }
+        # ^^^^^ REPLACE with real value once spec for calculating it's available
+
+      property :type,
+               type: String,
+               readable: true
+    end
+
+    class TaskBase < Base
+
+      property :task_type,
+               as: :type,
+               type: String,
+               readable: true
+
+      property :'completed?',
+               as: :complete,
+               type: :boolean,
+               readable: true
+    end
+
+    class ReadingTask < TaskBase
+      property :exercise_count,
+               type: Integer,
+               readable: true
+
+      property :complete_exercise_count,
+               type: Integer,
+               readable: true
+    end
+
+    class HomeworkTask < TaskBase
+      property :exercise_count,
+               type: Integer,
+               readable: true
+
+      property :complete_exercise_count,
+               type: Integer,
+               readable: true
+
+      property :correct_exercise_count,
+               type: Integer,
+               readable: true
+    end
+
+    class Role < Roar::Decorator
+      include Roar::JSON
+
+      property :id,
+               readable: true,
+               type: Integer
+
+      property :type,
+               readable: true,
+               type: String
+    end
+
+    class Course < Roar::Decorator
+      include Roar::JSON
+
+      property :name,
+               readable: true,
+               type: String
+
+      collection :teacher_names,
+                 readable: true,
+                 type: String
+    end
+
+    # Actual attributes below
+
+    collection :plans,
+               readable: true,
+               decorator: Plan
+
+    collection :tasks,
+               readable: true,
+               decorator: -> (task, *) {
+                 case task.task_type
+                 when 'reading'
+                   ReadingTask
+                 when 'homework'
+                   HomeworkTask
+                 end
+               }
+
+    property :role,
+             readable: true,
+             decorator: Role
+
+    property :course,
+             readable: true,
+             decorator: Course
+
+
+  end
+
+end

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -93,7 +93,16 @@ class Api::V1::CoursesController < Api::V1::ApiController
   def events
     course = Entity::Course.find(params[:id])
     result = GetRoleCourseEvents.call(course: course, role: get_course_role(types: :any))
+    GetTeacherNames(params[:id])
     respond_with result.outputs, represent_with: Api::V1::CourseEventsRepresenter
+  end
+
+  def dashboard
+    data = Api::V1::Courses::Dashboard.call(
+             course: params[:id],
+             role: get_course_role(types: :any)
+           ).outputs
+    respond_with data, represent_with: Api::V1::CourseDashboardRepresenter
   end
 
   api nil, nil, nil

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -96,6 +96,10 @@ class Api::V1::CoursesController < Api::V1::ApiController
     respond_with result.outputs, represent_with: Api::V1::CourseEventsRepresenter
   end
 
+  api :GET, '/courses/:course_id/dashboard(/role/:role_id)', 'Gets dashboard information for a given course'
+  description <<-EOS
+    #{json_schema(Api::V1::Courses::DashboardRepresenter, include: :readable)}
+  EOS
   def dashboard
     course = Entity::Course.find(params[:id])
     data = Api::V1::Courses::Dashboard.call(

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -98,11 +98,12 @@ class Api::V1::CoursesController < Api::V1::ApiController
   end
 
   def dashboard
+    course = Entity::Course.find(params[:id])
     data = Api::V1::Courses::Dashboard.call(
-             course: params[:id],
+             course: course,
              role: get_course_role(types: :any)
            ).outputs
-    respond_with data, represent_with: Api::V1::CourseDashboardRepresenter
+    respond_with data, represent_with: Api::V1::Courses::DashboardRepresenter
   end
 
   api nil, nil, nil

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -93,7 +93,6 @@ class Api::V1::CoursesController < Api::V1::ApiController
   def events
     course = Entity::Course.find(params[:id])
     result = GetRoleCourseEvents.call(course: course, role: get_course_role(types: :any))
-    GetTeacherNames(params[:id])
     respond_with result.outputs, represent_with: Api::V1::CourseEventsRepresenter
   end
 

--- a/app/subsystems/course_membership/get_role_type.rb
+++ b/app/subsystems/course_membership/get_role_type.rb
@@ -1,0 +1,9 @@
+class CourseMembership::GetRoleType
+  lev_routine
+
+  protected
+
+  def exec(role)
+
+  end
+end

--- a/app/subsystems/course_membership/get_role_type.rb
+++ b/app/subsystems/course_membership/get_role_type.rb
@@ -1,9 +1,0 @@
-class CourseMembership::GetRoleType
-  lev_routine
-
-  protected
-
-  def exec(role)
-
-  end
-end

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -93,7 +93,7 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
   end
 
   def exercise_steps
-    task_steps.where{tasked_type == 'Tasks::Models::TaskedExercise'}
+    task_steps.where{tasked_type.in %w(Tasks::Models::TaskedExercise Tasks::Models::TaskedPlaceholder)}
   end
 
   protected

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -80,6 +80,22 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
     spaced_practice_algorithm.call(event: event, task: self, current_time: current_time)
   end
 
+  def exercise_count
+    exercise_steps.count
+  end
+
+  def complete_exercise_count
+    exercise_steps.complete.count
+  end
+
+  def correct_exercise_count
+    exercise_steps.select{|step| step.tasked.is_correct?}.count
+  end
+
+  def exercise_steps
+    task_steps.where{tasked_type == 'Tasks::Models::TaskedExercise'}
+  end
+
   protected
 
   def opens_at_or_due_at

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -12,6 +12,7 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   delegate :can_be_answered?, :can_be_recovered?, to: :tasked
 
   scope :complete, -> { where{completed_at != nil} }
+  scope :incomplete, -> { where{completed_at == nil} }
 
   def complete(completion_time: Time.now)
     self.completed_at ||= completion_time

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -11,6 +11,8 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
 
   delegate :can_be_answered?, :can_be_recovered?, to: :tasked
 
+  scope :complete, -> { where{completed_at != nil} }
+
   def complete(completion_time: Time.now)
     self.completed_at ||= completion_time
   end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -69,7 +69,9 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   protected
 
   def identifier
-    task_step.task.taskings.first.role.id
+    # TODO this code (and the blatant hack above) have got to go! Had to add the
+    # tries and the secure random to a basic unit test to work.
+    task_step.task.taskings.try(:first).try(:role).try(:id) || SecureRandom.hex
   end
 
   def trial

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,6 +8,7 @@ require 'html_tree_operations'
 require 'fake_store'
 require 'verify_and_get_id_array'
 require 'entity'
+require 'hacks/answer_exercise'
 
 SITE_NAME = "OpenStax Tutor"
 COPYRIGHT_HOLDER = "Rice University"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         get 'plans'
         get 'tasks'
         get 'events(/role/:role_id)', action: :events
+        get 'dashboard(/role/:role_id)', action: :dashboard
         post 'practice(/role/:role_id)', action: :practice
         get 'practice(/role/:role_id)', action: :practice
       end

--- a/lib/hacks/answer_exercise.rb
+++ b/lib/hacks/answer_exercise.rb
@@ -1,0 +1,23 @@
+module Hacks
+  class AnswerExercise
+    lev_routine
+
+    protected
+
+    def exec(task_step:, is_correct:)
+      tasked = task_step.tasked
+      raise "Task step isn't an exercise" if !tasked.is_a?(Tasks::Models::TaskedExercise)
+
+      answer_id = if is_correct
+        tasked.correct_answer_id
+      else
+        wrong_answer_ids = tasked.answer_ids.reject{|id| id == tasked.correct_answer_id}
+        raise "No incorrect answers to choose" if wrong_answer_ids.size == 0
+        wrong_answer_ids.first
+      end
+
+      tasked.update_attributes(free_response: '.', answer_id: answer_id)
+      task_step.update_attributes(completed_at: Time.now)
+    end
+  end
+end

--- a/lib/hacks/answer_exercise.rb
+++ b/lib/hacks/answer_exercise.rb
@@ -17,7 +17,9 @@ module Hacks
       end
 
       tasked.update_attributes(free_response: '.', answer_id: answer_id)
-      task_step.update_attributes(completed_at: Time.now)
+
+      MarkTaskStepCompleted[task_step: task_step]
+      # task_step.update_attributes(completed_at: Time.now)
     end
   end
 end

--- a/lib/tasks/sprint/010dashboard.rake
+++ b/lib/tasks/sprint/010dashboard.rake
@@ -1,0 +1,13 @@
+namespace :sprint do
+  desc 'Sprint 10 dashboard api'
+  task :'010dashboard' => :environment do |tt, args|
+    require_relative 'sprint_010/dashboard.rb'
+    result = Sprint010::Dashboard.call
+
+    if result.errors.none?
+      puts "success"
+    else
+      result.errors.each{|error| puts "Error: " + Lev::ErrorTranslator.translate(error)}
+    end
+  end
+end

--- a/lib/tasks/sprint/sprint_010/dashboard.rb
+++ b/lib/tasks/sprint/sprint_010/dashboard.rb
@@ -1,0 +1,264 @@
+module Sprint010
+  class Dashboard
+    lev_routine
+
+    protected
+
+    def exec
+      OpenStax::BigLearn::V1.use_fake_client
+      # OpenStax::Exercises::V1.use_real_client
+
+      ## Retrieve a book from CNX
+      puts "===== FETCHING CNX BOOK ====="
+      cnx_book = OpenStax::Cnx::V1::Book.new(id: '7db9aa72-f815-4c3b-9cb6-d50cf5318b58@4.57')
+      visitor = OpenStax::Cnx::V1::BookToStringVisitor.new
+      cnx_book.visit(visitor: visitor)
+      puts visitor.to_s
+
+      ## Import the book (which imports the associated exercises)
+      puts "===== IMPORTING BOOK ====="
+      content_book = Content::ImportBook.call(cnx_book: cnx_book).outputs.book
+
+      ## Retrieve the page info
+      page_data = Content::VisitBook.call(book: content_book, visitor_names: :page_data).outputs.page_data
+
+      page_data.each do |page_data|
+        puts "id: #{page_data.id}"
+        puts "  title:   #{page_data.title}"
+        puts "  LOs:     #{page_data.los}"
+        puts "  version: #{page_data.version}"
+      end
+
+      puts "===== CREATING ASSISTANT and ASSIGNMENT DATA ====="
+
+      ## create the assistant
+      reading_assistant = FactoryGirl.create(:tasks_assistant,
+        code_class_name: 'Tasks::Assistants::IReadingAssistant'
+      )
+
+      homework_assistant = FactoryGirl.create(:tasks_assistant,
+        code_class_name: 'Tasks::Assistants::HomeworkAssistant'
+      )
+
+      ## assignment data
+      base_time = Time.now
+      task_dates = [
+        {opens_at: base_time - 25.days, due_at: base_time - 15.days},
+        {opens_at: base_time - 20.days, due_at: base_time - 10.days},
+        {opens_at: base_time -  5.days, due_at: base_time +  5.days},
+        {opens_at: base_time + 10.days, due_at: base_time + 20.days}
+      ]
+
+      puts "===== CREATING USERS, COURSES, ROLES and ASSIGNMENTS ====="
+
+      puts "--- 0 Plans ---"
+
+      zero_plan_course          = CreateCourse[name: 'Physics - 0 Plans']
+
+      zero_plan_student         = FactoryGirl.create :user_profile, username: 'zero_plan_student'
+      zero_plan_teacher         = FactoryGirl.create :user_profile, username: 'zero_plan_teacher'
+      zero_plan_teacher_student = FactoryGirl.create :user_profile, username: 'zero_plan_teacher_student'
+
+      AddUserAsCourseStudent.call(course: zero_plan_course, user: zero_plan_student.entity_user)
+      zero_plan_student_role_1 = Entity::Role.last
+
+      AddUserAsCourseTeacher.call(course: zero_plan_course, user: zero_plan_teacher.entity_user)
+      zero_plan_teacher_role_1 = Entity::Role.last
+
+      AddUserAsCourseStudent.call(course: zero_plan_course, user: zero_plan_teacher_student.entity_user)
+      zero_plan_student_role_2 = Entity::Role.last
+      AddUserAsCourseTeacher.call(course: zero_plan_course, user: zero_plan_teacher_student.entity_user)
+      zero_plan_teacher_role_2 = Entity::Role.last
+
+      puts zero_plan_course.inspect
+      puts zero_plan_student.inspect
+      puts zero_plan_teacher.inspect
+      puts zero_plan_teacher_student.inspect
+
+      puts "--- 1 Plan ---"
+
+      one_plan_course          = CreateCourse[name: 'Physics - 1 Plan']
+
+      one_plan_student         = FactoryGirl.create :user_profile, username: 'one_plan_student'
+      one_plan_teacher         = FactoryGirl.create :user_profile, username: 'one_plan_teacher'
+      one_plan_teacher_student = FactoryGirl.create :user_profile, username: 'one_plan_teacher_student'
+
+      AddUserAsCourseStudent.call(course: one_plan_course, user: one_plan_student.entity_user)
+      one_plan_student_role_1 = Entity::Role.last
+
+      AddUserAsCourseTeacher.call(course: one_plan_course, user: one_plan_teacher.entity_user)
+      one_plan_teacher_role_1 = Entity::Role.last
+
+      AddUserAsCourseStudent.call(course: one_plan_course, user: one_plan_teacher_student.entity_user)
+      one_plan_student_role_2 = Entity::Role.last
+      AddUserAsCourseTeacher.call(course: one_plan_course, user: one_plan_teacher_student.entity_user)
+      one_plan_teacher_role_2 = Entity::Role.last
+
+      puts one_plan_course.inspect
+      puts one_plan_student.inspect
+      puts one_plan_teacher.inspect
+      puts one_plan_teacher_student.inspect
+
+      taskee_roles = [one_plan_student_role_1, one_plan_student_role_2]
+      puts "taskee_roles: #{taskee_roles.inspect}"
+
+      ## task = reading_task_groups[assignment_index][taskee_index]
+      reading_task_groups = page_data[1..1].each_with_index.collect do |page_data, ii|
+        tasks = create_tasks(
+          settings:  { page_ids: [page_data.id] },
+          taskees:   taskee_roles,
+          assistant: reading_assistant,
+          owner:     one_plan_course,
+          opens_at:  task_dates[ii][:opens_at],
+          due_at:    task_dates[ii][:due_at],
+          title:     "iReading #{ii+1}: #{page_data.title}"
+        )
+        tasks
+      end
+
+      puts "--- Many Plan ---"
+
+      many_plan_course          = CreateCourse[name: 'Physics - Many Plan']
+
+      many_plan_student         = FactoryGirl.create :user_profile, username: 'many_plan_student'
+      many_plan_teacher         = FactoryGirl.create :user_profile,
+                                                     first_name: 'Andrew',
+                                                     last_name: 'Garcia',
+                                                     full_name: 'Andrew Garcia',
+                                                     username: 'many_plan_teacher'
+      many_plan_teacher_student = FactoryGirl.create :user_profile,
+                                                     first_name: 'Bob',
+                                                     last_name: 'Newhart',
+                                                     full_name: 'Bob Newhart',
+                                                     username: 'many_plan_teacher_student'
+
+      AddUserAsCourseStudent.call(course: many_plan_course, user: many_plan_student.entity_user)
+      many_plan_student_role_1 = Entity::Role.last
+
+      AddUserAsCourseTeacher.call(course: many_plan_course, user: many_plan_teacher.entity_user)
+      many_plan_teacher_role_1 = Entity::Role.last
+
+      AddUserAsCourseStudent.call(course: many_plan_course, user: many_plan_teacher_student.entity_user)
+      many_plan_student_role_2 = Entity::Role.last
+      AddUserAsCourseTeacher.call(course: many_plan_course, user: many_plan_teacher_student.entity_user)
+      many_plan_teacher_role_2 = Entity::Role.last
+
+      puts many_plan_course.inspect
+      puts many_plan_student.inspect
+      puts many_plan_teacher.inspect
+      puts many_plan_teacher_student.inspect
+
+      taskee_roles = [many_plan_student_role_1, many_plan_student_role_2]
+      puts "taskee_roles: #{taskee_roles.inspect}"
+
+      ## task = reading_task_groups[assignment_index][taskee_index]
+      reading_task_groups = page_data[1..4].each_with_index.collect do |page_data, ii|
+        tasks = create_tasks(
+          taskees:   taskee_roles,
+          assistant: reading_assistant,
+          settings:  { page_ids: [page_data.id] },
+          owner:     many_plan_course,
+          opens_at:  task_dates[ii][:opens_at],
+          due_at:    task_dates[ii][:due_at],
+          title:     "iReading #{ii+1}: #{page_data.title}"
+        )
+
+        # each ireading has one reading step, go ahead and complete it so placeholder exercises
+        # are populated.  Then complete the exercises for the 2nd reading
+
+        tasks.each do |task|
+          MarkTaskStepCompleted[task_step: task.task_steps.first]
+
+          if 1 == ii
+            task.exercise_steps.incomplete.each do |step|
+              Hacks::AnswerExercise[task_step: step, is_correct: true]
+            end
+          end
+        end
+
+      end
+
+      hw_configurations = [
+        {
+          exercise_ids: [1,3,5],
+          exercises_count_dynamic: 2,
+          answers: [true, false, nil]
+        },
+        {
+          exercise_ids: [7,9,11,13],
+          exercises_count_dynamic: 2,
+          answers: [true, true, false, true]
+        },
+        {
+          exercise_ids: [15,17],
+          exercises_count_dynamic: 2,
+          answers: [true, true, true]
+        },
+        {
+          exercise_ids: [19,21,23],
+          exercises_count_dynamic: 2,
+          answers: [false, false, nil]
+        },
+      ]
+
+      hw_configurations.each_with_index do |hw_configuration, ii|
+        tasks = create_tasks(
+          taskees:   taskee_roles,
+          assistant: homework_assistant,
+          settings:  {
+            exercise_ids: hw_configuration[:exercise_ids],
+            exercises_count_dynamic: hw_configuration[:exercises_count_dynamic]
+          },
+          owner:     many_plan_course,
+          opens_at:  task_dates[ii][:opens_at]+2.days,
+          due_at:    task_dates[ii][:due_at]+2.days,
+          title:     "Homework #{ii+1}"
+        )
+
+        tasks.each do |task|
+          hw_configuration[:answers].each_with_index do |answer, jj|
+            Hacks::AnswerExercise[task_step: task.task_steps[jj], is_correct: answer] if !answer.nil?
+          end
+
+          # If the core steps happen to be completed, any placeholders will become normal exercises;
+          # to demonstrate correctness counts, we need fully completed tasks, so go ahead and answer
+          # the remaining exercises correctly (spaced practice, personalized)
+          if task.core_task_steps_completed?
+            task.exercise_steps.incomplete.each do |step|
+              Hacks::AnswerExercise[task_step: step, is_correct: true]
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+    def create_tasks(settings:, taskees:, assistant:, owner:, opens_at: Time.now, due_at: opens_at+1.week, title: 'untitled')
+      ## create TaskPlans for each Page with LOs
+      task_plan = FactoryGirl.create(:tasks_task_plan,
+        assistant: assistant,
+        owner:     owner,
+        opens_at:  opens_at,
+        due_at:    due_at,
+        title:     title,
+        settings:  settings,
+        type:      (assistant.code_class_name == Tasks::Assistants::IReadingAssistant) ? 'reading' : 'homework'
+      )
+
+      ## Add TaskingPlans for each Taskee to the TaskPlans
+      taskees.each do |taskee|
+        task_plan.tasking_plans << FactoryGirl.create(:tasks_tasking_plan,
+          task_plan: task_plan,
+          target: taskee
+        )
+      end
+
+      ## Create assignment tasks
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+
+      tasks
+    end
+
+  end
+end

--- a/spec/controllers/api/v1/courses/dashboard_representer_spec.rb
+++ b/spec/controllers/api/v1/courses/dashboard_representer_spec.rb
@@ -21,15 +21,33 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, :type => :representer do
           opens_at: 'now',
           due_at: 'then',
           task_type: 'homework',
-          completed?: true
+          completed?: false,
+          past_due?: false,
+          exercise_count: 5,
+          complete_exercise_count: 4,
+          correct_exercise_count: 3
         }),
         Hashie::Mash.new({
           id: 37,
           title: 'Reading 1',
           due_at: 'then',
           task_type: 'reading',
-          completed?: false
-        })
+          completed?: false,
+          exercise_count: 7,
+          complete_exercise_count: 6,
+        }),
+        Hashie::Mash.new({
+          id: 89,
+          title: 'HW3',
+          opens_at: 'now',
+          due_at: 'then',
+          task_type: 'homework',
+          completed?: true,
+          past_due?: true,
+          exercise_count: 8,
+          complete_exercise_count: 8,
+          correct_exercise_count: 3
+        }),
       ]
       mash.course = {
         course_id: 2,
@@ -64,15 +82,30 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, :type => :representer do
           "opens_at" => "now",
           "due_at" => "then",
           "type" => "homework",
-          "complete" => true
+          "complete" => false,
+          "exercise_count" => 5,
+          "complete_exercise_count" => 4
         ),
         a_hash_including(
           "id" => 37,
           "title" => "Reading 1",
           "due_at" => "then",
           "type" => "reading",
-          "complete" => false
-        )
+          "complete" => false,
+          "exercise_count" => 7,
+          "complete_exercise_count" => 6
+        ),
+        a_hash_including(
+          "id" => 89,
+          "title" => "HW3",
+          "opens_at" => "now",
+          "due_at" => "then",
+          "type" => "homework",
+          "complete" => true,
+          "exercise_count" => 8,
+          "complete_exercise_count" => 8,
+          "correct_exercise_count" => 3
+        ),
       ],
       "role" => {
         "id" => 34,
@@ -84,6 +117,9 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, :type => :representer do
       }
     )
 
+    expect(representation["tasks"][0]).to_not have_key "correct_exercise_count"
+    expect(representation["tasks"][1]).to_not have_key "correct_exercise_count"
+    expect(representation["tasks"][2]).to     have_key "correct_exercise_count"
   end
 
 end

--- a/spec/controllers/api/v1/courses/dashboard_representer_spec.rb
+++ b/spec/controllers/api/v1/courses/dashboard_representer_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Courses::DashboardRepresenter, :type => :representer do
+
+  let(:data) {
+    Hashie::Mash.new.tap do |mash|
+      mash.plans = [
+        Hashie::Mash.new({
+          id: 23,
+          title: 'HW1',
+          opens_at: 'now',
+          due_at: 'then',
+          trouble: false,
+          type: 'homework'
+        })
+      ]
+      mash.tasks = [
+        Hashie::Mash.new({
+          id: 34,
+          title: 'HW2',
+          opens_at: 'now',
+          due_at: 'then',
+          task_type: 'homework',
+          completed?: true
+        }),
+        Hashie::Mash.new({
+          id: 37,
+          title: 'Reading 1',
+          due_at: 'then',
+          task_type: 'reading',
+          completed?: false
+        })
+      ]
+      mash.course = {
+        course_id: 2,
+        name: 'Physics 101',
+        teacher_names: ['Andrew Garcia', 'Bob Newhart']
+      }
+      mash.role = {
+        id: 34,
+        type: 'teacher'
+      }
+    end
+  }
+  # let(:representation) { Api::V1::TaskPlanRepresenter.new(task_plan).as_json }
+
+  it "represents dashboard output" do
+    representation = Api::V1::Courses::DashboardRepresenter.new(data).as_json
+
+    expect(representation).to include(
+      "plans" => [
+        a_hash_including(
+          "id" => 23,
+          "title" => "HW1",
+          "opens_at" => "now",
+          "due_at" => "then",
+          "type" => "homework"
+        )
+      ],
+      "tasks" => [
+        a_hash_including(
+          "id" => 34,
+          "title" => "HW2",
+          "opens_at" => "now",
+          "due_at" => "then",
+          "type" => "homework",
+          "complete" => true
+        ),
+        a_hash_including(
+          "id" => 37,
+          "title" => "Reading 1",
+          "due_at" => "then",
+          "type" => "reading",
+          "complete" => false
+        )
+      ],
+      "role" => {
+        "id" => 34,
+        "type" => "teacher"
+      },
+      "course" => {
+        "name" => "Physics 101",
+        "teacher_names" => [ "Andrew Garcia", "Bob Newhart" ]
+      }
+    )
+
+  end
+
+end

--- a/spec/controllers/api/v1/courses/dashboard_spec.rb
+++ b/spec/controllers/api/v1/courses/dashboard_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+require 'vcr_helper'
+
+describe Api::V1::Courses::Dashboard, :type => :routine, :vcr => VCR_OPTS do
+
+  let!(:course)         { CreateCourse[name: 'Physics 101'] }
+
+  let!(:student_user)   { FactoryGirl.create(:user_profile).entity_user }
+  let!(:student_role)   { AddUserAsCourseStudent.call(user: student_user,
+                                                      course: course)
+                                                .outputs.role }
+
+  let!(:teacher_user)   { FactoryGirl.create(:user_profile,
+                                             first_name: 'Bob',
+                                             last_name: 'Newhart',
+                                             full_name: 'Bob Newhart').entity_user }
+  let!(:teacher_role)   { AddUserAsCourseTeacher.call(user: teacher_user,
+                                                      course: course)
+                                                .outputs.role }
+
+  let!(:reading_task)   { FactoryGirl.create(:tasks_task,
+                                             task_type: 'reading',
+                                             step_types: [:tasks_tasked_reading,
+                                                          :tasks_tasked_exercise,
+                                                          :tasks_tasked_exercise],
+                                             tasked_to: student_role)}
+
+  let!(:homework_task)   { FactoryGirl.create(:tasks_task,
+                                              task_type: 'homework',
+                                              step_types: [:tasks_tasked_exercise,
+                                                           :tasks_tasked_exercise,
+                                                           :tasks_tasked_exercise],
+                                              tasked_to: student_role)}
+
+  let!(:plan) { FactoryGirl.create(:tasks_task_plan, owner: course)}
+
+  it "works for a student" do
+    outputs = Api::V1::Courses::Dashboard.call(course: course, role: student_role).outputs
+
+    expect(HashWithIndifferentAccess[outputs]).to include(
+      course: a_hash_including(
+        id: course.id,
+        name: "Physics 101",
+        teacher_names: ['Bob Newhart']
+      ),
+      role: {
+        id: student_role.id,
+        type: 'student'
+      },
+      tasks: [
+        reading_task,
+        homework_task
+      ]
+    )
+  end
+
+  it "works for a teacher" do
+    outputs = Api::V1::Courses::Dashboard.call(course: course, role: teacher_role).outputs
+
+    expect(HashWithIndifferentAccess[outputs]).to include(
+      course: a_hash_including(
+        id: course.id,
+        name: "Physics 101",
+        teacher_names: ['Bob Newhart']
+      ),
+      role: {
+        id: teacher_role.id,
+        type: 'teacher'
+      },
+      tasks: [],
+      plans: [plan]
+    )
+  end
+
+end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -448,25 +448,26 @@ RSpec.describe Api::V1::CoursesController, :type => :controller, :api => true,
   end
 
   describe "dashboard" do
-    let!(:student_user)   { FactoryGirl.create(:user_profile).entity_user }
+    let!(:student_profile){ FactoryGirl.create(:user_profile) }
+    let!(:student_user)   { student_profile.entity_user }
     let!(:student_role)   { AddUserAsCourseStudent.call(user: student_user,
                                                         course: course)
                                                   .outputs.role }
     let!(:student_token)  { FactoryGirl.create :doorkeeper_access_token,
                                                application: application,
-                                               resource_owner_id: student_user.id }
+                                               resource_owner_id: student_profile.id }
 
-
-    let!(:teacher_user)   { FactoryGirl.create(:user_profile,
+    let!(:teacher_profile){ FactoryGirl.create(:user_profile,
                                                first_name: 'Bob',
                                                last_name: 'Newhart',
-                                               full_name: 'Bob Newhart').entity_user }
+                                               full_name: 'Bob Newhart') }
+    let!(:teacher_user)   { teacher_profile.entity_user }
     let!(:teacher_role)   { AddUserAsCourseTeacher.call(user: teacher_user,
                                                         course: course)
                                                   .outputs.role }
     let!(:teacher_token)  { FactoryGirl.create :doorkeeper_access_token,
                                                application: application,
-                                               resource_owner_id: teacher_user.id }
+                                               resource_owner_id: teacher_profile.id }
 
     let!(:reading_task)   { FactoryGirl.create(:tasks_task,
                                                task_type: 'reading',

--- a/spec/factories/tasks/tasks.rb
+++ b/spec/factories/tasks/tasks.rb
@@ -21,11 +21,11 @@ FactoryGirl.define do
       end
 
       evaluator.num_random_taskings.times do
-        task.taskings << FactoryGirl.build(:tasks_tasking, task: task)
+        task.taskings << FactoryGirl.build(:tasks_tasking, task: task.entity_task)
       end
 
-      [evaluator.tasked_to].flatten.each do |taskee|
-        task.taskings << FactoryGirl.build(:tasks_tasking, task: task, taskee: taskee)
+      [evaluator.tasked_to].flatten.each do |role|
+        FactoryGirl.create(:tasks_tasking, task: task.entity_task, role: role)
       end
     end
   end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -117,4 +117,20 @@ RSpec.describe Tasks::Models::Task, :type => :model do
     expect(task.feedback_available?).to eq false
   end
 
+  it 'counts exercise steps' do
+    task = FactoryGirl.create(:tasks_task,
+                              task_type: 'homework',
+                              step_types: [:tasks_tasked_exercise,
+                                           :tasks_tasked_reading,
+                                           :tasks_tasked_exercise,
+                                           :tasks_tasked_exercise])
+
+    Hacks::AnswerExercise[task_step: task.task_steps[0], is_correct: true]
+    Hacks::AnswerExercise[task_step: task.task_steps[3], is_correct: false]
+
+    expect(task.exercise_count).to eq 3
+    expect(task.complete_exercise_count).to eq 2
+    expect(task.correct_exercise_count).to eq 1
+  end
+
 end


### PR DESCRIPTION
This PR deprecates the /api/courses/1/events endpoint with an improved /api/courses/1/dashboard endpoint (`/events` is still accessible and still has its own rake task).  The new endpoint builds on what @kevinburleigh75 and @nathanstitt created in the `/events` endpoint and adds course and role information (for showing other things like teacher names), in addition to `exercise_count`, `complete_exercise_count`, and `correct_exercise_count` fields on reading and homework tasks.  `correct_exercise_count` will only be visible if the user is allowed to see that information.  Works for both teachers and students.

The rake endpoint uses the same approach that @kevinburleigh75 setup for the events endpoint rake task:

`bundle exec rake db:drop db:create db:migrate sprint:010dashboard`

It creates three courses, one with no plans, one with 1 plan, and one with a bunch of plans.  The latter is for sure the most interesting, with a combination of readings and homeworks in various states of completion and with due dates before and after now.

After running the rake tasks:

  1. Run the server: `bundle exec rails s`
  2. Go to `http://localhost:3001/accounts/dev/accounts`
  3. Log in as `many_plan_student`.
  4. Go to http://localhost:3001/api/courses/3/dashboard

Here's the JSON output:

```
{
  tasks: [
    {
      id: 3,
      title: "iReading 1: Force",
      opens_at: "2015-04-01T07:30:54.564Z",
      due_at: "2015-04-11T07:30:54.564Z",
      type: "reading",
      complete: false,
      exercise_count: 2,
      complete_exercise_count: 0
    },
    {
      id: 5,
      title: "iReading 2: Newton's First Law of Motion: Inertia",
      opens_at: "2015-04-06T07:30:54.564Z",
      due_at: "2015-04-16T07:30:54.564Z",
      type: "reading",
      complete: true,
      exercise_count: 2,
      complete_exercise_count: 2
    },
    {
      id: 7,
      title: "iReading 3: Newton's Second Law of Motion:",
      opens_at: "2015-04-21T07:30:54.564Z",
      due_at: "2015-05-01T07:30:54.564Z",
      type: "reading",
      complete: false,
      exercise_count: 2,
      complete_exercise_count: 0
    },
    {
      id: 9,
      title: "iReading 4: Newton's Third Law of Motion",
      opens_at: "2015-05-06T07:30:54.564Z",
      due_at: "2015-05-16T07:30:54.564Z",
      type: "reading",
      complete: false,
      exercise_count: 2,
      complete_exercise_count: 0
    },
    {
      id: 11,
      title: "Homework 1",
      opens_at: "2015-04-03T07:30:54.564Z",
      due_at: "2015-04-13T07:30:54.564Z",
      type: "homework",
      complete: true,
      exercise_count: 7,
      complete_exercise_count: 7,
      correct_exercise_count: 6
    },
    {
      id: 13,
      title: "Homework 2",
      opens_at: "2015-04-08T07:30:54.564Z",
      due_at: "2015-04-18T07:30:54.564Z",
      type: "homework",
      complete: true,
      exercise_count: 8,
      complete_exercise_count: 8,
      correct_exercise_count: 7
    },
    {
      id: 15,
      title: "Homework 3",
      opens_at: "2015-04-23T07:30:54.564Z",
      due_at: "2015-05-03T07:30:54.564Z",
      type: "homework",
      complete: true,
      exercise_count: 6,
      complete_exercise_count: 6
    },
    {
      id: 17,
      title: "Homework 4",
      opens_at: "2015-05-08T07:30:54.564Z",
      due_at: "2015-05-18T07:30:54.564Z",
      type: "homework",
      complete: true,
      exercise_count: 7,
      complete_exercise_count: 7
    }
  ],
  role: {
    id: 9,
    type: "student"
  },
  course: {
    name: "Physics - Many Plan",
    teacher_names: [
      "Andrew Garcia",
      "Bob Newhart"
    ]
  }
}
```

If you login as `many_plan_teacher`, you'll see:

```
{
  plans: [
    {
      id: 9,
      title: "Homework 4",
      opens_at: "2015-05-08T07:30:54.564Z",
      due_at: "2015-05-18T07:30:54.564Z",
      trouble: false,
      type: "homework"
    },
    {
      id: 8,
      title: "Homework 3",
      opens_at: "2015-04-23T07:30:54.564Z",
      due_at: "2015-05-03T07:30:54.564Z",
      trouble: true,
      type: "homework"
    },
    {
      id: 7,
      title: "Homework 2",
      opens_at: "2015-04-08T07:30:54.564Z",
      due_at: "2015-04-18T07:30:54.564Z",
      trouble: true,
      type: "homework"
    },
    {
      id: 6,
      title: "Homework 1",
      opens_at: "2015-04-03T07:30:54.564Z",
      due_at: "2015-04-13T07:30:54.564Z",
      trouble: false,
      type: "homework"
    },
    {
      id: 5,
      title: "iReading 4: Newton's Third Law of Motion",
      opens_at: "2015-05-06T07:30:54.564Z",
      due_at: "2015-05-16T07:30:54.564Z",
      trouble: true,
      type: "homework"
    },
    {
      id: 4,
      title: "iReading 3: Newton's Second Law of Motion:",
      opens_at: "2015-04-21T07:30:54.564Z",
      due_at: "2015-05-01T07:30:54.564Z",
      trouble: false,
      type: "homework"
    },
    {
      id: 3,
      title: "iReading 2: Newton's First Law of Motion: Inertia",
      opens_at: "2015-04-06T07:30:54.564Z",
      due_at: "2015-04-16T07:30:54.564Z",
      trouble: true,
      type: "homework"
    },
    {
      id: 2,
      title: "iReading 1: Force",
      opens_at: "2015-04-01T07:30:54.564Z",
      due_at: "2015-04-11T07:30:54.564Z",
      trouble: false,
      type: "homework"
    }
  ],
  tasks: [ ],
  role: {
    id: 10,
    type: "teacher"
  },
  course: {
    name: "Physics - Many Plan",
    teacher_names: [
      "Andrew Garcia",
      "Bob Newhart"
    ]
  }
}
```

Notes:
  1. The endpoint takes an optional role, e.g. `/api/courses/1/dashboard(/role/2391)`
  1. The `trouble` indicator on plans show to teachers is still faked).
  2. The API documentation is incomplete for the dashboard; there's some problem with the automatic schema generation.  Hopefully the JSON examples are sufficient for now.
  3. If you login as the `many_plan_teacher_student`, you don't actually see the Tasks in addition to the Plans.  That's because we are showing that user's default role for the course, which is the teaching role.  To see the plans you'd have to specify the role number, e.g. if you go to `/api/courses/3/dashboard/role/11` you'd see that user's "student" view, which would have the tasks.  If you go to `/api/courses/3/dashboard/role/12` you see the teacher view (same as not specifying the role).  Incidentally, if you go to a different role number, you get booted out (no permissions).

/cc @pandafulmanda @nathanstitt @philschatz @darrenmason @kevinburleigh75 