### PR TITLE
fix for empty candidate exercises

### DIFF
--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -116,6 +116,7 @@ class Tasks::Assistants::HomeworkAssistant
       break if k_ago >= exercise_pools.count
 
       candidate_exercises = (exercise_pools[k_ago] - exercise_history).sort_by{|ex| ex.uid}.take(10)
+      break if candidate_exercises.count < number
 
       number.times do
         #puts "candidate_exercises: #{candidate_exercises.map(&:uid).sort}"

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -137,6 +137,7 @@ class Tasks::Assistants::IReadingAssistant
       break if k_ago >= exercise_pools.count
 
       candidate_exercises = (exercise_pools[k_ago] - exercise_history).sort_by{|ex| ex.id}.take(10)
+      break if candidate_exercises.count < number
 
       number.times do
         #puts "candidate_exercises: #{candidate_exercises.map(&:uid).sort}"


### PR DESCRIPTION
This fixes the problem with:
```
NoMethodError: undefined method `url' for nil:NilClass
```
happening in the sprint:010mix setup.