### PR TITLE
Added option to use in-memory sqlite database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,12 @@ gem 'pg'
 gem 'faker'
 
 group :development, :test do
+  # SQLite adapter
+  gem 'sqlite3'
+
+  # Allows the use of the in-memory SQLite3 database in Rails tests
+  gem 'memory_test_fix'
+
   # Get env variables from .env file
   gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,9 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     maruku (0.7.2)
+    memory_test_fix (1.2.2)
+      activerecord (>= 3.2.0, < 4.99.0)
+      railties (>= 3.2.0, < 4.99.0)
     method_source (0.8.2)
     mime-types (2.5)
     mini_magick (4.2.0)
@@ -392,6 +395,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.10)
     squeel (1.2.3)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
@@ -492,6 +496,7 @@ DEPENDENCIES
   lev (~> 4.1)
   lograge
   maruku
+  memory_test_fix
   mini_magick
   newrelic_rpm
   nifty-generators
@@ -516,6 +521,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   shoulda-matchers
   sortability
+  sqlite3
   squeel
   therubyracer
   thin

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -94,11 +94,11 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   def identifier
     # TODO this code (and the blatant hack above) have got to go! Had to add the
     # tries and the secure random to a basic unit test to work.
-    task_step.task.taskings.try(:first).try(:role).try(:id) || SecureRandom.hex
+    task_step.task.taskings.try(:first).try(:role).try(:id).try(:to_s) || SecureRandom.hex
   end
 
   def trial
-    SecureRandom.hex
+    task_step.id.to_s
   end
 
   # Eventually this will be enforced by the exercise substeps

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -98,7 +98,7 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   end
 
   def trial
-    task_step.id.to_s
+    SecureRandom.hex
   end
 
   # Eventually this will be enforced by the exercise substeps

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,15 +10,18 @@ default: &default
   password: <%= ENV['OXT_DB_PASS'] || 'ox_tutor_secret_password' %>
 
 development:
-  <<: *default
-  database: <%= ENV['OXT_DEV_DB'] || 'ox_tutor_dev' %>
+  adapter: sqlite3
+  database: ":memory:"
+  verbosity: quiet
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %><%= "_#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER'] %>
+  adapter: sqlite3
+  database: ":memory:"
+  verbosity: quiet
 
 ## Production database is intentionally left unconfigured
 #production:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,29 +1,18 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: postgresql
+  adapter: <%= ENV['OXT_IN_MEMORY_DB'] ? 'sqlite3' : 'postgresql' %>
   username: <%= ENV['OXT_DB_USER'] || 'ox_tutor' %>
   password: <%= ENV['OXT_DB_PASS'] || 'ox_tutor_secret_password' %>
+  verbosity: <%= 'quiet' if ENV['OXT_IN_MEMORY_DB'] %>
 
 development:
-  adapter: sqlite3
-  database: ":memory:"
-  verbosity: quiet
+  <<: *default
+  database: <%= ENV['OXT_IN_MEMORY_DB'] ? ':memory:' : (ENV['OXT_DEV_DB'] || 'ox_tutor_dev') %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  adapter: sqlite3
-  database: ":memory:"
-  verbosity: quiet
+  database: <%= ENV['OXT_IN_MEMORY_DB'] ? ':memory:' : (ENV['OXT_TEST_DB'] || 'ox_tutor_dev') %>
 
 ## Production database is intentionally left unconfigured
-#production:
-#  <<: *default
-#  database: <%= ENV['OXT_PROD_DB'] || 'ox_tutor_production' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,8 +12,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  adapter: <%= ENV['OXT_IN_MEMORY_TEST_DB'] ? 'sqlite3' : 'postgresql' %>
-  database: <%= ENV['OXT_IN_MEMORY_TEST_DB'] ? ':memory:' : ENV['OXT_TEST_DB'] || 'ox_tutor_dev' %>
-  verbosity: <%= 'quiet' if ENV['OXT_IN_MEMORY_TEST_DB'] %>
+  adapter: <%= ENV['OXT_TEST_DB'] == ':memory:' ? 'sqlite3' : 'postgresql' %>
+  database: '<%= ENV['OXT_TEST_DB'] || 'ox_tutor_dev' %>'
+  verbosity: <%= 'quiet' if ENV['OXT_TEST_DB'] == ':memory:' %>
 
 ## Production database is intentionally left unconfigured

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,7 @@ development:
 test:
   <<: *default
   adapter: <%= ENV['OXT_TEST_DB'] == ':memory:' ? 'sqlite3' : 'postgresql' %>
-  database: '<%= ENV['OXT_TEST_DB'] || 'ox_tutor_dev' %>'
+  database: '<%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %>'
   verbosity: <%= 'quiet' if ENV['OXT_TEST_DB'] == ':memory:' %>
 
 ## Production database is intentionally left unconfigured

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,18 +1,19 @@
 default: &default
-  adapter: <%= ENV['OXT_IN_MEMORY_DB'] ? 'sqlite3' : 'postgresql' %>
+  adapter: postgresql
   username: <%= ENV['OXT_DB_USER'] || 'ox_tutor' %>
   password: <%= ENV['OXT_DB_PASS'] || 'ox_tutor_secret_password' %>
-  verbosity: <%= 'quiet' if ENV['OXT_IN_MEMORY_DB'] %>
 
 development:
   <<: *default
-  database: <%= ENV['OXT_IN_MEMORY_DB'] ? ':memory:' : (ENV['OXT_DEV_DB'] || 'ox_tutor_dev') %>
+  database: <%= ENV['OXT_DEV_DB'] || 'ox_tutor_dev' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV['OXT_IN_MEMORY_DB'] ? ':memory:' : (ENV['OXT_TEST_DB'] || 'ox_tutor_dev') %>
+  adapter: <%= ENV['OXT_IN_MEMORY_TEST_DB'] ? 'sqlite3' : 'postgresql' %>
+  database: <%= ENV['OXT_IN_MEMORY_TEST_DB'] ? ':memory:' : ENV['OXT_TEST_DB'] || 'ox_tutor_dev' %>
+  verbosity: <%= 'quiet' if ENV['OXT_IN_MEMORY_TEST_DB'] %>
 
 ## Production database is intentionally left unconfigured

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,9 @@ development:
 test:
   <<: *default
   adapter: <%= ENV['OXT_TEST_DB'] == ':memory:' ? 'sqlite3' : 'postgresql' %>
-  database: '<%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %>'
+  database: '<%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %><%= \
+                 "_#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER'] && \
+                                                 ENV['OXT_TEST_DB'] != ':memory:' %>'
   verbosity: <%= 'quiet' if ENV['OXT_TEST_DB'] == ':memory:' %>
 
-## Production database is intentionally left unconfigured
+# Production database is intentionally left unconfigured

--- a/db/migrate/20140926213212_create_tasks_tasks.rb
+++ b/db/migrate/20140926213212_create_tasks_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasksTasks < ActiveRecord::Migration
     create_table :tasks_tasks do |t|
       t.references :tasks_task_plan
       t.references :entity_task
-      t.string :task_type, null: false
+      t.integer :task_type, null: false
       t.string :title, null: false
       t.datetime :opens_at
       t.datetime :due_at

--- a/db/migrate/20150428224104_change_task_type_to_integer_on_tasks_tasks.rb
+++ b/db/migrate/20150428224104_change_task_type_to_integer_on_tasks_tasks.rb
@@ -1,5 +1,0 @@
-class ChangeTaskTypeToIntegerOnTasksTasks < ActiveRecord::Migration
-  def change
-    change_column :tasks_tasks, :task_type, 'integer USING CAST(task_type AS integer)'
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428224104) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 20150420184110) do
 
   create_table "administrators", force: :cascade do |t|
     t.integer  "profile_id", null: false
@@ -22,7 +19,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "administrators", ["profile_id"], name: "index_administrators_on_profile_id", unique: true, using: :btree
+  add_index "administrators", ["profile_id"], name: "index_administrators_on_profile_id", unique: true
 
   create_table "content_book_parts", force: :cascade do |t|
     t.string   "url"
@@ -36,9 +33,9 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",          null: false
   end
 
-  add_index "content_book_parts", ["entity_book_id"], name: "index_content_book_parts_on_entity_book_id", using: :btree
-  add_index "content_book_parts", ["parent_book_part_id", "number"], name: "index_content_book_parts_on_parent_book_part_id_and_number", unique: true, using: :btree
-  add_index "content_book_parts", ["url"], name: "index_content_book_parts_on_url", unique: true, using: :btree
+  add_index "content_book_parts", ["entity_book_id"], name: "index_content_book_parts_on_entity_book_id"
+  add_index "content_book_parts", ["parent_book_part_id", "number"], name: "index_content_book_parts_on_parent_book_part_id_and_number", unique: true
+  add_index "content_book_parts", ["url"], name: "index_content_book_parts_on_url", unique: true
 
   create_table "content_exercise_tags", force: :cascade do |t|
     t.integer  "content_exercise_id", null: false
@@ -47,8 +44,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",          null: false
   end
 
-  add_index "content_exercise_tags", ["content_exercise_id", "content_tag_id"], name: "index_content_exercise_tags_on_c_e_id_and_c_t_id", unique: true, using: :btree
-  add_index "content_exercise_tags", ["content_tag_id"], name: "index_content_exercise_tags_on_content_tag_id", using: :btree
+  add_index "content_exercise_tags", ["content_exercise_id", "content_tag_id"], name: "index_content_exercise_tags_on_c_e_id_and_c_t_id", unique: true
+  add_index "content_exercise_tags", ["content_tag_id"], name: "index_content_exercise_tags_on_content_tag_id"
 
   create_table "content_exercises", force: :cascade do |t|
     t.string   "url"
@@ -58,8 +55,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "content_exercises", ["title"], name: "index_content_exercises_on_title", using: :btree
-  add_index "content_exercises", ["url"], name: "index_content_exercises_on_url", unique: true, using: :btree
+  add_index "content_exercises", ["title"], name: "index_content_exercises_on_title"
+  add_index "content_exercises", ["url"], name: "index_content_exercises_on_url", unique: true
 
   create_table "content_lo_teks_tags", force: :cascade do |t|
     t.integer  "lo_id",      null: false
@@ -68,7 +65,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "content_lo_teks_tags", ["lo_id", "teks_id"], name: "content_lo_teks_tag_lo_teks_uniq", unique: true, using: :btree
+  add_index "content_lo_teks_tags", ["lo_id", "teks_id"], name: "content_lo_teks_tag_lo_teks_uniq", unique: true
 
   create_table "content_page_tags", force: :cascade do |t|
     t.integer  "content_page_id", null: false
@@ -77,8 +74,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",      null: false
   end
 
-  add_index "content_page_tags", ["content_page_id", "content_tag_id"], name: "index_content_page_tags_on_content_page_id_and_content_tag_id", unique: true, using: :btree
-  add_index "content_page_tags", ["content_tag_id"], name: "index_content_page_tags_on_content_tag_id", using: :btree
+  add_index "content_page_tags", ["content_page_id", "content_tag_id"], name: "index_content_page_tags_on_content_page_id_and_content_tag_id", unique: true
+  add_index "content_page_tags", ["content_tag_id"], name: "index_content_page_tags_on_content_tag_id"
 
   create_table "content_pages", force: :cascade do |t|
     t.string   "url"
@@ -91,8 +88,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "content_pages", ["content_book_part_id", "number"], name: "index_content_pages_on_content_book_part_id_and_number", unique: true, using: :btree
-  add_index "content_pages", ["url"], name: "index_content_pages_on_url", unique: true, using: :btree
+  add_index "content_pages", ["content_book_part_id", "number"], name: "index_content_pages_on_content_book_part_id_and_number", unique: true
+  add_index "content_pages", ["url"], name: "index_content_pages_on_url", unique: true
 
   create_table "content_tags", force: :cascade do |t|
     t.string   "value",                   null: false
@@ -103,8 +100,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",              null: false
   end
 
-  add_index "content_tags", ["tag_type"], name: "index_content_tags_on_tag_type", using: :btree
-  add_index "content_tags", ["value"], name: "index_content_tags_on_value", unique: true, using: :btree
+  add_index "content_tags", ["tag_type"], name: "index_content_tags_on_tag_type"
+  add_index "content_tags", ["value"], name: "index_content_tags_on_value", unique: true
 
   create_table "course_content_course_books", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -113,8 +110,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_content_course_books", ["entity_book_id"], name: "index_course_content_course_books_on_entity_book_id", using: :btree
-  add_index "course_content_course_books", ["entity_course_id", "entity_book_id"], name: "[\"course_books_course_id_on_book_id_unique\"]", unique: true, using: :btree
+  add_index "course_content_course_books", ["entity_book_id"], name: "index_course_content_course_books_on_entity_book_id"
+  add_index "course_content_course_books", ["entity_course_id", "entity_book_id"], name: "[\"course_books_course_id_on_book_id_unique\"]", unique: true
 
   create_table "course_membership_students", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -123,7 +120,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_membership_students", ["entity_course_id", "entity_role_id"], name: "course_membership_student_course_role_uniq", unique: true, using: :btree
+  add_index "course_membership_students", ["entity_course_id", "entity_role_id"], name: "course_membership_student_course_role_uniq", unique: true
 
   create_table "course_membership_teachers", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -132,7 +129,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_membership_teachers", ["entity_course_id", "entity_role_id"], name: "course_membership_teacher_course_role_uniq", unique: true, using: :btree
+  add_index "course_membership_teachers", ["entity_course_id", "entity_role_id"], name: "course_membership_teacher_course_role_uniq", unique: true
 
   create_table "course_profile_profiles", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -141,8 +138,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_profile_profiles", ["entity_course_id"], name: "index_course_profile_profiles_on_entity_course_id", unique: true, using: :btree
-  add_index "course_profile_profiles", ["name"], name: "index_course_profile_profiles_on_name", using: :btree
+  add_index "course_profile_profiles", ["entity_course_id"], name: "index_course_profile_profiles_on_entity_course_id", unique: true
+  add_index "course_profile_profiles", ["name"], name: "index_course_profile_profiles_on_name"
 
   create_table "courses", force: :cascade do |t|
     t.string   "school",                          null: false
@@ -160,10 +157,10 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",                      null: false
   end
 
-  add_index "courses", ["ends_at", "starts_at"], name: "index_courses_on_ends_at_and_starts_at", using: :btree
-  add_index "courses", ["invisible_at", "visible_at"], name: "index_courses_on_invisible_at_and_visible_at", using: :btree
-  add_index "courses", ["school", "name"], name: "index_courses_on_school_and_name", unique: true, using: :btree
-  add_index "courses", ["short_name", "school"], name: "index_courses_on_short_name_and_school", unique: true, using: :btree
+  add_index "courses", ["ends_at", "starts_at"], name: "index_courses_on_ends_at_and_starts_at"
+  add_index "courses", ["invisible_at", "visible_at"], name: "index_courses_on_invisible_at_and_visible_at"
+  add_index "courses", ["school", "name"], name: "index_courses_on_school_and_name", unique: true
+  add_index "courses", ["short_name", "school"], name: "index_courses_on_short_name_and_school", unique: true
 
   create_table "educators", force: :cascade do |t|
     t.integer  "course_id",  null: false
@@ -172,8 +169,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "educators", ["course_id"], name: "index_educators_on_course_id", using: :btree
-  add_index "educators", ["user_id", "course_id"], name: "index_educators_on_user_id_and_course_id", unique: true, using: :btree
+  add_index "educators", ["course_id"], name: "index_educators_on_course_id"
+  add_index "educators", ["user_id", "course_id"], name: "index_educators_on_user_id_and_course_id", unique: true
 
   create_table "entity_books", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -191,7 +188,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",             null: false
   end
 
-  add_index "entity_roles", ["role_type"], name: "index_entity_roles_on_role_type", using: :btree
+  add_index "entity_roles", ["role_type"], name: "index_entity_roles_on_role_type"
 
   create_table "entity_tasks", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -210,7 +207,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "fake_stores", ["name"], name: "index_fake_stores_on_name", unique: true, using: :btree
+  add_index "fake_stores", ["name"], name: "index_fake_stores_on_name", unique: true
 
   create_table "fine_print_contracts", force: :cascade do |t|
     t.string   "name",       null: false
@@ -221,7 +218,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "fine_print_contracts", ["name", "version"], name: "index_fine_print_contracts_on_name_and_version", unique: true, using: :btree
+  add_index "fine_print_contracts", ["name", "version"], name: "index_fine_print_contracts_on_name_and_version", unique: true
 
   create_table "fine_print_signatures", force: :cascade do |t|
     t.integer  "contract_id", null: false
@@ -231,8 +228,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",  null: false
   end
 
-  add_index "fine_print_signatures", ["contract_id"], name: "index_fine_print_signatures_on_contract_id", using: :btree
-  add_index "fine_print_signatures", ["user_id", "user_type", "contract_id"], name: "index_fine_print_signatures_on_u_id_and_u_type_and_c_id", unique: true, using: :btree
+  add_index "fine_print_signatures", ["contract_id"], name: "index_fine_print_signatures_on_contract_id"
+  add_index "fine_print_signatures", ["user_id", "user_type", "contract_id"], name: "index_fine_print_signatures_on_u_id_and_u_type_and_c_id", unique: true
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -245,7 +242,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.string   "scopes"
   end
 
-  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id"
@@ -258,9 +255,9 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.string   "scopes"
   end
 
-  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
-  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
-  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true
 
   create_table "oauth_applications", force: :cascade do |t|
     t.string   "name",                      null: false
@@ -272,7 +269,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at"
   end
 
-  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true
 
   create_table "openstax_accounts_accounts", force: :cascade do |t|
     t.integer  "openstax_uid", null: false
@@ -286,12 +283,12 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",   null: false
   end
 
-  add_index "openstax_accounts_accounts", ["access_token"], name: "index_openstax_accounts_accounts_on_access_token", unique: true, using: :btree
-  add_index "openstax_accounts_accounts", ["first_name"], name: "index_openstax_accounts_accounts_on_first_name", using: :btree
-  add_index "openstax_accounts_accounts", ["full_name"], name: "index_openstax_accounts_accounts_on_full_name", using: :btree
-  add_index "openstax_accounts_accounts", ["last_name"], name: "index_openstax_accounts_accounts_on_last_name", using: :btree
-  add_index "openstax_accounts_accounts", ["openstax_uid"], name: "index_openstax_accounts_accounts_on_openstax_uid", unique: true, using: :btree
-  add_index "openstax_accounts_accounts", ["username"], name: "index_openstax_accounts_accounts_on_username", unique: true, using: :btree
+  add_index "openstax_accounts_accounts", ["access_token"], name: "index_openstax_accounts_accounts_on_access_token", unique: true
+  add_index "openstax_accounts_accounts", ["first_name"], name: "index_openstax_accounts_accounts_on_first_name"
+  add_index "openstax_accounts_accounts", ["full_name"], name: "index_openstax_accounts_accounts_on_full_name"
+  add_index "openstax_accounts_accounts", ["last_name"], name: "index_openstax_accounts_accounts_on_last_name"
+  add_index "openstax_accounts_accounts", ["openstax_uid"], name: "index_openstax_accounts_accounts_on_openstax_uid", unique: true
+  add_index "openstax_accounts_accounts", ["username"], name: "index_openstax_accounts_accounts_on_username", unique: true
 
   create_table "openstax_accounts_group_members", force: :cascade do |t|
     t.integer  "group_id",   null: false
@@ -300,8 +297,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "openstax_accounts_group_members", ["group_id", "user_id"], name: "index_openstax_accounts_group_members_on_group_id_and_user_id", unique: true, using: :btree
-  add_index "openstax_accounts_group_members", ["user_id"], name: "index_openstax_accounts_group_members_on_user_id", using: :btree
+  add_index "openstax_accounts_group_members", ["group_id", "user_id"], name: "index_openstax_accounts_group_members_on_group_id_and_user_id", unique: true
+  add_index "openstax_accounts_group_members", ["user_id"], name: "index_openstax_accounts_group_members_on_user_id"
 
   create_table "openstax_accounts_group_nestings", force: :cascade do |t|
     t.integer  "member_group_id",    null: false
@@ -310,8 +307,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",         null: false
   end
 
-  add_index "openstax_accounts_group_nestings", ["container_group_id"], name: "index_openstax_accounts_group_nestings_on_container_group_id", using: :btree
-  add_index "openstax_accounts_group_nestings", ["member_group_id"], name: "index_openstax_accounts_group_nestings_on_member_group_id", unique: true, using: :btree
+  add_index "openstax_accounts_group_nestings", ["container_group_id"], name: "index_openstax_accounts_group_nestings_on_container_group_id"
+  add_index "openstax_accounts_group_nestings", ["member_group_id"], name: "index_openstax_accounts_group_nestings_on_member_group_id", unique: true
 
   create_table "openstax_accounts_group_owners", force: :cascade do |t|
     t.integer  "group_id",   null: false
@@ -320,8 +317,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "openstax_accounts_group_owners", ["group_id", "user_id"], name: "index_openstax_accounts_group_owners_on_group_id_and_user_id", unique: true, using: :btree
-  add_index "openstax_accounts_group_owners", ["user_id"], name: "index_openstax_accounts_group_owners_on_user_id", using: :btree
+  add_index "openstax_accounts_group_owners", ["group_id", "user_id"], name: "index_openstax_accounts_group_owners_on_group_id_and_user_id", unique: true
+  add_index "openstax_accounts_group_owners", ["user_id"], name: "index_openstax_accounts_group_owners_on_user_id"
 
   create_table "openstax_accounts_groups", force: :cascade do |t|
     t.integer  "openstax_uid",                               null: false
@@ -333,7 +330,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",                                 null: false
   end
 
-  add_index "openstax_accounts_groups", ["openstax_uid"], name: "index_openstax_accounts_groups_on_openstax_uid", unique: true, using: :btree
+  add_index "openstax_accounts_groups", ["openstax_uid"], name: "index_openstax_accounts_groups_on_openstax_uid", unique: true
 
   create_table "role_users", force: :cascade do |t|
     t.integer  "entity_user_id", null: false
@@ -342,7 +339,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",     null: false
   end
 
-  add_index "role_users", ["entity_user_id", "entity_role_id"], name: "role_users_user_role_uniq", unique: true, using: :btree
+  add_index "role_users", ["entity_user_id", "entity_role_id"], name: "role_users_user_role_uniq", unique: true
 
   create_table "sections", force: :cascade do |t|
     t.integer  "course_id",  null: false
@@ -351,8 +348,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "sections", ["course_id"], name: "index_sections_on_course_id", using: :btree
-  add_index "sections", ["name", "course_id"], name: "index_sections_on_name_and_course_id", unique: true, using: :btree
+  add_index "sections", ["course_id"], name: "index_sections_on_course_id"
+  add_index "sections", ["name", "course_id"], name: "index_sections_on_name_and_course_id", unique: true
 
   create_table "students", force: :cascade do |t|
     t.integer  "course_id",                   null: false
@@ -367,14 +364,14 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",                  null: false
   end
 
-  add_index "students", ["course_id"], name: "index_students_on_course_id", using: :btree
-  add_index "students", ["educator_custom_identifier"], name: "index_students_on_educator_custom_identifier", using: :btree
-  add_index "students", ["level"], name: "index_students_on_level", using: :btree
-  add_index "students", ["random_education_identifier"], name: "index_students_on_random_education_identifier", unique: true, using: :btree
-  add_index "students", ["section_id"], name: "index_students_on_section_id", using: :btree
-  add_index "students", ["student_custom_identifier"], name: "index_students_on_student_custom_identifier", using: :btree
-  add_index "students", ["user_id", "course_id"], name: "index_students_on_user_id_and_course_id", unique: true, using: :btree
-  add_index "students", ["user_id", "section_id"], name: "index_students_on_user_id_and_section_id", unique: true, using: :btree
+  add_index "students", ["course_id"], name: "index_students_on_course_id"
+  add_index "students", ["educator_custom_identifier"], name: "index_students_on_educator_custom_identifier"
+  add_index "students", ["level"], name: "index_students_on_level"
+  add_index "students", ["random_education_identifier"], name: "index_students_on_random_education_identifier", unique: true
+  add_index "students", ["section_id"], name: "index_students_on_section_id"
+  add_index "students", ["student_custom_identifier"], name: "index_students_on_student_custom_identifier"
+  add_index "students", ["user_id", "course_id"], name: "index_students_on_user_id_and_course_id", unique: true
+  add_index "students", ["user_id", "section_id"], name: "index_students_on_user_id_and_section_id", unique: true
 
   create_table "tasks_assistants", force: :cascade do |t|
     t.string   "name",            null: false
@@ -383,8 +380,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",      null: false
   end
 
-  add_index "tasks_assistants", ["code_class_name"], name: "index_tasks_assistants_on_code_class_name", unique: true, using: :btree
-  add_index "tasks_assistants", ["name"], name: "index_tasks_assistants_on_name", unique: true, using: :btree
+  add_index "tasks_assistants", ["code_class_name"], name: "index_tasks_assistants_on_code_class_name", unique: true
+  add_index "tasks_assistants", ["name"], name: "index_tasks_assistants_on_name", unique: true
 
   create_table "tasks_course_assistants", force: :cascade do |t|
     t.integer  "entity_course_id",     null: false
@@ -396,8 +393,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "tasks_course_assistants", ["entity_course_id", "tasks_task_plan_type"], name: "index_tasks_course_assistants_on_course_id_and_task_plan_type", unique: true, using: :btree
-  add_index "tasks_course_assistants", ["tasks_assistant_id", "entity_course_id"], name: "index_tasks_course_assistants_on_assistant_id_and_course_id", using: :btree
+  add_index "tasks_course_assistants", ["entity_course_id", "tasks_task_plan_type"], name: "index_tasks_course_assistants_on_course_id_and_task_plan_type", unique: true
+  add_index "tasks_course_assistants", ["tasks_assistant_id", "entity_course_id"], name: "index_tasks_course_assistants_on_assistant_id_and_course_id"
 
   create_table "tasks_task_plans", force: :cascade do |t|
     t.integer  "tasks_assistant_id", null: false
@@ -413,9 +410,9 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",         null: false
   end
 
-  add_index "tasks_task_plans", ["due_at", "opens_at"], name: "index_tasks_task_plans_on_due_at_and_opens_at", using: :btree
-  add_index "tasks_task_plans", ["owner_id", "owner_type"], name: "index_tasks_task_plans_on_owner_id_and_owner_type", using: :btree
-  add_index "tasks_task_plans", ["tasks_assistant_id"], name: "index_tasks_task_plans_on_tasks_assistant_id", using: :btree
+  add_index "tasks_task_plans", ["due_at", "opens_at"], name: "index_tasks_task_plans_on_due_at_and_opens_at"
+  add_index "tasks_task_plans", ["owner_id", "owner_type"], name: "index_tasks_task_plans_on_owner_id_and_owner_type"
+  add_index "tasks_task_plans", ["tasks_assistant_id"], name: "index_tasks_task_plans_on_tasks_assistant_id"
 
   create_table "tasks_task_steps", force: :cascade do |t|
     t.integer  "tasks_task_id",             null: false
@@ -428,8 +425,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",                null: false
   end
 
-  add_index "tasks_task_steps", ["tasked_id", "tasked_type"], name: "index_tasks_task_steps_on_tasked_id_and_tasked_type", unique: true, using: :btree
-  add_index "tasks_task_steps", ["tasks_task_id", "number"], name: "index_tasks_task_steps_on_tasks_task_id_and_number", unique: true, using: :btree
+  add_index "tasks_task_steps", ["tasked_id", "tasked_type"], name: "index_tasks_task_steps_on_tasked_id_and_tasked_type", unique: true
+  add_index "tasks_task_steps", ["tasks_task_id", "number"], name: "index_tasks_task_steps_on_tasks_task_id_and_number", unique: true
 
   create_table "tasks_tasked_exercises", force: :cascade do |t|
     t.boolean  "can_be_recovered", default: false, null: false
@@ -442,7 +439,7 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",                       null: false
   end
 
-  add_index "tasks_tasked_exercises", ["url"], name: "index_tasks_tasked_exercises_on_url", using: :btree
+  add_index "tasks_tasked_exercises", ["url"], name: "index_tasks_tasked_exercises_on_url"
 
   create_table "tasks_tasked_interactives", force: :cascade do |t|
     t.string   "url",        null: false
@@ -477,8 +474,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",         null: false
   end
 
-  add_index "tasks_tasking_plans", ["target_id", "target_type", "tasks_task_plan_id"], name: "index_tasking_plans_on_t_id_and_t_type_and_t_p_id", unique: true, using: :btree
-  add_index "tasks_tasking_plans", ["tasks_task_plan_id"], name: "index_tasks_tasking_plans_on_tasks_task_plan_id", using: :btree
+  add_index "tasks_tasking_plans", ["target_id", "target_type", "tasks_task_plan_id"], name: "index_tasking_plans_on_t_id_and_t_type_and_t_p_id", unique: true
+  add_index "tasks_tasking_plans", ["tasks_task_plan_id"], name: "index_tasks_tasking_plans_on_tasks_task_plan_id"
 
   create_table "tasks_taskings", force: :cascade do |t|
     t.integer  "entity_role_id", null: false
@@ -487,8 +484,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",     null: false
   end
 
-  add_index "tasks_taskings", ["entity_role_id", "entity_task_id"], name: "[\"tasks_taskings_role_id_on_task_id_unique\"]", unique: true, using: :btree
-  add_index "tasks_taskings", ["entity_task_id"], name: "index_tasks_taskings_on_entity_task_id", using: :btree
+  add_index "tasks_taskings", ["entity_role_id", "entity_task_id"], name: "[\"tasks_taskings_role_id_on_task_id_unique\"]", unique: true
+  add_index "tasks_taskings", ["entity_task_id"], name: "index_tasks_taskings_on_entity_task_id"
 
   create_table "tasks_tasks", force: :cascade do |t|
     t.integer  "tasks_task_plan_id"
@@ -504,10 +501,10 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",                       null: false
   end
 
-  add_index "tasks_tasks", ["due_at", "opens_at"], name: "index_tasks_tasks_on_due_at_and_opens_at", using: :btree
-  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id", using: :btree
-  add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type", using: :btree
-  add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id", using: :btree
+  add_index "tasks_tasks", ["due_at", "opens_at"], name: "index_tasks_tasks_on_due_at_and_opens_at"
+  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id"
+  add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type"
+  add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id"
 
   create_table "user_profile_profiles", force: :cascade do |t|
     t.integer  "entity_user_id",      null: false
@@ -518,42 +515,8 @@ ActiveRecord::Schema.define(version: 20150428224104) do
     t.datetime "updated_at",          null: false
   end
 
-  add_index "user_profile_profiles", ["account_id"], name: "index_user_profile_profiles_on_account_id", unique: true, using: :btree
-  add_index "user_profile_profiles", ["deleted_at"], name: "index_user_profile_profiles_on_deleted_at", using: :btree
-  add_index "user_profile_profiles", ["exchange_identifier"], name: "index_user_profile_profiles_on_exchange_identifier", unique: true, using: :btree
+  add_index "user_profile_profiles", ["account_id"], name: "index_user_profile_profiles_on_account_id", unique: true
+  add_index "user_profile_profiles", ["deleted_at"], name: "index_user_profile_profiles_on_deleted_at"
+  add_index "user_profile_profiles", ["exchange_identifier"], name: "index_user_profile_profiles_on_exchange_identifier", unique: true
 
-  add_foreign_key "administrators", "user_profile_profiles", column: "profile_id", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_book_parts", "content_book_parts", column: "parent_book_part_id", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_book_parts", "entity_books", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_exercise_tags", "content_exercises", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_exercise_tags", "content_tags", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_lo_teks_tags", "content_tags", column: "lo_id"
-  add_foreign_key "content_lo_teks_tags", "content_tags", column: "teks_id"
-  add_foreign_key "content_page_tags", "content_pages", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_page_tags", "content_tags", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_pages", "content_book_parts", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "course_content_course_books", "entity_books"
-  add_foreign_key "course_content_course_books", "entity_courses"
-  add_foreign_key "course_membership_students", "entity_courses"
-  add_foreign_key "course_membership_students", "entity_roles"
-  add_foreign_key "course_membership_teachers", "entity_courses"
-  add_foreign_key "course_membership_teachers", "entity_roles"
-  add_foreign_key "course_profile_profiles", "entity_courses"
-  add_foreign_key "educators", "courses", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "educators", "user_profile_profiles", column: "user_id", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "role_users", "entity_roles"
-  add_foreign_key "role_users", "entity_users"
-  add_foreign_key "sections", "courses", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "students", "courses", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "students", "sections", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "students", "user_profile_profiles", column: "user_id", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_course_assistants", "entity_courses", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_course_assistants", "tasks_assistants", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_task_plans", "tasks_assistants", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_task_steps", "tasks_tasks", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_tasking_plans", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_taskings", "entity_roles"
-  add_foreign_key "tasks_taskings", "entity_tasks"
-  add_foreign_key "tasks_tasks", "entity_tasks", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_tasks", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,13 +13,16 @@
 
 ActiveRecord::Schema.define(version: 20150420184110) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "administrators", force: :cascade do |t|
     t.integer  "profile_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "administrators", ["profile_id"], name: "index_administrators_on_profile_id", unique: true
+  add_index "administrators", ["profile_id"], name: "index_administrators_on_profile_id", unique: true, using: :btree
 
   create_table "content_book_parts", force: :cascade do |t|
     t.string   "url"
@@ -33,9 +36,9 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",          null: false
   end
 
-  add_index "content_book_parts", ["entity_book_id"], name: "index_content_book_parts_on_entity_book_id"
-  add_index "content_book_parts", ["parent_book_part_id", "number"], name: "index_content_book_parts_on_parent_book_part_id_and_number", unique: true
-  add_index "content_book_parts", ["url"], name: "index_content_book_parts_on_url", unique: true
+  add_index "content_book_parts", ["entity_book_id"], name: "index_content_book_parts_on_entity_book_id", using: :btree
+  add_index "content_book_parts", ["parent_book_part_id", "number"], name: "index_content_book_parts_on_parent_book_part_id_and_number", unique: true, using: :btree
+  add_index "content_book_parts", ["url"], name: "index_content_book_parts_on_url", unique: true, using: :btree
 
   create_table "content_exercise_tags", force: :cascade do |t|
     t.integer  "content_exercise_id", null: false
@@ -44,8 +47,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",          null: false
   end
 
-  add_index "content_exercise_tags", ["content_exercise_id", "content_tag_id"], name: "index_content_exercise_tags_on_c_e_id_and_c_t_id", unique: true
-  add_index "content_exercise_tags", ["content_tag_id"], name: "index_content_exercise_tags_on_content_tag_id"
+  add_index "content_exercise_tags", ["content_exercise_id", "content_tag_id"], name: "index_content_exercise_tags_on_c_e_id_and_c_t_id", unique: true, using: :btree
+  add_index "content_exercise_tags", ["content_tag_id"], name: "index_content_exercise_tags_on_content_tag_id", using: :btree
 
   create_table "content_exercises", force: :cascade do |t|
     t.string   "url"
@@ -55,8 +58,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "content_exercises", ["title"], name: "index_content_exercises_on_title"
-  add_index "content_exercises", ["url"], name: "index_content_exercises_on_url", unique: true
+  add_index "content_exercises", ["title"], name: "index_content_exercises_on_title", using: :btree
+  add_index "content_exercises", ["url"], name: "index_content_exercises_on_url", unique: true, using: :btree
 
   create_table "content_lo_teks_tags", force: :cascade do |t|
     t.integer  "lo_id",      null: false
@@ -65,7 +68,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "content_lo_teks_tags", ["lo_id", "teks_id"], name: "content_lo_teks_tag_lo_teks_uniq", unique: true
+  add_index "content_lo_teks_tags", ["lo_id", "teks_id"], name: "content_lo_teks_tag_lo_teks_uniq", unique: true, using: :btree
 
   create_table "content_page_tags", force: :cascade do |t|
     t.integer  "content_page_id", null: false
@@ -74,8 +77,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",      null: false
   end
 
-  add_index "content_page_tags", ["content_page_id", "content_tag_id"], name: "index_content_page_tags_on_content_page_id_and_content_tag_id", unique: true
-  add_index "content_page_tags", ["content_tag_id"], name: "index_content_page_tags_on_content_tag_id"
+  add_index "content_page_tags", ["content_page_id", "content_tag_id"], name: "index_content_page_tags_on_content_page_id_and_content_tag_id", unique: true, using: :btree
+  add_index "content_page_tags", ["content_tag_id"], name: "index_content_page_tags_on_content_tag_id", using: :btree
 
   create_table "content_pages", force: :cascade do |t|
     t.string   "url"
@@ -88,8 +91,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "content_pages", ["content_book_part_id", "number"], name: "index_content_pages_on_content_book_part_id_and_number", unique: true
-  add_index "content_pages", ["url"], name: "index_content_pages_on_url", unique: true
+  add_index "content_pages", ["content_book_part_id", "number"], name: "index_content_pages_on_content_book_part_id_and_number", unique: true, using: :btree
+  add_index "content_pages", ["url"], name: "index_content_pages_on_url", unique: true, using: :btree
 
   create_table "content_tags", force: :cascade do |t|
     t.string   "value",                   null: false
@@ -100,8 +103,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",              null: false
   end
 
-  add_index "content_tags", ["tag_type"], name: "index_content_tags_on_tag_type"
-  add_index "content_tags", ["value"], name: "index_content_tags_on_value", unique: true
+  add_index "content_tags", ["tag_type"], name: "index_content_tags_on_tag_type", using: :btree
+  add_index "content_tags", ["value"], name: "index_content_tags_on_value", unique: true, using: :btree
 
   create_table "course_content_course_books", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -110,8 +113,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_content_course_books", ["entity_book_id"], name: "index_course_content_course_books_on_entity_book_id"
-  add_index "course_content_course_books", ["entity_course_id", "entity_book_id"], name: "[\"course_books_course_id_on_book_id_unique\"]", unique: true
+  add_index "course_content_course_books", ["entity_book_id"], name: "index_course_content_course_books_on_entity_book_id", using: :btree
+  add_index "course_content_course_books", ["entity_course_id", "entity_book_id"], name: "[\"course_books_course_id_on_book_id_unique\"]", unique: true, using: :btree
 
   create_table "course_membership_students", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -120,7 +123,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_membership_students", ["entity_course_id", "entity_role_id"], name: "course_membership_student_course_role_uniq", unique: true
+  add_index "course_membership_students", ["entity_course_id", "entity_role_id"], name: "course_membership_student_course_role_uniq", unique: true, using: :btree
 
   create_table "course_membership_teachers", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -129,7 +132,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_membership_teachers", ["entity_course_id", "entity_role_id"], name: "course_membership_teacher_course_role_uniq", unique: true
+  add_index "course_membership_teachers", ["entity_course_id", "entity_role_id"], name: "course_membership_teacher_course_role_uniq", unique: true, using: :btree
 
   create_table "course_profile_profiles", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -138,8 +141,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",       null: false
   end
 
-  add_index "course_profile_profiles", ["entity_course_id"], name: "index_course_profile_profiles_on_entity_course_id", unique: true
-  add_index "course_profile_profiles", ["name"], name: "index_course_profile_profiles_on_name"
+  add_index "course_profile_profiles", ["entity_course_id"], name: "index_course_profile_profiles_on_entity_course_id", unique: true, using: :btree
+  add_index "course_profile_profiles", ["name"], name: "index_course_profile_profiles_on_name", using: :btree
 
   create_table "courses", force: :cascade do |t|
     t.string   "school",                          null: false
@@ -157,10 +160,10 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",                      null: false
   end
 
-  add_index "courses", ["ends_at", "starts_at"], name: "index_courses_on_ends_at_and_starts_at"
-  add_index "courses", ["invisible_at", "visible_at"], name: "index_courses_on_invisible_at_and_visible_at"
-  add_index "courses", ["school", "name"], name: "index_courses_on_school_and_name", unique: true
-  add_index "courses", ["short_name", "school"], name: "index_courses_on_short_name_and_school", unique: true
+  add_index "courses", ["ends_at", "starts_at"], name: "index_courses_on_ends_at_and_starts_at", using: :btree
+  add_index "courses", ["invisible_at", "visible_at"], name: "index_courses_on_invisible_at_and_visible_at", using: :btree
+  add_index "courses", ["school", "name"], name: "index_courses_on_school_and_name", unique: true, using: :btree
+  add_index "courses", ["short_name", "school"], name: "index_courses_on_short_name_and_school", unique: true, using: :btree
 
   create_table "educators", force: :cascade do |t|
     t.integer  "course_id",  null: false
@@ -169,8 +172,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "educators", ["course_id"], name: "index_educators_on_course_id"
-  add_index "educators", ["user_id", "course_id"], name: "index_educators_on_user_id_and_course_id", unique: true
+  add_index "educators", ["course_id"], name: "index_educators_on_course_id", using: :btree
+  add_index "educators", ["user_id", "course_id"], name: "index_educators_on_user_id_and_course_id", unique: true, using: :btree
 
   create_table "entity_books", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -188,7 +191,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",             null: false
   end
 
-  add_index "entity_roles", ["role_type"], name: "index_entity_roles_on_role_type"
+  add_index "entity_roles", ["role_type"], name: "index_entity_roles_on_role_type", using: :btree
 
   create_table "entity_tasks", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -207,7 +210,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "fake_stores", ["name"], name: "index_fake_stores_on_name", unique: true
+  add_index "fake_stores", ["name"], name: "index_fake_stores_on_name", unique: true, using: :btree
 
   create_table "fine_print_contracts", force: :cascade do |t|
     t.string   "name",       null: false
@@ -218,7 +221,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "fine_print_contracts", ["name", "version"], name: "index_fine_print_contracts_on_name_and_version", unique: true
+  add_index "fine_print_contracts", ["name", "version"], name: "index_fine_print_contracts_on_name_and_version", unique: true, using: :btree
 
   create_table "fine_print_signatures", force: :cascade do |t|
     t.integer  "contract_id", null: false
@@ -228,8 +231,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",  null: false
   end
 
-  add_index "fine_print_signatures", ["contract_id"], name: "index_fine_print_signatures_on_contract_id"
-  add_index "fine_print_signatures", ["user_id", "user_type", "contract_id"], name: "index_fine_print_signatures_on_u_id_and_u_type_and_c_id", unique: true
+  add_index "fine_print_signatures", ["contract_id"], name: "index_fine_print_signatures_on_contract_id", using: :btree
+  add_index "fine_print_signatures", ["user_id", "user_type", "contract_id"], name: "index_fine_print_signatures_on_u_id_and_u_type_and_c_id", unique: true, using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -242,7 +245,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.string   "scopes"
   end
 
-  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id"
@@ -255,9 +258,9 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.string   "scopes"
   end
 
-  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
-  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
-  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
 
   create_table "oauth_applications", force: :cascade do |t|
     t.string   "name",                      null: false
@@ -269,7 +272,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at"
   end
 
-  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
 
   create_table "openstax_accounts_accounts", force: :cascade do |t|
     t.integer  "openstax_uid", null: false
@@ -283,12 +286,12 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",   null: false
   end
 
-  add_index "openstax_accounts_accounts", ["access_token"], name: "index_openstax_accounts_accounts_on_access_token", unique: true
-  add_index "openstax_accounts_accounts", ["first_name"], name: "index_openstax_accounts_accounts_on_first_name"
-  add_index "openstax_accounts_accounts", ["full_name"], name: "index_openstax_accounts_accounts_on_full_name"
-  add_index "openstax_accounts_accounts", ["last_name"], name: "index_openstax_accounts_accounts_on_last_name"
-  add_index "openstax_accounts_accounts", ["openstax_uid"], name: "index_openstax_accounts_accounts_on_openstax_uid", unique: true
-  add_index "openstax_accounts_accounts", ["username"], name: "index_openstax_accounts_accounts_on_username", unique: true
+  add_index "openstax_accounts_accounts", ["access_token"], name: "index_openstax_accounts_accounts_on_access_token", unique: true, using: :btree
+  add_index "openstax_accounts_accounts", ["first_name"], name: "index_openstax_accounts_accounts_on_first_name", using: :btree
+  add_index "openstax_accounts_accounts", ["full_name"], name: "index_openstax_accounts_accounts_on_full_name", using: :btree
+  add_index "openstax_accounts_accounts", ["last_name"], name: "index_openstax_accounts_accounts_on_last_name", using: :btree
+  add_index "openstax_accounts_accounts", ["openstax_uid"], name: "index_openstax_accounts_accounts_on_openstax_uid", unique: true, using: :btree
+  add_index "openstax_accounts_accounts", ["username"], name: "index_openstax_accounts_accounts_on_username", unique: true, using: :btree
 
   create_table "openstax_accounts_group_members", force: :cascade do |t|
     t.integer  "group_id",   null: false
@@ -297,8 +300,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "openstax_accounts_group_members", ["group_id", "user_id"], name: "index_openstax_accounts_group_members_on_group_id_and_user_id", unique: true
-  add_index "openstax_accounts_group_members", ["user_id"], name: "index_openstax_accounts_group_members_on_user_id"
+  add_index "openstax_accounts_group_members", ["group_id", "user_id"], name: "index_openstax_accounts_group_members_on_group_id_and_user_id", unique: true, using: :btree
+  add_index "openstax_accounts_group_members", ["user_id"], name: "index_openstax_accounts_group_members_on_user_id", using: :btree
 
   create_table "openstax_accounts_group_nestings", force: :cascade do |t|
     t.integer  "member_group_id",    null: false
@@ -307,8 +310,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",         null: false
   end
 
-  add_index "openstax_accounts_group_nestings", ["container_group_id"], name: "index_openstax_accounts_group_nestings_on_container_group_id"
-  add_index "openstax_accounts_group_nestings", ["member_group_id"], name: "index_openstax_accounts_group_nestings_on_member_group_id", unique: true
+  add_index "openstax_accounts_group_nestings", ["container_group_id"], name: "index_openstax_accounts_group_nestings_on_container_group_id", using: :btree
+  add_index "openstax_accounts_group_nestings", ["member_group_id"], name: "index_openstax_accounts_group_nestings_on_member_group_id", unique: true, using: :btree
 
   create_table "openstax_accounts_group_owners", force: :cascade do |t|
     t.integer  "group_id",   null: false
@@ -317,8 +320,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "openstax_accounts_group_owners", ["group_id", "user_id"], name: "index_openstax_accounts_group_owners_on_group_id_and_user_id", unique: true
-  add_index "openstax_accounts_group_owners", ["user_id"], name: "index_openstax_accounts_group_owners_on_user_id"
+  add_index "openstax_accounts_group_owners", ["group_id", "user_id"], name: "index_openstax_accounts_group_owners_on_group_id_and_user_id", unique: true, using: :btree
+  add_index "openstax_accounts_group_owners", ["user_id"], name: "index_openstax_accounts_group_owners_on_user_id", using: :btree
 
   create_table "openstax_accounts_groups", force: :cascade do |t|
     t.integer  "openstax_uid",                               null: false
@@ -330,7 +333,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",                                 null: false
   end
 
-  add_index "openstax_accounts_groups", ["openstax_uid"], name: "index_openstax_accounts_groups_on_openstax_uid", unique: true
+  add_index "openstax_accounts_groups", ["openstax_uid"], name: "index_openstax_accounts_groups_on_openstax_uid", unique: true, using: :btree
 
   create_table "role_users", force: :cascade do |t|
     t.integer  "entity_user_id", null: false
@@ -339,7 +342,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",     null: false
   end
 
-  add_index "role_users", ["entity_user_id", "entity_role_id"], name: "role_users_user_role_uniq", unique: true
+  add_index "role_users", ["entity_user_id", "entity_role_id"], name: "role_users_user_role_uniq", unique: true, using: :btree
 
   create_table "sections", force: :cascade do |t|
     t.integer  "course_id",  null: false
@@ -348,8 +351,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "sections", ["course_id"], name: "index_sections_on_course_id"
-  add_index "sections", ["name", "course_id"], name: "index_sections_on_name_and_course_id", unique: true
+  add_index "sections", ["course_id"], name: "index_sections_on_course_id", using: :btree
+  add_index "sections", ["name", "course_id"], name: "index_sections_on_name_and_course_id", unique: true, using: :btree
 
   create_table "students", force: :cascade do |t|
     t.integer  "course_id",                   null: false
@@ -364,14 +367,14 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",                  null: false
   end
 
-  add_index "students", ["course_id"], name: "index_students_on_course_id"
-  add_index "students", ["educator_custom_identifier"], name: "index_students_on_educator_custom_identifier"
-  add_index "students", ["level"], name: "index_students_on_level"
-  add_index "students", ["random_education_identifier"], name: "index_students_on_random_education_identifier", unique: true
-  add_index "students", ["section_id"], name: "index_students_on_section_id"
-  add_index "students", ["student_custom_identifier"], name: "index_students_on_student_custom_identifier"
-  add_index "students", ["user_id", "course_id"], name: "index_students_on_user_id_and_course_id", unique: true
-  add_index "students", ["user_id", "section_id"], name: "index_students_on_user_id_and_section_id", unique: true
+  add_index "students", ["course_id"], name: "index_students_on_course_id", using: :btree
+  add_index "students", ["educator_custom_identifier"], name: "index_students_on_educator_custom_identifier", using: :btree
+  add_index "students", ["level"], name: "index_students_on_level", using: :btree
+  add_index "students", ["random_education_identifier"], name: "index_students_on_random_education_identifier", unique: true, using: :btree
+  add_index "students", ["section_id"], name: "index_students_on_section_id", using: :btree
+  add_index "students", ["student_custom_identifier"], name: "index_students_on_student_custom_identifier", using: :btree
+  add_index "students", ["user_id", "course_id"], name: "index_students_on_user_id_and_course_id", unique: true, using: :btree
+  add_index "students", ["user_id", "section_id"], name: "index_students_on_user_id_and_section_id", unique: true, using: :btree
 
   create_table "tasks_assistants", force: :cascade do |t|
     t.string   "name",            null: false
@@ -380,8 +383,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",      null: false
   end
 
-  add_index "tasks_assistants", ["code_class_name"], name: "index_tasks_assistants_on_code_class_name", unique: true
-  add_index "tasks_assistants", ["name"], name: "index_tasks_assistants_on_name", unique: true
+  add_index "tasks_assistants", ["code_class_name"], name: "index_tasks_assistants_on_code_class_name", unique: true, using: :btree
+  add_index "tasks_assistants", ["name"], name: "index_tasks_assistants_on_name", unique: true, using: :btree
 
   create_table "tasks_course_assistants", force: :cascade do |t|
     t.integer  "entity_course_id",     null: false
@@ -393,8 +396,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",           null: false
   end
 
-  add_index "tasks_course_assistants", ["entity_course_id", "tasks_task_plan_type"], name: "index_tasks_course_assistants_on_course_id_and_task_plan_type", unique: true
-  add_index "tasks_course_assistants", ["tasks_assistant_id", "entity_course_id"], name: "index_tasks_course_assistants_on_assistant_id_and_course_id"
+  add_index "tasks_course_assistants", ["entity_course_id", "tasks_task_plan_type"], name: "index_tasks_course_assistants_on_course_id_and_task_plan_type", unique: true, using: :btree
+  add_index "tasks_course_assistants", ["tasks_assistant_id", "entity_course_id"], name: "index_tasks_course_assistants_on_assistant_id_and_course_id", using: :btree
 
   create_table "tasks_task_plans", force: :cascade do |t|
     t.integer  "tasks_assistant_id", null: false
@@ -410,9 +413,9 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",         null: false
   end
 
-  add_index "tasks_task_plans", ["due_at", "opens_at"], name: "index_tasks_task_plans_on_due_at_and_opens_at"
-  add_index "tasks_task_plans", ["owner_id", "owner_type"], name: "index_tasks_task_plans_on_owner_id_and_owner_type"
-  add_index "tasks_task_plans", ["tasks_assistant_id"], name: "index_tasks_task_plans_on_tasks_assistant_id"
+  add_index "tasks_task_plans", ["due_at", "opens_at"], name: "index_tasks_task_plans_on_due_at_and_opens_at", using: :btree
+  add_index "tasks_task_plans", ["owner_id", "owner_type"], name: "index_tasks_task_plans_on_owner_id_and_owner_type", using: :btree
+  add_index "tasks_task_plans", ["tasks_assistant_id"], name: "index_tasks_task_plans_on_tasks_assistant_id", using: :btree
 
   create_table "tasks_task_steps", force: :cascade do |t|
     t.integer  "tasks_task_id",             null: false
@@ -425,8 +428,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",                null: false
   end
 
-  add_index "tasks_task_steps", ["tasked_id", "tasked_type"], name: "index_tasks_task_steps_on_tasked_id_and_tasked_type", unique: true
-  add_index "tasks_task_steps", ["tasks_task_id", "number"], name: "index_tasks_task_steps_on_tasks_task_id_and_number", unique: true
+  add_index "tasks_task_steps", ["tasked_id", "tasked_type"], name: "index_tasks_task_steps_on_tasked_id_and_tasked_type", unique: true, using: :btree
+  add_index "tasks_task_steps", ["tasks_task_id", "number"], name: "index_tasks_task_steps_on_tasks_task_id_and_number", unique: true, using: :btree
 
   create_table "tasks_tasked_exercises", force: :cascade do |t|
     t.boolean  "can_be_recovered", default: false, null: false
@@ -439,7 +442,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",                       null: false
   end
 
-  add_index "tasks_tasked_exercises", ["url"], name: "index_tasks_tasked_exercises_on_url"
+  add_index "tasks_tasked_exercises", ["url"], name: "index_tasks_tasked_exercises_on_url", using: :btree
 
   create_table "tasks_tasked_interactives", force: :cascade do |t|
     t.string   "url",        null: false
@@ -474,8 +477,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",         null: false
   end
 
-  add_index "tasks_tasking_plans", ["target_id", "target_type", "tasks_task_plan_id"], name: "index_tasking_plans_on_t_id_and_t_type_and_t_p_id", unique: true
-  add_index "tasks_tasking_plans", ["tasks_task_plan_id"], name: "index_tasks_tasking_plans_on_tasks_task_plan_id"
+  add_index "tasks_tasking_plans", ["target_id", "target_type", "tasks_task_plan_id"], name: "index_tasking_plans_on_t_id_and_t_type_and_t_p_id", unique: true, using: :btree
+  add_index "tasks_tasking_plans", ["tasks_task_plan_id"], name: "index_tasks_tasking_plans_on_tasks_task_plan_id", using: :btree
 
   create_table "tasks_taskings", force: :cascade do |t|
     t.integer  "entity_role_id", null: false
@@ -484,8 +487,8 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",     null: false
   end
 
-  add_index "tasks_taskings", ["entity_role_id", "entity_task_id"], name: "[\"tasks_taskings_role_id_on_task_id_unique\"]", unique: true
-  add_index "tasks_taskings", ["entity_task_id"], name: "index_tasks_taskings_on_entity_task_id"
+  add_index "tasks_taskings", ["entity_role_id", "entity_task_id"], name: "[\"tasks_taskings_role_id_on_task_id_unique\"]", unique: true, using: :btree
+  add_index "tasks_taskings", ["entity_task_id"], name: "index_tasks_taskings_on_entity_task_id", using: :btree
 
   create_table "tasks_tasks", force: :cascade do |t|
     t.integer  "tasks_task_plan_id"
@@ -501,10 +504,10 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",                       null: false
   end
 
-  add_index "tasks_tasks", ["due_at", "opens_at"], name: "index_tasks_tasks_on_due_at_and_opens_at"
-  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id"
-  add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type"
-  add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id"
+  add_index "tasks_tasks", ["due_at", "opens_at"], name: "index_tasks_tasks_on_due_at_and_opens_at", using: :btree
+  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id", using: :btree
+  add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type", using: :btree
+  add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id", using: :btree
 
   create_table "user_profile_profiles", force: :cascade do |t|
     t.integer  "entity_user_id",      null: false
@@ -515,8 +518,42 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.datetime "updated_at",          null: false
   end
 
-  add_index "user_profile_profiles", ["account_id"], name: "index_user_profile_profiles_on_account_id", unique: true
-  add_index "user_profile_profiles", ["deleted_at"], name: "index_user_profile_profiles_on_deleted_at"
-  add_index "user_profile_profiles", ["exchange_identifier"], name: "index_user_profile_profiles_on_exchange_identifier", unique: true
+  add_index "user_profile_profiles", ["account_id"], name: "index_user_profile_profiles_on_account_id", unique: true, using: :btree
+  add_index "user_profile_profiles", ["deleted_at"], name: "index_user_profile_profiles_on_deleted_at", using: :btree
+  add_index "user_profile_profiles", ["exchange_identifier"], name: "index_user_profile_profiles_on_exchange_identifier", unique: true, using: :btree
 
+  add_foreign_key "administrators", "user_profile_profiles", column: "profile_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_book_parts", "content_book_parts", column: "parent_book_part_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_book_parts", "entity_books", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_exercise_tags", "content_exercises", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_exercise_tags", "content_tags", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_lo_teks_tags", "content_tags", column: "lo_id"
+  add_foreign_key "content_lo_teks_tags", "content_tags", column: "teks_id"
+  add_foreign_key "content_page_tags", "content_pages", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_page_tags", "content_tags", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_pages", "content_book_parts", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "course_content_course_books", "entity_books"
+  add_foreign_key "course_content_course_books", "entity_courses"
+  add_foreign_key "course_membership_students", "entity_courses"
+  add_foreign_key "course_membership_students", "entity_roles"
+  add_foreign_key "course_membership_teachers", "entity_courses"
+  add_foreign_key "course_membership_teachers", "entity_roles"
+  add_foreign_key "course_profile_profiles", "entity_courses"
+  add_foreign_key "educators", "courses", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "educators", "user_profile_profiles", column: "user_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "role_users", "entity_roles"
+  add_foreign_key "role_users", "entity_users"
+  add_foreign_key "sections", "courses", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "students", "courses", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "students", "sections", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "students", "user_profile_profiles", column: "user_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_course_assistants", "entity_courses", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_course_assistants", "tasks_assistants", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_task_plans", "tasks_assistants", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_task_steps", "tasks_tasks", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_tasking_plans", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_taskings", "entity_roles"
+  add_foreign_key "tasks_taskings", "entity_tasks"
+  add_foreign_key "tasks_tasks", "entity_tasks", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_tasks", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
 end

--- a/spec/subsystems/content/routines/import_page_spec.rb
+++ b/spec/subsystems/content/routines/import_page_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Content::Routines::ImportPage, :type => :routine, :vcr => VCR_OPT
         result = nil
         expect {
           result = Content::Routines::ImportPage.call(cnx_page: cnx_page,
-                                            book_part: book_part)
+                                                      book_part: book_part)
         }.to change{ Content::Models::Tag.lo.count }.by(2)
 
         tags = Content::Models::Tag.lo.order(:id).to_a
@@ -51,8 +51,8 @@ RSpec.describe Content::Routines::ImportPage, :type => :routine, :vcr => VCR_OPT
 
         tagged_tags = result.outputs[:tags]
         expect(tagged_tags).not_to be_empty
-        expect(tagged_tags).to(
-          eq Content::Models::Page.last.page_tags.collect{|pt| pt.tag}
+        expect(Set.new tagged_tags.collect{|t| t.value}).to(
+          eq Set.new(Content::Models::Page.last.page_tags.collect{|pt| pt.tag.value})
         )
         expected_tagged_tags = ['k12phys-ch04-s01-lo01', 'k12phys-ch04-s01-lo02']
         expected_tagged_tags << 'ost-tag-teks-112-39-c-4c' if name.to_s == 'latest'

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe Tasks::Models::TaskedExercise, :type => :model do
     tasked_exercise.free_response = 'abc'
     tasked_exercise.answer_id = answer_id
     expect(OpenStax::Exchange).to receive(:record_multiple_choice_answer)
-                                   .with(exchange_identifier,
-                                         tasked_exercise.url,
-                                         tasked_exercise.task_step.id.to_s,
-                                         answer_id)
+                                    .with(exchange_identifier,
+                                          tasked_exercise.url,
+                                          a_kind_of(String),
+                                          answer_id)
     tasked_exercise.handle_task_step_completion!
   end
 end


### PR DESCRIPTION
- Disabled by default
- Activate by specifying the env variable `OXT_TEST_DB=:memory:` or `OXT_DEV_DB=:memory:` (prepend to `rake` or `export` it or use dotenv)
- Active in the specified environment only
- Saves about 1 minute running specs on my machine: ~7 minutes -> ~6 minutes (most likely will be more if you don't have SSD or have lots of RAM, less if you have low RAM)