### PR TITLE
WIP: Run specs in parallel, using all cpu cores (really only for discussion)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,9 @@ group :development, :test do
   # Get env variables from .env file
   gem 'dotenv-rails'
 
+  # Run specs in parallel
+  gem "parallel_tests"
+
   # Allows 'ap' alternative to 'pp'
   gem 'awesome_print'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,9 @@ GEM
       lev
       rails (>= 3.1)
     pager (1.0.1)
+    parallel (1.4.1)
+    parallel_tests (1.3.7)
+      parallel
     pg (0.18.1)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
@@ -496,6 +499,7 @@ DEPENDENCIES
   openstax_api (~> 5.3.0)
   openstax_exchange
   openstax_utilities (~> 4.2.0)
+  parallel_tests
   pg
   pry
   pry-nav

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %>
+  database: <%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %>_<%= #{ENV['TEST_ENV_NUMBER']} %>
 
 ## Production database is intentionally left unconfigured
 #production:

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %>_<%= #{ENV['TEST_ENV_NUMBER']} %>
+  database: <%= ENV['OXT_TEST_DB'] || 'ox_tutor_test' %><%= "_#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER'] %>
 
 ## Production database is intentionally left unconfigured
 #production:


### PR DESCRIPTION
This is the results of an experiment I ran to run the specs in parallel using the "parallel_tests" gem https://github.com/grosser/parallel_tests

It chopped my spec run down from 7:05 to 2:56.  That's on a 8 core macbook, so it divided the specs by 8 and then ran each batch in it's own sub-process.  I'm somewhat disappointed in this, since I'd hoped it'd be close to 8 times faster.

It takes a bit of work to setup, you have to run:
 * `rake parallel:create` (one time after installing the gem)
 * `rake parallel:prepare` (after migrating, to populate all the DBs)
 * and then `rake parallel:spec` to run the specs