### PR TITLE
Don't send profile updates to accounts during setup

### DIFF
--- a/lib/tasks/setup_001.rb
+++ b/lib/tasks/setup_001.rb
@@ -172,14 +172,12 @@ class Setup001
     first_name, last_name = name.split(' ')
     raise "need a full name" if last_name.nil?
 
-    # I don't think password is actually used here
-    # TODO change :create_profile to take explicit attributes
+    # The password will be set if stubbing is disabled
     profile = run(:create_profile, attrs: { username: username,
                                             password: password } ).outputs.profile
 
-    profile.account.update_attributes(first_name: first_name,
-                                      last_name: last_name,
-                                      full_name: name)
+    # We call update_columns here so this update is not sent to OpenStax Accounts
+    profile.account.update_columns(first_name: first_name, last_name: last_name, full_name: name)
 
     profile
   end


### PR DESCRIPTION
Because we don't have permission to update the temp account