### PR TITLE
Return the currently logged in user's name

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -9,22 +9,15 @@ class Api::V1::UsersController < Api::V1::ApiController
   end
 
   api :GET, '/user', <<-EOS
-    If requested by a session/OAuth user, returns header ok (200).
+    If requested by a session/OAuth user, returns a JSON object containing only the users name.
     Otherwise returns header forbidden (403).
   EOS
   def show
-    ## TODO: Eventually convert this to something like:
-    ##         standard_real(current_human_user)
-    ##       once error/exception handling mechasmism
-    ##       have been updated.
-    status = if current_human_user.nil?
-               :forbidden
-             elsif current_human_user.is_anonymous?
-               :forbidden
-             else
-               :ok
-             end
-    head status
+    if current_human_user.nil? || current_human_user.is_anonymous?
+      head :forbidden
+    else
+      render json: { name: current_human_user.name }
+    end
   end
 
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,15 +8,18 @@ class Api::V1::UsersController < Api::V1::ApiController
     EOS
   end
 
-  api :GET, '/user', <<-EOS
-    If requested by a session/OAuth user, returns a JSON object containing only the users name.
+  api :GET, '/user', 'Returns information about the currently logged in user'
+  description <<-EOS
+    If requested by a session/OAuth user,
+    returns a JSON object containing only information that the user should be able to view.
     Otherwise returns header forbidden (403).
+    #{json_schema(Api::V1::UserProfileRepresenter, include: :readable)}
   EOS
   def show
     if current_human_user.nil? || current_human_user.is_anonymous?
       head :forbidden
     else
-      render json: { name: current_human_user.name }
+      respond_with current_human_user, represent_with: Api::V1::UserProfileRepresenter
     end
   end
 

--- a/app/representers/api/v1/user_profile_representer.rb
+++ b/app/representers/api/v1/user_profile_representer.rb
@@ -1,0 +1,11 @@
+module Api::V1
+
+  # Represents the information that a user should be able to view about their profile
+  class UserProfileRepresenter < ::Roar::Decorator
+
+    include ::Roar::JSON
+
+    property :name
+
+  end
+end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -17,6 +17,8 @@ describe Api::V1::UsersController, :type => :controller, :api => true, :version 
       it "should return an ok (200) code" do
         api_get :show, user_1_token
         expect(response.code).to eq('200')
+        payload = JSON.parse(response.body)
+        expect(payload).to eq("name" => user_1.name)
       end
     end
     context "caller does not have an authorization token" do

--- a/spec/representers/api/v1/user_profile_representer_spec.rb
+++ b/spec/representers/api/v1/user_profile_representer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TaskPlanWithDetailedStatsRepresenter, :type => :representer do
+
+
+  let(:user)           { FactoryGirl.build(:user_profile) }
+  let(:representation) { Api::V1::UserProfileRepresenter.new(user).as_json }
+
+  it "generates a JSON representation of a user that contains only the name" do
+    expect(representation).to eq("name" => user.name)
+  end
+
+end


### PR DESCRIPTION
The front-end needs a method to determine the name of the currently logged in user for display on the top navbar.

This is a quick implementation of it for discussion.  If there's no security objections with displaying it, I'll expand it to use a proper representer so the endpoint can be documented by apipie.

The corresponding FE PR is: https://github.com/openstax/tutor-js/pull/183