### PR TITLE
exercise indicators (with dummy related_content)

### DIFF
--- a/app/representers/api/v1/tasks/task_step_properties.rb
+++ b/app/representers/api/v1/tasks/task_step_properties.rb
@@ -52,5 +52,15 @@ module Api::V1::Tasks
                description: "Whether or not this step is complete"
              }
 
+    collection :related_content,
+               writeable: false,
+               readable: true,
+               # decorator: TaskStepRepresenter,
+               getter: lambda {|*| task_step.related_content },
+               schema_info: {
+                 required: true,
+                 description: "Misc information related to this exercise"
+               }
+
   end
 end

--- a/app/representers/api/v1/tasks/task_step_properties.rb
+++ b/app/representers/api/v1/tasks/task_step_properties.rb
@@ -52,15 +52,5 @@ module Api::V1::Tasks
                description: "Whether or not this step is complete"
              }
 
-    collection :related_content,
-               writeable: false,
-               readable: true,
-               # decorator: TaskStepRepresenter,
-               getter: lambda {|*| task_step.related_content },
-               schema_info: {
-                 required: true,
-                 description: "Misc information related to this exercise"
-               }
-
   end
 end

--- a/app/representers/api/v1/tasks/task_step_properties.rb
+++ b/app/representers/api/v1/tasks/task_step_properties.rb
@@ -52,5 +52,14 @@ module Api::V1::Tasks
                description: "Whether or not this step is complete"
              }
 
+    collection :related_content,
+               writeable: false,
+               readable: true,
+               getter: lambda {|*| task_step.related_content },
+               schema_info: {
+                 required: true,
+                 description: "Misc information related to this step"
+               }
+
   end
 end

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -5,10 +5,10 @@ module Api::V1::Tasks
     include Representable::Coercion
 
     property :url,
+             as: :content_url,
              type: String,
              writeable: false,
              readable: true,
-             as: :content_url,
              schema_info: {
                required: false,
                description: "The source URL for this Exercise"

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -99,5 +99,16 @@ module Api::V1::Tasks
                description: "Whether or not the answer given by the student is correct"
              }
 
+    ## TODO: Move this to TaskStepProperties
+    collection :related_content,
+               writeable: false,
+               readable: true,
+               # decorator: TaskStepRepresenter,
+               getter: lambda {|*| task_step.related_content },
+               schema_info: {
+                 required: true,
+                 description: "Misc information related to this exercise"
+               }
+
   end
 end

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -43,6 +43,16 @@ module Api::V1::Tasks
                description: "Whether or not a recovery exercise is available"
              }
 
+    property :group_name,
+             as: :group,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: lambda {|*| task_step.group_name },
+             schema_info: {
+                description: "Which exercise group the exercise belongs to (default,core,spaced practice,personalized)"
+             }
+
     # The properties below assume an Exercise with only 1 Question
     property :answer_id,
              type: String,

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -99,16 +99,5 @@ module Api::V1::Tasks
                description: "Whether or not the answer given by the student is correct"
              }
 
-    ## TODO: Move this to TaskStepProperties
-    collection :related_content,
-               writeable: false,
-               readable: true,
-               # decorator: TaskStepRepresenter,
-               getter: lambda {|*| task_step.related_content },
-               schema_info: {
-                 required: true,
-                 description: "Misc information related to this exercise"
-               }
-
   end
 end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -44,4 +44,8 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   def feedback_available?
     completed? && task.feedback_available?
   end
+
+  def group_name
+    group_type.gsub(/_group\z/, '').gsub('_', ' ')
+  end
 end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -48,4 +48,13 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   def group_name
     group_type.gsub(/_group\z/, '').gsub('_', ' ')
   end
+
+  def related_content
+    [
+      {
+        title: "Some Dummy Title",
+        chapter_section: "3.14"
+      }
+    ]
+  end
 end

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -68,7 +68,7 @@ describe Api::V1::TaskStepsController, :type => :controller, :api => true, :vers
       api_get :show, user_1_token, parameters: { task_id: task_step.task.id, id: task_step.id }
       expect(response).to have_http_status(:success)
 
-      expect(response.body_as_hash).to eq({
+      expect(response.body_as_hash).to include({
         id: task_step.id.to_s,
         task_id: task_step.tasks_task_id.to_s,
         type: 'reading',
@@ -76,7 +76,8 @@ describe Api::V1::TaskStepsController, :type => :controller, :api => true, :vers
         chapter_section: task_step.tasked.chapter_section,
         is_completed: false,
         content_url: 'http://u.rl',
-        content_html: 'content'
+        content_html: 'content',
+        related_content: a_kind_of(Array)
       })
     end
   end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     ## TaskedExercise-specific properties
     allow(@tasked_exercise).to receive(:url).and_return('Some url')
     allow(@tasked_exercise).to receive(:title).and_return('Some title')
-    allow(@tasked_exercise).to receive(:content_without_correctness).and_return('Some content')
+    allow(@tasked_exercise).to receive(:content_hash_without_correctness).and_return('Some content')
     allow(@tasked_exercise).to receive(:feedback).and_return('Some feedback')
     allow(@tasked_exercise).to receive(:correct_answer_id).and_return('456')
     allow(@tasked_exercise).to receive(:can_be_recovered?).and_return(false)
@@ -45,8 +45,8 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
 
     it "correctly references the TaskStep and Task ids" do
       expect(representation).to include(
-        "id"           => 15,
-        "task_id"      => 42
+        "id"      => 15.to_s,
+        "task_id" => 42.to_s
       )
     end
 
@@ -90,7 +90,6 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
 
     it "'has_recovery' is not included" do
       expect(representation).to_not include("has_recovery")
-          "task_id"           => tasked_exercise.task_step.task.id.to_s,
     end
 
     it "'feedback_html' is not included" do
@@ -102,7 +101,6 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     end
 
   end
-          "task_id"           => tasked_exercise.task_step.task.id.to_s,
 
   context "completed exercise" do
 

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -1,92 +1,163 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer do
-
-  let(:exercise_content) { OpenStax::Exercises::V1.fake_client.new_exercise_hash }
-  let(:tasked_exercise) {
-    FactoryGirl.create(:tasks_tasked_exercise, content: exercise_content.to_json)
+  let!(:task_step) {
+    @task_step = instance_double(Tasks::Models::TaskStep)
+    allow(@task_step).to receive(:id).and_return(15)
+    allow(@task_step).to receive(:tasks_task_id).and_return(42)
+    @task_step
   }
-  let(:representation) { Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked_exercise).as_json }
 
-  it "represents a tasked exercise" do
-    content = exercise_content.deep_stringify_keys
-    content['questions'].each do |q|
-      q['answers'].each do |a|
-        a.delete('correctness')
-        a.delete('feedback_html')
-      end
+  let!(:tasked_exercise) {
+    @tasked_exercise = instance_double(Tasks::Models::TaskedExercise)
+
+    ## Avoid rspec double class when figuring out :type
+    allow(@tasked_exercise).to receive(:class).and_return(Tasks::Models::TaskedExercise)
+
+    allow(@tasked_exercise).to receive(:task_step).and_return(@task_step)
+
+    ## TaskedExercise-specific properties
+    allow(@tasked_exercise).to receive(:url).and_return('Some url')
+    allow(@tasked_exercise).to receive(:title).and_return('Some title')
+    allow(@tasked_exercise).to receive(:content_without_correctness).and_return('Some content')
+    allow(@tasked_exercise).to receive(:feedback).and_return('Some feedback')
+    allow(@tasked_exercise).to receive(:correct_answer_id).and_return('456')
+    allow(@tasked_exercise).to receive(:can_be_recovered?).and_return(false)
+    allow(@tasked_exercise).to receive(:is_correct?).and_return(false)
+
+    @tasked_exercise
+  }
+
+  let(:representation) {
+    Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked_exercise).as_json
+  }
+
+  shared_examples "a good exercise representation should" do
+    it "'type' == 'exercise'" do
+      expect(representation).to include("type" => "exercise")
     end
 
-    expect(representation).to include(
-      "id"           => tasked_exercise.task_step.id.to_s,
-      "task_id"      => tasked_exercise.task_step.task.id.to_s,
-      "type"         => "exercise",
-      "is_completed" => false,
-      "content_url"  => tasked_exercise.url,
-      "content" => content
-    )
+    it "correctly references the TaskStep and Task ids" do
+      expect(representation).to include(
+        "id"           => 15,
+        "task_id"      => 42
+      )
+    end
+
+    it "has the correct 'content_url'" do
+      expect(representation).to include("content_url" => 'Some url')
+    end
+
+    it "has the correct 'title'" do
+      expect(representation).to include("title" => 'Some title')
+    end
+
+    it "has the correct 'content'" do
+      expect(representation).to include("content" => 'Some content')
+    end
   end
 
 
-  context "when complete and" do
+  context "non-completed exercise" do
 
-    let!(:answer_id)         { tasked_exercise.answer_ids.first }
-    let!(:correct_answer_id) { tasked_exercise.correct_answer_id }
+    before(:each) do
+      allow(@tasked_exercise).to receive(:free_response).and_return(nil)
+      allow(@tasked_exercise).to receive(:answer_id).and_return(nil)
 
-    before do
-      tasked_exercise.free_response = 'Four score and seven years ago ...'
-      tasked_exercise.answer_id = answer_id
-      tasked_exercise.save!
-      tasked_exercise.task_step.complete
-      tasked_exercise.task_step.save!
+      allow(@task_step).to receive(:completed?).and_return(false)
+      allow(@task_step).to receive(:feedback_available?).and_return(false)
     end
 
-    context "feedback is available for the task" do
+    it_behaves_like "a good exercise representation should"
 
-      before do
-        tasked_exercise.task_step.task.feedback_at = Time.now
-        tasked_exercise.task_step.task.save!
-      end
+    it "'is_completed' == false" do
+      expect(representation).to include("is_completed" => false)
+    end
 
-      it "has additional fields" do
-        expect(representation).to include(
-          "id"                => tasked_exercise.task_step.id.to_s,
+    it "'has_recovery' is not included" do
+      expect(representation).to_not include("has_recovery")
           "task_id"           => tasked_exercise.task_step.task.id.to_s,
-          "type"              => "exercise",
-          "is_completed"      => true,
-          "content_url"       => tasked_exercise.url,
-          "correct_answer_id" => correct_answer_id.to_s,
-          "answer_id"         => answer_id.to_s,
-          "free_response"     => "Four score and seven years ago ...",
-          "has_recovery"      => false,
-          "is_correct"        => true
-        )
-      end
-
     end
 
-    context "feedback is not available for the task" do
+    it "'feedback_html' is not included" do
+      expect(representation).to_not include("feedback_html")
+    end
 
-      it "has no additional fields" do
-        expect(representation).to include(
-          "id"                => tasked_exercise.task_step.id.to_s,
+    it "'correct_answer_id' is not included" do
+      expect(representation).to_not include("correct_answer_id")
+    end
+
+  end
           "task_id"           => tasked_exercise.task_step.task.id.to_s,
-          "type"              => "exercise",
-          "is_completed"      => true,
-          "content_url"       => tasked_exercise.url,
-          "answer_id"         => answer_id.to_s,
-          "free_response"     => "Four score and seven years ago ..."
-        )
 
-        expect(representation).not_to include(
-          "correct_answer_id" => correct_answer_id.to_s,
-          "has_recovery"      => false,
-          "is_correct"        => true
-        )
+  context "completed exercise" do
+
+    before(:each) do
+      allow(@tasked_exercise).to receive(:free_response).and_return('Some response')
+      allow(@tasked_exercise).to receive(:answer_id).and_return('123')
+
+      allow(@task_step).to receive(:completed?).and_return(true)
+    end
+
+    context "feedback available" do
+
+      before(:each) do
+        allow(@task_step).to receive(:feedback_available?).and_return(true)
+      end
+
+      it_behaves_like "a good exercise representation should"
+
+      it "'is_completed' == true" do
+        expect(representation).to include("is_completed" => true)
+      end
+
+      it "has correct 'has_recovery'" do
+        expect(representation).to include("has_recovery" => false)
+      end
+
+      it "has correct 'feedback_html'" do
+        expect(representation).to include("feedback_html" => 'Some feedback')
+      end
+
+      it "has the correct 'is_correct'" do
+        expect(representation).to include("is_correct" => false)
+      end
+
+      it "has the correct 'correct_answer_id'" do
+        expect(representation).to include("correct_answer_id" => '456')
       end
 
     end
 
+    context "feedback unavailable" do
+
+      before(:each) do
+        allow(@task_step).to receive(:feedback_available?).and_return(false)
+      end
+
+      it_behaves_like "a good exercise representation should"
+
+      it "'is_completed' == true" do
+        expect(representation).to include("is_completed" => true)
+      end
+
+      it "'has_recovery' is not included" do
+        expect(representation).to_not include("has_recovery")
+      end
+
+      it "'feedback_html' is not included" do
+        expect(representation).to_not include("feedback_html")
+      end
+
+      it "'is_correct' is not included" do
+        expect(representation).to_not include("is_correct")
+      end
+
+      it "'correct_answer_id' is not included" do
+        expect(representation).to_not include("correct_answer_id")
+      end
+
+    end
   end
 
 end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     @task_step = instance_double(Tasks::Models::TaskStep)
     allow(@task_step).to receive(:id).and_return(15)
     allow(@task_step).to receive(:tasks_task_id).and_return(42)
+    allow(@task_step).to receive(:group_name).and_return('Some group')
     @task_step
   }
 
@@ -54,6 +55,10 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
 
     it "has the correct 'content'" do
       expect(representation).to include("content" => 'Some content')
+    end
+
+    it "has the correct 'group'" do
+      expect(representation).to include("group" => 'Some group')
     end
   end
 

--- a/spec/representers/api/v1/tasks/tasked_reading_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_reading_representer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Tasks::TaskedReadingRepresenter, :type => :representer d
     task_step = FactoryGirl.create(:tasks_tasked_reading).task_step
     json = Api::V1::Tasks::TaskedReadingRepresenter.new(task_step.tasked).to_json
 
-    expect(JSON.parse(json)).to eq({
+    expect(JSON.parse(json)).to include({
       id: task_step.id.to_s,
       task_id: task_step.tasks_task_id.to_s,
       type: "reading",
@@ -13,7 +13,8 @@ RSpec.describe Api::V1::Tasks::TaskedReadingRepresenter, :type => :representer d
       chapter_section: task_step.tasked.chapter_section,
       is_completed: false,
       content_url: task_step.tasked.url,
-      content_html: task_step.tasked.content
+      content_html: task_step.tasked.content,
+      related_content: a_kind_of(Array)
     }.stringify_keys)
   end
 end

--- a/spec/representers/api/v1/tasks/tasked_video_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_video_representer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Tasks::TaskedVideoRepresenter, :type => :representer do
     task_step = FactoryGirl.create(:tasks_tasked_video).task_step
     json = Api::V1::Tasks::TaskedVideoRepresenter.new(task_step.tasked).to_json
 
-    expect(JSON.parse(json)).to eq({
+    expect(JSON.parse(json)).to include({
       id: task_step.id.to_s,
       task_id: task_step.tasks_task_id.to_s,
       type: 'video',
@@ -13,6 +13,7 @@ RSpec.describe Api::V1::Tasks::TaskedVideoRepresenter, :type => :representer do
       is_completed: false,
       content_url: task_step.tasked.url,
       content_html: task_step.tasked.content,
+      related_content: a_kind_of(Array)
     }.stringify_keys)
   end
 end

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -21,4 +21,18 @@ RSpec.describe Tasks::Models::TaskStep, :type => :model do
     task_step.tasked = FactoryGirl.build :tasks_tasked_exercise, task_step: task_step
     expect { task_step.save! }.to change{ task_step.task.cache_key }
   end
+
+  it "converts its group type to a name" do
+    name_by_type = {
+      "default_group"         => "default",
+      "core_group"            => "core",
+      "spaced_practice_group" => "spaced practice",
+      "personalized_group"    => "personalized"
+    }
+
+    Tasks::Models::TaskStep.group_types.keys.each do |group_type|
+      allow(task_step).to receive(:group_type).and_return(group_type)
+      expect(task_step.group_name).to eq(name_by_type[group_type])
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `related_content` and `group` to `TaskedExerciseRepresenter` output, and also includes related changes to `TaskStep` and `TaskedExercise`.  The specs for `TaskedExerciseRepresenter` have be overhauled to be more explicit and customizable.

Now included in this PR: all TaskSteps can have related_content, though it is not required.