### PR TITLE
assistants add related_content to task steps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,6 +126,9 @@ group :development, :test do
   # Thin development server
   gem 'thin'
 
+  # Call 'debugger' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug'
+
   # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console
   gem 'pry' # needed when debugging without 'rails_helper'
   gem 'pry-nav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,10 @@ GEM
       sass (~> 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -106,6 +110,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
+    columnize (0.9.0)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -133,6 +138,7 @@ GEM
     daemons (1.2.2)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
+    debugger-linecache (1.2.0)
     deep_cloneable (2.1.1)
       activerecord (>= 3.1.0, < 5.0.0)
     descendants_tracker (0.0.4)
@@ -489,6 +495,7 @@ DEPENDENCIES
   aws-ses (~> 0.6.0)
   bootstrap-sass (~> 3.2.0)
   brakeman
+  byebug
   capybara-webkit
   carrierwave
   cheat

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -121,7 +121,7 @@ class Tasks::Assistants::HomeworkAssistant
     pages = Content::Models::Page.joins{page_tags.tag}
                                  .where{page_tags.tag.id.in los.map(&:id)}
 
-    raise "multiple pages found for exercise #{cnx_exercise.url}" unless pages.one?
+    raise "#{pages.count} pages found for exercise #{cnx_exercise.url}" unless pages.one?
     pages.first
   end
 

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -224,7 +224,7 @@ class Tasks::Assistants::IReadingAssistant
     pages = Content::Models::Page.joins{page_tags.tag}
                                  .where{page_tags.tag.id.in los.map(&:id)}
 
-    raise "multiple pages found for exercise #{content_exercise.url}" unless pages.one?
+    raise "#{pages.count} pages found for exercise #{content_exercise.url}" unless pages.one?
     pages.first
   end
 

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -90,31 +90,32 @@ class Tasks::Assistants::IReadingAssistant
   def self.add_core_steps!(task:, cnx_pages:)
     cnx_pages.each do |page|
       # Chapter intro pages get their titles from the chapter instead
-      title = page.is_intro? ? page.book_part_title : page.title
+      page_title = page.is_intro? ? page.book_part_title : page.title
 
+      fragment_title = page_title
       page.fragments.each do |fragment|
         step = Tasks::Models::TaskStep.new(task: task)
 
         case fragment
         when OpenStax::Cnx::V1::Fragment::ExerciseChoice
-          tasked_exercise_choice(exercise_choice_fragment: fragment, step: step, title: title)
+          tasked_exercise_choice(exercise_choice_fragment: fragment, step: step, title: fragment_title)
         when OpenStax::Cnx::V1::Fragment::Exercise
-          tasked_exercise(exercise_fragment: fragment, step: step, title: title)
+          tasked_exercise(exercise_fragment: fragment, step: step, title: fragment_title)
         when OpenStax::Cnx::V1::Fragment::Video
-          tasked_video(video_fragment: fragment, step: step, title: title)
+          tasked_video(video_fragment: fragment, step: step, title: fragment_title)
         when OpenStax::Cnx::V1::Fragment::Interactive
-          tasked_interactive(interactive_fragment: fragment, step: step, title: title)
+          tasked_interactive(interactive_fragment: fragment, step: step, title: fragment_title)
         else
-          tasked_reading(reading_fragment: fragment, page: page, title: title, step: step)
+          tasked_reading(reading_fragment: fragment, page: page, title: fragment_title, step: step)
         end
 
         next if step.tasked.nil?
         step.core_group!
-
+        step.add_related_content({title: page_title, chapter_section: page.chapter_section})
         task.task_steps << step
 
         # Only the first step for each Page should have a title
-        title = nil
+        fragment_title = nil
       end
     end
 
@@ -146,10 +147,13 @@ class Tasks::Assistants::IReadingAssistant
         chosen_exercise = candidate_exercises.first #sample
         #puts "chosen exercise:     #{chosen_exercise.uid}"
 
+        related_content = get_related_content_for(chosen_exercise)
+
         candidate_exercises.delete(chosen_exercise)
         exercise_history.push(chosen_exercise)
 
         step = add_exercise_step(task: task, exercise: chosen_exercise)
+        step.add_related_content(related_content)
         step.spaced_practice_group!
       end
     end
@@ -201,6 +205,27 @@ class Tasks::Assistants::IReadingAssistant
 
   def self.k_ago_map
     [ [1,1], [2,1] ]
+  end
+
+  def self.get_related_content_for(content_exercise)
+    page = content_exercise_page(content_exercise)
+
+    {
+      title: page.title,
+      chapter_section: page.chapter_section
+    }
+  end
+
+  def self.content_exercise_page(content_exercise)
+    los = Content::Models::Tag.joins{exercise_tags.exercise}
+                              .where{exercise_tags.exercise.url == content_exercise.url}
+                              .select{|tag| tag.lo?}
+
+    pages = Content::Models::Page.joins{page_tags.tag}
+                                 .where{page_tags.tag.id.in los.map(&:id)}
+
+    raise "multiple pages found for exercise #{content_exercise.url}" unless pages.one?
+    pages.first
   end
 
   def self.add_exercise_step(task:, exercise:)

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -4,6 +4,8 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
 
   enum group_type: [:default_group, :core_group, :spaced_practice_group]
 
+  serialize :settings, JSON
+
   validates :task, presence: true
   validates :tasked, presence: true
   validates :tasked_id, uniqueness: { scope: :tasked_type }
@@ -13,6 +15,17 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
 
   scope :complete, -> { where{completed_at != nil} }
   scope :incomplete, -> { where{completed_at == nil} }
+
+  after_initialize :init_settings
+  after_initialize :init_related_content
+
+  def init_settings
+    self.settings ||= {}
+  end
+
+  def init_related_content
+    self.settings['related_content'] ||= []
+  end
 
   def has_correctness?
     tasked.has_correctness?
@@ -50,11 +63,15 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   end
 
   def related_content
-    [
-      {
-        title: "Some Dummy Title",
-        chapter_section: "3.14"
-      }
-    ]
+    self.settings['related_content']
   end
+
+  def related_content=(value)
+    self.settings['related_content'] = value
+  end
+
+  def add_related_content(related_content_hash)
+    self.settings['related_content'] << related_content_hash
+  end
+
 end

--- a/db/migrate/20141021205221_create_tasks_task_steps.rb
+++ b/db/migrate/20141021205221_create_tasks_task_steps.rb
@@ -6,6 +6,7 @@ class CreateTasksTaskSteps < ActiveRecord::Migration
       t.integer :number, null: false
       t.datetime :completed_at
       t.integer :group_type, default: 0, null: false
+      t.text :settings, null: false
 
       t.timestamps null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -427,6 +427,7 @@ ActiveRecord::Schema.define(version: 20150420184110) do
     t.integer  "number",                    null: false
     t.datetime "completed_at"
     t.integer  "group_type",    default: 0, null: false
+    t.text     "settings",                  null: false
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
   end

--- a/lib/tasks/setup_001.rb
+++ b/lib/tasks/setup_001.rb
@@ -110,7 +110,8 @@ class Setup001
                                               settings: {
                                                 exercise_ids: Content::Models::Exercise
                                                                 .order(:created_at)
-                                                                .last(2).collect{ |e| e.id.to_s },
+                                                                .last(3).first(2) ## the last exercise is mis-tagged
+                                                                .collect{ |e| e.id.to_s },
                                                 exercises_count_dynamic: 2
                                               })
     hw_tp.tasking_plans << Tasks::Models::TaskingPlan.create!(target: course, task_plan: hw_tp)

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -682,7 +682,10 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
           assistant: hw_assistant,
           opens_at: Time.now,
           due_at: Time.now + 2.week,
-          settings: { exercise_ids: Content::Models::Exercise.last(2).collect{ |e| e.id.to_s },
+          settings: { exercise_ids: Content::Models::Exercise.all
+                                                             .sort_by{|ex| ex.url}
+                                                             .last(3).first(2) ## the last exercise is mis-tagged
+                                                             .collect{ |e| e.id.to_s },
                       exercises_count_dynamic: 2 }
         )
         tp.tasking_plans << Tasks::Models::TaskingPlan.create!(target: course, task_plan: tp)

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -28,28 +28,37 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
     let!(:core_step_gold_data) {
       [
         { klass: Tasks::Models::TaskedReading,
-          title: "Forces and Newton's Laws of Motion"},
+          title: "Forces and Newton's Laws of Motion",
+          related_content: [{title: "Forces and Newton's Laws of Motion", chapter_section: "8.1"}] },
         { klass: Tasks::Models::TaskedReading,
-          title: "Force"},
+          title: "Force",
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
         { klass: Tasks::Models::TaskedVideo,
-          title: nil},
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
         { klass: Tasks::Models::TaskedReading,
-          title: nil},
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
         { klass: Tasks::Models::TaskedReading,
-          title: nil},
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
         { klass: Tasks::Models::TaskedExercise,
-          title: nil},
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
         { klass: Tasks::Models::TaskedReading,
-          title: nil}
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] }
       ]
     }
 
     let!(:spaced_practice_step_gold_data) {
       [
         { klass: Tasks::Models::TaskedExercise,
-          title: nil},
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
         { klass: Tasks::Models::TaskedExercise,
-          title: nil},
+          title: nil,
+          related_content: [{title: "Force", chapter_section: "8.2"}] },
       ]
     }
 
@@ -103,6 +112,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         task_steps.each_with_index do |task_step, ii|
           expect(task_step.tasked.class).to eq(task_step_gold_data[ii][:klass])
           expect(task_step.tasked.title).to eq(task_step_gold_data[ii][:title])
+          expect(task_step.related_content).to eq(task_step_gold_data[ii][:related_content])
         end
 
         core_task_steps = task.core_task_steps

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -35,4 +35,25 @@ RSpec.describe Tasks::Models::TaskStep, :type => :model do
       expect(task_step.group_name).to eq(name_by_type[group_type])
     end
   end
+
+  context "related content" do
+    it "can get related content" do
+      expect(task_step.related_content).to eq([])
+    end
+
+    it "can set related content" do
+      target_related_content = [{title: 'blah', chapter_section: 'blah'}]
+      task_step.related_content = target_related_content
+      expect(task_step.related_content).to eq(target_related_content)
+    end
+
+    it "can add new related content" do
+      expect(task_step.related_content).to eq([])
+
+      content = {title: 'blah', chapter_section: 'blah'}
+      expect{
+        task_step.add_related_content content
+      }.to change{task_step.related_content}.by [content]
+    end
+  end
 end


### PR DESCRIPTION
This PR fulfills the backend population of TaskStep related_content, per [this napkin note](https://github.com/openstax/napkin-notes/blob/master/jp/exercise_sources.md).

It also corrects the use of a mis-labeled exercise in several test setups and adds the `byebug` gem.
