### PR TITLE
Admin edit tags

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -1,0 +1,22 @@
+class Admin::TagsController < Admin::BaseController
+  before_action :get_tag, except: [:index]
+
+  def index
+    @tags = Content::SearchTags[tag_value: "%#{params[:value]}%"].limit(100) if params[:value].present?
+  end
+
+  def edit
+  end
+
+  def update
+    @tag.update_attributes(name: params[:tags][:name],
+                           description: params[:tags][:description])
+    flash[:notice] = 'The tag has been updated.'
+    redirect_to admin_tags_path(value: @tag.value)
+  end
+
+  private
+  def get_tag
+    @tag = Content::Models::Tag.find(params[:id])
+  end
+end

--- a/app/representers/api/v1/user_profile_representer.rb
+++ b/app/representers/api/v1/user_profile_representer.rb
@@ -7,5 +7,8 @@ module Api::V1
 
     property :name
 
+    property :is_admin?,
+             as: :is_admin
+
   end
 end

--- a/app/subsystems/content/search_tags.rb
+++ b/app/subsystems/content/search_tags.rb
@@ -1,0 +1,9 @@
+class Content::SearchTags
+  lev_routine express_output: :tags
+
+  protected
+
+  def exec(tag_value:)
+    outputs[:tags] = Content::Models::Tag.where { value.like tag_value }
+  end
+end

--- a/app/subsystems/user_profile/models/profile.rb
+++ b/app/subsystems/user_profile/models/profile.rb
@@ -36,6 +36,10 @@ class UserProfile::Models::Profile < Tutor::SubSystems::BaseModel
     !deleted_at.nil?
   end
 
+  def is_admin?
+    !administrator.nil?
+  end
+
   def destroy
     update_attribute(:deleted_at, Time.now)
   end

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,0 +1,25 @@
+<% method ||= :post %>
+
+<%= lev_form_for :tag, url: url, method: method do |f| %>
+  <table>
+    <tr>
+      <td><%= f.label :value, 'ID' %></td>
+      <td><%= f.text_field :value, disabled: 'disabled' %></td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :name %></td>
+      <td><%= f.text_field :name, size: 50 %></td>
+    </tr>
+
+    <tr>
+      <td><%= f.label :description %></td>
+      <td><%= f.text_area :description, rows: 5, cols: 50 %></td>
+    </tr>
+
+    <tr>
+      <td></td>
+      <td><%= f.submit 'Save', class: 'btn btn-primary' %></td>
+    </tr>
+  </table>
+<% end %>

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', url: admin_tag_path, method: :put %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,0 +1,32 @@
+<%= form_tag '', method: :get do %>
+  <%= label_tag :value, 'Tag ID' %>
+  <%= text_field_tag :value, params[:value] %>
+  <%= submit_tag 'Search' %>
+<% end %>
+
+<% if params[:value] && @tags.empty? %>
+  <p>No tags found.</p>
+<% end %>
+
+<% if @tags.present? %>
+  <table border="1">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @tags.each do |tag| %>
+        <tr>
+          <td><%= tag.value %></td>
+          <td><%= tag.name %></td>
+          <td>
+            <%= link_to 'edit', edit_admin_tag_path(tag.id) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/layouts/admin/_header.html.erb
+++ b/app/views/layouts/admin/_header.html.erb
@@ -4,6 +4,7 @@
     <%= link_to 'Dashboard', dashboard_path %>&nbsp;|
     <%= link_to 'Courses', admin_courses_path %>&nbsp;|
     <%= link_to 'Users', admin_users_path %>&nbsp;|
+    <%= link_to 'Tags', admin_tags_path %>&nbsp;|
     <%= render 'layouts/authentication' %>
   </nav>
 </header>

--- a/app/views/layouts/admin/_header.html.erb
+++ b/app/views/layouts/admin/_header.html.erb
@@ -1,6 +1,7 @@
 <header>
   <h1>Tutor Administration</h1>
   <nav>
+    <%= link_to 'Dashboard', dashboard_path %>&nbsp;|
     <%= link_to 'Courses', admin_courses_path %>&nbsp;|
     <%= link_to 'Users', admin_users_path %>&nbsp;|
     <%= render 'layouts/authentication' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,8 @@ Rails.application.routes.draw do
         patch 'undelete'
       end
     end
+
+    resources :tags, only: [:index, :edit, :update, :show]
   end
 
   namespace :dev do

--- a/lib/tasks/setup_001.rb
+++ b/lib/tasks/setup_001.rb
@@ -42,6 +42,10 @@ class Setup001
                                            assistant: hw_assistant,
                                            tasks_task_plan_type: 'homework')
 
+    # Add an admin user
+    admin = new_profile(username: 'admin', name: 'Administrator User')
+    UserProfile::MakeAdministrator[user: admin.entity_user]
+
     # Add teacher to course
     teacher = new_profile(username: 'teacher', name: 'Bill Nye')
     run(:add_teacher, course: course, user: teacher.entity_user)

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Admin::TagsController do
+  let!(:admin) { FactoryGirl.create :user_profile, :administrator }
+
+  let!(:tag_1) { FactoryGirl.create :content_tag, value: 'k12phys-ch04-ex003' }
+  let!(:tag_2) { FactoryGirl.create :content_tag, value: 'k12phys-ch04-s03-lo01' }
+  let!(:tag_3) { FactoryGirl.create :content_tag, value: 'ost-tag-teks-112-39-c-4d' }
+
+  before { controller.sign_in(admin) }
+
+  describe 'GET #index' do
+    it 'does not list tags' do
+      get :index
+      expect(assigns[:tags]).to be_nil
+    end
+
+    it 'returns a list of tags that matches tag value' do
+      get :index, value: 'k12phys'
+
+      expect(assigns[:tags].order(:id)).to eq [tag_1, tag_2]
+    end
+
+    it 'returns nothing if there are no matches' do
+      get :index, value: 'time-short'
+
+      expect(assigns[:tags]).to eq []
+    end
+  end
+
+  describe 'PUT #update' do
+    it 'updates the name and description of the tag' do
+      put :update, id: tag_1.id, tags: {
+        name: 'k12 physics chapter 4 exercise 3',
+        description: 'Student should be able to do this exercise',
+        value: 'immutable'
+      }
+
+      tag_1.reload
+      expect(tag_1.value).to eq 'k12phys-ch04-ex003'
+      expect(tag_1.name).to eq 'k12 physics chapter 4 exercise 3'
+      expect(tag_1.description).to eq 'Student should be able to do this exercise'
+    end
+  end
+
+  context 'disallowing baddies' do
+    it 'disallows unauthenticated visitors' do
+      allow(controller).to receive(:current_account) { nil }
+      allow(controller).to receive(:current_user) { nil }
+
+      get :index
+      expect(response).not_to be_success
+
+      put :update, id: tag_1.id
+      expect(response).not_to be_success
+    end
+
+    it 'disallows non-admin authenticated visitors' do
+      non_admin = FactoryGirl.create :user_profile
+      controller.sign_in(non_admin)
+
+      expect { get :index }.to raise_error(SecurityTransgression)
+      expect { put :update, id: tag_1.id }.to raise_error(SecurityTransgression)
+    end
+  end
+end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -8,6 +8,11 @@ describe Api::V1::UsersController, :type => :controller, :api => true, :version 
                                               application: application,
                                               resource_owner_id: user_1.id }
 
+  let!(:admin)           { FactoryGirl.create :user_profile, :administrator }
+  let!(:admin_token)     { FactoryGirl.create :doorkeeper_access_token,
+                                              application: application,
+                                              resource_owner_id: admin.id }
+
   let!(:userless_token)  { FactoryGirl.create :doorkeeper_access_token,
                                               application: application,
                                               resource_owner_id: nil }
@@ -18,7 +23,14 @@ describe Api::V1::UsersController, :type => :controller, :api => true, :version 
         api_get :show, user_1_token
         expect(response.code).to eq('200')
         payload = JSON.parse(response.body)
-        expect(payload).to eq("name" => user_1.name)
+        expect(payload).to eq("name" => user_1.name, 'is_admin' => false)
+      end
+
+      it 'returns is_admin flag correctly' do
+        api_get :show, admin_token
+        expect(response.code).to eq('200')
+        payload = JSON.parse(response.body)
+        expect(payload).to eq("name" => admin.name, 'is_admin' => true)
       end
     end
     context "caller does not have an authorization token" do

--- a/spec/representers/api/v1/user_profile_representer_spec.rb
+++ b/spec/representers/api/v1/user_profile_representer_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Api::V1::TaskPlanWithDetailedStatsRepresenter, :type => :represen
   let(:user)           { FactoryGirl.build(:user_profile) }
   let(:representation) { Api::V1::UserProfileRepresenter.new(user).as_json }
 
-  it "generates a JSON representation of a user that contains only the name" do
-    expect(representation).to eq("name" => user.name)
+  it "generates a JSON representation of a user" do
+    expect(representation).to eq("name" => user.name, 'is_admin' => false)
   end
 
 end


### PR DESCRIPTION
- Add an admin user in setup:001 rake task

- Return whether user is an admin in /api/user

- Include link back to Dashboard in admin console

- Add admin views to edit name and description of tags
