### PR TITLE
set default number of personalized exercises to zero

### DIFF
--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -262,7 +262,7 @@ class Tasks::Assistants::HomeworkAssistant
   end
 
   def self.num_personalized_exercises
-    1
+    0
   end
 
   def self.assign_task!(task:, taskee:)


### PR DESCRIPTION
This gives the front end time to prepare for `TaskedPlaceholder`s and other personalized exercise trickery.