### PR TITLE
Improve learning guide performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,12 @@ gem 'axlsx', '~> 2.1.0.pre'
 gem 'will_paginate', '~> 3.0.6'
 
 group :development, :test do
+  # Nail down n+1 queries and unused eager loading
+  gem 'bullet'
+
+  # Trace AR queries
+  gem 'active_record_query_trace'
+
   # SQLite adapter
   gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     active_attr (0.8.5)
       activemodel (>= 3.0.2, < 5.0)
       activesupport (>= 3.0.2, < 5.0)
+    active_record_query_trace (1.4)
     activejob (4.2.0)
       activesupport (= 4.2.0)
       globalid (>= 0.3.0)
@@ -77,6 +78,9 @@ GEM
       sass (~> 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    bullet (4.14.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     byebug (3.5.1)
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
@@ -492,6 +496,7 @@ GEM
     unicorn-worker-killer (0.4.3)
       get_process_mem (~> 0)
       unicorn (~> 4)
+    uniform_notifier (1.9.0)
     validates_timeliness (3.0.14)
       timeliness (~> 0.3.6)
     vcr (2.9.3)
@@ -524,6 +529,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_record_query_trace
   addressable
   apipie-rails
   autoprefixer-rails
@@ -532,6 +538,7 @@ DEPENDENCIES
   axlsx (~> 2.1.0.pre)
   bootstrap-sass (~> 3.2.0)
   brakeman
+  bullet
   byebug
   capybara-webkit
   carrierwave

--- a/app/subsystems/content/models/page_data_visitor.rb
+++ b/app/subsystems/content/models/page_data_visitor.rb
@@ -27,7 +27,7 @@ class Content::Models::PageDataVisitor < Content::Models::BookVisitor
   end
 
   def get_page_tags(page)
-    page.page_tags.collect do |page_tag|
+    page.page_tags.includes(:tag).collect do |page_tag|
       { type: page_tag.tag.tag_type, value: page_tag.tag.value }
     end
   end

--- a/app/subsystems/course_membership/get_course_roles.rb
+++ b/app/subsystems/course_membership/get_course_roles.rb
@@ -17,14 +17,14 @@ class CourseMembership::GetCourseRoles
     roles = types.collect do |type|
       case type
       when :student
-        CourseMembership::Models::Student.where{entity_course_id == course.id}
+        CourseMembership::Models::Student.includes(:role).where{entity_course_id == course.id}
 
         # Temporarily removed because of a problem (with entity_extensions?):
         # Entity::Role.joins { students }
         #             .where { students.entity_course_id == course.id }
 
       when :teacher
-        CourseMembership::Models::Teacher.where{entity_course_id == course.id}
+        CourseMembership::Models::Teacher.includes(:role).where{entity_course_id == course.id}
 
         # Temporarily removed because of a problem (with entity_extensions?):
         # Entity::Role.joins { teachers }

--- a/app/subsystems/tasks/get_role_completed_task_steps.rb
+++ b/app/subsystems/tasks/get_role_completed_task_steps.rb
@@ -10,7 +10,7 @@ module Tasks
     def exec(roles:)
       run(:get_tasks, roles: roles)
 
-      outputs[:task_steps] = Models::Task.includes(:task_steps)
+      outputs[:task_steps] = Models::Task.includes(task_steps: :tasked)
                                          .where(entity_task: outputs.tasks)
                                          .collect(&:task_steps).flatten
                                          .select(&:completed?)

--- a/app/subsystems/tasks/get_tasks.rb
+++ b/app/subsystems/tasks/get_tasks.rb
@@ -11,6 +11,7 @@ class Tasks::GetTasks
     role_ids = verify_and_get_id_array(roles, Entity::Role)
 
     entity_tasks = Tasks::Models::Tasking.
+                     includes(:task).
                      where{entity_role_id.in role_ids}.
                      collect{|tasking| tasking.task}
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,5 +42,10 @@ Rails.application.configure do
 
   # Don't error out when trying to connect to external sites
   WebMock.allow_net_connect!
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true # tail -f log/bullet.log
+  end
 end
 

--- a/config/initializers/trace_activerecord_queries.rb
+++ b/config/initializers/trace_activerecord_queries.rb
@@ -1,0 +1,1 @@
+ActiveRecordQueryTrace.enabled = ((ENV['TRACE_ACTIVERECORD_QUERIES'] || '').downcase == 'true')

--- a/config/initializers/trace_activerecord_queries.rb
+++ b/config/initializers/trace_activerecord_queries.rb
@@ -1,1 +1,1 @@
-ActiveRecordQueryTrace.enabled = ((ENV['TRACE_ACTIVERECORD_QUERIES'] || '').downcase == 'true')
+ActiveRecordQueryTrace.enabled = EnvUtilities.load_boolean(name: 'TRACE_ACTIVERECORD_QUERIES', default: false)


### PR DESCRIPTION
* Adds gem `bullet` for N+1 and unused eager loading detection
  * `tail -f log/bullet.log`
* Adds gem `active_record_query_trace` (disabled by default) to show the app trace of every query
  * set `ENV['TRACE_ACTIVERECORD_QUERIES']` to `true`
* Adds eager loading to various learning guide related routines, as pointed out by using bullet