### PR TITLE
Changed logout to use GET

### DIFF
--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -10,7 +10,7 @@ OpenStax::Accounts.configure do |config|
   config.openstax_application_secret = secrets['secret']
   config.openstax_accounts_url = secrets['url']
   config.enable_stubbing = stub
-  config.logout_via = :delete
+  config.logout_via = :get
   config.account_user_mapper = MapUsersAccounts
 end
 


### PR DESCRIPTION
@philschatz 

This works for me (src/api.coffee line 196):

```js
CurrentUserActions.logout.addListener 'trigger', ->
    window.location.href = '/accounts/logout'
```

but you may wanna change that logout link to be a raw anchor.