### PR TITLE
TaskStep labels

### DIFF
--- a/app/external/openstax/cnx/v1/fragment/acts_as_fragment.rb
+++ b/app/external/openstax/cnx/v1/fragment/acts_as_fragment.rb
@@ -1,0 +1,24 @@
+module OpenStax::Cnx::V1::Fragment
+  module ActsAsFragment
+    def visit(visitor:, depth: 0)
+      visitor.pre_order_visit(elem: self, depth: depth)
+      visitor.in_order_visit(elem: self, depth: depth)
+      custom_visit(visitor: visitor, depth: depth)
+      visitor.post_order_visit(elem: self, depth: depth)
+    end
+
+    def labels
+      @labels ||= []
+    end
+
+    def add_labels(labels)
+      @labels = [@labels, labels].flatten.compact.uniq
+    end
+
+    protected
+
+    def custom_visit(visitor:, depth:)
+      ## override this to customize visitation
+    end
+  end
+end

--- a/app/external/openstax/cnx/v1/fragment/embedded.rb
+++ b/app/external/openstax/cnx/v1/fragment/embedded.rb
@@ -1,5 +1,6 @@
 module OpenStax::Cnx::V1::Fragment
   class Embedded
+    include ActsAsFragment
 
     class_attribute :default_width, :default_height
 
@@ -73,12 +74,6 @@ module OpenStax::Cnx::V1::Fragment
       end
 
       @to_html ||= node.to_html
-    end
-
-    def visit(visitor:, depth: 0)
-      visitor.pre_order_visit(elem: self, depth: depth)
-      visitor.in_order_visit(elem: self, depth: depth)
-      visitor.post_order_visit(elem: self, depth: depth)
     end
 
     protected

--- a/app/external/openstax/cnx/v1/fragment/exercise.rb
+++ b/app/external/openstax/cnx/v1/fragment/exercise.rb
@@ -1,5 +1,6 @@
 module OpenStax::Cnx::V1::Fragment
   class Exercise
+    include ActsAsFragment
 
     # Used to get the title
     TITLE_CSS = '[data-type="title"]'
@@ -31,12 +32,6 @@ module OpenStax::Cnx::V1::Fragment
 
     def embed_tag
       @short_code ||= EMBED_TAG_REGEX.match(embed_code).try(:[], 1)
-    end
-
-    def visit(visitor:, depth: 0)
-      visitor.pre_order_visit(elem: self, depth: depth)
-      visitor.in_order_visit(elem: self, depth: depth)
-      visitor.post_order_visit(elem: self, depth: depth)
     end
 
   end

--- a/app/external/openstax/cnx/v1/fragment/exercise_choice.rb
+++ b/app/external/openstax/cnx/v1/fragment/exercise_choice.rb
@@ -1,5 +1,6 @@
 module OpenStax::Cnx::V1::Fragment
   class ExerciseChoice
+    include ActsAsFragment
 
     # Used to get the title
     TITLE_CSS = '[data-type="title"]'
@@ -29,13 +30,12 @@ module OpenStax::Cnx::V1::Fragment
       end
     end
 
-    def visit(visitor:, depth: 0)
-      visitor.pre_order_visit(elem: self, depth: depth)
-      visitor.in_order_visit(elem: self, depth: depth)
+    protected
+
+    def custom_visit(visitor:, depth:)
       exercise_fragments.each do |exercise_fragment|
         exercise_fragment.visit(visitor: visitor, depth: depth+1)
       end
-      visitor.post_order_visit(elem: self, depth: depth)
     end
 
   end

--- a/app/external/openstax/cnx/v1/fragment/interactive.rb
+++ b/app/external/openstax/cnx/v1/fragment/interactive.rb
@@ -1,5 +1,7 @@
 module OpenStax::Cnx::V1::Fragment
   class Interactive < Embedded
+    include ActsAsFragment
+
     self.default_width = 960
     self.default_height = 560
   end

--- a/app/external/openstax/cnx/v1/fragment/text.rb
+++ b/app/external/openstax/cnx/v1/fragment/text.rb
@@ -1,5 +1,6 @@
 module OpenStax::Cnx::V1::Fragment
   class Text
+    include ActsAsFragment
 
     # Used to get the title
     TITLE_CSS = '[data-type="title"]'
@@ -26,12 +27,5 @@ module OpenStax::Cnx::V1::Fragment
     def to_html
       node.to_html
     end
-
-    def visit(visitor:, depth: 0)
-      visitor.pre_order_visit(elem: self, depth: depth)
-      visitor.in_order_visit(elem: self, depth: depth)
-      visitor.post_order_visit(elem: self, depth: depth)
-    end
-
   end
 end

--- a/app/external/openstax/cnx/v1/fragment/video.rb
+++ b/app/external/openstax/cnx/v1/fragment/video.rb
@@ -1,5 +1,7 @@
 module OpenStax::Cnx::V1::Fragment
   class Video < Embedded
+    include ActsAsFragment
+
     self.default_width = 560
     self.default_height = 315
   end

--- a/app/external/openstax/cnx/v1/page.rb
+++ b/app/external/openstax/cnx/v1/page.rb
@@ -218,26 +218,23 @@ module OpenStax::Cnx::V1
     protected
 
     def node_to_fragment(node)
-      klass = node['class']
+      klass = node['class'] || []
 
-      return Fragment::Text.new(node: node) if klass.nil?
+      fragment =
+        if INTERACTIVE_CLASSES.any? { |interactive_class| klass.include?(interactive_class) }
+          Fragment::Interactive.new(node: node)
+        elsif klass.include?(VIDEO_CLASS)
+          Fragment::Video.new(node: node)
+        elsif klass.include?(EXERCISE_CHOICE_CLASS)
+          Fragment::ExerciseChoice.new(node: node)
+        elsif klass.include?(EXERCISE_CLASS)
+          Fragment::Exercise.new(node: node)
+        else
+          Fragment::Text.new(node: node)
+        end
 
-      if INTERACTIVE_CLASSES.any? { |interactive_class| klass.include?(interactive_class) }
-        # Simulation
-        Fragment::Interactive.new(node: node)
-      elsif klass.include?(VIDEO_CLASS)
-        # Video
-        Fragment::Video.new(node: node)
-      elsif klass.include?(EXERCISE_CHOICE_CLASS)
-        # Exercise choice
-        Fragment::ExerciseChoice.new(node: node)
-      elsif klass.include?(EXERCISE_CLASS)
-        # Exercise
-        Fragment::Exercise.new(node: node)
-      else
-        # Nothing matched, so consider it to be plain text
-        Fragment::Text.new(node: node)
-      end
+      fragment.add_labels('worked-example') if klass.include?('worked-example')
+      fragment
     end
 
     def split_into_fragments(node)

--- a/app/representers/api/v1/tasks/task_step_properties.rb
+++ b/app/representers/api/v1/tasks/task_step_properties.rb
@@ -69,7 +69,16 @@ module Api::V1::Tasks
                getter: lambda {|*| task_step.related_content },
                schema_info: {
                  required: true,
-                 description: "Misc information related to this step"
+                 description: "Misc content related to this step"
+               }
+
+    collection :labels,
+               writeable: false,
+               readable: true,
+               getter: lambda {|*| task_step.labels },
+               schema_info: {
+                 required: true,
+                 description: "Misc properties related to this step"
                }
 
   end

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -121,6 +121,7 @@ class Tasks::Assistants::IReadingAssistant
 
         next if step.tasked.nil?
         step.core_group!
+        step.add_labels(fragment.labels)
         step.add_related_content(related_content_for_page(page: page, title: page_title))
         task.task_steps << step
 

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -91,9 +91,7 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   end
 
   def add_labels(labels)
-    [labels].flatten.each do |label|
-      self.settings['labels'] << label
-    end
+    self.settings['labels'] = [self.settings['labels'], labels].flatten.compact.uniq
   end
 
 end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -19,10 +19,15 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   scope :exercises, -> { where{tasked_type == Tasks::Models::TaskedExercise.name} }
 
   after_initialize :init_settings
+  after_initialize :init_labels
   after_initialize :init_related_content
 
   def init_settings
     self.settings ||= {}
+  end
+
+  def init_labels
+    self.settings['labels'] ||= []
   end
 
   def init_related_content
@@ -74,6 +79,21 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
 
   def add_related_content(related_content_hash)
     self.settings['related_content'] << related_content_hash
+  end
+
+  def labels
+    self.settings['labels']
+  end
+
+  def labels=(value)
+    self.settings['labels'] = value
+    self.settings['labels'] ||= []
+  end
+
+  def add_labels(labels)
+    [labels].flatten.each do |label|
+      self.settings['labels'] << label
+    end
   end
 
 end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -2,36 +2,36 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer do
   let!(:task_step) {
-    @task_step = instance_double(Tasks::Models::TaskStep)
-    allow(@task_step).to receive(:id).and_return(15)
-    allow(@task_step).to receive(:tasks_task_id).and_return(42)
-    allow(@task_step).to receive(:group_name).and_return('Some group')
-    allow(@task_step).to receive(:completed?).and_return(false)
-    allow(@task_step).to receive(:feedback_available?).and_return(false)
-    allow(@task_step).to receive(:related_content).and_return([])
-    @task_step
+    step = instance_double(Tasks::Models::TaskStep)
+    allow(step).to receive(:id).and_return(15)
+    allow(step).to receive(:tasks_task_id).and_return(42)
+    allow(step).to receive(:group_name).and_return('Some group')
+    allow(step).to receive(:completed?).and_return(false)
+    allow(step).to receive(:feedback_available?).and_return(false)
+    allow(step).to receive(:related_content).and_return([])
+    step
   }
 
   let!(:tasked_exercise) {
-    @tasked_exercise = instance_double(Tasks::Models::TaskedExercise)
+    exercise = instance_double(Tasks::Models::TaskedExercise)
 
     ## Avoid rspec double class when figuring out :type
-    allow(@tasked_exercise).to receive(:class).and_return(Tasks::Models::TaskedExercise)
+    allow(exercise).to receive(:class).and_return(Tasks::Models::TaskedExercise)
 
-    allow(@tasked_exercise).to receive(:task_step).and_return(@task_step)
+    allow(exercise).to receive(:task_step).and_return(task_step)
 
     ## TaskedExercise-specific properties
-    allow(@tasked_exercise).to receive(:url).and_return('Some url')
-    allow(@tasked_exercise).to receive(:title).and_return('Some title')
-    allow(@tasked_exercise).to receive(:content_hash_without_correctness).and_return('Some content')
-    allow(@tasked_exercise).to receive(:feedback).and_return('Some feedback')
-    allow(@tasked_exercise).to receive(:correct_answer_id).and_return('456')
-    allow(@tasked_exercise).to receive(:can_be_recovered?).and_return(false)
-    allow(@tasked_exercise).to receive(:is_correct?).and_return(false)
-    allow(@tasked_exercise).to receive(:free_response).and_return(nil)
-    allow(@tasked_exercise).to receive(:answer_id).and_return(nil)
+    allow(exercise).to receive(:url).and_return('Some url')
+    allow(exercise).to receive(:title).and_return('Some title')
+    allow(exercise).to receive(:content_hash_without_correctness).and_return('Some content')
+    allow(exercise).to receive(:feedback).and_return('Some feedback')
+    allow(exercise).to receive(:correct_answer_id).and_return('456')
+    allow(exercise).to receive(:can_be_recovered?).and_return(false)
+    allow(exercise).to receive(:is_correct?).and_return(false)
+    allow(exercise).to receive(:free_response).and_return(nil)
+    allow(exercise).to receive(:answer_id).and_return(nil)
 
-    @tasked_exercise
+    exercise
   }
 
   let(:representation) { ## NOTE: This is lazily-evaluated on purpose!
@@ -75,11 +75,11 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
   context "non-completed exercise" do
 
     before(:each) do
-      allow(@tasked_exercise).to receive(:free_response).and_return(nil)
-      allow(@tasked_exercise).to receive(:answer_id).and_return(nil)
+      allow(tasked_exercise).to receive(:free_response).and_return(nil)
+      allow(tasked_exercise).to receive(:answer_id).and_return(nil)
 
-      allow(@task_step).to receive(:completed?).and_return(false)
-      allow(@task_step).to receive(:feedback_available?).and_return(false)
+      allow(task_step).to receive(:completed?).and_return(false)
+      allow(task_step).to receive(:feedback_available?).and_return(false)
     end
 
     it_behaves_like "a good exercise representation should"
@@ -105,10 +105,10 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
   context "completed exercise" do
 
     before(:each) do
-      allow(@tasked_exercise).to receive(:free_response).and_return('Some response')
-      allow(@tasked_exercise).to receive(:answer_id).and_return('123')
+      allow(tasked_exercise).to receive(:free_response).and_return('Some response')
+      allow(tasked_exercise).to receive(:answer_id).and_return('123')
 
-      allow(@task_step).to receive(:completed?).and_return(true)
+      allow(task_step).to receive(:completed?).and_return(true)
     end
 
     it "'is_completed' == true" do
@@ -118,7 +118,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     context "feedback available" do
 
       before(:each) do
-        allow(@task_step).to receive(:feedback_available?).and_return(true)
+        allow(task_step).to receive(:feedback_available?).and_return(true)
       end
 
       it_behaves_like "a good exercise representation should"
@@ -144,7 +144,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     context "feedback unavailable" do
 
       before(:each) do
-        allow(@task_step).to receive(:feedback_available?).and_return(false)
+        allow(task_step).to receive(:feedback_available?).and_return(false)
       end
 
       it_behaves_like "a good exercise representation should"
@@ -172,7 +172,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
   context "without related content" do
 
     before(:each) do
-      allow(@task_step).to receive(:related_content).and_return([])
+      allow(task_step).to receive(:related_content).and_return([])
     end
 
     it_behaves_like "a good exercise representation should"
@@ -186,7 +186,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
   context "with related content" do
 
     before(:each) do
-      allow(@task_step).to receive(:related_content).and_return([{title: "Some title", chapter_section: "4.2"}])
+      allow(task_step).to receive(:related_content).and_return([{title: "Some title", chapter_section: "4.2"}])
     end
 
     it_behaves_like "a good exercise representation should"

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     allow(step).to receive(:completed?).and_return(false)
     allow(step).to receive(:feedback_available?).and_return(false)
     allow(step).to receive(:related_content).and_return([])
+    allow(step).to receive(:labels).and_return([])
     step
   }
 
@@ -44,6 +45,8 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     end
 
     it "correctly references the TaskStep and Task ids" do
+      allow(task_step).to receive(:id).and_return(15)
+      allow(task_step).to receive(:tasks_task_id).and_return(42)
       expect(representation).to include(
         "id"      => 15.to_s,
         "task_id" => 42.to_s
@@ -51,23 +54,33 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, :type => :representer 
     end
 
     it "has the correct 'content_url'" do
+      allow(tasked_exercise).to receive(:url).and_return('Some url')
       expect(representation).to include("content_url" => 'Some url')
     end
 
     it "has the correct 'title'" do
+      allow(tasked_exercise).to receive(:title).and_return('Some title')
       expect(representation).to include("title" => 'Some title')
     end
 
     it "has the correct 'content'" do
+      allow(tasked_exercise).to receive(:content_hash_without_correctness).and_return('Some content')
       expect(representation).to include("content" => 'Some content')
     end
 
     it "has the correct 'group'" do
+      allow(task_step).to receive(:group_name).and_return('Some group')
       expect(representation).to include("group" => 'Some group')
     end
 
     it "has 'related_content'" do
+      allow(task_step).to receive(:related_content).and_return([])
       expect(representation).to include("related_content")
+    end
+
+    it "has 'labels'" do
+      allow(task_step).to receive(:labels).and_return([])
+      expect(representation).to include("labels")
     end
 
   end

--- a/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
@@ -2,28 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, :type => :representer do
   let!(:task_step) {
-    @task_step = instance_double(Tasks::Models::TaskStep)
-    allow(@task_step).to receive(:id).and_return(15)
-    allow(@task_step).to receive(:tasks_task_id).and_return(42)
-    allow(@task_step).to receive(:group_name).and_return('Some group')
-    allow(@task_step).to receive(:completed?).and_return(false)
-    allow(@task_step).to receive(:feedback_available?).and_return(false)
-    allow(@task_step).to receive(:related_content).and_return([])
-    @task_step
+    step = instance_double(Tasks::Models::TaskStep)
+    allow(step).to receive(:id).and_return(15)
+    allow(step).to receive(:tasks_task_id).and_return(42)
+    allow(step).to receive(:group_name).and_return('Some group')
+    allow(step).to receive(:completed?).and_return(false)
+    allow(step).to receive(:feedback_available?).and_return(false)
+    allow(step).to receive(:related_content).and_return([])
+    allow(step).to receive(:labels).and_return([])
+    step
   }
 
   let!(:tasked_placeholder) {
-    @tasked_placeholder = instance_double(Tasks::Models::TaskedPlaceholder)
+    placeholder = instance_double(Tasks::Models::TaskedPlaceholder)
 
     ## Avoid rspec double class when figuring out :type
-    allow(@tasked_placeholder).to receive(:class).and_return(Tasks::Models::TaskedPlaceholder)
+    allow(placeholder).to receive(:class).and_return(Tasks::Models::TaskedPlaceholder)
 
-    allow(@tasked_placeholder).to receive(:task_step).and_return(@task_step)
+    allow(placeholder).to receive(:task_step).and_return(task_step)
 
     ## TaskedPlaceholder-specific properties
-    allow(@tasked_placeholder).to receive(:placeholder_name).and_return('Some step type')
+    allow(placeholder).to receive(:placeholder_name).and_return('Some step type')
 
-    @tasked_placeholder
+    placeholder
   }
 
   let(:representation) { ## NOTE: This is lazily-evaluated on purpose!
@@ -35,10 +36,13 @@ RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, :type => :represent
   end
 
   it "has the correct 'placeholder_for'" do
+    allow(tasked_placeholder).to receive(:placeholder_name).and_return('Some step type')
     expect(representation).to include("placeholder_for" => 'Some step type')
   end
 
   it "correctly references the TaskStep and Task ids" do
+    allow(task_step).to receive(:id).and_return(15)
+    allow(task_step).to receive(:tasks_task_id).and_return(42)
     expect(representation).to include(
       "id"      => 15.to_s,
       "task_id" => 42.to_s
@@ -46,14 +50,17 @@ RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, :type => :represent
   end
 
   it "'is_completed' == false" do
+    allow(task_step).to receive(:completed?).and_return(false)
     expect(representation).to include("is_completed" => false)
   end
 
   it "has the correct 'group'" do
+    allow(task_step).to receive(:group_name).and_return('Some group')
     expect(representation).to include("group" => 'Some group')
   end
 
   it "has 'related_content'" do
+    allow(task_step).to receive(:related_content).and_return([])
     expect(representation).to include("related_content")
   end
 

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -77,4 +77,25 @@ RSpec.describe Tasks::Models::TaskStep, :type => :model do
       }.to change{task_step.related_content}.by [content]
     end
   end
+
+  context "labels" do
+    it "can get labels" do
+      expect(task_step.labels).to eq([])
+    end
+
+    it "can set labels" do
+      target_labels = ['label1', 'label2']
+      task_step.labels = target_labels
+      expect(task_step.labels).to eq(target_labels)
+    end
+
+    it "can add new labels" do
+      expect(task_step.labels).to eq([])
+
+      labels = ['a', 'b']
+      expect{
+        task_step.add_labels labels
+      }.to change{task_step.labels}.by labels
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a collection of strings called `labels` to `TaskStep`s.

Ultimately this collection will hold `"worked-example"` to indicate which `Reading` fragments are worked examples.