### PR TITLE
Remove application.js and application.css from admin pages

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -2,8 +2,6 @@
 <html>
   <head>
     <title>OpenStax Tutor : Administration</title>
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= stylesheet_link_tag 'admin', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'admin', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
There's an error from application.js (home/main.js) about .localScroll()
not being defined on admin pages, this causes the datepicker in admin.js
to not activate sometimes.