### PR TITLE
Tag visible flag

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -9,8 +9,8 @@ class Admin::TagsController < Admin::BaseController
   end
 
   def update
-    @tag.update_attributes(name: params[:tags][:name],
-                           description: params[:tags][:description])
+    @tag.update_attributes(name: params[:tag][:name],
+                           description: params[:tag][:description])
     flash[:notice] = 'The tag has been updated.'
     redirect_to admin_tags_path(value: @tag.value)
   end

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -10,7 +10,8 @@ class Admin::TagsController < Admin::BaseController
 
   def update
     @tag.update_attributes(name: params[:tag][:name],
-                           description: params[:tag][:description])
+                           description: params[:tag][:description],
+                           visible: params[:tag][:visible])
     flash[:notice] = 'The tag has been updated.'
     redirect_to admin_tags_path(value: @tag.value)
   end

--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -28,10 +28,11 @@ module Api::V1
              getter: ->(*) { ::JSON.parse(content) },
              schema_info: { required: true }
 
-    collection :tags_with_teks,
+    collection :tags,
                as: :tags,
                readable: true,
                writeable: false,
+               getter: -> (*) { tags_with_teks.select { |tag| tag.visible } },
                decorator: TagRepresenter,
                schema_info: { required: true, description: 'Tags for this exercise' }
 

--- a/app/representers/api/v1/tag_representer.rb
+++ b/app/representers/api/v1/tag_representer.rb
@@ -35,5 +35,10 @@ module Api::V1
                description: 'The chapter and section in the book, e.g. [5, 2]'
              }
 
+    property :data,
+             type: String,
+             readable: true,
+             writeable: false
+
   end
 end

--- a/app/subsystems/content/models/tag.rb
+++ b/app/subsystems/content/models/tag.rb
@@ -10,7 +10,7 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
   validates :value, presence: true
   validates :tag_type, presence: true
 
-  before_save :update_tag_type
+  before_save :update_tag_type_and_visible
 
   TAG_TYPE_REGEX = {
     dok: /^dok/,
@@ -19,6 +19,8 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
     teks: /^ost-tag-teks-/,
     lo: /-lo\d+$/
   }
+
+  VISIBLE_TAG_TYPES = [:teks, :lo, :dok, :blooms, :length]
 
   def chapter_section
     matches = /-ch(\d+)-s(\d+)-lo\d+$/.match(value)
@@ -48,8 +50,12 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
     template
   end
 
-  def update_tag_type
+  def update_tag_type_and_visible
     self.tag_type = get_tag_type if tag_type.nil? || tag_type == 'generic'
+    self.visible = VISIBLE_TAG_TYPES.include?(tag_type.to_sym) if visible.nil?
+    # need to return true here because if self.visible evaluates to false, the
+    # record does not get saved
+    return true
   end
 
   def get_tag_type

--- a/app/subsystems/content/models/tag.rb
+++ b/app/subsystems/content/models/tag.rb
@@ -5,10 +5,20 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
   has_many :teks_tags, through: :lo_teks_tags, class_name: 'Tag', source: :teks
 
   # List the different types of tags
-  enum tag_type: [ :generic, :teks, :lo ]
+  enum tag_type: [ :generic, :teks, :lo, :dok, :blooms, :length ]
 
   validates :value, presence: true
   validates :tag_type, presence: true
+
+  before_save :update_tag_type
+
+  TAG_TYPE_REGEX = {
+    dok: /^dok/,
+    blooms: /^blooms-/,
+    length: /^time-/,
+    teks: /^ost-tag-teks-/,
+    lo: /-lo\d+$/
+  }
 
   def chapter_section
     matches = /-ch(\d+)-s(\d+)-lo\d+$/.match(value)
@@ -38,5 +48,17 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
     template
   end
 
+  def update_tag_type
+    self.tag_type = get_tag_type if tag_type.nil? || tag_type == 'generic'
+  end
+
+  def get_tag_type
+    TAG_TYPE_REGEX.each do |type, regex|
+      if value.match(regex)
+        return type
+      end
+    end
+    return :generic
+  end
 
 end

--- a/app/subsystems/content/models/tag.rb
+++ b/app/subsystems/content/models/tag.rb
@@ -10,13 +10,13 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
   validates :value, presence: true
   validates :tag_type, presence: true
 
-  before_save :update_tag_type_and_visible
+  before_save :update_tag_type_data_and_visible
 
   TAG_TYPE_REGEX = {
-    dok: /^dok/,
-    blooms: /^blooms-/,
-    length: /^time-/,
-    teks: /^ost-tag-teks-/,
+    dok: /^dok(\d+)$/,
+    blooms: /^blooms-(\d+)$/,
+    length: /^time-(.+)$/,
+    teks: /^ost-tag-teks-.*-(.+)$/,
     lo: /-lo\d+$/
   }
 
@@ -50,8 +50,9 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
     template
   end
 
-  def update_tag_type_and_visible
+  def update_tag_type_data_and_visible
     self.tag_type = get_tag_type if tag_type.nil? || tag_type == 'generic'
+    self.data = get_data if data.nil?
     self.visible = VISIBLE_TAG_TYPES.include?(tag_type.to_sym) if visible.nil?
     # need to return true here because if self.visible evaluates to false, the
     # record does not get saved
@@ -65,6 +66,11 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
       end
     end
     return :generic
+  end
+
+  def get_data
+    m = value.match(TAG_TYPE_REGEX[tag_type.to_sym] || //)
+    return m && m[1]
   end
 
 end

--- a/app/subsystems/content/search_tags.rb
+++ b/app/subsystems/content/search_tags.rb
@@ -4,6 +4,6 @@ class Content::SearchTags
   protected
 
   def exec(tag_value:)
-    outputs[:tags] = Content::Models::Tag.where { value.like tag_value }
+    outputs[:tags] = Content::Models::Tag.where { value.like tag_value }.order { value }
   end
 end

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -18,6 +18,11 @@
     </tr>
 
     <tr>
+      <td><%= f.label :visible %></td>
+      <td><%= f.check_box :visible %></td>
+    </tr>
+
+    <tr>
       <td></td>
       <td><%= f.submit 'Save', class: 'btn btn-primary' %></td>
     </tr>

--- a/db/migrate/20141106215530_create_content_tags.rb
+++ b/db/migrate/20141106215530_create_content_tags.rb
@@ -5,6 +5,7 @@ class CreateContentTags < ActiveRecord::Migration
       t.integer :tag_type, null: false, default: 0
       t.string :name
       t.text :description
+      t.boolean :visible, default: true
 
       t.timestamps null: false
 

--- a/db/migrate/20141106215530_create_content_tags.rb
+++ b/db/migrate/20141106215530_create_content_tags.rb
@@ -5,6 +5,7 @@ class CreateContentTags < ActiveRecord::Migration
       t.integer :tag_type, null: false, default: 0
       t.string :name
       t.text :description
+      t.string :data
       t.boolean :visible
 
       t.timestamps null: false

--- a/db/migrate/20141106215530_create_content_tags.rb
+++ b/db/migrate/20141106215530_create_content_tags.rb
@@ -5,7 +5,7 @@ class CreateContentTags < ActiveRecord::Migration
       t.integer :tag_type, null: false, default: 0
       t.string :name
       t.text :description
-      t.boolean :visible, default: true
+      t.boolean :visible
 
       t.timestamps null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,13 +90,13 @@ ActiveRecord::Schema.define(version: 20150507224137) do
   add_index "content_pages", ["url"], name: "index_content_pages_on_url", unique: true, using: :btree
 
   create_table "content_tags", force: :cascade do |t|
-    t.string   "value",                      null: false
-    t.integer  "tag_type",    default: 0,    null: false
+    t.string   "value",                   null: false
+    t.integer  "tag_type",    default: 0, null: false
     t.string   "name"
     t.text     "description"
-    t.boolean  "visible",     default: true
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.boolean  "visible"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   add_index "content_tags", ["tag_type"], name: "index_content_tags_on_tag_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 20150507224137) do
     t.integer  "tag_type",    default: 0, null: false
     t.string   "name"
     t.text     "description"
+    t.string   "data"
     t.boolean  "visible"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,12 +90,13 @@ ActiveRecord::Schema.define(version: 20150507224137) do
   add_index "content_pages", ["url"], name: "index_content_pages_on_url", unique: true, using: :btree
 
   create_table "content_tags", force: :cascade do |t|
-    t.string   "value",                   null: false
-    t.integer  "tag_type",    default: 0, null: false
+    t.string   "value",                      null: false
+    t.integer  "tag_type",    default: 0,    null: false
     t.string   "name"
     t.text     "description"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.boolean  "visible",     default: true
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
   end
 
   add_index "content_tags", ["tag_type"], name: "index_content_tags_on_tag_type", using: :btree

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Admin::TagsController do
 
   describe 'PUT #update' do
     it 'updates the name and description of the tag' do
-      put :update, id: tag_1.id, tags: {
+      put :update, id: tag_1.id, tag: {
         name: 'k12 physics chapter 4 exercise 3',
         description: 'Student should be able to do this exercise',
         value: 'immutable'

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -29,17 +29,19 @@ RSpec.describe Admin::TagsController do
   end
 
   describe 'PUT #update' do
-    it 'updates the name and description of the tag' do
+    it 'updates the name, description and visible flag of the tag' do
       put :update, id: tag_1.id, tag: {
         name: 'k12 physics chapter 4 exercise 3',
         description: 'Student should be able to do this exercise',
-        value: 'immutable'
+        value: 'immutable',
+        visible: '0'
       }
 
       tag_1.reload
       expect(tag_1.value).to eq 'k12phys-ch04-ex003'
       expect(tag_1.name).to eq 'k12 physics chapter 4 exercise 3'
       expect(tag_1.description).to eq 'Student should be able to do this exercise'
+      expect(tag_1.visible).to be false
     end
   end
 

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Api::V1::ExerciseRepresenter, type: :representer do
         'id' => 'ost-tag-teks-112-39-c-4d',
         'type' => 'teks',
         'name' => '(D)',
-        'description' => 'calculate the effect of forces on objects'
+        'description' => 'calculate the effect of forces on objects',
+        'data' => '4d'
       }]
     )
   end

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::ExerciseRepresenter, type: :representer do
         'chapter_section' => [4,2],
       }, {
         'id' => 'ost-tag-teks-112-39-c-4d',
-        'type' => 'generic',
+        'type' => 'teks',
         'name' => '(D)',
         'description' => 'calculate the effect of forces on objects'
       }]

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Api::V1::ExerciseRepresenter, type: :representer do
                        name: 'Describe Newton\'s first law and friction',
                        description: nil
   }
+  let!(:lo2) {
+    FactoryGirl.create :content_tag,
+                       tag_type: :lo,
+                       value: 'ost-tag-lo-k12phys-ch04-s02-lo02',
+                       name: 'Learning Objective 2',
+                       description: nil,
+                       visible: false
+  }
   let!(:teks) {
     FactoryGirl.create :content_tag,
                        value: 'ost-tag-teks-112-39-c-4d',
@@ -17,6 +25,7 @@ RSpec.describe Api::V1::ExerciseRepresenter, type: :representer do
   }
   let!(:lo_teks) { FactoryGirl.create :content_lo_teks_tag, lo: lo, teks: teks }
   let!(:exercise_tag) { FactoryGirl.create :content_exercise_tag, exercise: exercise, tag: lo }
+  let!(:exercise_tag_2) { FactoryGirl.create :content_exercise_tag, exercise: exercise, tag: lo2 }
 
   it 'represents an exercise with tags' do
     representation = Api::V1::ExerciseRepresenter.new(exercise).as_json

--- a/spec/representers/api/v1/tag_representer_spec.rb
+++ b/spec/representers/api/v1/tag_representer_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Api::V1::TagRepresenter, type: :representer do
       'name' => '(D)',
       'description' => 'calculate the effect of forces on objects',
       'type' => 'teks',
+      'data' => '4d'
     )
   end
 

--- a/spec/subsystems/content/models/tag_spec.rb
+++ b/spec/subsystems/content/models/tag_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Content::Models::Tag, :type => :model do
   let!(:tag) { FactoryGirl.create :content_tag, value: 'k12phys-ch04-s01-lo01', name: 'jimmy' }
+
   it { is_expected.to have_many(:page_tags).dependent(:destroy) }
   it { is_expected.to have_many(:exercise_tags).dependent(:destroy) }
 
@@ -16,17 +17,42 @@ RSpec.describe Content::Models::Tag, :type => :model do
     expect(tag.name).to eq 'jimmy'
   end
 
-  it 'picks a default DOK name' do
-    expect(Content::Models::Tag.new(value: 'dok1').name).to eq('DOK: 1')
+  it 'does not assign a tag type if tag type is not generic' do
+    tag = FactoryGirl.create :content_tag, tag_type: :lo
+    expect(tag.tag_type).to eq 'lo'
   end
 
-  it 'picks a default Blooms name' do
-    expect(Content::Models::Tag.new(value: 'blooms-3').name).to eq('Blooms: 3')
+  it 'creates a LO tag' do
+    expect(tag.tag_type).to eq 'lo'
   end
 
-  it 'picks default time names' do
-    expect(Content::Models::Tag.new(value: 'time-short').name).to eq('Length: S')
-    expect(Content::Models::Tag.new(value: 'time-med').name).to eq('Length: M')
-    expect(Content::Models::Tag.new(value: 'time-long').name).to eq('Length: L')
+  it 'creates a TEKS tag' do
+    tag = FactoryGirl.create :content_tag, name: '(4E)', value: 'ost-tag-teks-112-39-c-4e'
+    expect(tag.name).to eq '(4E)'
+    expect(tag.tag_type).to eq 'teks'
+  end
+
+  it 'creates a DOK tag' do
+    tag = FactoryGirl.create :content_tag, name: nil, value: 'dok1'
+    expect(tag.name).to eq('DOK: 1')
+    expect(tag.tag_type).to eq 'dok'
+  end
+
+  it 'creates a Blooms tag' do
+    tag = FactoryGirl.create :content_tag, name: nil, value: 'blooms-3'
+    expect(tag.name).to eq('Blooms: 3')
+    expect(tag.tag_type).to eq 'blooms'
+  end
+
+  it 'creates a Length tag' do
+    tag = FactoryGirl.create :content_tag, name: nil, value: 'time-short'
+    expect(tag.name).to eq('Length: S')
+    expect(tag.tag_type).to eq 'length'
+
+    tag = FactoryGirl.create :content_tag, name: nil, value: 'time-med'
+    expect(tag.name).to eq('Length: M')
+
+    tag = FactoryGirl.create :content_tag, name: nil, value: 'time-long'
+    expect(tag.name).to eq('Length: L')
   end
 end

--- a/spec/subsystems/content/models/tag_spec.rb
+++ b/spec/subsystems/content/models/tag_spec.rb
@@ -22,37 +22,59 @@ RSpec.describe Content::Models::Tag, :type => :model do
     expect(tag.tag_type).to eq 'lo'
   end
 
+  it 'does not assign the visible field if it is already set' do
+    tag = FactoryGirl.create :content_tag, visible: true
+    expect(tag.visible).to be true
+
+    tag = FactoryGirl.create :content_tag, visible: false
+    expect(tag.visible).to be false
+  end
+
+  it 'creates a generic tag' do
+    tag = FactoryGirl.create :content_tag
+    expect(tag.visible).to be false
+  end
+
   it 'creates a LO tag' do
     expect(tag.tag_type).to eq 'lo'
+    expect(tag.visible).to be true
   end
 
   it 'creates a TEKS tag' do
     tag = FactoryGirl.create :content_tag, name: '(4E)', value: 'ost-tag-teks-112-39-c-4e'
     expect(tag.name).to eq '(4E)'
     expect(tag.tag_type).to eq 'teks'
+    expect(tag.visible).to be true
   end
 
   it 'creates a DOK tag' do
     tag = FactoryGirl.create :content_tag, name: nil, value: 'dok1'
     expect(tag.name).to eq('DOK: 1')
     expect(tag.tag_type).to eq 'dok'
+    expect(tag.visible).to be true
   end
 
   it 'creates a Blooms tag' do
     tag = FactoryGirl.create :content_tag, name: nil, value: 'blooms-3'
     expect(tag.name).to eq('Blooms: 3')
     expect(tag.tag_type).to eq 'blooms'
+    expect(tag.visible).to be true
   end
 
   it 'creates a Length tag' do
     tag = FactoryGirl.create :content_tag, name: nil, value: 'time-short'
     expect(tag.name).to eq('Length: S')
     expect(tag.tag_type).to eq 'length'
+    expect(tag.visible).to be true
 
     tag = FactoryGirl.create :content_tag, name: nil, value: 'time-med'
     expect(tag.name).to eq('Length: M')
+    expect(tag.tag_type).to eq 'length'
+    expect(tag.visible).to be true
 
     tag = FactoryGirl.create :content_tag, name: nil, value: 'time-long'
     expect(tag.name).to eq('Length: L')
+    expect(tag.tag_type).to eq 'length'
+    expect(tag.visible).to be true
   end
 end

--- a/spec/subsystems/content/models/tag_spec.rb
+++ b/spec/subsystems/content/models/tag_spec.rb
@@ -32,11 +32,13 @@ RSpec.describe Content::Models::Tag, :type => :model do
 
   it 'creates a generic tag' do
     tag = FactoryGirl.create :content_tag
+    expect(tag.data).to be_nil
     expect(tag.visible).to be false
   end
 
   it 'creates a LO tag' do
     expect(tag.tag_type).to eq 'lo'
+    expect(tag.data).to be_nil
     expect(tag.visible).to be true
   end
 
@@ -44,6 +46,7 @@ RSpec.describe Content::Models::Tag, :type => :model do
     tag = FactoryGirl.create :content_tag, name: '(4E)', value: 'ost-tag-teks-112-39-c-4e'
     expect(tag.name).to eq '(4E)'
     expect(tag.tag_type).to eq 'teks'
+    expect(tag.data).to eq '4e'
     expect(tag.visible).to be true
   end
 
@@ -51,6 +54,7 @@ RSpec.describe Content::Models::Tag, :type => :model do
     tag = FactoryGirl.create :content_tag, name: nil, value: 'dok1'
     expect(tag.name).to eq('DOK: 1')
     expect(tag.tag_type).to eq 'dok'
+    expect(tag.data).to eq '1'
     expect(tag.visible).to be true
   end
 
@@ -58,6 +62,7 @@ RSpec.describe Content::Models::Tag, :type => :model do
     tag = FactoryGirl.create :content_tag, name: nil, value: 'blooms-3'
     expect(tag.name).to eq('Blooms: 3')
     expect(tag.tag_type).to eq 'blooms'
+    expect(tag.data).to eq '3'
     expect(tag.visible).to be true
   end
 
@@ -65,16 +70,19 @@ RSpec.describe Content::Models::Tag, :type => :model do
     tag = FactoryGirl.create :content_tag, name: nil, value: 'time-short'
     expect(tag.name).to eq('Length: S')
     expect(tag.tag_type).to eq 'length'
+    expect(tag.data).to eq 'short'
     expect(tag.visible).to be true
 
-    tag = FactoryGirl.create :content_tag, name: nil, value: 'time-med'
+    tag = FactoryGirl.create :content_tag, name: nil, value: 'time-medium'
     expect(tag.name).to eq('Length: M')
     expect(tag.tag_type).to eq 'length'
+    expect(tag.data).to eq 'medium'
     expect(tag.visible).to be true
 
     tag = FactoryGirl.create :content_tag, name: nil, value: 'time-long'
     expect(tag.name).to eq('Length: L')
     expect(tag.tag_type).to eq 'length'
+    expect(tag.data).to eq 'long'
     expect(tag.visible).to be true
   end
 end


### PR DESCRIPTION
- Add visible flag for content tags
- Only return visible tags in exercise representer
- Fix tags controller update action and order tags by ID
- Make tag visible flag editable in the admin views
- Create more tag types and assign them according to the value
- Auto populate tag visible flag based on tag type
