### PR TITLE
Distribute tasks background jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,9 @@ group :development, :test do
   # Fake in-memory Redis for development and testing
   gem 'fakeredis'
 
+  # Resque in test mode
+  gem 'resque_spec'
+
   # Get env variables from .env file
   gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,11 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque_spec (0.16.0)
+      resque (>= 1.19.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+      rspec-mocks (>= 3.0.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -608,6 +613,7 @@ DEPENDENCIES
   redis-rails
   remotipart
   resque
+  resque_spec
   rspec-collection_matchers
   rspec-rails
   sass-rails (~> 5.0.0)

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -154,7 +154,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
   api :POST, '/courses/:course_id/performance/export',
              'Begins the export of the performance report for authorized teachers'
   description <<-EOS
-    201 if the role is a teacher of a course
+    202 if the role is a teacher of a course
       -- The export background job will be started
   EOS
   def performance_export

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,21 +1,30 @@
-module Api
-  module V1
-    class JobsController < ApiController
-      def show
-        status = Lev::Status.find(params[:id])
-        code = http_status_code(status['state'])
-        render json: status, status: code
-      end
+class Api::V1::JobsController < Api::V1::ApiController
+  resource_description do
+    api_versions "v1"
+    short_description 'Represents queued jobs in the system'
+    description <<-EOS
+      ActiveJob jobs description to be written...
+    EOS
+  end
 
-      private
-      def http_status_code(switch)
-        case switch
-        when Lev::Status::STATE_COMPLETED
-          200
-        else
-          202
-        end
-      end
+  api :GET, '/jobs/:id', 'Returns job statuses'
+  description <<-EOS
+    Returns queues job statuses in the system
+    { status: [:queued, :working, :complete] }
+  EOS
+  def show
+    status = Lev::Status.find(params[:id])
+    code = http_status_code(status['state'])
+    render json: status, status: code
+  end
+
+  private
+  def http_status_code(switch)
+    case switch
+    when Lev::Status::STATE_COMPLETED
+      200
+    else
+      202
     end
   end
 end

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -77,7 +77,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
 
     if (settings = CheckValidSettings[validatable: task_plan])[:valid]
       job = DistributeTasks.perform_later(task_plan, validate: false)
-      render json: { id: task_plan.id, job: "/jobs/#{job.job_id}" }, status: :accepted
+      render json: { task_plan: api_task_plan_path(task_plan) }, status: :accepted
     else
       render json: settings[:errors], status: :unprocessable_entity
     end

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -76,7 +76,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
     OSU::AccessPolicy.require_action_allowed!(:publish, current_api_user, task_plan)
 
     if (settings = CheckValidSettings[validatable: task_plan])[:valid]
-      job = DistributeTasks.perform_later(task_plan, validate: false)
+      job = DistributeTasks.perform_later(task_plan)
       render json: { task_plan: api_task_plan_path(task_plan) }, status: :accepted
     else
       render json: settings[:errors], status: :unprocessable_entity

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -75,14 +75,12 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
     task_plan = Tasks::Models::TaskPlan.find(params[:id])
     OSU::AccessPolicy.require_action_allowed!(:publish, current_api_user, task_plan)
 
-    result = DistributeTasks.call(task_plan)
-    if result.errors.empty?
-      respond_with task_plan, represent_with: Api::V1::TaskPlanRepresenter, location: nil
+    if (settings = CheckValidSettings[validatable: task_plan])[:valid]
+      DistributeTasks.perform_later(task_plan)
+      respond_with task_plan.reload,
+        represent_with: Api::V1::TaskPlanRepresenter, location: nil
     else
-      error_hashes = result.errors.collect do |error|
-        {code: error.code, message: error.message, data: error.data}
-      end
-      render json: { errors: error_hashes }, status: :unprocessable_entity
+      render json: settings[:errors].last, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -76,10 +76,10 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
     OSU::AccessPolicy.require_action_allowed!(:publish, current_api_user, task_plan)
 
     if (settings = CheckValidSettings[validatable: task_plan])[:valid]
-      job = DistributeTasks.perform_later(task_plan)
+      job = DistributeTasks.perform_later(task_plan, validate: false)
       render json: { id: task_plan.id, job: "/jobs/#{job.job_id}" }, status: :accepted
     else
-      render json: settings[:errors].last, status: :unprocessable_entity
+      render json: settings[:errors], status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -76,9 +76,8 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
     OSU::AccessPolicy.require_action_allowed!(:publish, current_api_user, task_plan)
 
     if (settings = CheckValidSettings[validatable: task_plan])[:valid]
-      DistributeTasks.perform_later(task_plan)
-      respond_with task_plan.reload,
-        represent_with: Api::V1::TaskPlanRepresenter, location: nil
+      job = DistributeTasks.perform_later(task_plan)
+      render json: { id: task_plan.id, job: "/jobs/#{job.job_id}" }, status: :accepted
     else
       render json: settings[:errors].last, status: :unprocessable_entity
     end

--- a/app/routines/check_valid_settings.rb
+++ b/app/routines/check_valid_settings.rb
@@ -4,8 +4,7 @@ class CheckValidSettings
   # Validate the given settings against the assistant's schema
   # Intervention settings already included when the task_plan was saved
 
-  lev_routine express_output: :settings,
-              raise_fatal_errors: false
+  lev_routine express_output: :settings
 
   protected
   def exec(validatable:, options: {})
@@ -14,14 +13,16 @@ class CheckValidSettings
     if (err = JSON::Validator.fully_validate(validatable.assistant.schema,
                                              validatable.settings,
                                              options)).empty?
-      outputs[:settings] = { valid: true, errors: [] }
+      outputs[:settings] = Hashie::Mash.new({ valid: true, errors: {} })
     else
-      nonfatal_error(code: :invalid_settings, message: 'Invalid settings', data: err)
-
-      outputs[:settings] = {
+      outputs[:settings] = Hashie::Mash.new({
         valid: false,
-        errors: errors
-      }
+        errors: {
+          code: :invalid_settings,
+          message: 'Invalid settings',
+          data: err
+        }
+      })
     end
   end
 end

--- a/app/routines/check_valid_settings.rb
+++ b/app/routines/check_valid_settings.rb
@@ -1,0 +1,27 @@
+require 'json-schema'
+
+class CheckValidSettings
+  # Validate the given settings against the assistant's schema
+  # Intervention settings already included when the task_plan was saved
+
+  lev_routine express_output: :settings,
+              raise_fatal_errors: false
+
+  protected
+  def exec(validatable:, options: {})
+    options[:insert_defaults] = true if options[:insert_defaults].nil?
+
+    if (err = JSON::Validator.fully_validate(validatable.assistant.schema,
+                                             validatable.settings,
+                                             options)).empty?
+      outputs[:settings] = { valid: true, errors: [] }
+    else
+      nonfatal_error(code: :invalid_settings, message: 'Invalid settings', data: err)
+
+      outputs[:settings] = {
+        valid: false,
+        errors: errors
+      }
+    end
+  end
+end

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -1,5 +1,3 @@
-require 'json-schema'
-
 class DistributeTasks
 
   lev_routine
@@ -8,21 +6,9 @@ class DistributeTasks
 
   protected
 
-  def validate_json(schema, object, options = {})
-    options[:insert_defaults] = true if options[:insert_defaults].nil?
-
-    JSON::Validator.fully_validate(schema, object, options)
-  end
-
   def exec(task_plan)
     owner = task_plan.owner
     assistant = task_plan.assistant
-
-    # Validate the given settings against the assistant's schema
-    # Intervention settings already included when the task_plan was saved
-    err = validate_json(assistant.schema, task_plan.settings)
-
-    fatal_error(code: :invalid_settings, message: 'Invalid settings', data: err) unless err.empty?
 
     # Delete pre-existing assignments
     unless task_plan.tasks.empty?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,6 @@ Rails.application.configure do
   WebMock.allow_net_connect!
 
   OpenStax::Cnx::V1.set_archive_url_base(url: 'https://archive-staging-tutor.cnx.org/contents/')
+
+  config.active_job.queue_adapter = :inline
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
   api :v1, :default => true do
     resources :jobs, only: :show
 
+    resources :jobs, only: :show
+
     resources :users, only: [:index]
 
     resource :user, only: [:show] do

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -768,7 +768,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
     it 'returns 202 for authorized teachers' do
       api_post :performance_export, teacher_token, parameters: { id: course.id }
       expect(response.status).to eq(202)
-      expect(response.body_as_hash[:job]).to match(%r{http://test.host/api/jobs/[a-z0-9-]+})
+      expect(response.body_as_hash[:job]).to match(%r{/api/jobs/[a-z0-9-]+})
     end
 
     it 'returns the job path for the performance book export for authorized teachers' do

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -768,6 +768,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
     it 'returns 202 for authorized teachers' do
       api_post :performance_export, teacher_token, parameters: { id: course.id }
       expect(response.status).to eq(202)
+      expect(response.body_as_hash[:job]).to match(%r{http://test.host/api/jobs/[a-z0-9-]+})
     end
 
     it 'returns the job path for the performance book export for authorized teachers' do

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -206,10 +206,11 @@ describe Api::V1::TaskPlansController, :type => :controller, :api => true, :vers
       task_plan.save!
 
       controller.sign_in teacher
-      expect { api_post :publish, nil, parameters: { course_id: course.id, id: task_plan.id } }
-        .not_to change{ Tasks::Models::Task.count }
+      expect {
+        api_post :publish, nil, parameters: { course_id: course.id, id: task_plan.id }
+      }.not_to change{ Tasks::Models::Task.count }
       expect(response).to have_http_status(:unprocessable_entity)
-      error = response.body_as_hash[:errors].first
+      error = response.body_as_hash
       expect(error[:code]).to eq 'invalid_settings'
       expect(error[:message]).to eq 'Invalid settings'
       expect(error[:data].first).to include("The property '#/' contains additional properties [\"exercise_ids\", \"exercises_count_dynamic\"] outside of the schema when none are allowed in schema")

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -189,8 +189,7 @@ describe Api::V1::TaskPlansController, :type => :controller, :api => true, :vers
 
       job_hash = JSON.parse(response.body)
 
-      expect(job_hash['id']).to eq(task_plan.id)
-      expect(job_hash['job']).to match(/\A\/jobs\/[a-z0-9-]+\z/)
+      expect(job_hash['task_plan']).to eq("/api/plans/#{task_plan.id}")
     end
 
     it 'does not allow an unauthorized user to publish a task_plan' do

--- a/spec/routines/check_valid_settings_spec.rb
+++ b/spec/routines/check_valid_settings_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CheckValidSettings do
+  let!(:user)      { FactoryGirl.create :user_profile }
+  let!(:task_plan) { FactoryGirl.create(:tasks_tasking_plan, target: user).task_plan }
+
+  it 'validates the task_plan settings against the assistant schema' do
+    allow(DummyAssistant).to receive(:schema).and_return(
+      '{
+        "type": "object",
+        "required": [
+          "page_ids"
+        ],
+        "properties": {
+          "page_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          }
+        },
+        "additionalProperties": false
+      }'
+    )
+    result = CheckValidSettings[validatable: task_plan]
+    expect(result.errors.code).to eq :invalid_settings
+    expect(task_plan.reload.published_at).to be_nil
+    expect(task_plan.tasks).to be_blank
+  end
+
+end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -5,32 +5,6 @@ RSpec.describe DistributeTasks, type: :routine do
     let!(:user)      { FactoryGirl.create :user_profile }
     let!(:task_plan) { FactoryGirl.create(:tasks_tasking_plan, target: user).task_plan }
 
-    it 'validates the task_plan settings against the assistant schema' do
-      allow(DummyAssistant).to receive(:schema).and_return(
-        '{
-          "type": "object",
-          "required": [
-            "page_ids"
-          ],
-          "properties": {
-            "page_ids": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            }
-          },
-          "additionalProperties": false
-        }'
-      )
-      expect(DummyAssistant).not_to receive(:build_tasks)
-
-      result = DistributeTasks.call(task_plan)
-      expect(result.errors.first.code).to eq :invalid_settings
-      expect(task_plan.reload.published_at).to be_nil
-      expect(task_plan.tasks).to be_blank
-    end
-
     it "calls the build_tasks method on the task_plan's assistant" do
       expect(DummyAssistant).to receive(:build_tasks).and_return([])
 
@@ -51,35 +25,6 @@ RSpec.describe DistributeTasks, type: :routine do
       DistributeTasks.call(tp)
       tp.reload
     }
-
-    it 'validates the task_plan settings against the assistant schema' do
-      previous_published_at = task_plan.published_at
-      previous_tasks = task_plan.tasks
-
-      allow(DummyAssistant).to receive(:schema).and_return(
-        '{
-          "type": "object",
-          "required": [
-            "page_ids"
-          ],
-          "properties": {
-            "page_ids": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            }
-          },
-          "additionalProperties": false
-        }'
-      )
-      expect(DummyAssistant).not_to receive(:build_tasks)
-
-      result = DistributeTasks.call(task_plan)
-      expect(result.errors.first.code).to eq :invalid_settings
-      expect(task_plan.reload.published_at).to eq previous_published_at
-      expect(task_plan.tasks).to eq previous_tasks
-    end
 
     it "calls the build_tasks method on the task_plan's assistant" do
       expect(DummyAssistant).to receive(:build_tasks).and_return([])


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/95180724

Need to know how front-end response changes since `TaskPlans#publish` now runs `DistributeTasks` asynchronously

*Front End MUST note:*

```javascript
// TaskPlans#publish response on error is no longer:

response.body.errors[0]

// it is now

response.body
```

After calling for a publish to the task plan, query the task plan for the published_at attribute

```ruby
post '/api/plans/123/publish', course_id: 456

# response:
json: { task_plan: '/api/plans/123' }

get '/api/plans/123' #=> Until you get non-null 'published_at' attribute
```