### PR TITLE
Fix some default URL's (dev environment only)

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -33,7 +33,7 @@ development:
     exercises:
       client_id: <%= ENV["OPENSTAX_EXERCISES_CLIENT_ID"] %>
       secret: <%= ENV["OPENSTAX_EXERCISES_SECRET"] %>
-      url: <%= ENV["OPENSTAX_EXERCISES_URL"] || 'http://exercises-dev.openstax.org' %>
+      url: <%= ENV["OPENSTAX_EXERCISES_URL"] || 'https://exercises-dev.openstax.org' %>
       stub: <%= ENV["OPENSTAX_EXERCISES_STUB"] %>
     biglearn:
       client_id: <%= ENV["OPENSTAX_BIGLEARN_CLIENT_ID"] %>
@@ -105,7 +105,7 @@ production:
     biglearn:
       client_id: <%= ENV["OPENSTAX_BIGLEARN_CLIENT_ID"] %>
       secret: <%= ENV["OPENSTAX_BIGLEARN_SECRET"] %>
-      url: <%= ENV["OPENSTAX_BIGLEARN_URL"] || 'http://biglearn.openstax.org' %>
+      url: <%= ENV["OPENSTAX_BIGLEARN_URL"] || 'https://biglearn.openstax.org' %>
       stub: <%= ENV["OPENSTAX_BIGLEARN_STUB"] %>
   aws:
     ses:


### PR DESCRIPTION
Since we match exercises on URL, the comparison fails with the local defaults since biglearn-dev has https url's and the default is http.

Not messing with test yet because we have to change all the cassettes.