### PR TITLE
Don't change the master server process date on bootup

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -17,4 +17,8 @@ if ENV['RAILS_ENV'] == 'production'
 end
 
 require ::File.expand_path('../config/environment',  __FILE__)
+
+# Ensure that the main server process has the actual time
+Timecop.return
+
 run Rails.application


### PR DESCRIPTION
Should fix unicorn-worker-killer timeouts in production at the beginning of requests