### PR TITLE
Performance report by periods

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -191,7 +191,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
     course = Entity::Course.find(params[:id])
     preport = Tasks::GetPerformanceReport[course: course, role: get_course_role]
 
-    respond_with(Hashie::Mash.new(preport), represent_with: Api::V1::PerformanceReportRepresenter)
+    respond_with(preport, represent_with: Api::V1::PerformanceReportRepresenter)
   end
 
   api :GET, '/courses/:course_id/students', 'Returns all the students in the course'

--- a/app/representers/api/v1/performance_report_representer.rb
+++ b/app/representers/api/v1/performance_report_representer.rb
@@ -67,9 +67,10 @@ module Api::V1
 
       include Roar::JSON
 
-      property :period,
+      property :period_id,
+               type: String,
                readable: true,
-               decorator: PeriodRepresenter
+               getter: -> (*) { period.id.to_s }
 
       collection :data_headings,
                  readable: true,

--- a/app/representers/api/v1/performance_report_representer.rb
+++ b/app/representers/api/v1/performance_report_representer.rb
@@ -1,7 +1,7 @@
 module Api::V1
   class PerformanceReportRepresenter < Roar::Decorator
 
-    include Roar::JSON
+    include Representable::JSON::Collection
 
     class StudentData < Roar::Decorator
 
@@ -63,17 +63,24 @@ module Api::V1
                readable: true
     end
 
-    property :period,
-             readable: true,
-             decorator: PeriodRepresenter
+    class ReportPerPeriod < Roar::Decorator
 
-    collection :data_headings,
-               readable: true,
-               decorator: DataHeadings
+      include Roar::JSON
 
-    collection :students,
+      property :period,
                readable: true,
-               decorator: Students
+               decorator: PeriodRepresenter
+
+      collection :data_headings,
+                 readable: true,
+                 decorator: DataHeadings
+
+      collection :students,
+                 readable: true,
+                 decorator: Students
+    end
+
+    items extend: ReportPerPeriod
 
   end
 

--- a/app/routines/get_student_profiles.rb
+++ b/app/routines/get_student_profiles.rb
@@ -14,8 +14,8 @@ class GetStudentProfiles
                translations: { outputs: { type: :verbatim } }
 
   protected
-  def exec(course: course)
-    student_roles = run(:get_students, course).outputs.students
+  def exec(period: period)
+    student_roles = run(:get_students, period: period).outputs.students
     users = run(:get_users_for_roles, student_roles).outputs.users
     names = run(:get_user_full_names, users).outputs.full_names
     role_users = Role::Models::User.where(entity_user_id: users.collect(&:id))

--- a/app/subsystems/course_membership/get_students.rb
+++ b/app/subsystems/course_membership/get_students.rb
@@ -3,10 +3,10 @@ class CourseMembership::GetStudents
 
   protected
 
-  def exec(course)
+  def exec(period:)
     outputs[:students] = CourseMembership::Models::Student
                            .includes(:role)
-                           .where(period: course.periods)
+                           .where(period: period)
                            .collect(&:role)
   end
 end

--- a/app/subsystems/tasks/export_performance_report.rb
+++ b/app/subsystems/tasks/export_performance_report.rb
@@ -19,7 +19,7 @@ module Tasks
         axlsx.use_shared_strings = true # OS X Numbers interoperability
         axlsx.workbook.styles.fonts.first.name = 'Helvetica Neue'
         create_summary_worksheet(package: axlsx)
-        create_data_worksheet(package: axlsx)
+        create_data_worksheets(package: axlsx)
         axlsx.serialize(tmp_file_path)
       end
 
@@ -38,23 +38,25 @@ module Tasks
       end
     end
 
-    def create_data_worksheet(package:)
-      package.workbook.add_worksheet(name: 'Student Performance') do |sheet|
-        sheet.add_row(data_headers)
-        sheet.add_row(gather_averages)
-        outputs.performance_report.students.each do |student|
-          sheet.add_row student_data(student)
+    def create_data_worksheets(package:)
+      outputs.performance_report.each do |report|
+        package.workbook.add_worksheet(name: report[:period][:name]) do |sheet|
+          sheet.add_row(data_headers(report[:data_headings]))
+          sheet.add_row(gather_averages(report[:data_headings]))
+          report.students.each do |student|
+            sheet.add_row(student_data(student))
+          end
         end
       end
     end
 
-    def data_headers
-      headings = outputs.performance_report.data_headings.collect(&:title)
+    def data_headers(data_headings)
+      headings = data_headings.collect(&:title)
       (['Students'] + headings).collect { |header| bold_text(header) }
     end
 
-    def gather_averages
-      averages = outputs.performance_report.data_headings.collect(&:average)
+    def gather_averages(data_headings)
+      averages = data_headings.collect(&:average)
       (['Average'] + averages).collect { |average| bold_text(average) }
     end
 

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -58,7 +58,9 @@ module Tasks
     end
 
     def get_exercises(tasks)
-      tasked_ids = tasks.collect(&:task_steps).flatten.collect(&:tasked_id)
+      task_steps = tasks.collect(&:task_steps).flatten
+      tasked_exercises = task_steps.select { |ts| ts.tasked_type == 'Tasks::Models::TaskedExercise' }
+      tasked_ids = tasked_exercises.collect(&:tasked_id)
       Models::TaskedExercise.where(id: tasked_ids)
     end
 
@@ -99,7 +101,8 @@ module Tasks
     end
 
     def exercise_count(task_steps, exercises, index)
-      tasked_ids = task_steps.collect(&:tasked_id)
+      tasked_exercises = task_steps.select { |ts| ts.tasked_type == 'Tasks::Models::TaskedExercise' }
+      tasked_ids = tasked_exercises.collect(&:tasked_id)
       exercises = exercises.select { |e| tasked_ids.include?(e.id) }
 
       attempted_count = task_steps.select(&:completed?).length

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -20,31 +20,35 @@ module Tasks
     private
 
     def get_performance_report_for_teacher(course)
-      student_tasks, student_data = [], []
-      student_profiles = run(:get_student_profiles, course: course).outputs.profiles
-      tasks = get_tasks(student_profiles)
-      exercises = get_exercises(tasks)
+      @tasks = {}
+      course.periods.collect do |period|
+        student_tasks, student_data = [], []
+        student_profiles = run(:get_student_profiles, period: period).outputs.profiles
+        tasks = get_tasks(student_profiles, period.id)
+        exercises = get_exercises(tasks)
 
-      student_profiles.collect do |student_profile|
-        student_tasks = tasks.select { |t| taskings_exist?(t, student_profile) }
-        @average = [[]] * student_tasks.length
+        student_profiles.collect do |student_profile|
+          student_tasks = tasks.select { |t| taskings_exist?(t, student_profile) }
+          @average = [[]] * student_tasks.length
 
-        student_data << {
-          name: student_profile.full_name,
-          role: student_profile.entity_role_id
-        }.merge(get_student_data(student_tasks, exercises))
+          student_data << {
+            name: student_profile.full_name,
+            role: student_profile.entity_role_id
+          }.merge(get_student_data(student_tasks, exercises))
+        end
+
+        Hashie::Mash.new({
+          period: period,
+          data_headings: get_data_headings(student_tasks),
+          students: student_data
+        })
       end
-
-      {
-        data_headings: get_data_headings(student_tasks),
-        students: student_data
-      }
     end
 
-    def get_tasks(student_profiles)
+    def get_tasks(student_profiles, period_id)
       role_ids = student_profiles.collect(&:entity_role_id)
       # Return reading and homework tasks for a student ordered by due date
-      @tasks ||= Models::Task
+      @tasks[period_id] ||= Models::Task
         .joins { taskings }
         .where { taskings.entity_role_id.in role_ids }
         .where { task_type.in Models::Task.task_types.values_at(:reading, :homework) }

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -21,6 +21,7 @@ module Tasks
 
     def get_performance_report_for_teacher(course)
       @tasks = {}
+      @average = Hash.new { |h, k| h[k] = [] }
       course.periods.collect do |period|
         student_tasks, student_data = [], []
         student_profiles = run(:get_student_profiles, period: period).outputs.profiles
@@ -29,7 +30,6 @@ module Tasks
 
         student_profiles.collect do |student_profile|
           student_tasks = tasks.select { |t| taskings_exist?(t, student_profile) }
-          @average = [[]] * student_tasks.length
 
           student_data << {
             name: student_profile.full_name,

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -21,8 +21,9 @@ module Tasks
 
     def get_performance_report_for_teacher(course)
       @tasks = {}
-      @average = Hash.new { |h, k| h[k] = [] }
+      @average = []
       course.periods.collect do |period|
+        @average << Hash.new { |h, k| h[k] = [] }
         student_tasks, student_data = [], []
         student_profiles = run(:get_student_profiles, period: period).outputs.profiles
         tasks = get_tasks(student_profiles, period.id)
@@ -73,9 +74,9 @@ module Tasks
 
     def average(task, index)
       # check if the task is a homework and at least one person has started on it
-      return {} unless task.task_type == 'homework' && @average[index].present?
+      return {} unless task.task_type == 'homework' && @average[-1][index].present?
       {
-        average: @average[index].reduce(:+) * 100 / @average[index].length
+        average: @average[-1][index].reduce(:+) * 100 / @average[-1][index].length
       }
     end
 
@@ -105,7 +106,7 @@ module Tasks
       correct_count = exercises.select(&:is_correct?).length
 
       if attempted_count > 0
-        @average[index] << (Float(correct_count) / attempted_count)
+        @average[-1][index] << (Float(correct_count) / attempted_count)
       end
 
       {

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -48,7 +48,7 @@ module Tasks
         .joins { taskings }
         .where { taskings.entity_role_id.in role_ids }
         .where { task_type.in Models::Task.task_types.values_at(:reading, :homework) }
-        .order { due_at }
+        .order('due_at DESC')
         .includes(:taskings, :task_steps)
     end
 

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -694,7 +694,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               {
                 type: 'homework',
                 id: kind_of(Integer),
-                status: 'in_progress',
+                status: 'completed',
                 exercise_count: 4,
                 correct_exercise_count: 3,
                 recovered_exercise_count: 0

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -681,10 +681,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
 
         expect(response).to have_http_status :success
         expect(response.body_as_hash).to include(
-          period: {
-            id: course.periods.first.id.to_s,
-            name: course.periods.first.name
-          },
+          period_id: course.periods.first.id.to_s,
           data_headings: [
             { title: 'Homework 2 task plan', average: kind_of(Float) },
             { title: 'Reading task plan' },

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -665,14 +665,21 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
       let(:teacher) { FactoryGirl.create :user_profile }
       let(:teacher_token) { FactoryGirl.create :doorkeeper_access_token,
                               resource_owner_id: teacher.id }
-      let(:student_1) { FactoryGirl.create :user_profile }
+      let(:student_1) { FactoryGirl.create :user_profile,
+                                           first_name: 'Student',
+                                           last_name: 'One',
+                                           full_name: 'Student One' }
       let(:student_1_token) { FactoryGirl.create :doorkeeper_access_token,
                                 resource_owner_id: student_1.id }
+      let(:student_2) { FactoryGirl.create :user_profile,
+                                           first_name: 'Student',
+                                           last_name: 'Two',
+                                           full_name: 'Student Two' }
 
       before do
         SetupPerformanceReportData[course: course,
                                    teacher: teacher,
-                                   students: student_1,
+                                   students: [student_1, student_2],
                                    book: @book]
       end
 
@@ -680,20 +687,21 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         api_get :performance, teacher_token, parameters: { id: course.id }
 
         expect(response).to have_http_status :success
-        expect(response.body_as_hash).to include(
+        resp = response.body_as_hash
+        expect(resp).to eq([{
           period_id: course.periods.first.id.to_s,
           data_headings: [
-            { title: 'Homework 2 task plan', average: kind_of(Float) },
+            { title: 'Homework 2 task plan', average: 87.5 },
             { title: 'Reading task plan' },
-            { title: 'Homework task plan', average: kind_of(Float) }
+            { title: 'Homework task plan', average: 75.0 }
           ],
           students: [{
-            name: kind_of(String),
-            role: kind_of(Integer),
+            name: 'Student One',
+            role: resp[0][:students][0][:role],
             data: [
               {
                 type: 'homework',
-                id: kind_of(Integer),
+                id: resp[0][:students][0][:data][0][:id],
                 status: 'completed',
                 exercise_count: 4,
                 correct_exercise_count: 3,
@@ -701,12 +709,12 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               },
               {
                 type: 'reading',
-                id: kind_of(Integer),
+                id: resp[0][:students][0][:data][1][:id],
                 status: 'completed'
               },
               {
                 type: 'homework',
-                id: kind_of(Integer),
+                id: resp[0][:students][0][:data][2][:id],
                 status: 'completed',
                 exercise_count: 6,
                 correct_exercise_count: 6,
@@ -714,12 +722,12 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               }
             ]
           }, {
-            name: kind_of(String),
-            role: kind_of(Integer),
+            name: 'Student Two',
+            role: resp[0][:students][1][:role],
             data: [
               {
                 type: 'homework',
-                id: kind_of(Integer),
+                id: resp[0][:students][1][:data][0][:id],
                 status: 'in_progress',
                 exercise_count: 3,
                 correct_exercise_count: 1,
@@ -727,12 +735,12 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               },
               {
                 type: 'reading',
-                id: kind_of(Integer),
+                id: resp[0][:students][1][:data][1][:id],
                 status: 'in_progress'
               },
               {
                 type: 'homework',
-                id: kind_of(Integer),
+                id: resp[0][:students][1][:data][2][:id],
                 status: 'in_progress',
                 exercise_count: 5,
                 correct_exercise_count: 2,
@@ -740,7 +748,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               }
             ]
           }]
-        )
+        }])
       end
 
       it 'raises error for users not in the course' do

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -682,9 +682,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response).to have_http_status :success
         expect(response.body_as_hash).to include(
           data_headings: [
-            { title: 'Homework task plan', average: kind_of(Float) },
+            { title: 'Homework 2 task plan', average: kind_of(Float) },
             { title: 'Reading task plan' },
-            { title: 'Homework 2 task plan', average: kind_of(Float) }
+            { title: 'Homework task plan', average: kind_of(Float) }
           ],
           students: [{
             name: kind_of(String),
@@ -693,9 +693,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               {
                 type: 'homework',
                 id: kind_of(Integer),
-                status: 'completed',
-                exercise_count: 6,
-                correct_exercise_count: 6,
+                status: 'in_progress',
+                exercise_count: 4,
+                correct_exercise_count: 3,
                 recovered_exercise_count: 0
               },
               {
@@ -706,9 +706,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
               {
                 type: 'homework',
                 id: kind_of(Integer),
-                status: 'in_progress',
-                exercise_count: 4,
-                correct_exercise_count: 3,
+                status: 'completed',
+                exercise_count: 6,
+                correct_exercise_count: 6,
                 recovered_exercise_count: 0
               }
             ]
@@ -720,8 +720,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 type: 'homework',
                 id: kind_of(Integer),
                 status: 'in_progress',
-                exercise_count: 5,
-                correct_exercise_count: 2,
+                exercise_count: 3,
+                correct_exercise_count: 1,
                 recovered_exercise_count: 0
               },
               {
@@ -733,8 +733,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 type: 'homework',
                 id: kind_of(Integer),
                 status: 'in_progress',
-                exercise_count: 3,
-                correct_exercise_count: 1,
+                exercise_count: 5,
+                correct_exercise_count: 2,
                 recovered_exercise_count: 0
               }
             ]

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -676,10 +676,23 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                                            last_name: 'Two',
                                            full_name: 'Student Two' }
 
+      let(:student_2) { FactoryGirl.create :user_profile,
+                                           first_name: 'Student',
+                                           last_name: 'Two',
+                                           full_name: 'Student Two' }
+      let(:student_3) { FactoryGirl.create :user_profile,
+                                           first_name: 'Student',
+                                           last_name: 'Three',
+                                           full_name: 'Student Three' }
+      let(:student_4) { FactoryGirl.create :user_profile,
+                                           first_name: 'Student',
+                                           last_name: 'Four',
+                                           full_name: 'Student Four' }
+
       before do
         SetupPerformanceReportData[course: course,
                                    teacher: teacher,
-                                   students: [student_1, student_2],
+                                   students: [student_1, student_2, student_3, student_4],
                                    book: @book]
       end
 
@@ -744,6 +757,66 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 status: 'in_progress',
                 exercise_count: 5,
                 correct_exercise_count: 2,
+                recovered_exercise_count: 0
+              }
+            ]
+          }]
+        }, {
+          period_id: course.periods.order(:id).last.id.to_s,
+          data_headings: [
+            { title: 'Homework 2 task plan' },
+            { title: 'Reading task plan' },
+            { title: 'Homework task plan', average: 100.0 }
+          ],
+          students: [{
+            name: student_3.full_name,
+            role: resp[1][:students][0][:role],
+            data: [
+              {
+                type: 'homework',
+                id: resp[1][:students][0][:data][0][:id],
+                status: 'not_started',
+                exercise_count: 3,
+                correct_exercise_count: 0,
+                recovered_exercise_count: 0
+              },
+              {
+                type: 'reading',
+                id: resp[1][:students][0][:data][1][:id],
+                status: 'not_started'
+              },
+              {
+                type: 'homework',
+                id: resp[1][:students][0][:data][2][:id],
+                status: 'completed',
+                exercise_count: 6,
+                correct_exercise_count: 6,
+                recovered_exercise_count: 0
+              }
+            ]
+          }, {
+            name: student_4.full_name,
+            role: resp[1][:students][1][:role],
+            data: [
+              {
+                type: 'homework',
+                id: resp[1][:students][1][:data][0][:id],
+                status: 'not_started',
+                exercise_count: 3,
+                correct_exercise_count: 0,
+                recovered_exercise_count: 0
+              },
+              {
+                type: 'reading',
+                id: resp[1][:students][1][:data][1][:id],
+                status: 'not_started'
+              },
+              {
+                type: 'homework',
+                id: resp[1][:students][1][:data][2][:id],
+                status: 'not_started',
+                exercise_count: 5,
+                correct_exercise_count: 0,
                 recovered_exercise_count: 0
               }
             ]

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -681,6 +681,10 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
 
         expect(response).to have_http_status :success
         expect(response.body_as_hash).to include(
+          period: {
+            id: course.periods.first.id.to_s,
+            name: course.periods.first.name
+          },
           data_headings: [
             { title: 'Homework 2 task plan', average: kind_of(Float) },
             { title: 'Reading task plan' },

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -18,7 +18,7 @@ class SetupPerformanceReportData
 
     CourseContent::AddBookToCourse.call(course: course, book: book)
     AddUserAsCourseTeacher[course: course, user: teacher.entity_user]
-    period = CreatePeriod[course: course]
+    period = course.periods.empty? ? CreatePeriod[course: course] : course.periods.first
     students.each do |student|
       AddUserAsPeriodStudent[period: period, user: student.entity_user]
     end

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -9,18 +9,22 @@ class SetupPerformanceReportData
     homework_assistant = FactoryGirl.create :tasks_assistant,
       code_class_name: 'Tasks::Assistants::HomeworkAssistant'
 
-    if students.none?
-      students = [FactoryGirl.create(:user_profile),
-                  FactoryGirl.create(:user_profile)]
-    elsif students.one?
+    # There should be at least 4 students
+    (students.length + 1..4).each do |extra_student|
       students << FactoryGirl.create(:user_profile)
     end
 
     CourseContent::AddBookToCourse.call(course: course, book: book)
     AddUserAsCourseTeacher[course: course, user: teacher.entity_user]
-    period = course.periods.empty? ? CreatePeriod[course: course] : course.periods.first
-    students.each do |student|
-      AddUserAsPeriodStudent[period: period, user: student.entity_user]
+    period_1 = course.periods.empty? ? CreatePeriod[course: course] : course.periods.first
+    period_2 = CreatePeriod[course: course]
+    # Add first 2 students to period 1
+    students[0..1].each do |student|
+      AddUserAsPeriodStudent[period: period_1, user: student.entity_user]
+    end
+    # Add the rest of the students to period 2
+    students[2..-1].each do |student|
+      AddUserAsPeriodStudent[period: period_2, user: student.entity_user]
     end
 
     page_ids = Content::Models::Page.all.map(&:id)
@@ -73,27 +77,16 @@ class SetupPerformanceReportData
 
     DistributeTasks[homework2_taskplan]
 
-    student_1_role = GetUserCourseRoles[course: course,
-                                        user: students[0].entity_user].first
-    student_2_role = GetUserCourseRoles[course: course,
-                                        user: students[1].entity_user].first
-    task_types = Tasks::Models::Task.task_types.values_at(:reading, :homework)
-
-    student_1_tasks = Tasks::Models::Task
-      .joins { taskings }
-      .where { taskings.entity_role_id == my { student_1_role.id } }
-      .where { task_type.in my { task_types } }
-      .order { due_at }
-      .includes { task_steps.tasked }
-
-    student_2_tasks = Tasks::Models::Task
-      .joins { taskings }
-      .where { taskings.entity_role_id == my { student_2_role.id } }
-      .where { task_type.in my { task_types } }
-      .order { due_at }
-      .includes { task_steps.tasked }
+    student_roles = students.collect do |student|
+      GetUserCourseRoles[course: course,
+                         user: student.entity_user].first
+    end
+    student_tasks = student_roles.collect do |student_role|
+      get_student_tasks(student_role)
+    end
 
     # User 1 answered everything in homework task plan correctly
+    student_1_tasks = student_tasks[0]
     student_1_tasks[0].core_task_steps.each do |ts|
       Hacks::AnswerExercise[task_step: ts, is_correct: true]
     end
@@ -120,6 +113,7 @@ class SetupPerformanceReportData
 
     # User 2 answered 2 questions correctly and 2 incorrectly in
     # homework task plan
+    student_2_tasks = student_tasks[1]
     core_task_steps = student_2_tasks[0].core_task_steps
     raise "expected at least 4 core task steps" if core_task_steps.count < 4
     core_task_steps.first(2).each do |ts|
@@ -135,5 +129,24 @@ class SetupPerformanceReportData
     # User 2 answered 1 correct in 2nd homework
     Hacks::AnswerExercise[task_step: student_2_tasks[2].core_task_steps.first,
                           is_correct: true]
+
+    # User 3 answered everything in homework task plan correctly
+    student_3_tasks = student_tasks[2]
+    student_3_tasks[0].core_task_steps.each do |ts|
+      Hacks::AnswerExercise[task_step: ts, is_correct: true]
+    end
+    student_3_tasks[0].non_core_task_steps.each do |ts|
+      Hacks::AnswerExercise[task_step: ts, is_correct: true]
+    end
+  end
+
+  def get_student_tasks(role)
+    task_types = Tasks::Models::Task.task_types.values_at(:reading, :homework)
+    Tasks::Models::Task
+      .joins { taskings }
+      .where { taskings.entity_role_id == my { role.id } }
+      .where { task_type.in my { task_types } }
+      .order { due_at }
+      .includes { task_steps.tasked }
   end
 end

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -115,6 +115,8 @@ class SetupPerformanceReportData
     end
     Hacks::AnswerExercise[task_step: student_1_tasks[2].non_core_task_steps.first,
                           is_correct: true]
+    Hacks::AnswerExercise[task_step: student_1_tasks[2].non_core_task_steps.last,
+                          is_correct: false]
 
     # User 2 answered 2 questions correctly and 2 incorrectly in
     # homework task plan
@@ -122,6 +124,9 @@ class SetupPerformanceReportData
     raise "expected at least 4 core task steps" if core_task_steps.count < 4
     core_task_steps.first(2).each do |ts|
       Hacks::AnswerExercise[task_step: ts, is_correct: true]
+    end
+    core_task_steps.last(2).each do |ts|
+      Hacks::AnswerExercise[task_step: ts, is_correct: false]
     end
 
     # User 2 started the reading task plan


### PR DESCRIPTION
- Change performance report to be reverse chronological (latest first)
- Change performance report APIs to be broken down by period
 - Performance report API returns a list, one set of data per period
 - Performance report exports have one worksheet per period
- Change period hash to period_id in performance report API
- Update SetupPerformanceReportData to do as the comments say
- Use exact match in performance API test to test calculation of average
- Add more students and periods to performance API test
-  Fix code for getting exercises in Tasks::GetPerformanceReport