### PR TITLE
Update lev reference to version with "nil state" bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'apipie-rails'
 gem 'maruku'
 
 # Lev framework
-gem 'lev', github: 'lml/lev', ref: 'ba7634ba437'
+gem 'lev', github: 'lml/lev', ref: '3bfe3f4172ede83df02b97b371d252aaf39c9aff'
 
 # Ruby dsl for SQL queries
 gem 'squeel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/lml/lev.git
-  revision: ba7634ba4373b178131dc59288df2e51138c869b
-  ref: ba7634ba437
+  revision: 3bfe3f4172ede83df02b97b371d252aaf39c9aff
+  ref: 3bfe3f4172ede83df02b97b371d252aaf39c9aff
   specs:
     lev (4.3.0)
       actionpack (>= 3.0)


### PR DESCRIPTION
I tried to make a spec for this, but couldn't figure out how to target the correct controller since it's part of `Accounts::Engine`