### PR TITLE
Specify page with version as separate route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,10 @@ Rails.application.routes.draw do
       end
     end
 
-    get 'pages/:uuid(@:version)', controller: :pages, action: :get_page
+    scope 'pages', controller: :pages, action: :get_page do
+      get ':uuid@:version'
+      get ':uuid'
+    end
   end
 
   namespace 'admin' do

--- a/spec/routing/api/v1/pages_controller_routing_spec.rb
+++ b/spec/routing/api/v1/pages_controller_routing_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe Api::V1::CoursesController, :type => :routing, :api => true, :version => :v1 do
+
+  describe "/api/pages controller" do
+
+    it "routes with a version" do
+      expect(:get => "/api/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2")
+        .to route_to(
+                     format: "json",
+                     controller: "api/v1/pages",
+                     action: "get_page",
+                     uuid: "1bb611e9-0ded-48d6-a107-fbb9bd900851",
+                     version: "2"
+                     )
+    end
+
+    it "routes without a version" do
+      expect(:get => "/api/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851")
+        .to route_to(
+                     format: "json",
+                     controller: "api/v1/pages",
+                     action: "get_page",
+                     uuid: "1bb611e9-0ded-48d6-a107-fbb9bd900851"
+                     )
+    end
+
+  end
+
+end


### PR DESCRIPTION
Rails routes seemingly cannot use the '@' symbol as a separator.  The original really seems like it should have worked but it would never set the `:version` parameter.

Previously a request for `/api/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2` would set `:uuid` to `1bb611e9-0ded-48d6-a107-fbb9bd900851@2` and leave `:version` nil.  Since there isn't a page with the `@2` as part of it's `:uuid`, it would always return 404.

I also played with using regex based constraints.  They worked, but I thought this was a bit clearer.