### PR TITLE
Ensure consistent Courses API

### DIFF
--- a/app/access_policies/course_access_policy.rb
+++ b/app/access_policies/course_access_policy.rb
@@ -6,9 +6,10 @@ class CourseAccessPolicy
     when :read, :readings, :task_plans
       # readings should be readable by course teachers and students because FE
       # uses it for the reference view
-      requestor.is_human? && \
-      (UserIsCourseStudent[user: requestor.entity_user, course: course] || \
-       UserIsCourseTeacher[user: requestor.entity_user, course: course])
+      requestor.is_human? &&
+        (requestor.is_admin? ||
+          UserIsCourseStudent[user: requestor.entity_user, course: course] ||
+            UserIsCourseTeacher[user: requestor.entity_user, course: course])
     when :exercises, :export, :roster
       requestor.is_human? && UserIsCourseTeacher[user: requestor.entity_user, course: course]
     else

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -323,6 +323,20 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         }.to_json)
       end
     end
+
+    context 'user is an admin' do
+      before { user_1.create_administrator }
+
+      it 'allows access' do
+        api_get :show, user_1_token, parameters: { id: course.id }
+        expect(response.body).to include({
+          id: course.id.to_s,
+          name: course.profile.name,
+          periods: [{ id: zeroth_period.id.to_s, name: zeroth_period.name },
+                    { id: period.id.to_s, name: period.name }]
+        }.to_json)
+      end
+    end
   end
 
   describe "practice_post" do


### PR DESCRIPTION
From @jpslav 

@joemsak can you look into this?

https://github.com/openstax/tutor-server/blob/master/app/controllers/api/v1/courses_controller.rb#L20 seems to imply that /api/user/courses has both roles and periods, but that's not what @philschatz is seeing.

Can you make sure that both routes are showing periods and roles?

Can you also make sure that the get of /api/courses/1 is only accessible to people who are admins or who have a role in the course?