### PR TITLE
Include jquery_ujs in admin.js

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,4 +1,5 @@
 //= require jquery
+//= require jquery_ujs
 //= require jquery.datetimepicker
 //= require jquery-ui-1.11.4.custom.min
 


### PR DESCRIPTION
jquery_ujs is necessary for making links using `link_to` `method: :post` work.

Fix "sign in as" link on admin users page.

https://www.pivotaltracker.com/n/projects/1156756/stories/97198930