### PR TITLE
Authorization audit

### DIFF
--- a/app/access_policies/course_access_policy.rb
+++ b/app/access_policies/course_access_policy.rb
@@ -3,12 +3,12 @@ class CourseAccessPolicy
     case action
     when :index
       !requestor.is_anonymous?
-    when :read
+    when :read, :readings
+      # readings should be readable by course teachers and students because FE
+      # uses it for the reference view
       requestor.is_human? && \
       (UserIsCourseStudent[user: requestor.entity_user, course: course] || \
        UserIsCourseTeacher[user: requestor.entity_user, course: course])
-    when :readings
-      requestor.is_human?
     when :exercises, :export, :roster
       requestor.is_human? && UserIsCourseTeacher[user: requestor.entity_user, course: course]
     else

--- a/app/access_policies/course_access_policy.rb
+++ b/app/access_policies/course_access_policy.rb
@@ -3,7 +3,7 @@ class CourseAccessPolicy
     case action
     when :index
       !requestor.is_anonymous?
-    when :read, :readings
+    when :read, :readings, :task_plans
       # readings should be readable by course teachers and students because FE
       # uses it for the reference view
       requestor.is_human? && \

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -78,7 +78,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
   EOS
   def plans
     course = Entity::Course.find(params[:id])
-    # OSU::AccessPolicy.require_action_allowed!(:task_plans, current_api_user, course)
+    OSU::AccessPolicy.require_action_allowed!(:task_plans, current_api_user, course)
 
     out = GetCourseTaskPlans.call(course: course).outputs
     respond_with out, represent_with: Api::V1::TaskPlanSearchRepresenter

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -41,6 +41,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
   EOS
   def readings
     course = Entity::Course.find(params[:id])
+    OSU::AccessPolicy.require_action_allowed!(:readings, current_api_user, course)
 
     # For the moment, we're assuming just one book per course
     books = CourseContent::GetCourseBooks.call(course: course).outputs.books

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -687,6 +687,22 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                   parameters: { id: course.id, role_id: student_role }
         end
       end
+
+      context 'and a student role is not given' do
+        it 'raises IllegalState' do
+          expect {
+            api_get :stats, user_1_token, parameters: { id: course.id }
+          }.to raise_error(IllegalState)
+        end
+      end
+    end
+
+    context 'user is anonymous' do
+      it 'raises IllegalState' do
+        expect {
+          api_get :stats, nil, parameters: { id: course.id }
+        }.to raise_error(IllegalState)
+      end
     end
   end
 

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -682,6 +682,18 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         AddUserAsCourseTeacher.call(course: course, user: user_1.entity_user)
       end
 
+      it 'raises SecurityTransgression if user is anonymous or not a teacher' do
+        page_ids = Content::Models::Page.all.map(&:id)
+
+        expect {
+          api_get :exercises, nil, parameters: { id: course.id, page_ids: page_ids }
+        }.to raise_error(SecurityTransgression)
+
+        expect {
+          api_get :exercises, user_2_token, parameters: { id: course.id, page_ids: page_ids }
+        }.to raise_error(SecurityTransgression)
+      end
+
       it "should return an empty result if no page_ids specified" do
         api_get :exercises, user_1_token, parameters: {id: course.id}
 

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -529,6 +529,16 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
 
     let!(:plan) { FactoryGirl.create(:tasks_task_plan, owner: course)}
 
+    it 'raises IllegalState if user is anonymous or not in course' do
+      expect {
+        api_get :dashboard, nil, parameters: { id: course.id }
+      }.to raise_error(IllegalState)
+
+      expect {
+        api_get :dashboard, user_1_token, parameters: { id: course.id }
+      }.to raise_error(IllegalState)
+    end
+
     it "works for a student without a role specified" do
       Hacks::AnswerExercise[task_step: hw1_task.task_steps[0], is_correct: true]
       Hacks::AnswerExercise[task_step: hw1_task.task_steps[2], is_correct: false]

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -469,6 +469,21 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
 
       expect(response).to have_http_status(:success)
     end
+
+    it 'raises IllegalState if user is anonymous or not in the course or is not a student' do
+      expect {
+        api_get :practice, nil, parameters: { id: course.id }
+      }.to raise_error(IllegalState)
+
+      expect {
+        api_get :practice, user_1_token, parameters: { id: course.id }
+      }.to raise_error(IllegalState)
+
+      AddUserAsCourseTeacher.call(course: course, user: user_1.entity_user)
+      expect {
+        api_get :practice, user_1_token, parameters: { id: course.id }
+      }.to raise_error(IllegalState)
+    end
   end
 
   describe "dashboard" do

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -81,6 +81,16 @@ describe Api::V1::TaskStepsController, :type => :controller, :api => true, :vers
         related_content: a_kind_of(Array)
       })
     end
+
+    it 'raises SecurityTransgression when user is anonymous or not a teacher' do
+      expect {
+        api_get :show, nil, parameters: { task_id: task_step.task.id, id: task_step.id }
+      }.to raise_error(SecurityTransgression)
+
+      expect {
+        api_get :show, user_2_token, parameters: { task_id: task_step.task.id, id: task_step.id }
+      }.to raise_error(SecurityTransgression)
+    end
   end
 
   describe "PATCH update" do

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -33,6 +33,16 @@ describe Api::V1::TasksController, :type => :controller, :api => true, :version 
       expect(response.body_as_hash[:steps][0]).to include(type: 'reading')
       expect(response.body_as_hash[:steps][1]).to include(type: 'exercise')
     end
+
+    it 'raises SecurityTransgression when user is anonymous or not a teacher' do
+      expect {
+        api_get :show, nil, parameters: { id: task_1.id }
+      }.to raise_error(SecurityTransgression)
+
+      expect {
+        api_get :show, user_2_token, parameters: { id: task_1.id }
+      }.to raise_error(SecurityTransgression)
+    end
   end
 
 end


### PR DESCRIPTION
- Restrict courses readings API to course teachers and students
  - Courses readings API was originally going to be restricted to course
    teachers in commit cfb649ae.  Course students need access to it too
    because the readings API is also used for the reference view in the FE.
- Add security transgression tests for courses exercises API
- Restrict courses plans API to course teachers and students
- Add illegal state tests for courses dashboard API
- Add illegal state tests for courses stats API
- Add illegal state tests for courses practice (GET) API
- Add security transgression tests for tasks API
- Add security transgression for task steps show API