### PR TITLE
Fix issue with entity/role being loaded twice

### DIFF
--- a/app/subsystems/role/create_user_role.rb
+++ b/app/subsystems/role/create_user_role.rb
@@ -1,5 +1,3 @@
-require_relative '../../models/entity/role'
-
 class Role::CreateUserRole
   lev_routine express_output: :role
 

--- a/config/initializers/01-subsystems.rb
+++ b/config/initializers/01-subsystems.rb
@@ -1,5 +1,9 @@
 require 'tutor/subsystems'
 
+# Manually require entity/role
+# If it's not required first, it will conflict when files are loaded from the Role subsystem
+require 'entity/role'
+
 # Only these namespaces have been configured and should be extended
 # Once they are all configured, we can remove this line entirely,
 # but will still need to require the subsystems on rails boot, before any models are loaded


### PR DESCRIPTION
If the role subsystem was loaded before entity/role Rails and/or Ruby would get confused on whether entity/role.rb had already been defined and reload the file twice

This would then trigger an exception when Entity::Role's enum was defined for the second time.

This fixes an exception that would occur on `POST /api/courses/1/students`

Things I tried unsucessfully before adding the require to the subsystems initializer:
  * Added a `unless ::Entity.const_defined?(:Role)` guard to the require in `create_user_role.rb`
  * Changed all `Role::` references to be absolute `::Role::`

Neither method worked and the require would still load `entity/role.rb` twice, blowing up on the second time. :(

The exception is:

    ArgumentError (You tried to define an enum named "role_type" on the model "Entity::Role", but this will generate a instance method "role_type=", which is already defined by another enum.):
      app/models/entity/role.rb:3:in `<class:Role>'
      app/models/entity/role.rb:1:in `<top (required)>'
      app/subsystems/role/create_user_role.rb:1:in `<top (required)>'
      app/routines/add_user_as_period_student.rb:6:in `<class:AddUserAsPeriodStudent>'
      app/routines/add_user_as_period_student.rb:1:in `<top (required)>'
      app/routines/create_student.rb:8:in `<class:CreateStudent>'
      app/routines/create_student.rb:1:in `<top (required)>'
      app/controllers/api/v1/students_controller.rb:39:in `block in create'
      app/controllers/api/v1/students_controller.rb:35:in `create'


