### PR TITLE
added roles to /api/courses/:id

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -2,7 +2,7 @@ class Admin::CoursesController < Admin::BaseController
   before_action :get_users, only: [:new, :edit]
 
   def index
-    @courses = ListCourses.call(with: :teacher_names).outputs.courses
+    @courses = CollectCourseInfo[with: :teacher_names]
   end
 
   def create

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -16,19 +16,26 @@ class Api::V1::CoursesController < Api::V1::ApiController
   EOS
   def index
     OSU::AccessPolicy.require_action_allowed!(:index, current_api_user, Entity::Course)
-    courses = ListCourses.call(user: current_human_user.entity_user,
-                               with: [:roles, :periods]).outputs.courses
-    respond_with courses, represent_with: Api::V1::CoursesRepresenter
+    courses_info = CollectCourseInfo[user: current_human_user.entity_user,
+                                     with: [:roles, :periods]]
+    respond_with courses_info, represent_with: Api::V1::CoursesRepresenter
   end
 
   api :GET, '/courses/:course_id', 'Returns information about a specific course, including periods'
   description <<-EOS
-    Returns information about a specific course, including periods
+    Returns information about a specific course, including periods and roles
     #{json_schema(Api::V1::CourseRepresenter, include: :readable)}
   EOS
   def show
     course = Entity::Course.find(params[:id])
-    standard_read course, Api::V1::CourseRepresenter
+    OSU::AccessPolicy.require_action_allowed!(:read, current_api_user, course)
+
+    # Use CollectCourseInfo instead of just representing the entity course so
+    # we can gather extra information
+    course_info = CollectCourseInfo[course: course,
+                                    user: current_human_user.entity_user,
+                                    with: [:roles, :periods]].first
+    respond_with course_info, represent_with: Api::V1::CourseRepresenter
   end
 
   api :GET, '/courses/:course_id/readings', 'Returns a course\'s readings'

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::CoursesController do
   before { controller.sign_in(admin) }
 
   describe 'GET #index' do
-    it 'assigns all ListCourses output to @courses' do
+    it 'assigns all CollectCourseInfo output to @courses' do
       CreateCourse.call(name: 'Hello World')
       get :index
 


### PR DESCRIPTION
With this PR, both `/api/courses/1` and `/api/user/courses` return role information in their response.  Note that role information is only included for the user making the request

`/api/user/courses` returns:

```ruby
[
  {
    id: "1",
    name: "Physics I",
    roles: [
      {
        id: "1",
        type: "teacher"
      }
    ],
    periods: [
      {
        id: "1",
        name: "1st"
      },
      {
        id: "2",
        name: "2nd"
      }
    ]
  }
]
```

`/api/courses/1` returns:

```ruby
{
  id: "1",
  name: "Physics I",
  roles: [
    {
      id: "1",
      type: "teacher"
    }
  ],
  periods: [
    {
      id: "1",
      name: "1st"
    },
    {
      id: "2",
      name: "2nd"
    }
  ]
}
```