### PR TITLE
External assignments student deidentifier and templatized URL

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -1,0 +1,15 @@
+class Admin::StudentsController < Admin::BaseController
+  before_action :get_course, only: [:index]
+
+  def index
+    @students = GetStudentRoster[course: @entity_course]
+    @students.sort! { |a, b| a.username <=> b.username }
+  end
+
+  protected
+
+  def get_course
+    @entity_course = Entity::Course.find(params[:course_id])
+    @course = GetCourseProfile[course: @entity_course]
+  end
+end

--- a/app/models/entity/role.rb
+++ b/app/models/entity/role.rb
@@ -7,5 +7,5 @@ class Entity::Role < Tutor::SubSystems::BaseModel
   has_one :role_user, dependent: :destroy, subsystem: :role
   has_one :user, through: :role_user
 
-  delegate :username, :first_name, :last_name, :full_name, to: :user
+  delegate :username, :first_name, :last_name, :full_name, :name, to: :user
 end

--- a/app/models/entity/user.rb
+++ b/app/models/entity/user.rb
@@ -4,5 +4,5 @@ class Entity::User < Tutor::SubSystems::BaseModel
   has_many :role_user, subsystem: :role
   has_many :roles, through: :role_user
 
-  delegate :username, :first_name, :last_name, :full_name, to: :profile
+  delegate :username, :first_name, :last_name, :full_name, :name, to: :profile
 end

--- a/app/representers/api/v1/new_student_representer.rb
+++ b/app/representers/api/v1/new_student_representer.rb
@@ -61,5 +61,10 @@ module Api::V1
              writeable: true,
              readable: true
 
+    property :deidentifier,
+             type: String,
+             writeable: false,
+             readable: true
+
   end
 end

--- a/app/representers/api/v1/student_representer.rb
+++ b/app/representers/api/v1/student_representer.rb
@@ -45,5 +45,10 @@ module Api::V1
              writeable: false,
              readable: true
 
+    property :deidentifier,
+             type: String,
+             writeable: false,
+             readable: true
+
   end
 end

--- a/app/routines/get_student_roster.rb
+++ b/app/routines/get_student_roster.rb
@@ -15,8 +15,11 @@ class GetStudentRoster
         first_name: student.first_name,
         last_name: student.last_name,
         full_name: student.full_name,
+        name: student.name,
         course_membership_period_id: student.course_membership_period_id,
-        entity_role_id: student.entity_role_id
+        entity_role_id: student.entity_role_id,
+        username: student.username,
+        deidentifier: student.deidentifier
       })
     end
   end

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -6,6 +6,19 @@ class CourseMembership::Models::Student < Tutor::SubSystems::BaseModel
 
   validates :period, presence: true
   validates :role, presence: true, uniqueness: { scope: :course_membership_period_id }
+  validates :deidentifier, uniqueness: true
 
   delegate :username, :first_name, :last_name, :full_name, to: :role
+
+  before_save :generate_deidentifier
+
+  protected
+
+  def generate_deidentifier
+    begin
+      deidentifier = SecureRandom.hex(4)
+    end while CourseMembership::Models::Student.exists?(deidentifier: deidentifier)
+    self.deidentifier ||= deidentifier
+  end
+
 end

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -8,7 +8,7 @@ class CourseMembership::Models::Student < Tutor::SubSystems::BaseModel
   validates :role, presence: true, uniqueness: { scope: :course_membership_period_id }
   validates :deidentifier, uniqueness: true
 
-  delegate :username, :first_name, :last_name, :full_name, to: :role
+  delegate :username, :first_name, :last_name, :full_name, :name, to: :role
 
   before_save :generate_deidentifier
 

--- a/app/subsystems/role/models/role_user.rb
+++ b/app/subsystems/role/models/role_user.rb
@@ -5,5 +5,5 @@ class Role::Models::RoleUser < Tutor::SubSystems::BaseModel
   validates :entity_user_id, presence: true
   validates :entity_role_id, presence: true
 
-  delegate :username, :first_name, :last_name, :full_name, to: :user
+  delegate :username, :first_name, :last_name, :full_name, :name, to: :user
 end

--- a/app/subsystems/tasks/assistants/external_assignment_assistant.rb
+++ b/app/subsystems/tasks/assistants/external_assignment_assistant.rb
@@ -16,17 +16,24 @@ class Tasks::Assistants::ExternalAssignmentAssistant
   end
 
   def self.build_tasks(task_plan:, taskees:)
-    url = task_plan.settings['external_url']
-    taskees.collect do |taskee|
-      build_external_task(task_plan: task_plan, taskee: taskee, url: url)
+    students = taskees.collect { |taskee| taskee.students.first }.compact
+
+    raise StandardError, 'External assignment taskees must all be students'\
+      if students.length != taskees.length
+
+    taskees.collect.with_index do |taskee, i|
+      build_external_task(task_plan: task_plan,
+                          taskee: taskee,
+                          student: students[i])
     end
   end
 
   protected
-  def self.build_external_task(task_plan:, taskee:, url:)
+  def self.build_external_task(task_plan:, taskee:, student:)
     task = build_task(task_plan: task_plan)
     step = Tasks::Models::TaskStep.new(task: task)
-    Tasks::Models::TaskedExternalUrl.new(task_step: step, url: url)
+    tasked_external_url(task_step: step, taskee: taskee, student: student,
+                        url: task_plan.settings['external_url'])
     task.task_steps << step
     task
   end
@@ -41,5 +48,14 @@ class Tasks::Assistants::ExternalAssignmentAssistant
       title: title,
       description: description
     ]
+  end
+
+  def self.tasked_external_url(task_step:, taskee:, student:, url:)
+    {
+      deidentifier: student.try(:deidentifier)
+    }.each do |key, value|
+      url = url.gsub("{{#{key}}}", value)
+    end
+    Tasks::Models::TaskedExternalUrl.new(task_step: task_step, url: url)
   end
 end

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -13,7 +13,10 @@
       <tr>
         <td><%= course.name %></td>
         <td><%= course.teacher_names.to_sentence %></td>
-        <td><%= link_to 'Edit', edit_admin_course_path(course.id), class: "btn btn-xs btn-primary" %></td>
+        <td>
+          <%= link_to 'Edit', edit_admin_course_path(course.id), class: "btn btn-xs btn-primary" %>
+          <%= link_to 'Students', students_admin_course_path(course.id), class: 'btn btn-xs btn-primary' %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/students/index.html.erb
+++ b/app/views/admin/students/index.html.erb
@@ -1,0 +1,20 @@
+<h2>Students for course "<%= @course.name %>"</h2>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Username</th>
+      <th>Name</th>
+      <th>Deidentifier</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @students.each do |student| %>
+    <tr>
+      <td><%= student.username %></td>
+      <td><%= student.name %></td>
+      <td><%= student.deidentifier %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,9 +89,10 @@ Rails.application.routes.draw do
 
     resources :courses, except: :destroy do
       member do
-        post 'students'
+        post :students
       end
       resources :periods, shallow: true
+      resources :students, only: [:index], shallow: true
     end
 
     resource :cron, only: [:update]

--- a/db/migrate/01000_create_course_membership_students.rb
+++ b/db/migrate/01000_create_course_membership_students.rb
@@ -3,10 +3,12 @@ class CreateCourseMembershipStudents < ActiveRecord::Migration
     create_table :course_membership_students do |t|
       t.integer :course_membership_period_id, null: false
       t.integer :entity_role_id,   null: false
+      t.string :deidentifier, null: false
       t.timestamps null: false
 
       t.index [:course_membership_period_id, :entity_role_id],
               unique: true, name: 'course_membership_student_period_role_uniq'
+      t.index :deidentifier, unique: true
     end
 
      add_foreign_key :course_membership_students, :course_membership_periods

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,11 +129,13 @@ ActiveRecord::Schema.define(version: 20150712051607) do
   create_table "course_membership_students", force: :cascade do |t|
     t.integer  "course_membership_period_id", null: false
     t.integer  "entity_role_id",              null: false
+    t.string   "deidentifier",                null: false
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
   end
 
   add_index "course_membership_students", ["course_membership_period_id", "entity_role_id"], name: "course_membership_student_period_role_uniq", unique: true, using: :btree
+  add_index "course_membership_students", ["deidentifier"], name: "index_course_membership_students_on_deidentifier", unique: true, using: :btree
 
   create_table "course_membership_teachers", force: :cascade do |t|
     t.integer  "entity_course_id", null: false

--- a/spec/controllers/admin/students_controller_spec.rb
+++ b/spec/controllers/admin/students_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Admin::StudentsController do
+  let!(:admin) { FactoryGirl.create(:user_profile, :administrator) }
+
+  before { controller.sign_in(admin) }
+
+  describe 'GET #index' do
+    let!(:course) { CreateCourse[name: 'Physics'] }
+    let!(:course_2) { CreateCourse[name: 'Biology'] }
+
+    let!(:periods) { [
+      CreatePeriod[course: course],
+      CreatePeriod[course: course]
+    ] }
+    let!(:periods_2) { [CreatePeriod[course: course_2]] }
+
+    let!(:profile_1) {
+      FactoryGirl.create(:user_profile, username: 'benjamin')
+    }
+    let!(:profile_2) {
+      FactoryGirl.create(:user_profile, username: 'nicolai')
+    }
+    let!(:profile_3) {
+      FactoryGirl.create(:user_profile, username: 'freja')
+    }
+    let!(:profile_4) {
+      FactoryGirl.create(:user_profile, username: 'oskar')
+    }
+
+    let!(:student_1) {
+      AddUserAsPeriodStudent.call(user: profile_1.entity_user, period: periods[0]).outputs.student
+    }
+    let!(:student_2) {
+      AddUserAsPeriodStudent.call(user: profile_2.entity_user, period: periods[0]).outputs.student
+    }
+    let!(:student_3) {
+      AddUserAsPeriodStudent.call(user: profile_3.entity_user, period: periods[1]).outputs.student
+    }
+    let!(:student_4) {
+      AddUserAsPeriodStudent.call(user: profile_4.entity_user, period: periods_2[0]).outputs.student
+    }
+
+    it 'returns all the students in a course' do
+      get :index, course_id: course.id
+      expect(assigns[:course].name).to eq 'Physics'
+      expect(assigns[:students]).to eq([
+        {
+          'id' => student_1.id,
+          'username' => 'benjamin',
+          'first_name' => profile_1.first_name,
+          'last_name' => profile_1.last_name,
+          'full_name' => profile_1.full_name,
+          'entity_role_id' => student_1.entity_role_id,
+          'course_membership_period_id' => student_1.period.id,
+          'name' => profile_1.name,
+          'deidentifier' => student_1.deidentifier
+        },
+        {
+          'id' => student_3.id,
+          'username' => 'freja',
+          'first_name' => profile_3.first_name,
+          'last_name' => profile_3.last_name,
+          'full_name' => profile_3.full_name,
+          'entity_role_id' => student_3.entity_role_id,
+          'course_membership_period_id' => student_3.period.id,
+          'name' => profile_3.name,
+          'deidentifier' => student_3.deidentifier
+        },
+        {
+          'id' => student_2.id,
+          'username' => 'nicolai',
+          'first_name' => profile_2.first_name,
+          'last_name' => profile_2.last_name,
+          'full_name' => profile_2.full_name,
+          'entity_role_id' => student_2.entity_role_id,
+          'course_membership_period_id' => student_2.period.id,
+          'name' => profile_2.name,
+          'deidentifier' => student_2.deidentifier
+        }
+      ])
+    end
+  end
+end

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -70,7 +70,8 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
               last_name: student.last_name,
               full_name: student.full_name,
               period_id: period.id.to_s,
-              role_id: student_role.id.to_s
+              role_id: student_role.id.to_s,
+              deidentifier: student.deidentifier
             },
             {
               id: student_2.id.to_s,
@@ -78,7 +79,8 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
               last_name: student_2.last_name,
               full_name: student_2.full_name,
               period_id: period.id.to_s,
-              role_id: student_role_2.id.to_s
+              role_id: student_role_2.id.to_s,
+              deidentifier: student_2.deidentifier
             },
             {
               id: student_3.id.to_s,
@@ -86,7 +88,8 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
               last_name: student_3.last_name,
               full_name: student_3.full_name,
               period_id: period_2.id.to_s,
-              role_id: student_role_3.id.to_s
+              role_id: student_role_3.id.to_s,
+              deidentifier: student_3.deidentifier
             }
           ]
         end
@@ -146,7 +149,8 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
             last_name: 'User',
             full_name: 'Dummy User',
             period_id: period.id.to_s,
-            role_id: new_student.entity_role_id.to_s
+            role_id: new_student.entity_role_id.to_s,
+            deidentifier: new_student.deidentifier
           })
         end
       end
@@ -193,7 +197,8 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
             last_name: student.last_name,
             full_name: student.full_name,
             period_id: period_2.id.to_s,
-            role_id: student.entity_role_id.to_s
+            role_id: student.entity_role_id.to_s,
+            deidentifier: student.deidentifier
           })
           expect(student.reload.period).to eq period_2.to_model
         end

--- a/spec/representers/api/v1/student_representer_spec.rb
+++ b/spec/representers/api/v1/student_representer_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::StudentRepresenter, type: :representer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:user) { FactoryGirl.create(:user_profile).entity_user }
+  let!(:period) { FactoryGirl.create(:period) }
+  let!(:student) {
+    AddUserAsPeriodStudent.call(period: period, user: user).outputs.student
+  }
+
+  it 'represents a student' do
+    representation = Api::V1::StudentRepresenter.new(student).as_json
+    expect(representation).to eq(
+      'id' => student.id.to_s,
+      'period_id' => period.id.to_s,
+      'role_id' => student.role.id.to_s,
+      'first_name' => student.first_name,
+      'last_name' => student.last_name,
+      'full_name' => student.full_name,
+      'deidentifier' => student.deidentifier
+    )
+  end
 end

--- a/spec/routines/get_student_roster_spec.rb
+++ b/spec/routines/get_student_roster_spec.rb
@@ -45,24 +45,33 @@ describe GetStudentRoster do
         'first_name' => student_1.first_name,
         'last_name' => student_1.last_name,
         'full_name' => student_1.full_name,
+        'name' => student_1.name,
         'course_membership_period_id' => period_1.id,
         'entity_role_id' => student_1_role.id,
+        'username' => student_1.username,
+        'deidentifier' => student_1_role.students.first.deidentifier
       },
       {
         'id' => students[1].id,
         'first_name' => student_2.first_name,
         'last_name' => student_2.last_name,
         'full_name' => student_2.full_name,
+        'name' => student_2.name,
         'course_membership_period_id' => period_1.id,
         'entity_role_id' => student_2_role.id,
+        'username' => student_2.username,
+        'deidentifier' => student_2_role.students.first.deidentifier
       },
       {
         'id' => students[2].id,
         'first_name' => student_3.first_name,
         'last_name' => student_3.last_name,
         'full_name' => student_3.full_name,
+        'name' => student_3.name,
         'course_membership_period_id' => period_2.id,
         'entity_role_id' => student_3_role.id,
+        'username' => student_3.username,
+        'deidentifier' => student_3_role.students.first.deidentifier
       }
     ])
   end

--- a/spec/subsystems/course_membership/models/student_spec.rb
+++ b/spec/subsystems/course_membership/models/student_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CourseMembership::Models::Student, type: :model do
+  it { is_expected.to belong_to(:role) }
+  it { is_expected.to belong_to(:period) }
+  it { is_expected.to have_one(:course) }
+
+  it { is_expected.to validate_presence_of(:period) }
+  it { is_expected.to validate_presence_of(:role) }
+
+  [:username, :first_name, :last_name, :full_name].each do |method|
+    it { is_expected.to delegate_method(method).to(:role) }
+  end
+
+  context 'deidentifier' do
+    let!(:user) { FactoryGirl.create(:user_profile).entity_user }
+    let!(:period) { FactoryGirl.create(:period) }
+    let!(:student) {
+      AddUserAsPeriodStudent.call(period: period, user: user).outputs.student
+    }
+
+    it 'is generated before save and is 8 characters long' do
+      expect(student.deidentifier.length).to eq 8
+    end
+
+    it 'stays the same after multiple saves' do
+      old_deidentifier = student.deidentifier
+      student.save
+      expect(student.deidentifier).to eq old_deidentifier
+    end
+
+    it 'must be unique' do
+      user2 = FactoryGirl.create(:user_profile).entity_user
+      student_2 = AddUserAsPeriodStudent.call(period: period, user: user2).outputs.student
+      student_2.deidentifier = student.deidentifier
+      expect(student_2).not_to be_valid
+      expect(student_2.errors.messages).to eq({
+        deidentifier: ['has already been taken']
+      })
+    end
+  end
+end


### PR DESCRIPTION
- Add auto generated unique deidentifier field to course students

- Allow templatized url in external assignment urls

  At the moment, only `deidentifier` will work in templatized url.

  The syntax looks like this:

  `https://www.example.org/survey?id={{deidentifier}}`

  For a student with deidentifier "1433f416", they will get this url:

  `https://www.example.org/survey?id=1433f416`

- Add admin view to show students for a course

  Shows username, name and deidentifier

- Add deidentifier to student representer