### PR TITLE
Cache book visitors

### DIFF
--- a/app/subsystems/content/get_los.rb
+++ b/app/subsystems/content/get_los.rb
@@ -7,12 +7,9 @@ class Content::GetLos
   def exec(options = {})
     page_ids = [options[:page_ids]].flatten.compact
     book_part_ids = [options[:book_part_ids]].flatten.compact
-    book_part_ids.each do |book_part_id|
-      book_part = Content::Models::BookPart.find(book_part_id)
-      page_ids += Content::VisitBookPart[book_part: book_part,
-                                         visitor_names: 'page_data']
-                    .collect{|info| info[:id]}
-    end
+
+    page_ids += Content::Models::Page.where(content_book_part_id: book_part_ids)
+                                     .pluck(:id)
 
     outputs[:los] = Content::Models::Tag.lo
                                         .joins(:page_tags)

--- a/app/subsystems/content/models/book_part.rb
+++ b/app/subsystems/content/models/book_part.rb
@@ -2,6 +2,8 @@ class Content::Models::BookPart < Tutor::SubSystems::BaseModel
   acts_as_resource allow_nil: true
 
   serialize :chapter_section, Array
+  serialize :toc_cache, Hash
+  serialize :page_data_cache, Array
 
   belongs_to :book, subsystem: :entity
 

--- a/app/subsystems/content/visit_book_part.rb
+++ b/app/subsystems/content/visit_book_part.rb
@@ -5,18 +5,114 @@ class Content::VisitBookPart
   protected
 
   def exec(book_part:, visitor_names:)
+    # handle string or symbol names, array or single entry
+    visitor_names = [visitor_names].flatten.collect(&:to_sym)
 
-    visitor_names = [visitor_names].flatten
+    uncached_visitor_names = process_cached_visitors(book_part, visitor_names)
+    process_uncached_visitors(book_part, uncached_visitor_names)
+
+    enable_express_output_if_only_one_visitor(visitor_names)
+  end
+
+  private
+
+  VISITOR_INFO = {
+    toc: {
+      visitor_class: Content::Models::TocVisitor,
+      cached_attribute: :toc_cache
+    },
+    exercises: {
+      visitor_class: Content::Models::ExerciseVisitor
+    },
+    page_data: {
+      visitor_class: Content::Models::PageDataVisitor,
+      cached_attribute: :page_data_cache
+    }
+  }
+
+  def process_cached_visitors(book_part, visitor_names)
+    uncached_visitor_names = []
+
+    visitor_names.each do |visitor_name|
+      cached_value = get_cached_value(book_part, visitor_name)
+
+      if cached_value
+        # Put the cached value in the output
+        outputs[visitor_name] = cached_value
+      else
+        # Take a note that we still need to run this visitor
+        uncached_visitor_names.push(visitor_name)
+      end
+    end
+
+    uncached_visitor_names
+  end
+
+  def get_cached_value(book_part, visitor_name)
+    return nil if cached_attribute(visitor_name).nil?
+
+    # Rails casts nil values to the empty form of the serialized attribute, e.g. {} for a Hash,
+    # so if it is empty, return nil so the visitor actually runs.  If the actual cached value is
+    # empty (rare), it is no loss to actually run the visitor.
+
+    cached_value = book_part.send(cached_attribute(visitor_name))
+    cached_value.empty? ? nil : cached_value
+  end
+
+  def set_cached_value(book_part, visitor_name, value)
+    return if cached_attribute(visitor_name).nil?
+    book_part.update_attribute(cached_attribute(visitor_name), value)
+  end
+
+  def cached_attribute(visitor_name)
+    VISITOR_INFO[visitor_name][:cached_attribute]
+  end
+
+  def process_uncached_visitors(book_part, visitor_names)
     visitors = map_visitor_names_to_visitors(visitor_names)
 
     # Kick off the recursive visitation
     visit_book_part(book_part, visitors)
 
-    replace_outputs_with_visited_output(visitor_names)
-    enable_express_output_for_single_visitor(visitor_names)
+    replace_outputs_with_visited_output(book_part, visitor_names)
   end
 
-  private
+  def map_visitor_names_to_visitors(visitor_names)
+    visitor_names.collect do |name|
+      outputs[name] = VISITOR_INFO[name][:visitor_class].new
+    end
+  end
+
+  def replace_outputs_with_visited_output(book_part, visitor_names)
+    # We've temporarily stored the visitor objects in the outputs
+    # structure for convenience.  Now iterate back through them
+    # replace them with their visited output.
+    #
+    # Also, this is where we cache results, if appropriate
+
+    visitor_names.each do |name|
+      visited_output = outputs[name].output
+      set_cached_value(book_part, name, visited_output)
+      outputs[name] = visited_output
+    end
+  end
+
+  def enable_express_output_if_only_one_visitor(visitor_names)
+    if visitor_names.count == 1
+      outputs[:visit_book_part] = outputs[visitor_names.first]
+    end
+  end
+
+  def verify_valid_visitor_names(visitor_names)
+    if (VISITOR_INFO.keys & visitor_names).length != visitor_names.length
+      raise "undefined visitor in #{visitor_names}. Try one of toc, exercises, page_data"
+    end
+  end
+
+  # The visitation methods
+  #
+  # We made an explicit choice to not dirty up the BookPart and Page classes,
+  # and instead put the visitation methods here.
 
   def visit_book_part(book_part, visitors)
     child_book_part_includes, page_includes = set_visitor_defined_includes(
@@ -38,34 +134,15 @@ class Content::VisitBookPart
     end
   end
 
-  def map_visitor_names_to_visitors(visitor_names)
-    visitor_names.collect do |name|
-      case name.to_s
-      when 'toc'
-        outputs[:toc] = Content::Models::TocVisitor.new
-      when 'exercises'
-        outputs[:exercises] = Content::Models::ExerciseVisitor.new
-      when 'page_data'
-        outputs[:page_data] = Content::Models::PageDataVisitor.new
-      else
-        raise "undefined visitor #{name}. Try one of toc, exercises, page_data"
-      end
+  def visit_pages(book_part, includes, visitors)
+    book_part.pages.includes(includes.uniq).each do |page|
+      visit_page(page, visitors)
     end
   end
 
-  def replace_outputs_with_visited_output(visitor_names)
-    # We've temporarily stored the visitor objects in the outputs
-    # structure for convenience.  Now iterate back through them
-    # replace them with their visited output.
-
-    visitor_names.each do |name|
-      outputs[name] = outputs[name].output
-    end
-  end
-
-  def enable_express_output_for_single_visitor(visitor_names)
-    if visitor_names.count == 1
-      outputs[:visit_book_part] = outputs[visitor_names.first]
+  def visit_book_parts(book_part, includes, visitors)
+    book_part.child_book_parts.includes(includes.uniq).each do |child_book_part|
+      visit_book_part(child_book_part, visitors)
     end
   end
 
@@ -83,21 +160,6 @@ class Content::VisitBookPart
     end
 
     return child_book_part_includes, page_includes
-  end
-
-  # We made an explicit choice to not dirty up the BookPart and Page classes,
-  # and instead put the visitation methods here.
-
-  def visit_pages(book_part, includes, visitors)
-    book_part.pages.includes(includes.uniq).each do |page|
-      visit_page(page, visitors)
-    end
-  end
-
-  def visit_book_parts(book_part, includes, visitors)
-    book_part.child_book_parts.includes(includes.uniq).each do |child_book_part|
-      visit_book_part(child_book_part, visitors)
-    end
   end
 
 end

--- a/db/migrate/20150712051607_add_visitor_caches_to_content_book_part.rb
+++ b/db/migrate/20150712051607_add_visitor_caches_to_content_book_part.rb
@@ -1,0 +1,6 @@
+class AddVisitorCachesToContentBookPart < ActiveRecord::Migration
+  def change
+    add_column :content_book_parts, :toc_cache, :text
+    add_column :content_book_parts, :page_data_cache, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150708120910) do
+ActiveRecord::Schema.define(version: 20150712051607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 20150708120910) do
     t.text     "chapter_section"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.text     "toc_cache"
+    t.text     "page_data_cache"
   end
 
   add_index "content_book_parts", ["entity_book_id"], name: "index_content_book_parts_on_entity_book_id", using: :btree

--- a/spec/subsystems/content/visit_book_part_spec.rb
+++ b/spec/subsystems/content/visit_book_part_spec.rb
@@ -106,4 +106,24 @@ RSpec.describe Content::VisitBookPart, :type => :routine do
 
   end
 
+  it "should cache visitations" do
+    trials = [
+      { name: :toc,       attribute: :toc_cache,       fake_data: {'fake' => 'hash'} },
+      { name: :page_data, attribute: :page_data_cache, fake_data: ['fake', 'array']}
+    ]
+
+
+    trials.each do |trial|
+      Content::VisitBookPart[book_part: book_part, visitor_names: trial[:name]]
+      book_part.reload
+
+      expect(book_part.send(trial[:attribute])).not_to be_blank
+
+      book_part.update_attribute(trial[:attribute], trial[:fake_data])
+
+      value = Content::VisitBookPart[book_part: book_part, visitor_names: trial[:name]]
+      expect(value).to eq(trial[:fake_data])
+    end
+  end
+
 end


### PR DESCRIPTION
Adds caching to book visitors, so we only have to get the `:toc` or `:page_data` once (which is good since books don't change (yet)).

Incidentally simplified `Content::GetLos` to use direct relations instead of book visitation.