### PR TITLE
Demo usernames, only one task per assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,22 +94,20 @@ By default, all YAML files in that directory are run (with the exception of `peo
 
 `bundle exec rake db:drop db:create db:migrate db:seed demo[biology]`
 
-As an admin you can search for the various users set up by the demo scripts (or you can check out the demo YAML files in `/lib/tasks`).  For your convenience, here are a few of the student usernames:
+As an admin you can search for the various users set up by the demo scripts (or you can check out the demo YAML files in `/lib/tasks`).  For your convenience, here are a few of the student usernames and the courses they are setup with:
 
-  * student-ak
-  * student-hp
-  * student-hg
-  * student-cd
-  * student-nz
-  * student-ne
-  * student-sd
+  * student01 - biology and physics
+  * student02 - biology and physics
+  * student03 - biology and physics
+  * student08 - physics only
+  * student09 - biology only
+  * student31 - biology only
+  * student33 - physics only
 
-The teacher login is: teacher-cm
+A teacher is setup with username: `teacher01`
 
-These teachers and students derive their username from the full names.  E.g. `student-cd` maps to the user "Clarissa Dalloway".  The full list of names and initials can be [found here](https://github.com/openstax/tutor-server/blob/master/lib/tasks/demo/people.yml).
+The full list of teachers and students can be [found here](https://github.com/openstax/tutor-server/blob/master/lib/tasks/demo/people.yml).
 
 ## Profiling
 
 See [this napkin note](https://github.com/openstax/napkin-notes/blob/master/jp/profiling_tutor_server.md)
-
-

--- a/lib/tasks/demo/biology.yml
+++ b/lib/tasks/demo/biology.yml
@@ -39,7 +39,7 @@ assignments:
         students: {an: 100,cg: 82,cd: 71,dp: 90,fa: 78,jr: 87,js: i,lh: i,ms: 90,rb: 85,wh: ns}
 
   - type: reading
-    step_types: [ r, r, r, r, r, r, r, e, r, r, e, r, r, r, p ]
+    step_types: [ r, r, r, r, r, r, r, e, r, r, e, r, r, r, r, p ]
     chapter_sections: [[6, 0], [6, 1], [6, 2]]
     title: Read Chapter 6. Metabolism
     periods:
@@ -47,28 +47,28 @@ assignments:
         due_at: <%= due_two_days_ago %>
         students:
           ak: 94
-          at: [ 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1 ]
+          at: [ 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1 ]
           bh: 40
-          gj: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1 ]
+          gj: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0 ]
           kl: 60
           ir: i
           mb: ns
           ra: 72
-          sg: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]  # explicit example, could also be `100`
+          sg: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]  # explicit example, could also be `100`
       - index: 3 # 3rd period
         due_at: <%= due_today %>
         students:
           an: 80
           cg: 100
-          cd: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1 ]
-          dp: [ 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1 ]
-          fa: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0 ]
+          cd: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1 ]
+          dp: [ 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1 ]
+          fa: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1 ]
           jr: 79
-          js: [ 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1 ]
+          js: [ 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1 ]
           lh: i
           ms: i
-          rb: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1 ]
-          wh: [ 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1 ]
+          rb: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0 ]
+          wh: [ 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1 ]
 
   - type: homework
     step_types: [ e, e, e, e, e, e, e, e, e, e, p ]

--- a/lib/tasks/demo/people.yml
+++ b/lib/tasks/demo/people.yml
@@ -1,55 +1,55 @@
 admin: Administrator User
 teachers:
-  cm: Charles Morris
+  cm: {name: Charles Morris,     username: teacher01 }
 
 students:
-  af: Atticus Finch
-  ag: Ashleigh Goyette
-  ak: Albin Kirlin
-  am: Augie March
-  an: Alene Macejkovic
-  ap: Alden Pyle
-  at: Alyce Tromp
-  bb: Beatrice Batz
-  bh: Bettie Hackett
-  bs: Bernhard Stark
-  cd: Clarissa Dalloway
-  cg: Clyde Griffiths
-  cm: Charlie Marlow
-  cp: Cleve Pacocha
-  dp: Dorthy Pagac
-  eh: Earlene Hayes
-  fa: Florentino Ariza
-  ft: Fabiola Thiel
-  gj: Giovanny Jaskolski
-  gs: George Smiley
-  hc: Henry Chinaski
-  hg: Holly Golightly
-  hp: Harry Potter
-  hs: Helmer Schuppe
-  ir: Ignatius Reilly
-  iu: Isobel Russel
-  iw: Isobel Witting
-  jb: Jean Brodie
-  jr: Jared Fritsch
-  js: Janelle Skiles
-  kl: Kevin Lowe
-  lb: Leopold Bloom
-  lt: Lily Bart
-  lh: Lionel Hayes
-  mb: Molly Bloom
-  mu: Mariah Buckridge
-  mh: Mikayla Hintz
-  mr: Myriam Reynolds
-  ms: Myron Sauer
-  ne: Nellie Effertz
-  nz: Nathan Zuckerman
-  ra: Rabbit Angstrom
-  rb: Regan Buckridge
-  rh: Rigoberto Hegmann
-  rl: Richmond Lang
-  sd: Stephen Dedalus
-  sg: Seymour Glass
-  sk: Sean Kuvalis
-  vw: Vernien Walker
-  wh: Willie Herman
+  af: {name: Atticus Finch,      username: student01 }
+  ag: {name: Ashleigh Goyette,   username: student02 }
+  ak: {name: Albin Kirlin,       username: student03 }
+  am: {name: Augie March,        username: student04 }
+  an: {name: Alene Macejkovic,   username: student05 }
+  ap: {name: Alden Pyle,         username: student06 }
+  at: {name: Alyce Tromp,        username: student07 }
+  bb: {name: Beatrice Batz,      username: student08 }
+  bh: {name: Bettie Hackett,     username: student09 }
+  bs: {name: Bernhard Stark,     username: student10 }
+  cd: {name: Clarissa Dalloway,  username: student11 }
+  cg: {name: Clyde Griffiths,    username: student12 }
+  cm: {name: Charlie Marlow,     username: student13 }
+  cp: {name: Cleve Pacocha,      username: student14 }
+  dp: {name: Dorthy Pagac,       username: student15 }
+  eh: {name: Earlene Hayes,      username: student16 }
+  fa: {name: Florentino Ariza,   username: student17 }
+  ft: {name: Fabiola Thiel,      username: student18 }
+  gj: {name: Giovanny Jaskolski, username: student19 }
+  gs: {name: George Smiley,      username: student20 }
+  hc: {name: Henry Chinaski,     username: student21 }
+  hg: {name: Holly Golightly,    username: student22 }
+  hp: {name: Harry Potter,       username: student23 }
+  hs: {name: Helmer Schuppe,     username: student24 }
+  ir: {name: Ignatius Reilly,    username: student25 }
+  iu: {name: Isobel Russel,      username: student26 }
+  iw: {name: Isobel Witting,     username: student27 }
+  jb: {name: Jean Brodie,        username: student28 }
+  jr: {name: Jared Fritsch,      username: student29 }
+  js: {name: Janelle Skiles,     username: student30 }
+  kl: {name: Kevin Lowe,         username: student31 }
+  lb: {name: Leopold Bloom,      username: student32 }
+  lt: {name: Lily Bart,          username: student33 }
+  lh: {name: Lionel Hayes,       username: student34 }
+  mb: {name: Molly Bloom,        username: student35 }
+  mu: {name: Mariah Buckridge,   username: student36 }
+  mh: {name: Mikayla Hintz,      username: student37 }
+  mr: {name: Myriam Reynolds,    username: student38 }
+  ms: {name: Myron Sauer,        username: student39 }
+  ne: {name: Nellie Effertz,     username: student40 }
+  nz: {name: Nathan Zuckerman,   username: student41 }
+  ra: {name: Rabbit Angstrom,    username: student42 }
+  rb: {name: Regan Buckridge,    username: student43 }
+  rh: {name: Rigoberto Hegmann,  username: student44 }
+  rl: {name: Richmond Lang,      username: student45 }
+  sd: {name: Stephen Dedalus,    username: student46 }
+  sg: {name: Seymour Glass,      username: student47 }
+  sk: {name: Sean Kuvalis,       username: student48 }
+  vw: {name: Vernien Walker,     username: student49 }
+  wh: {name: Willie Herman,      username: student50 }

--- a/lib/tasks/demo_001.rb
+++ b/lib/tasks/demo_001.rb
@@ -37,10 +37,10 @@ class Demo001 < DemoBase
         period = run(:create_period, course: course, name: period_content.name).outputs.period
         log("  Created period: #{period_content.name}")
         period_content.students.each do | initials |
-          name = people.students[initials]
+          student_info = people.students[initials]
           profile = get_student_profile(initials) ||
-                    new_user_profile(username: "student-#{initials}", name: name)
-          log("    #{initials} (#{name})")
+                    new_user_profile(username: student_info.username, name:  student_info.name)
+          log("    #{initials} (#{student_info.name})")
 
           run(AddUserAsPeriodStudent, period: period, user: profile.entity_user)
         end
@@ -54,12 +54,12 @@ class Demo001 < DemoBase
 
 
       teacher_profile = get_teacher_profile(content.teacher) ||
-                        new_user_profile(username: "teacher-#{content.teacher}",
-                                         name: people.teachers[content.teacher])
+                        new_user_profile(username: people.teachers[content.teacher].username,
+                                         name: people.teachers[content.teacher].name)
 
       run(:add_teacher, course: course, user: teacher_profile.entity_user)
 
-      log("Created course '#{content.course_name}' with '#{people.teachers[content.teacher]}' as teacher")
+      log("Created course '#{content.course_name}' with '#{people.teachers[content.teacher].name}' as teacher")
 
     end # book
 

--- a/lib/tasks/demo_002.rb
+++ b/lib/tasks/demo_002.rb
@@ -38,6 +38,7 @@ class Demo002 < DemoBase
 
             responses = responses_list[ user.profile.id ]
             unless responses
+              binding.pry
               raise "#{assignment.title} period index #{period['index']} has no responses for task #{index} for user #{user.profile.id} #{user.username}"
             end
             work_task(task: task, responses: responses)

--- a/lib/tasks/demo_002.rb
+++ b/lib/tasks/demo_002.rb
@@ -17,58 +17,53 @@ class Demo002 < DemoBase
     ContentConfiguration[book.to_sym].each do | content |
       content.assignments.each do | assignment |
 
-        log("Creating #{assignment.type} #{assignment.title} for course #{content.course_name}")
+        log("Creating #{assignment.type} #{assignment.title} for course #{content.course_name} (#{assignment.step_types.length} steps)")
+
+        task_plan = if assignment.type == 'reading'
+                 assign_ireading(course: content.course,
+                                 chapter_sections: assignment.chapter_sections,
+                                 title: assignment.title)
+               else
+                 assign_homework(course: content.course,
+                                 chapter_sections: assignment.chapter_sections,
+                                 title: assignment.title,
+                                 num_exercises: assignment.num_exercises)
+               end
 
         assignment.periods.each do | period |
+          log("  Adding tasking plan for period #{period[:index]}")
 
-          responses_list = new_responses_list(
-            students: period.students,
-            assignment_type: assignment.type.to_sym,
-            step_types: assignment.step_types,
-          )
-
-          tasks = if assignment.type == 'reading'
-                    create_and_work_reading(content, period, assignment, responses_list)
-                  else
-                    create_and_work_homework(content, period, assignment, responses_list)
-                  end
-
-          tasks.each_with_index do | task, index |
-            user = task.taskings.first.role.user.user
-
-            responses = responses_list[ user.profile.id ]
-            unless responses
-              binding.pry
-              raise "#{assignment.title} period index #{period['index']} has no responses for task #{index} for user #{user.profile.id} #{user.username}"
-            end
-            work_task(task: task, responses: responses)
-          end
-
+          add_tasking_plan(task_plan: task_plan,
+                           to: content.course.periods.order(:created_at).at(period[:index]),
+                           opens_at: period.opens_at,
+                           due_at: period.due_at)
 
         end
+
+        log("  Distributing tasks")
+        tasks = distribute_tasks(task_plan:task_plan)
+
+        responses_list = new_responses_list(
+          students: assignment.periods.map{|period| period.students.map(&:to_a) }.flatten(1),
+          assignment_type: assignment.type.to_sym,
+          step_types: assignment.step_types,
+        )
+
+        tasks.each_with_index do | task, index |
+          user = task.taskings.first.role.user.user
+          responses = responses_list[ user.profile.id ]
+          unless responses
+            raise "#{assignment.title} period index #{period['index']} has no responses for task #{index} for user #{user.profile.id} #{user.username}"
+          end
+          log("    Working task # #{index}")
+          work_task(task: task, responses: responses)
+        end
+
       end
     end
 
     Timecop.return_all
   end
 
-  def create_and_work_homework(content, period, assignment, responses_list)
-    assign_homework(course: content.course,
-                    chapter_sections: assignment.chapter_sections,
-                    title: assignment.title,
-                    num_exercises: assignment.num_exercises,
-                    to: content.course.periods.order(:created_at).at(period[:index]),
-                    opens_at: period.opens_at,
-                    due_at: period.due_at)
-  end
-
-  def create_and_work_reading(content, period, assignment, responses_list)
-    assign_ireading(course: content.course,
-                    to: content.course.periods.order(:created_at).at(period[:index]),
-                    chapter_sections: assignment.chapter_sections,
-                    title: assignment.title,
-                    opens_at: period.opens_at,
-                    due_at: period.due_at)
-  end
 
 end

--- a/lib/tasks/demo_base.rb
+++ b/lib/tasks/demo_base.rb
@@ -29,17 +29,21 @@ class DemoBase
     @people ||= Hashie::Mash.load(File.dirname(__FILE__)+"/demo/people.yml")
   end
 
-  def user_profile_for_name(name)
+  def user_profile_for_username(username)
     UserProfile::Models::Profile.joins(:account)
-      .where(account: { full_name: name }).first
+      .where(account: { username: username }).first
   end
 
   def get_teacher_profile(initials)
-    user_profile_for_name people.teachers[initials]
+    teacher_info = people.teachers[initials]
+    raise "Unable to find teacher for #{initials}" unless teacher_info
+    user_profile_for_username teacher_info.username
   end
 
   def get_student_profile(initials)
-    user_profile_for_name people.students[initials]
+    student_info = people.students[initials]
+    raise "Unable to find student for #{initials}" unless student_info
+    user_profile_for_username student_info.username
   end
 
   class ResponsesList


### PR DESCRIPTION
Sets explicit usernames for accounts that are created and also fixes a bug where multiple tasks were being created per assignment (one per period)