### PR TITLE
Rename role-user relationship to role_user

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -17,8 +17,8 @@ class Admin::CoursesController < Admin::BaseController
     entity_course = Entity::Course.find(params[:id])
     @course = GetCourseProfile[course: entity_course]
     @periods = entity_course.periods
-    teachers = entity_course.teachers.includes(role: { user: { user: { profile: :account } } })
-    @teachers = teachers.collect { |t| t.role.user.user.profile }
+    teachers = entity_course.teachers.includes(role: { role_user: { user: { profile: :account } } })
+    @teachers = teachers.collect { |t| t.role.role_user.user.profile }
   end
 
   def update

--- a/app/models/entity/role.rb
+++ b/app/models/entity/role.rb
@@ -4,7 +4,7 @@ class Entity::Role < Tutor::SubSystems::BaseModel
   has_many :students, dependent: :destroy, subsystem: :course_membership
   has_many :teachers, dependent: :destroy, subsystem: :course_membership
 
-  has_one :user, dependent: :destroy, subsystem: :role
+  has_one :role_user, dependent: :destroy, class_name: '::Role::Models::User'
 
-  delegate :username, :first_name, :last_name, :full_name, to: :user
+  delegate :username, :first_name, :last_name, :full_name, to: :role_user
 end

--- a/app/models/entity/user.rb
+++ b/app/models/entity/user.rb
@@ -1,5 +1,7 @@
 class Entity::User < Tutor::SubSystems::BaseModel
   has_one :profile, subsystem: :user_profile
 
+  has_one :role_user, class_name: '::Role::Models::User'
+
   delegate :username, :first_name, :last_name, :full_name, to: :profile
 end

--- a/app/routines/get_student_roster.rb
+++ b/app/routines/get_student_roster.rb
@@ -7,7 +7,7 @@ class GetStudentRoster
     students = CourseMembership::Models::Student
       .joins { period }
       .where { period.entity_course_id == course.id }
-      .includes(role: { user: { user: { profile: :account } } })
+      .includes(role: { role_user: { user: { profile: :account } } })
 
     outputs[:students] = students.collect do |student|
       Hashie::Mash.new({

--- a/lib/tasks/demo_002.rb
+++ b/lib/tasks/demo_002.rb
@@ -50,7 +50,7 @@ class Demo002 < DemoBase
         )
 
         tasks.each_with_index do | task, index |
-          user = task.taskings.first.role.user.user
+          user = task.taskings.first.role.role_user.user
           responses = responses_list[ user.profile.id ]
           unless responses
             raise "#{assignment.title} period index #{period['index']} has no responses for task #{index} for user #{user.profile.id} #{user.username}"

--- a/spec/routines/create_student_spec.rb
+++ b/spec/routines/create_student_spec.rb
@@ -13,7 +13,7 @@ describe CreateStudent, type: :routine do
     expect(result.errors).to be_empty
 
     student = result.outputs.student
-    expect(student.role.user.user.profile.account.username).to eq 'dummyuser'
+    expect(student.role.role_user.user.profile.account.username).to eq 'dummyuser'
     expect(student.first_name).to eq 'Dummy'
     expect(student.last_name).to eq 'User'
     expect(student.full_name).to eq 'Dummy User'


### PR DESCRIPTION
It used to be user and we end up with something like

```
entity_course.teachers.includes(role: { user: { user: { profile: :account } } })
```

the double user is kind of confusing, after renaming:

```
entity_course.teachers.includes(role: { role_user: { user: { profile: :account } } })
```