### PR TITLE
need type in data heading for performance report to set different headings for external

### DIFF
--- a/app/representers/api/v1/performance_report_representer.rb
+++ b/app/representers/api/v1/performance_report_representer.rb
@@ -62,6 +62,10 @@ module Api::V1
                type: String,
                readable: true
 
+      property :type,
+               type: String,
+               readable: true
+
       property :average,
                type: Float,
                readable: true

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -62,7 +62,7 @@ module Tasks
 
     def get_data_headings(tasks)
       tasks.collect.with_index { |t, i|
-        { title: t.title, plan_id: t.tasks_task_plan_id }.merge(average(t, i))
+        { title: t.title, plan_id: t.tasks_task_plan_id, type: t.task_type }.merge(average(t, i))
       }
     end
 

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -781,9 +781,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(resp).to eq([{
           period_id: course.periods.first.id.to_s,
           data_headings: [
-            { title: 'Homework 2 task plan', plan_id: resp[0][:data_headings][0][:plan_id], average: 87.5 },
-            { title: 'Reading task plan', plan_id: resp[0][:data_headings][1][:plan_id]  },
-            { title: 'Homework task plan', plan_id: resp[0][:data_headings][2][:plan_id], average: 75.0 }
+            { title: 'Homework 2 task plan', type: 'homework', plan_id: resp[0][:data_headings][0][:plan_id], average: 87.5 },
+            { title: 'Reading task plan', type: 'homework', plan_id: resp[0][:data_headings][1][:plan_id]  },
+            { title: 'Homework task plan', type: 'homework', plan_id: resp[0][:data_headings][2][:plan_id], average: 75.0 }
           ],
           students: [{
             name: 'Student One',
@@ -841,9 +841,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         }, {
           period_id: course.periods.order(:id).last.id.to_s,
           data_headings: [
-            { title: 'Homework 2 task plan', plan_id: resp[1][:data_headings][0][:plan_id] },
-            { title: 'Reading task plan', plan_id: resp[1][:data_headings][1][:plan_id]  },
-            { title: 'Homework task plan', plan_id: resp[1][:data_headings][2][:plan_id], average: 100.0 }
+            { title: 'Homework 2 task plan', type: 'homework', plan_id: resp[1][:data_headings][0][:plan_id] },
+            { title: 'Reading task plan', type: 'reading', plan_id: resp[1][:data_headings][1][:plan_id]  },
+            { title: 'Homework task plan', type: 'homework', plan_id: resp[1][:data_headings][2][:plan_id], average: 100.0 }
           ],
           students: [{
             name: student_3.full_name,

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -781,9 +781,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(resp).to eq([{
           period_id: course.periods.first.id.to_s,
           data_headings: [
-            { title: 'Homework 2 task plan', type: 'homework', plan_id: resp[0][:data_headings][0][:plan_id], average: 87.5 },
-            { title: 'Reading task plan', type: 'homework', plan_id: resp[0][:data_headings][1][:plan_id]  },
-            { title: 'Homework task plan', type: 'homework', plan_id: resp[0][:data_headings][2][:plan_id], average: 75.0 }
+            { title: 'Homework 2 task plan', plan_id: resp[0][:data_headings][0][:plan_id], type: 'homework', average: 87.5 },
+            { title: 'Reading task plan', plan_id: resp[0][:data_headings][1][:plan_id], type: 'reading' },
+            { title: 'Homework task plan', plan_id: resp[0][:data_headings][2][:plan_id], type: 'homework', average: 75.0 }
           ],
           students: [{
             name: 'Student One',
@@ -841,9 +841,9 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         }, {
           period_id: course.periods.order(:id).last.id.to_s,
           data_headings: [
-            { title: 'Homework 2 task plan', type: 'homework', plan_id: resp[1][:data_headings][0][:plan_id] },
-            { title: 'Reading task plan', type: 'reading', plan_id: resp[1][:data_headings][1][:plan_id]  },
-            { title: 'Homework task plan', type: 'homework', plan_id: resp[1][:data_headings][2][:plan_id], average: 100.0 }
+            { title: 'Homework 2 task plan', plan_id: resp[1][:data_headings][0][:plan_id], type: 'homework' },
+            { title: 'Reading task plan', plan_id: resp[1][:data_headings][1][:plan_id], type: 'reading'  },
+            { title: 'Homework task plan', plan_id: resp[1][:data_headings][2][:plan_id], type: 'homework', average: 100.0 }
           ],
           students: [{
             name: student_3.full_name,


### PR DESCRIPTION
Is this allowed?

Wanted for openstax/tutor-js#477 so that there's a way to differentiate external heading from reading and homework heading and avoid linking to stats review