### PR TITLE
Assign teachers UI improvements

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -40,7 +40,7 @@ $(document).ready(function() {
         success: function(data) {
           response($.map(data.items, function(item) {
             return {
-              label: item.full_name,
+              label: item.full_name + ' (' + item.username + ')',
               value: item.id
             };
           }));

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -15,15 +15,18 @@ $(document).ready(function() {
   $('#course_teacher').autocomplete({
     minLength: 2,
     select: function(event_, ui) {
-      var checkbox = $('<input type="checkbox" name="course[teacher_ids][]"/>');
-      checkbox.val(ui.item.value);
-      checkbox.attr('checked', true);
-      checkbox.attr('id', 'checkbox-' + Date.now());
+      var hidden = $('<input type="hidden" name="course[teacher_ids][]"/>');
+      hidden.val(ui.item.value);
       var label = $('<label>');
       label.text(ui.item.label);
-      label.attr('for', checkbox.attr('id'));
+      var remove = $('<button class="btn btn-default btn-xs">');
+      remove.text('remove');
+      remove.click(function() {
+        $(this).parent().detach();
+        return false;
+      });
       var li = $('<li>');
-      li.append(checkbox).append(label);
+      li.append(hidden).append(label).append('&nbsp;&nbsp;').append(remove);
       $('#assigned-teachers').append(li);
       $('#course_teacher').val('');
       return false;

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -28,6 +28,7 @@ $(document).ready(function() {
       var li = $('<li>');
       li.append(hidden).append(label).append('&nbsp;&nbsp;').append(remove);
       $('#assigned-teachers').append(li);
+      $('#assigned-teachers').find('.help-block').removeClass('hidden');
       $('#course_teacher').val('');
       return false;
     },

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -21,7 +21,7 @@
       <%= f.text_field :teacher, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
       <ul id="assigned-teachers">
       <% @teachers.each do |teacher| %>
-        <li><%= teacher.name %></li>
+        <li><%= teacher.name %> (<%= teacher.username %>)</li>
       <% end %>
       </ul>
     </div>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -22,6 +22,7 @@
       <ul id="assigned-teachers">
       <% @teachers.each do |teacher| %>
         <li><%= teacher.name %> (<%= teacher.username %>)</li>
+        <li class="hidden help-block">Click "Save" to assign the following teachers.</li>
       <% end %>
       </ul>
     </div>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -18,7 +18,7 @@
   <% unless @course.nil? %>
     <div class="form-group">
       <%= f.label :teacher, 'Assign teachers' %>
-      <%= f.text_field :teacher, class: 'form-control' %>
+      <%= f.text_field :teacher, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
       <ul id="assigned-teachers">
       <% @teachers.each do |teacher| %>
         <li><%= teacher.name %></li>

--- a/app/views/admin/courses/edit.html.erb
+++ b/app/views/admin/courses/edit.html.erb
@@ -1,21 +1,51 @@
+<!-- nav tabs -->
 <% @page_header = "Edit Course" %>
 
-<%= render 'form', url: admin_course_path, method: :put %>
+<ul class="nav nav-tabs" role="tablist">
+  <li role="presentation" class="active">
+    <a href="#main" aria-controls="main" role="tab" data-toggle="tab">
+      Edit course
+    </a>
+  </li>
+  <li role="presentation">
+    <a href="#books" aria-controls="books" role="tab" data-toggle="tab">
+      Course books
+    </a>
+  </li>
+  <li role="presentation">
+    <a href="#periods" aria-controls="periods" role="tab" data-toggle="tab">
+      Periods
+    </a>
+  </li>
+  <li role="presentation">
+    <a href="#roster" aria-controls="roster" role="tab" data-toggle="tab">
+      Student Roster
+    </a>
+  </li>
+</ul>
 
-<hr/>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="main">
+    <h3>Course</h3>
 
-<h3>Select a course book</h3>
+    <%= render 'form', url: admin_course_path, method: :put %>
+  </div>
 
-<%= render 'set_book', url: set_book_admin_course_path(@course.course_id) %>
+  <div role="tabpanel" class="tab-pane" id="books">
+    <h3>Select a course book</h3>
 
-<hr/>
+    <%= render 'set_book', url: set_book_admin_course_path(@course.course_id) %>
+  </div>
 
-<h3>Periods</h3>
+  <div role="tabpanel" class="tab-pane" id="periods">
+    <h3>Periods</h3>
 
-<%= render 'periods' %>
+    <%= render 'periods' %>
+  </div>
 
-<hr/>
+  <div role="tabpanel" class="tab-pane" id="roster">
+    <h3>Upload Student Roster</h3>
 
-<h3>Upload Student Roster</h3>
-
-<%= render 'students', url: students_admin_course_path(@course.course_id) %>
+    <%= render 'students', url: students_admin_course_path(@course.course_id) %>
+  </div>
+</div>


### PR DESCRIPTION
- Change admin edit courses page to use bootstrap tabs
- Add placeholder text for assign teacher textbox

  Makes it more clear that the user needs to start typing to search for a
  user to add as a teacher to a course.

- Add username next to full name for assign teacher textbox
- Make assign teachers UI slightly more clear when removing a teacher

  There's still no way to remove an assigned teacher.  But when you're
  assigning (before clicking "Save"), there is now a button that says
  "remove".

- Add help text to remind user to "save" after adding assigned teachers