### PR TITLE
Use time cop to work tasks before due date unless otherwise specified

### DIFF
--- a/lib/tasks/demo/biology.yml
+++ b/lib/tasks/demo/biology.yml
@@ -24,12 +24,10 @@ assignments:
     step_types: [ r, r, e, r, r, e, r, r, e, r, r, e, r, e, r, p, e, e, r, r, e ]
     chapter_sections: [[1, 0], [1, 1], [1, 2]]
     title: Read Chapter 1. The Study of Life
-    late:
-      ak: <%= 1.day %>
     periods:
       - id: p1
-        opens_at: <%= open_three_days_ago %>
-        due_at: <%= due_today %>
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_tomorrow %>
         students: {ak: 98,at: 67,bh: 55,gj: 77,kl: 88,ir: ns,mb: 78,ra: 100,sg: 86}
 
       - id: p2
@@ -51,6 +49,11 @@ assignments:
     step_types: [ r, r, r, r, r, r, r, e, r, r, e, r, r, r, r, p ]
     chapter_sections: [[6, 0], [6, 1], [6, 2]]
     title: Read Chapter 6. Metabolism
+    late:
+      ak: <%= 1.day %>
+      cg: <%= 4.hours %>
+      fa: <%= 1.day %>
+      ra: <%= 10.minutes %>
     periods:
       - id: p1
         opens_at: <%= open_three_days_ago %>
@@ -86,10 +89,15 @@ assignments:
     chapter_sections: [[1, 0], [1, 1], [1, 2]]
     title: HW The Study of Life
     num_exercises: 10
+    late:
+      ap: <%= 1.day %>
+      bs: <%= 4.hours %>
+      hg: <%= 1.day %>
+      an: <%= 10.minutes %>
     periods:
       - id: p3
         opens_at: <%= open_three_days_ago %>
-        due_at: <%= due_three_days_ago %>
+        due_at: <%= due_yesterday %>
         students:
           ag: 90
           ap: 87
@@ -104,7 +112,7 @@ assignments:
           sk: 65
       - id: p4
         opens_at: <%= open_two_days_ago %>
-        due_at: <%= due_two_days_ago %>
+        due_at: <%= due_today %>
         students:
           an: 100
           cg: [ 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1 ]

--- a/lib/tasks/demo/biology.yml
+++ b/lib/tasks/demo/biology.yml
@@ -24,6 +24,8 @@ assignments:
     step_types: [ r, r, e, r, r, e, r, r, e, r, r, e, r, e, r, p, e, e, r, r, e ]
     chapter_sections: [[1, 0], [1, 1], [1, 2]]
     title: Read Chapter 1. The Study of Life
+    late:
+      ak: <% 1.day %>
     periods:
       - id: p1
         opens_at: <%= open_three_days_ago %>

--- a/lib/tasks/demo/biology.yml
+++ b/lib/tasks/demo/biology.yml
@@ -25,7 +25,7 @@ assignments:
     chapter_sections: [[1, 0], [1, 1], [1, 2]]
     title: Read Chapter 1. The Study of Life
     late:
-      ak: <% 1.day %>
+      ak: <%= 1.day %>
     periods:
       - id: p1
         opens_at: <%= open_three_days_ago %>

--- a/lib/tasks/demo/content_configuration.rb
+++ b/lib/tasks/demo/content_configuration.rb
@@ -1,82 +1,17 @@
 require 'hashie/mash'
 require 'yaml'
 require 'erb'
+require_relative 'content_configuration_yaml_methods'
 
 # Reads in a YAML file containg configuration for a course and it's students
 class ContentConfiguration
   # Yaml files will be located inside this directory
   DEFAULT_CONFIG_DIR = File.dirname(__FILE__)
 
-  # Methods in this class are available inside ERB blocks in the YAML file
-  class YamlERB
-
-    attr_reader :noon_today
-
-    def initialize
-      @noon_today = Time.now.noon
-    end
-
-    def get_binding
-      binding
-    end
-
-    def school_day_on_or_before(time)
-      while time.sunday? || time.saturday?
-        time = time.yesterday
-      end
-      time
-    end
-
-    def today
-      @noon_today
-    end
-
-    def standard_opens_at(time)
-      time.midnight + 1.minute
-    end
-
-    def standard_due_at(time)
-      time.midnight + 7.hours
-    end
-
-    def open_today
-      standard_opens_at(school_day_on_or_before(today))
-    end
-
-    def open_one_day_ago
-      standard_opens_at(school_day_on_or_before(today - 1.day))
-    end
-
-    def open_two_days_ago
-      standard_opens_at(school_day_on_or_before(today - 2.days))
-    end
-
-    def open_three_days_ago
-      standard_opens_at(school_day_on_or_before(today - 3.days))
-    end
-
-    def due_today
-      standard_due_at(today)
-    end
-
-    def due_one_day_ago
-      standard_due_at(school_day_on_or_before(today - 1.day))
-    end
-
-    def due_two_days_ago
-      standard_due_at(school_day_on_or_before(today - 2.days))
-    end
-
-    def due_three_days_ago
-      standard_due_at(school_day_on_or_before(today - 3.days))
-    end
-
-  end
-
   class ConfigFileParser
     def initialize(file_path)
       @content = File.read(file_path)
-      @helpers = YamlERB.new
+      @helpers = ContentConfigurationYamlMethods.new
       @file_path = file_path
     end
 

--- a/lib/tasks/demo/content_configuration_yaml_methods.rb
+++ b/lib/tasks/demo/content_configuration_yaml_methods.rb
@@ -1,0 +1,112 @@
+# Methods in this class are available inside ERB blocks in the YAML file
+class ContentConfigurationYamlMethods
+
+    attr_reader :noon_today
+
+    def initialize
+        @noon_today = Time.now.noon
+    end
+
+    def get_binding
+        binding
+    end
+
+    def school_day_on_or_before(time)
+        while time.sunday? || time.saturday?
+            time = time.yesterday
+        end
+        time
+    end
+
+    def school_day_on_or_after(time)
+        while time.sunday? || time.saturday?
+            time = time.tomorrow
+        end
+        time
+    end
+
+    def today
+        @noon_today
+    end
+
+    def standard_opens_at(time)
+        time.midnight + 1.minute
+    end
+
+    def standard_due_at(time)
+        time.midnight + 7.hours
+    end
+
+    # opens methods
+    def open_today
+        standard_opens_at(school_day_on_or_before(today))
+    end
+
+    # opens in past
+    def open_yesterday
+        open_one_day_ago
+    end
+    def open_one_day_ago
+        standard_opens_at(school_day_on_or_before(today - 1.day))
+    end
+
+    def open_two_days_ago
+        standard_opens_at(school_day_on_or_before(today - 2.days))
+    end
+
+    def open_three_days_ago
+        standard_opens_at(school_day_on_or_before(today - 3.days))
+    end
+
+    # opens in future
+    def open_tomorrow
+        open_one_day_from_now
+    end
+    def open_one_day_from_now
+        standard_opens_at(school_day_on_or_after(1.day.from_now))
+    end
+
+    def open_two_days_from_now
+        standard_opens_at(school_day_on_or_after(2.day.from_now))
+    end
+
+    def open_three_days_from_now
+        standard_opens_at(school_day_on_or_after(3.day.from_now))
+    end
+
+
+    # due methods
+    def due_today
+        standard_due_at(today)
+    end
+
+    # due in past
+    def due_yesterday
+        due_one_day_ago
+    end
+    def due_one_day_ago
+        standard_due_at(school_day_on_or_before(today - 1.day))
+    end
+
+    def due_two_days_ago
+        standard_due_at(school_day_on_or_before(today - 2.days))
+    end
+
+    def due_three_days_ago
+        standard_due_at(school_day_on_or_before(today - 3.days))
+    end
+
+    # due in future
+    def due_tomorrow
+        standard_due_at(school_day_on_or_after(today + 1.day))
+    end
+
+    def due_two_days_from_now
+        standard_due_at(school_day_on_or_after(today + 2.days))
+    end
+
+    def due_three_days_from_now
+        standard_due_at(school_day_on_or_after(today + 3.days))
+    end
+
+end

--- a/lib/tasks/demo/physics.yml
+++ b/lib/tasks/demo/physics.yml
@@ -20,8 +20,8 @@ assignments:
     step_types: [ r, r, i, e, r, r, r, e, v, e, p ]
     periods:
       - id: p1
-        opens_at: <%= open_three_days_ago %>
-        due_at: <%= due_today %>
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
         students: {ak: 98, at: 67,cp: 55,gj: 77,hp: 88,lb: i,lt: ns,ne: 78,sd: 100,vw: 100}
       - id: p2
         opens_at: <%= open_three_days_ago %>
@@ -34,8 +34,8 @@ assignments:
     step_types: [ r, i, e, r, r, r, e, r, r, r, e, r, e, p]
     periods:
       - id: p1
-        opens_at: <%= open_three_days_ago %>
-        due_at: <%= due_today %>
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_tomorrow %>
         students:
           ak: 88
           at: [ 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0 ]
@@ -67,6 +67,11 @@ assignments:
     title: Read 4.1-4.2 Force & Motion Pt1
     chapter_sections: [[4, 0], [4, 1], [4, 2]]
     step_types: [ r, r, v, e, e, e, i, e, e, p ]
+    late:
+      ak: <%= 2.hours %>
+      hp: <%= 2.days %>
+      at: <%= 10.minutes %>
+      nz: <%= 8.hours %>
     periods:
       - id: p1
         opens_at: <%= open_three_days_ago %>
@@ -102,28 +107,16 @@ assignments:
     num_exercises: 10
     chapter_sections: [[3, 0], [3, 1], [3, 2]]
     step_types: [ e, e, e, e, e, e, e, e, e, e, p ]
-    late:
-      ak: <%= 2.hours %>
     periods:
       - id: p1
-        opens_at: <%= open_one_day_ago %>
-        due_at: <%= due_today %>
-        students:
-          ak: 90
-          at: 87
-          cp: 98
-          gj: [ 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1 ]
-          hp: 88
-          lb: ns
-          lt: ns
-          ne: 100
-          sd: i
-          vw: [ 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0 ]
+        opens_at: <%= open_tomorrow %>
+        due_at: <%= due_three_days_from_now %>
+        students: { ak: ns, at: ns, cp: ns, gj: ns, hp: ns, lb: ns, lt: ns, ne: ns, sd: ns, vw: ns }
       - id: p2
-        opens_at: <%= open_one_day_ago %>
-        due_at: <%= due_today %>
+        opens_at: <%= open_today %>
+        due_at: <%= due_tomorrow %>
         students:
-          af: 86
+          af: ns
           ag: [ 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1 ]
           bb: [ 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0 ]
           cd: [ 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1 ]
@@ -131,5 +124,5 @@ assignments:
           ft: [ 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1 ]
           js: i
           ms: i
-          nz: 98
-          ra: 23
+          nz: i
+          ra: i

--- a/lib/tasks/demo/physics.yml
+++ b/lib/tasks/demo/physics.yml
@@ -102,6 +102,8 @@ assignments:
     num_exercises: 10
     chapter_sections: [[3, 0], [3, 1], [3, 2]]
     step_types: [ e, e, e, e, e, e, e, e, e, e, p ]
+    late:
+      ak: <%= 2.hours %>
     periods:
       - id: p1
         opens_at: <%= open_one_day_ago %>

--- a/lib/tasks/demo/work.rb
+++ b/lib/tasks/demo/work.rb
@@ -18,7 +18,7 @@ class DemoWork < DemoBase
 
         task_plan = Tasks::Models::TaskPlan.where(owner: content.course, title: assignment.title).first!
 
-        responses_list = new_responses_list(
+        tasks_profile = build_tasks_profile(
           students: assignment.periods.map{|period| period.students.map(&:to_a) }.flatten(1),
           assignment_type: assignment.type.to_sym,
           step_types: assignment.step_types,
@@ -26,12 +26,18 @@ class DemoWork < DemoBase
         log("Working assignment: #{assignment.title}")
         task_plan.tasks.each_with_index do | task, index |
           user = task.taskings.first.role.user
-          responses = responses_list[ user.profile.id ]
-          unless responses
+          profile = tasks_profile[ user.profile.id ]
+
+          unless profile
             raise "#{assignment.title} period #{period.id} has no responses for task #{index} for user #{user.profile.id} #{user.username}"
           end
           log("  Task # #{index}")
-          work_task(task: task, responses: responses)
+          lateness = assignment.late[profile.initials]
+          if lateness
+            binding.pry
+          else
+            work_task(task: task, responses: profile.responses)
+          end
         end
 
       end

--- a/lib/tasks/demo/work.rb
+++ b/lib/tasks/demo/work.rb
@@ -33,13 +33,9 @@ class DemoWork < DemoBase
           end
           lateness = assignment.late ? assignment.late[profile.initials] : nil
           log("  Work #{profile.initials}")
-          if lateness
-            period_info = assignment.periods.detect{|pr| pr.students[profile.initials] }
-            log("    ... #{lateness} seconds late")
-            Timecop.freeze(period_info.opens_at + lateness) do
-              work_task(task: task, responses: profile.responses)
-            end
-          else
+          worked_at = task.due_at + (lateness ? lateness : -60)
+
+          Timecop.freeze(worked_at) do
             work_task(task: task, responses: profile.responses)
           end
         end

--- a/lib/tasks/demo/work.rb
+++ b/lib/tasks/demo/work.rb
@@ -31,10 +31,14 @@ class DemoWork < DemoBase
           unless profile
             raise "#{assignment.title} period #{period.id} has no responses for task #{index} for user #{user.profile.id} #{user.username}"
           end
-          log("  Task # #{index}")
-          lateness = assignment.late[profile.initials]
+          lateness = assignment.late ? assignment.late[profile.initials] : nil
+          log("  Work #{profile.initials}")
           if lateness
-            binding.pry
+            period_info = assignment.periods.detect{|pr| pr.students[profile.initials] }
+            log("    ... #{lateness} seconds late")
+            Timecop.freeze(period_info.opens_at + lateness) do
+              work_task(task: task, responses: profile.responses)
+            end
           else
             work_task(task: task, responses: profile.responses)
           end


### PR DESCRIPTION
 By default the importer was working tasks after the due_at.  This adds a late setting so some students can be marked late, and other's will be worked 1 minute before due_at.