### PR TITLE
Hide uncertain clues from the learning guide

### DIFF
--- a/app/external/openstax/biglearn/v1.rb
+++ b/app/external/openstax/biglearn/v1.rb
@@ -8,7 +8,23 @@ module OpenStax::Biglearn::V1
     tags = [tags].flatten.compact
     roles = [roles].flatten.compact
 
-    client.get_clue(roles: roles, tags: tags)
+    clue = client.get_clue(roles: roles, tags: tags) || {}
+    clue[:aggregate]
+  end
+
+  # Gets the CLUE value and then determines if it should be displayed or hidden
+  def self.get_filtered_clue(roles:, tags:)
+    tags = [tags].flatten.compact
+    roles = [roles].flatten.compact
+
+    clue = client.get_clue(roles: roles, tags: tags) || {}
+
+    if clue[:threshold] != 'above' && clue[:confidence] != 'good'
+      clue[:aggregate] = nil
+      clue[:level] = nil
+    end
+
+    clue
   end
 
   def self.add_exercises(exercises)

--- a/app/external/openstax/biglearn/v1/fake_client.rb
+++ b/app/external/openstax/biglearn/v1/fake_client.rb
@@ -7,7 +7,15 @@ class OpenStax::Biglearn::V1::FakeClient
   #
 
   def get_clue(roles:, tags:)
-    rand(0.0..1.0)
+    aggregate = rand(0.0..1.0)
+    level = aggregate >= 0.8 ? 'high' : (aggregate >= 0.3 ? 'medium' : 'low')
+    confidence = ['good', 'bad'].sample
+    threshold = 'above'
+
+    { aggregate: aggregate,
+      level: level,
+      confidence: confidence,
+      threshold: threshold }
   end
 
   def add_exercises(exercises)

--- a/app/representers/api/v1/course_guide_child_representer.rb
+++ b/app/representers/api/v1/course_guide_child_representer.rb
@@ -22,8 +22,12 @@ module Api::V1
     property :current_level,
              type: Float,
              readable: true,
-             writeable: false,
-             schema_info: { required: true }
+             writeable: false
+
+    property :interpretation,
+             type: String,
+             readable: true,
+             writeable: false
 
     property :practice_count,
              type: Integer,

--- a/lib/course_guide_methods.rb
+++ b/lib/course_guide_methods.rb
@@ -61,19 +61,21 @@ module CourseGuideMethods
     tags = get_lo_and_aplos(tasked_exercises)
     roles = tasked_exercises.collect{ |ts| ts.task_step.task.taskings.collect{ |tg| tg.role } }
                             .flatten
-    OpenStax::Biglearn::V1.get_clue(roles: roles, tags: tags)
+    OpenStax::Biglearn::V1.get_filtered_clue(roles: roles, tags: tags)
   end
 
   def compile_pages(tasked_exercises, book)
     group_tasked_exercises_by_pages_from_book(tasked_exercises, book)
       .collect do |page, tasked_exercises|
       practices = completed_practices(tasked_exercises)
+      clue = get_current_level(tasked_exercises)
 
       {
         title: page.title,
         chapter_section: page.chapter_section,
         questions_answered_count: tasked_exercises.count,
-        current_level: get_current_level(tasked_exercises),
+        current_level: clue[:aggregate],
+        interpretation: clue[:level],
         practice_count: practices.count,
         page_ids: [page.id]
       }
@@ -85,12 +87,14 @@ module CourseGuideMethods
       .collect do |chapter, tasked_exercises|
       pages = compile_pages(tasked_exercises, book)
       practices = completed_practices(tasked_exercises)
+      clue = get_current_level(tasked_exercises)
 
       {
         title: chapter.title,
         chapter_section: chapter.chapter_section,
         questions_answered_count: tasked_exercises.count,
-        current_level: get_current_level(tasked_exercises),
+        current_level: clue[:aggregate],
+        interpretation: clue[:level],
         practice_count: practices.count,
         page_ids: pages.collect{|pp| pp[:page_ids]}.flatten,
         children: pages

--- a/spec/cassettes/OpenStax_Biglearn_V1_RealClient/calls_clue_well.yml
+++ b/spec/cassettes/OpenStax_Biglearn_V1_RealClient/calls_clue_well.yml
@@ -2,7 +2,43 @@
 http_interactions:
 - request:
     method: get
-    uri: https://biglearn-dev1.openstax.org/knowledge/clue?aggregations=(%22k12phys-ch04-s02-lo01%22)&learners=0edbe5f8f30abc5ba56b5b890bddbbe2
+    uri: http://biglearn-dev.openstax.org/knowledge/clue?aggregations=(%22k12phys-ch04-s02-lo01%22)&learners=0edbe5f8f30abc5ba56b5b890bddbbe2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 24 Jul 2015 02:23:00 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '178'
+      Connection:
+      - keep-alive
+      Location:
+      - https://biglearn-dev.openstax.org/knowledge/clue?aggregations=%28%22k12phys-ch04-s02-lo01%22%29&learners=0edbe5f8f30abc5ba56b5b890bddbbe2
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 02:22:12 GMT
+- request:
+    method: get
+    uri: https://biglearn-dev.openstax.org/knowledge/clue?aggregations=(%22k12phys-ch04-s02-lo01%22)&learners=0edbe5f8f30abc5ba56b5b890bddbbe2
     body:
       encoding: US-ASCII
       string: ''
@@ -19,21 +55,25 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.4.6 (Ubuntu)
+      - nginx
       Date:
-      - Tue, 19 May 2015 00:38:33 GMT
+      - Fri, 24 Jul 2015 02:23:00 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '111'
+      - '386'
       Connection:
       - keep-alive
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains
     body:
       encoding: UTF-8
-      string: "{\n  \"aggregates\": [\n    {\n      \"aggregate\": 0.5, \n      \"tag_query\":
-        \"(\\\"k12phys-ch04-s02-lo01\\\")\"\n    }\n  ]\n}"
+      string: "{\n  \"aggregates\": [\n    {\n      \"aggregate\": 0.49943281162580061,
+        \n      \"confidence\": {\n        \"left\": 0.93822089658017793, \n        \"right\":
+        0.034306225533957423, \n        \"sample_size\": 0\n      }, \n      \"interpretation\":
+        {\n        \"confidence\": \"good\", \n        \"level\": \"medium\", \n        \"threshold\":
+        \"below\"\n      }, \n      \"tag_query\": \"(\\\"k12phys-ch04-s02-lo01\\\")\"\n
+        \   }\n  ]\n}"
     http_version: 
-  recorded_at: Tue, 19 May 2015 00:38:32 GMT
+  recorded_at: Fri, 24 Jul 2015 02:22:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/OpenStax_Biglearn_V1_RealClient/calls_projection_questions_well.yml
+++ b/spec/cassettes/OpenStax_Biglearn_V1_RealClient/calls_projection_questions_well.yml
@@ -2,35 +2,109 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api1.biglearn.openstax.org/projections/questions?allow_repetition=true&learner_id=123&number_of_questions=5&tag_query=((%22os-practice-concepts%22%20OR%20%22os-practice-problems%22%20OR%20(%22test-prep%22%20AND%20%22multiple-choice%22))%20AND%20(%22k12phys-ch04-s01-lo01%22%20OR%20%22k12phys-ch04-s01-lo02%22))
+    uri: http://biglearn-dev.openstax.org/projections/questions?allow_repetition=true&learner_id=123&number_of_questions=5&tag_query=((%22os-practice-concepts%22%20OR%20%22os-practice-problems%22%20OR%20(%22test-prep%22%20AND%20%22multiple-choice%22))%20AND%20(%22k12phys-ch04-s01-lo01%22%20OR%20%22k12phys-ch04-s01-lo02%22))
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - Faraday v0.9.1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 24 Jul 2015 02:23:00 GMT
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '178'
+      Connection:
+      - keep-alive
+      Location:
+      - https://biglearn-dev.openstax.org/projections/questions?allow_repetition=true&learner_id=123&number_of_questions=5&tag_query=%28%28%22os-practice-concepts%22+OR+%22os-practice-problems%22+OR+%28%22test-prep%22+AND+%22multiple-choice%22%29%29+AND+%28%22k12phys-ch04-s01-lo01%22+OR+%22k12phys-ch04-s01-lo02%22%29%29
+    body:
+      encoding: UTF-8
+      string: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body
+        bgcolor=\"white\">\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 02:22:12 GMT
+- request:
+    method: get
+    uri: https://biglearn-dev.openstax.org/projections/questions?allow_repetition=true&learner_id=123&number_of_questions=5&tag_query=((%22os-practice-concepts%22%20OR%20%22os-practice-problems%22%20OR%20(%22test-prep%22%20AND%20%22multiple-choice%22))%20AND%20(%22k12phys-ch04-s01-lo01%22%20OR%20%22k12phys-ch04-s01-lo02%22))
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
       User-Agent:
-      - Ruby
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.4.6 (Ubuntu)
+      - nginx
       Date:
-      - Fri, 08 May 2015 20:11:34 GMT
+      - Fri, 24 Jul 2015 02:23:00 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '45'
+      - '2846'
       Connection:
       - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
     body:
       encoding: UTF-8
-      string: "{\n  \"learner_id\": \"123\", \n  \"questions\": []\n}"
+      string: "{\n  \"learner_id\": \"123\", \n  \"questions\": [\n    {\n      \"difficulty\":
+        0.0, \n      \"projected_tags\": [\n        \"k12phys-ch04-s01-lo02\"\n      ],
+        \n      \"question\": \"https://exercises-dev.openstax.org/exercises/391\",
+        \n      \"success_probability\": 0.0, \n      \"tags\": [\n        \"k12phys-ch04-s01-lo02\",
+        \n        \"time-short\", \n        \"display-free-response\", \n        \"display-rec-sensitive\",
+        \n        \"dok2\", \n        \"tutor-only\", \n        \"blooms-1\", \n        \"k12phys\",
+        \n        \"os-practice-concepts\", \n        \"k12phys-ch04\", \n        \"k12phys-ch04-s01\",
+        \n        \"k12phys-ch04-ot007\"\n      ]\n    }, \n    {\n      \"difficulty\":
+        0.0, \n      \"projected_tags\": [\n        \"k12phys-ch04-s01-lo02\"\n      ],
+        \n      \"question\": \"https://exercises-dev.openstax.org/exercises/314\",
+        \n      \"success_probability\": 0.0, \n      \"tags\": [\n        \"k12phys-ch04-s01-lo02\",
+        \n        \"inbook-yes\", \n        \"dok1\", \n        \"time-short\", \n
+        \       \"display-free-response\", \n        \"display-rec-sensitive\", \n
+        \       \"blooms-1\", \n        \"k12phys\", \n        \"os-practice-concepts\",
+        \n        \"k12phys-ch04\", \n        \"k12phys-ch04-s01\", \n        \"k12phys-ch04-ex003\"\n
+        \     ]\n    }, \n    {\n      \"difficulty\": 0.0, \n      \"projected_tags\":
+        [\n        \"k12phys-ch04-s01-lo02\"\n      ], \n      \"question\": \"https://exercises-dev.openstax.org/exercises/389\",
+        \n      \"success_probability\": 0.0, \n      \"tags\": [\n        \"k12phys-ch04-s01-lo02\",
+        \n        \"dok1\", \n        \"time-short\", \n        \"display-free-response\",
+        \n        \"display-rec-sensitive\", \n        \"tutor-only\", \n        \"blooms-1\",
+        \n        \"k12phys\", \n        \"os-practice-concepts\", \n        \"k12phys-ch04\",
+        \n        \"k12phys-ch04-s01\", \n        \"k12phys-ch04-ot005\"\n      ]\n
+        \   }, \n    {\n      \"difficulty\": 0.0, \n      \"projected_tags\": [\n
+        \       \"k12phys-ch04-s01-lo01\"\n      ], \n      \"question\": \"https://exercises-dev.openstax.org/exercises/313\",
+        \n      \"success_probability\": 0.0, \n      \"tags\": [\n        \"k12phys-ch04-s01-lo01\",
+        \n        \"inbook-yes\", \n        \"time-short\", \n        \"display-free-response\",
+        \n        \"display-rec-sensitive\", \n        \"blooms-2\", \n        \"dok2\",
+        \n        \"k12phys\", \n        \"os-practice-concepts\", \n        \"k12phys-ch04\",
+        \n        \"k12phys-ch04-s01\", \n        \"k12phys-ch04-ex002\"\n      ]\n
+        \   }, \n    {\n      \"difficulty\": 0.0, \n      \"projected_tags\": [\n
+        \       \"k12phys-ch04-s01-lo02\"\n      ], \n      \"question\": \"https://exercises-dev.openstax.org/exercises/315\",
+        \n      \"success_probability\": 0.0, \n      \"tags\": [\n        \"k12phys-ch04-s01-lo02\",
+        \n        \"inbook-yes\", \n        \"time-short\", \n        \"display-free-response\",
+        \n        \"display-rec-sensitive\", \n        \"dok2\", \n        \"blooms-1\",
+        \n        \"k12phys\", \n        \"os-practice-concepts\", \n        \"k12phys-ch04\",
+        \n        \"k12phys-ch04-s01\", \n        \"k12phys-ch04-ex004\"\n      ]\n
+        \   }\n  ]\n}"
     http_version: 
-  recorded_at: Fri, 08 May 2015 20:11:44 GMT
+  recorded_at: Fri, 24 Jul 2015 02:22:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/external/openstax/biglearn/v1/fake_client_spec.rb
+++ b/spec/external/openstax/biglearn/v1/fake_client_spec.rb
@@ -90,5 +90,21 @@ module OpenStax::Biglearn
       end
     end
 
+    context "get_clue" do
+      it 'returns a well-formatted clue' do
+        profile = UserProfile::CreateProfile.call(username: SecureRandom.hex).outputs.profile
+        profile.update_attribute(:exchange_read_identifier, '0edbe5f8f30abc5ba56b5b890bddbbe2')
+        role = Role::CreateUserRole[profile.entity_user]
+
+        # This assumes that a book has been imported
+        clue = client.get_clue(roles: role, tags: 'k12phys-ch04-s02-lo01')
+
+        expect(clue[:aggregate]).to be_a(Float)
+        expect(['high', 'medium', 'low']).to include(clue[:level])
+        expect(['good', 'bad']).to include(clue[:confidence])
+        expect(['above', 'below']).to include(clue[:threshold])
+      end
+    end
+
   end
 end

--- a/spec/external/openstax/biglearn/v1/real_client_spec.rb
+++ b/spec/external/openstax/biglearn/v1/real_client_spec.rb
@@ -6,7 +6,7 @@ module OpenStax::Biglearn
 
     let(:configuration) {
       c = OpenStax::Biglearn::V1::Configuration.new
-      c.server_url = 'http://api1.biglearn.openstax.org/'
+      c.server_url = 'http://biglearn-dev.openstax.org/'
       c
     }
 
@@ -72,18 +72,17 @@ module OpenStax::Biglearn
     end
 
     it 'calls clue well' do
-      dev1_configuration = OpenStax::Biglearn::V1::Configuration.new
-      dev1_configuration.server_url = 'https://biglearn-dev1.openstax.org'
-      dev1_client = OpenStax::Biglearn::V1::RealClient.new(dev1_configuration)
-
       profile = UserProfile::CreateProfile.call(username: SecureRandom.hex).outputs.profile
       profile.update_attribute(:exchange_read_identifier, '0edbe5f8f30abc5ba56b5b890bddbbe2')
       role = Role::CreateUserRole[profile.entity_user]
 
       # This assumes that a book has been imported
-      clue = dev1_client.get_clue(roles: role, tags: 'k12phys-ch04-s02-lo01')
+      clue = client.get_clue(roles: role, tags: 'k12phys-ch04-s02-lo01')
 
-      expect(clue).to eq 0.5
+        expect(clue[:aggregate]).to be_a(Float)
+        expect(['high', 'medium', 'low']).to include(clue[:level])
+        expect(['good', 'bad']).to include(clue[:confidence])
+        expect(['above', 'below']).to include(clue[:threshold])
     end
 
   end

--- a/spec/external/openstax/biglearn/v1_spec.rb
+++ b/spec/external/openstax/biglearn/v1_spec.rb
@@ -32,8 +32,17 @@ RSpec.describe OpenStax::Biglearn::V1, :type => :external do
     let!(:exercise) { OpenStax::Biglearn::V1::Exercise.new('e42', 'topic') }
 
     it 'delegates get_clue to the client' do
-      expect(client).to receive(:get_clue).twice.with(roles: [role], tags: [tag])
+      clue = OpenStax::Biglearn::V1::FakeClient.instance.get_clue(roles: [role], tags: [tag])
+      expect(client).to receive(:get_clue).twice.with(roles: [role], tags: [tag]) { clue }
       expect(OpenStax::Biglearn::V1.get_clue(roles: [role], tags: [tag])).to(
+        eq client.get_clue(roles: [role], tags: [tag])[:aggregate]
+      )
+    end
+
+    it 'delegates get_filtered_clue as get_clue to the client' do
+      clue = OpenStax::Biglearn::V1::FakeClient.instance.get_clue(roles: [role], tags: [tag])
+      expect(client).to receive(:get_clue).twice.with(roles: [role], tags: [tag]) { clue }
+      expect(OpenStax::Biglearn::V1.get_filtered_clue(roles: [role], tags: [tag])).to(
         eq client.get_clue(roles: [role], tags: [tag])
       )
     end

--- a/spec/representers/api/v1/teacher_course_guide_representer_spec.rb
+++ b/spec/representers/api/v1/teacher_course_guide_representer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::V1::TeacherCourseGuideRepresenter do
                                              chapter_section: [1, 4],
                                              questions_answered_count: 25,
                                              current_level: 0.89,
+                                             interpretation: 'high',
                                              practice_count: 3,
                                              page_ids: [4, 5, 6] }] })]
 
@@ -32,6 +33,7 @@ RSpec.describe Api::V1::TeacherCourseGuideRepresenter do
       'chapter_section' => [1, 4],
       'questions_answered_count' => 25,
       'current_level' => 0.89,
+      'interpretation' => 'high',
       'practice_count' => 3,
       'page_ids' => ['4', '5', '6']
     }])

--- a/spec/routines/get_student_guide_spec.rb
+++ b/spec/routines/get_student_guide_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe GetStudentGuide do
       "chapter_section"=>[3],
       "questions_answered_count"=>2,
       "current_level"=>kind_of(Float),
+      "interpretation"=>kind_of(String),
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)],
       "children"=> array_including(kind_of(Hash))
@@ -72,6 +73,7 @@ RSpec.describe GetStudentGuide do
       "chapter_section"=>[3, 1],
       "questions_answered_count"=>2,
       "current_level"=>kind_of(Float),
+      "interpretation"=>kind_of(String),
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)]
     )

--- a/spec/routines/get_teacher_guide_spec.rb
+++ b/spec/routines/get_teacher_guide_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe GetTeacherGuide do
       "chapter_section"=>[3],
       "questions_answered_count"=>2,
       "current_level"=>kind_of(Float),
+      "interpretation"=>kind_of(String),
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)],
       "children" => array_including(kind_of(Hash))
@@ -67,6 +68,7 @@ RSpec.describe GetTeacherGuide do
       "chapter_section"=>[3],
       "questions_answered_count"=>3,
       "current_level"=>kind_of(Float),
+      "interpretation"=>kind_of(String),
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)],
       "children" => array_including(kind_of(Hash))
@@ -81,6 +83,7 @@ RSpec.describe GetTeacherGuide do
                        "chapter_section"=>[3, 1],
                        "questions_answered_count"=>2,
                        "current_level"=>kind_of(Float),
+                       "interpretation"=>kind_of(String),
                        "practice_count"=>0,
                        "page_ids"=>[kind_of(Integer)])
     )
@@ -92,6 +95,7 @@ RSpec.describe GetTeacherGuide do
                        "chapter_section"=>[3, 2],
                        "questions_answered_count"=>3,
                        "current_level"=>kind_of(Float),
+                       "interpretation"=>kind_of(String),
                        "practice_count"=>0,
                        "page_ids"=>[kind_of(Integer)])
     )


### PR DESCRIPTION
This does not handle "never hide a CLUE once it is displayed", though the rules from BL ensure that a CLUE is never hidden after 5 questions are answered.