### PR TITLE
Remove Api::V1::CoursesController#plans

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -86,18 +86,6 @@ class Api::V1::CoursesController < Api::V1::ApiController
     respond_with search_outputs, represent_with: Api::V1::ExerciseSearchRepresenter
   end
 
-  api :GET, '/courses/:course_id/plans', 'Returns a course\'s plans'
-  description <<-EOS
-    #{json_schema(Api::V1::TaskPlanSearchRepresenter, include: :writeable)}
-  EOS
-  def plans
-    course = Entity::Course.find(params[:id])
-    OSU::AccessPolicy.require_action_allowed!(:task_plans, current_api_user, course)
-
-    out = GetCourseTaskPlans.call(course: course).outputs
-    respond_with out, represent_with: Api::V1::TaskPlanSearchRepresenter
-  end
-
   api :GET, '/courses/:course_id/tasks', 'Gets all course tasks assigned to the role holder making the request'
   description <<-EOS
     #{json_schema(Api::V1::TaskSearchRepresenter, include: :readable)}

--- a/app/representers/api/v1/task_plan_search_representer.rb
+++ b/app/representers/api/v1/task_plan_search_representer.rb
@@ -1,9 +1,0 @@
-module Api::V1
-  class TaskPlanSearchRepresenter < OpenStax::Api::V1::AbstractSearchRepresenter
-
-    collection :items, inherit: true,
-                       class: ::Tasks::Models::TaskPlan,
-                       decorator: TaskPlanRepresenter
-
-  end
-end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -113,40 +113,6 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
     end
   end
 
-  describe "#plans" do
-    let!(:task_plan) { FactoryGirl.create :tasks_task_plan, owner: course }
-
-    it 'raises SecurityTransgression if user is anonymous or not in the course' do
-      expect {
-        api_get :plans, nil, parameters: { id: course.id }
-      }.to raise_error(SecurityTransgression)
-
-      expect {
-        api_get :plans, user_1_token, parameters: { id: course.id }
-      }.to raise_error(SecurityTransgression)
-    end
-
-    it 'returns task plans for course teachers' do
-      AddUserAsCourseTeacher.call(course: course, user: user_1.entity_user)
-      api_get :plans, user_1_token, parameters: {id: course.id}
-
-      expect(response).to have_http_status(:success)
-      expect(response.body).to(
-        eq({ total_count: 1, items: [Api::V1::TaskPlanRepresenter.new(task_plan)] }.to_json)
-      )
-    end
-
-    it 'returns task plans for course students' do
-      AddUserAsPeriodStudent.call(period: period, user: user_2.entity_user)
-      api_get :plans, user_2_token, parameters: {id: course.id}
-
-      expect(response).to have_http_status(:success)
-      expect(response.body).to(
-        eq({ total_count: 1, items: [Api::V1::TaskPlanRepresenter.new(task_plan)] }.to_json)
-      )
-    end
-  end
-
   describe "tasks" do
     it "temporarily mirrors /api/user/tasks" do
       api_get :tasks, user_1_token, parameters: {id: course.id}

--- a/spec/representers/api/v1/task_plan_search_representer_spec.rb
+++ b/spec/representers/api/v1/task_plan_search_representer_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Api::V1::TaskPlanSearchRepresenter, :type => :representer do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Courses plans API is an old GET endpoint no longer used by the FE.  They
use /dashboard endpoing now for this.

Close #449