### PR TITLE
Fix charset in meta tag to have dash

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>OpenStax Tutor</title>
-  <meta http-equiv="content-type" content="text/html; charset=UTF8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel='stylesheet' href='<%= Rails.application.secrets[:css_url] %>' />
   <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='<%= Rails.application.secrets[:js_url] %>' async></script>


### PR DESCRIPTION
The proper name is utf-8 (with dash).  Case doesn't really matter,
but I think lowercase is more typical.