### PR TITLE
loosened practice widget timing; access policy is now task friendly

### DIFF
--- a/app/access_policies/task_access_policy.rb
+++ b/app/access_policies/task_access_policy.rb
@@ -3,8 +3,14 @@ class TaskAccessPolicy
     case action
     when :read
       requestor.is_human? && (
-        (DoesTaskingExist[task_component: task, user: requestor] && task.past_open?) ||
-        UserIsCourseTeacher[user: requestor.entity_user, course: task.task_plan.owner]
+        (
+          DoesTaskingExist[task_component: task, user: requestor] &&
+          task.past_open?
+        ) ||
+        (
+          (course = task.task_plan.try(:owner)).is_a?(Entity::Course) &&
+          UserIsCourseTeacher[user: requestor.entity_user, course: course]
+        )
       )
     else
       false

--- a/app/routines/reset_practice_widget.rb
+++ b/app/routines/reset_practice_widget.rb
@@ -45,10 +45,17 @@ class ResetPracticeWidget
                   :mixed_practice
                 end
 
+    # In a multi-web server environment, it is possible for one server to create
+    # the practice task and another to request it very quickly and if the server
+    # times are not completely sync'd the request can be reject because the task
+    # looks non open.  When we have PracticeTasks maybe they can not have an opens_at
+    # but for now HACK it by setting it to open in the near past.
+    task_time = 10.minutes.ago
+
     task = Tasks::BuildTask[task_type: task_type,
                             title: 'Practice',
-                            opens_at: Time.now,
-                            feedback_at: Time.now]
+                            opens_at: task_time,
+                            feedback_at: task_time]
 
     exercises.each do |exercise|
       step = Tasks::Models::TaskStep.new(task: task)


### PR DESCRIPTION
On QA we were people successfully create practice widgets but then get a 500 when those practice tasks were requested.  The 500 was due to an assumption we shouldn't have been making, but the 500 was reached because the times on our different web servers were 40 seconds apart.  So one server made a practice task that was open "now" but the other server was involved in the GET of that task and its clock was 40 seconds behind so the task was not open.

Made the practice task open a few minutes in the past.  Also fixed the 500-causing assumption.  @cnuber is going to work on updating the server times with a different reference time and update it daily.