### PR TITLE
Provide publishing and jobs info on teacher dashboard 

### DIFF
--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -35,11 +35,29 @@ module Api::V1::Courses
                readable: true,
                writeable: false
 
+
+      property :is_publish_requested,
+               readable: true,
+               writeable: true,
+               getter: ->(*) { is_publish_requested? },
+               schema_info: { type: 'boolean' }
+
       property :published_at,
                type: String,
                readable: true,
                writeable: false,
                getter: ->(*) { DateTimeUtilities.to_api_s(published_at) }
+
+      property :publish_last_requested_at,
+               type: String,
+               readable: true,
+               writeable: false,
+               getter: ->(*) { DateTimeUtilities.to_api_s(publish_last_requested_at) }
+
+      property :publish_job_uuid,
+               type: String,
+               readable: true,
+               writeable: false
 
       collection :tasking_plans,
                  readable: true,

--- a/spec/representers/api/v1/courses/dashboard_representer_spec.rb
+++ b/spec/representers/api/v1/courses/dashboard_representer_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, :type => :representer do
           title: 'HW1',
           trouble: false,
           type: 'homework',
+          is_publish_requested?: true,
           published_at: published_at,
+          publish_last_requested_at: published_at,
+          publish_job_uuid: "394839483948",
           tasking_plans: [
             Hashie::Mash.new(
               target_id: 42,
@@ -101,7 +104,10 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, :type => :representer do
           "id" => '23',
           "title" => "HW1",
           "type" => "homework",
+          "is_publish_requested" => true,
           "published_at" => be_kind_of(String),
+          "publish_last_requested_at" => be_kind_of(String),
+          "publish_job_uuid" => "394839483948",
           "tasking_plans" => [
             {
               "target_id" => '42',


### PR DESCRIPTION
add more info to the teacher dashboard on plan publishing and jobs so that the FE can check on jobs

- [x] update specs?