### PR TITLE
Absolutize exercise urls using exercises api url

### DIFF
--- a/app/subsystems/content/routines/update_page_content.rb
+++ b/app/subsystems/content/routines/update_page_content.rb
@@ -45,15 +45,15 @@ class Content::Routines::UpdatePageContent
 
   def absolutize_exercise_links(attr)
     # Change exercise links (like #ost/api/ex/apbio-ch02-ex026) to absolute
-    # urls (like https://exercises-dev.openstax.org/exercises/475@3)
+    # urls (like https://exercises-dev.openstax.org/api/exercises?q=tag:apbio-ch02-ex026)
 
     if attr.value.starts_with?('#ost/')
-      exercise_tag = attr.value.split('/').last
-      tag = Content::Models::Tag.where { value == exercise_tag }.first
-      return if tag.nil? # nothing to do if we can't find the tag
-      exercise = tag.exercises.first
-      return if exercise.nil? # nothing to do if we don't have the exercise
-      attr.value = exercise.url.gsub(/\/exercises\//, '/api/exercises/')
+      tag_name = attr.value.split('/').last
+      # exercises url looks like "https://exercises-dev.openstax.org"
+      exercises_url = OpenStax::Exercises::V1.configuration.server_url
+      uri = Addressable::URI.join(exercises_url, '/api/exercises')
+      uri.query_values = { q: "tag:#{tag_name}" }
+      attr.value = uri.to_s
     end
   end
 

--- a/spec/subsystems/content/routines/update_page_content_spec.rb
+++ b/spec/subsystems/content/routines/update_page_content_spec.rb
@@ -81,36 +81,6 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine, vcr: VCR_OP
   it 'updates exercise links to absolute urls' do
     doc = Nokogiri::HTML(page_with_exercises.content)
 
-    # get all the exercise links (links that start with #ost)
-    expected_links = doc.xpath('//a[starts-with(@href, "#ost")]').collect do |link|
-      link.attribute('href').value
-    end
-
-    # Remove the exercise linked to apbio-ch02-ex031 (to test error handling)
-    Content::Models::Tag.find_by_value('apbio-ch02-ex031').exercises
-      .destroy_all
-
-    # Remove the tag for apbio-ch02-ex032 (to test error handling)
-    Content::Models::Tag.find_by_value('apbio-ch02-ex032').destroy
-
-    # Get the rest of the tags with exercises
-    tags = Content::Models::Tag.where { value.like 'apbio-ch02-ex0%' }
-                               .order(:value)
-                               .includes(:exercises)
-
-    # Construct the expected links:
-    #
-    # 1. Start with the original exercise links (links that start with #ost)
-    #    that we got from the html
-    # 2. Replace the the links with Content::Models::Exercise.url and format as API links
-    # 3. Except for apbio-ch02-ex031 because we removed the exercise (to test
-    #    error handling)
-    # 4. Except for apbio-ch02-ex032 because we removed the tag (to test error
-    #    handling)
-    tags.each_with_index do |tag, i|
-      expected_links[i] = tag.exercises.first.url.gsub(/\/exercises\//, '/api/exercises/') unless tag.exercises.empty?
-    end
-
     Content::Routines::UpdatePageContent.call(book_part: book_part)
     page_with_exercises.reload
 
@@ -121,6 +91,15 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine, vcr: VCR_OP
       link.attribute('href').value
     end
 
-    expect(links).to eq expected_links
+    # %3A is :
+    expect(links).to eq([
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex026',
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex027',
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex028',
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex029',
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex030',
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex031',
+      'https://exercises-dev.openstax.org/api/exercises?q=tag%3Aapbio-ch02-ex032'
+    ])
   end
 end


### PR DESCRIPTION
Instead of the url stored in Content::Models::Exercise, in case we don't
have the exercises yet.