### PR TITLE
Better free response checking

### DIFF
--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -5,7 +5,8 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
 
   validates :url, presence: true
   validates :content, presence: true
-  validate :valid_state, :valid_answer, :no_feedback
+  validate :free_response_provided, on: :update
+  validate :valid_answer, :no_feedback
 
   delegate :uid, :questions, :question_formats, :question_answers, :question_answer_ids,
            :correct_question_answers, :correct_question_answer_ids, :feedback_map,
@@ -104,16 +105,10 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
     task_step.id.to_s
   end
 
-  # Eventually this will be enforced by the exercise substeps
-  def valid_state
-    # Can't answer multiple choice before free response
-    # if question formats includes 'free-response'
-    return if !free_response.blank? || \
-              answer_id.blank? || \
-              !formats.include?('free-response')
-
-    errors.add(:free_response, 'must not be blank before entering a multiple choice answer')
-    false
+  def free_response_provided
+    errors.add(:free_response, 'is required') \
+      if formats.include?('free-response') && free_response.blank?
+    errors.any?
   end
 
   def valid_answer

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -138,6 +138,13 @@ describe Api::V1::TaskStepsController, :type => :controller, :api => true, :vers
       expect(tasked.reload.answer_id).to be_nil
     end
 
+    it 'returns an error when the free response is blank' do
+      api_put :update, user_1_token,
+              parameters: id_parameters, raw_post_data: { free_response: ' ' }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
   end
 
   describe "#recovery" do

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Tasks::Models::TaskedExercise, :type => :model do
     expect(tasked_exercise).to be_valid
   end
 
+  it 'does not accept a blank free response if the free-response format is present' do
+    tasked_exercise.free_response = ' '
+    expect(tasked_exercise).not_to be_valid
+  end
+
   it 'does not accept a multiple choice answer that is not listed' do
     tasked_exercise.free_response = 'abc'
     tasked_exercise.answer_id = SecureRandom.hex


### PR DESCRIPTION
switched blank free response validation to when first updated -- too late to do it when m/c response chosen