### PR TITLE
Add link "Terms" which goes to /fine_print/contracts

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -47,6 +47,7 @@
             <% if Timecop.enabled? %>
               <li><%= link_to 'Time Travel', admin_timecop_path %></li>
             <% end %>
+            <li><%= link_to 'Terms', fine_print_path %></li>
           </ul>
 
           <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
"Terms" in admin console: (as expected)

![admin-terms-1](https://cloud.githubusercontent.com/assets/153353/9049087/4b4e2d28-3a36-11e5-8101-6fb6a57fca21.jpg)

The "terms" page: (unstyled page)

![admin-terms-2](https://cloud.githubusercontent.com/assets/153353/9049101/61f8ae54-3a36-11e5-899f-4ddd54e5a757.jpg)


Should I change the page to look more like the other admin pages?