### PR TITLE
Always set trouble to false in dashboard representer

### DIFF
--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -26,7 +26,7 @@ module Api::V1::Courses
                as: :is_trouble,
                readable: true,
                writeable: false,
-               getter: lambda{|*| rand(0..1)==0 },
+               getter: ->(*) { false },
                schema_info: { type: 'boolean' }
         # ^^^^^ REPLACE with real value once spec for calculating it's available
 


### PR DESCRIPTION
Was randomly returning true or false for FE, but we never actually
implemented it.