### PR TITLE
Add config/schedule.rb to sync with accounts

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,4 @@
+every 5.minutes do
+  runner "OpenStax::Accounts::SyncAccounts.call"
+  runner "OpenStax::Accounts::SyncGroups.call"
+end


### PR DESCRIPTION
Add config/schedule.rb for syncing data from accounts

config/schedule.rb was generated using
`rails generate openstax:accounts:schedule`
    
After that, run `whenever` which gives us something like this for adding
to crontab:
    
```
0,5,10,15,20,25,30,35,40,45,50,55 * * * * /bin/bash -l -c 'cd /home/karen/tutor-server && bin/rails runner -e production '\''OpenStax::Accounts::SyncAccounts.call'\'''

0,5,10,15,20,25,30,35,40,45,50,55 * * * * /bin/bash -l -c 'cd /home/karen/tutor-server && bin/rails runner -e production '\''OpenStax::Accounts::SyncGroups.call'\'''
```


-----

This is for getting updates from accounts to tutor.

I think @Dantemss said accounts is already getting updates from tutor?