### PR TITLE
Provide bootstrap data to app via script tag

### DIFF
--- a/app/helpers/webview_helper.rb
+++ b/app/helpers/webview_helper.rb
@@ -1,0 +1,13 @@
+module WebviewHelper
+
+  # Generates data for the FE to read as it boots up
+  def bootstrap_data
+    {
+      user: Api::V1::UserProfileRepresenter.new(current_user),
+      courses: Api::V1::CoursesRepresenter.new(
+        CollectCourseInfo[user: current_user.entity_user, with: [:roles, :periods]]
+      )
+    }
+  end
+
+end

--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -9,7 +9,7 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
-  <script id="tutor-boostrap-data" type="application/json"><%=raw bootstrap_data.to_json %></script>
+  <script id="tutor-boostrap-data" type="application/json"><%=raw json_escape bootstrap_data.to_json %></script>
   <%= yield %>
 </body>
 </html>

--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -9,6 +9,7 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
+  <script id="tutor-boostrap-data" type="application/json"><%=raw bootstrap_data.to_json %></script>
   <%= yield %>
 </body>
 </html>

--- a/spec/controllers/webview_controller_spec.rb
+++ b/spec/controllers/webview_controller_spec.rb
@@ -32,11 +32,23 @@ RSpec.describe WebviewController, :type => :controller do
       expect(response).to have_http_status(:found)
     end
 
-    it 'returns http success' do
-      controller.sign_in registered_user
-      get :index
-      expect(response).to have_http_status(:success)
+    context "as a signed in user" do
+      render_views
+
+      it 'sets boostrap data in script tag' do
+        controller.sign_in registered_user
+        get :index
+        expect(response).to have_http_status(:success)
+        doc = Nokogiri::HTML(response.body)
+        data = ::JSON.parse(doc.css('body script#tutor-boostrap-data').inner_text)
+        expect(data).to include({
+          'courses'=> CollectCourseInfo[user: registered_user.entity_user, with: [:roles, :periods]].as_json,
+          'user' => Api::V1::UserProfileRepresenter.new(registered_user).as_json
+        })
+      end
     end
+
   end
+
 
 end


### PR DESCRIPTION
Goes along with FE PR [#577](https://github.com/openstax/tutor-js/pull/577)  More details are listed there.

In order for the FE to determine what views should be visible to each user it needs to know the course roles very early in it's lifecycle, even before it fires of any XHR requests.

Therefore the only way for it to obtain that information is for the BE to provide it to the app as it is initialized.

This is only an exploration of a possible approach.  No specs because I'm not sure this is the way to go with it yet.   Comments are welcomed on both PR's.