### PR TITLE
Add ability for admins to remove teachers + a lot of small improvements for the admin courses page

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -46,7 +46,7 @@ $(document).ready(function() {
           response($.map(data.items, function(item) {
             return {
               label: item.full_name + ' (' + item.username + ')',
-              value: item.id
+              value: item.entity_user_id
             };
           }));
         }

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -16,21 +16,11 @@ $(document).ready(function() {
   $('#course_teacher').autocomplete({
     minLength: 2,
     select: function(event_, ui) {
+      $('#course_teacher').val(ui.item.label);
       var hidden = $('<input type="hidden" name="teacher_ids[]"/>');
       hidden.val(ui.item.value);
-      var label = $('<label>');
-      label.text(ui.item.label);
-      var remove = $('<button class="btn btn-default btn-xs">');
-      remove.text('remove');
-      remove.click(function() {
-        $(this).parent().detach();
-        return false;
-      });
-      var li = $('<li>');
-      li.append(hidden).append(label).append('&nbsp;&nbsp;').append(remove);
-      $('#assigned-teachers').append(li);
-      $('#assigned-teachers').find('.help-block').removeClass('hidden');
-      $('#course_teacher').val('');
+      $('#course_teacher').after(hidden);
+      $('#assign-teachers-form').submit();
       return false;
     },
     source: function(request, response, url) {

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -12,10 +12,11 @@ $(document).ready(function() {
 
 //============= Courses =================//
 $(document).ready(function() {
+  //=========== Course teacher auto complete ==============//
   $('#course_teacher').autocomplete({
     minLength: 2,
     select: function(event_, ui) {
-      var hidden = $('<input type="hidden" name="course[teacher_ids][]"/>');
+      var hidden = $('<input type="hidden" name="teacher_ids[]"/>');
       hidden.val(ui.item.value);
       var label = $('<label>');
       label.text(ui.item.label);

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -53,4 +53,10 @@ $(document).ready(function() {
       });
     }
   });
+
+  //========== Course tab selection =============//
+  var tab = window.location.hash;
+  if (tab) {
+    $('a[href="' + tab + '"]').click();
+  }
 });

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -45,7 +45,7 @@ $(document).ready(function() {
         success: function(data) {
           response($.map(data.items, function(item) {
             return {
-              label: item.full_name + ' (' + item.username + ')',
+              label: item.name + ' (' + item.username + ')',
               value: item.entity_user_id
             };
           }));

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -50,7 +50,7 @@ class Admin::CoursesController < Admin::BaseController
       add_students(period, users)
       flash[:notice] = 'Student roster has been uploaded.'
     end
-    redirect_to edit_admin_course_path(params[:id])
+    redirect_to edit_admin_course_path(params[:id], anchor: 'roster')
   end
 
   def set_book
@@ -67,7 +67,7 @@ class Admin::CoursesController < Admin::BaseController
       CourseContent::AddBookToCourse.call(course: course, book: book, remove_other_books: true)
       flash[:notice] = "Course book \"#{book.root_book_part.title}\" selected for \"#{course.profile.name}\""
     end
-    redirect_to edit_admin_course_path(params[:id])
+    redirect_to edit_admin_course_path(params[:id], anchor: 'books')
   end
 
   private

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -17,8 +17,7 @@ class Admin::CoursesController < Admin::BaseController
     entity_course = Entity::Course.find(params[:id])
     @course = GetCourseProfile[course: entity_course]
     @periods = entity_course.periods
-    teachers = entity_course.teachers.includes(role: { user: { profile: :account } })
-    @teachers = teachers.collect { |t| t.role.user.profile }
+    @teachers = entity_course.teachers.includes(role: { user: { profile: :account } })
     @books = Content::ListBooks[]
     @course_book = entity_course.books.first
   end

--- a/app/controllers/admin/periods_controller.rb
+++ b/app/controllers/admin/periods_controller.rb
@@ -9,7 +9,7 @@ class Admin::PeriodsController < Admin::BaseController
   def create
     period = CreatePeriod[course: @course, name: params[:period][:name]]
     flash[:notice] = "Period \"#{period.name}\" created."
-    redirect_to edit_admin_course_path(@course.id)
+    redirect_to edit_admin_course_path(@course.id, anchor: 'periods')
   end
 
   def edit
@@ -18,7 +18,7 @@ class Admin::PeriodsController < Admin::BaseController
   def update
     @period.update_attributes(name: params[:period][:name])
     flash[:notice] = 'Period updated.'
-    redirect_to edit_admin_course_path(@course.id)
+    redirect_to edit_admin_course_path(@course.id, anchor: 'periods')
   end
 
   def destroy
@@ -27,7 +27,7 @@ class Admin::PeriodsController < Admin::BaseController
     else
       flash[:error] = @period.errors.full_messages
     end
-    redirect_to edit_admin_course_path(@course.id)
+    redirect_to edit_admin_course_path(@course.id, anchor: 'periods')
   end
 
   private

--- a/app/controllers/admin/periods_controller.rb
+++ b/app/controllers/admin/periods_controller.rb
@@ -7,7 +7,8 @@ class Admin::PeriodsController < Admin::BaseController
   end
 
   def create
-    CreatePeriod[course: @course, name: params[:period][:name]]
+    period = CreatePeriod[course: @course, name: params[:period][:name]]
+    flash[:notice] = "Period \"#{period.name}\" created."
     redirect_to edit_admin_course_path(@course.id)
   end
 
@@ -16,6 +17,7 @@ class Admin::PeriodsController < Admin::BaseController
 
   def update
     @period.update_attributes(name: params[:period][:name])
+    flash[:notice] = 'Period updated.'
     redirect_to edit_admin_course_path(@course.id)
   end
 

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -1,0 +1,12 @@
+class Admin::TeachersController < Admin::BaseController
+  def teachers
+    course = Entity::Course.find(params[:id])
+    (params[:teacher_ids] || []).each do |user_id|
+      user = Entity::User.find(user_id)
+      AddUserAsCourseTeacher.call(course: course, user: user)
+    end
+
+    flash[:notice] = 'Teachers updated.'
+    redirect_to edit_admin_course_path(course)
+  end
+end

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -9,4 +9,11 @@ class Admin::TeachersController < Admin::BaseController
     flash[:notice] = 'Teachers updated.'
     redirect_to edit_admin_course_path(course, anchor: 'teachers')
   end
+
+  def destroy
+    teacher = CourseMembership::Models::Teacher.find(params[:id])
+    teacher.destroy
+    flash[:notice] = "Teacher \"#{teacher.role.name}\" removed from course."
+    redirect_to edit_admin_course_path(teacher.course, anchor: 'teachers')
+  end
 end

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -7,6 +7,6 @@ class Admin::TeachersController < Admin::BaseController
     end
 
     flash[:notice] = 'Teachers updated.'
-    redirect_to edit_admin_course_path(course)
+    redirect_to edit_admin_course_path(course, anchor: 'teachers')
   end
 end

--- a/app/routines/update_course.rb
+++ b/app/routines/update_course.rb
@@ -2,17 +2,10 @@ class UpdateCourse
   lev_routine
 
   uses_routine CourseProfile::UpdateProfile, as: :update_profile
-  uses_routine AddUserAsCourseTeacher, as: :assign_teacher
 
   protected
 
   def exec(id, course_params)
-    course_params.delete(:teacher_ids) { |key| [] }.reject(&:blank?).each do |user_id|
-      user = Entity::User.find(user_id)
-      course = Entity::Course.find(id)
-      run(:assign_teacher, course: course, user: user)
-    end
-
     run(:update_profile, id, course_params)
   end
 

--- a/app/subsystems/user_profile/search_profiles.rb
+++ b/app/subsystems/user_profile/search_profiles.rb
@@ -23,6 +23,7 @@ module UserProfile
             account_id: profile.account_id,
             entity_user_id: profile.entity_user_id,
             full_name: profile.full_name,
+            name: profile.name,
             username: profile.username
           }
         end

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -15,18 +15,5 @@
                             class: 'form-control' %>
   </div>
 
-  <% unless @course.nil? %>
-    <div class="form-group">
-      <%= f.label :teacher, 'Assign teachers' %>
-      <%= f.text_field :teacher, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
-      <ul id="assigned-teachers">
-      <% @teachers.each do |teacher| %>
-        <li><%= teacher.name %> (<%= teacher.username %>)</li>
-      <% end %>
-      <li class="hidden help-block">Click "Save" to assign the following teachers.</li>
-      </ul>
-    </div>
-  <% end %>
-
   <%= f.submit 'Save', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/admin/courses/_students.html.erb
+++ b/app/views/admin/courses/_students.html.erb
@@ -9,7 +9,7 @@
   <div class='form-group'>
     <%= label_tag :student_roster %>
     <%= file_field_tag :student_roster %>
-    <p class='help-block'>Upload a CSV file only, with columns "first_name", "last_name", "username", "email".</p>
+    <p class='help-block'>Upload a CSV file only, with columns "first_name", "last_name", "username", "password".</p>
   </div>
 
   <%= f.submit 'Upload', class: 'btn btn-primary' %>

--- a/app/views/admin/courses/edit.html.erb
+++ b/app/views/admin/courses/edit.html.erb
@@ -8,6 +8,11 @@
     </a>
   </li>
   <li role="presentation">
+    <a href="#teachers" aria-controls="teachers" role="tab" data-toggle="tab">
+      Teachers
+    </a>
+  </li>
+  <li role="presentation">
     <a href="#books" aria-controls="books" role="tab" data-toggle="tab">
       Course books
     </a>
@@ -29,6 +34,12 @@
     <h3>Course</h3>
 
     <%= render 'form', url: admin_course_path, method: :put %>
+  </div>
+
+  <div role="tabpanel" class="tab-pane" id="teachers">
+    <h3>Assign teachers</h3>
+
+    <%= render 'admin/teachers/edit', url: teachers_admin_course_path(@course.course_id) %>
   </div>
 
   <div role="tabpanel" class="tab-pane" id="books">

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -18,8 +18,8 @@
         <td>
           <%= link_to 'Edit', edit_admin_course_path(course.id),
                               class: "btn btn-xs btn-primary" %>
-          <%= link_to 'Students', students_admin_course_path(course.id),
-                                  class: 'btn btn-xs btn-primary' %>
+          <%= link_to 'List Students', students_admin_course_path(course.id),
+                                       class: 'btn btn-xs btn-primary' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/teachers/_edit.html.erb
+++ b/app/views/admin/teachers/_edit.html.erb
@@ -19,15 +19,8 @@
   </tbody>
 </table>
 
-<%= form_tag(url, method: method) do |f| %>
+<%= form_tag(url, method: method, id: 'assign-teachers-form') do |f| %>
   <div class="form-group">
     <%= text_field_tag :course_teacher, nil, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
-    <ul id="assigned-teachers">
-    <li class="hidden help-block">Click "Save" to assign the following teachers.</li>
-    </ul>
-  </div>
-
-  <div class="form-group">
-    <%= submit_tag 'Save', class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/admin/teachers/_edit.html.erb
+++ b/app/views/admin/teachers/_edit.html.erb
@@ -11,9 +11,18 @@
   <tbody>
   <% @teachers.each do |teacher| %>
     <tr>
-      <td><%= teacher.username %></td>
-      <td><%= teacher.name %></td>
-      <td></td>
+      <td><%= teacher.role.username %></td>
+      <td><%= teacher.role.name %></td>
+      <td>
+        <%= link_to 'Remove from course',
+                    admin_teacher_path(teacher),
+                    method: :delete,
+                    class: 'btn btn-xs btn-primary',
+                    data: {
+                      confirm: "Are you sure you want to remove teacher \"#{teacher.role.name}\" from the course?"
+                    } %>
+
+      </td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/admin/teachers/_edit.html.erb
+++ b/app/views/admin/teachers/_edit.html.erb
@@ -1,0 +1,17 @@
+<% method ||= :post %>
+
+<%= form_tag(url, method: method) do |f| %>
+  <div class="form-group">
+    <%= text_field_tag :course_teacher, nil, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
+    <ul id="assigned-teachers">
+    <% @teachers.each do |teacher| %>
+      <li><%= teacher.name %> (<%= teacher.username %>)</li>
+    <% end %>
+    <li class="hidden help-block">Click "Save" to assign the following teachers.</li>
+    </ul>
+  </div>
+
+  <div class="form-group">
+    <%= submit_tag 'Save', class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/admin/teachers/_edit.html.erb
+++ b/app/views/admin/teachers/_edit.html.erb
@@ -1,12 +1,28 @@
 <% method ||= :post %>
 
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Username</th>
+      <th>Name</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @teachers.each do |teacher| %>
+    <tr>
+      <td><%= teacher.username %></td>
+      <td><%= teacher.name %></td>
+      <td></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
 <%= form_tag(url, method: method) do |f| %>
   <div class="form-group">
     <%= text_field_tag :course_teacher, nil, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
     <ul id="assigned-teachers">
-    <% @teachers.each do |teacher| %>
-      <li><%= teacher.name %> (<%= teacher.username %>)</li>
-    <% end %>
     <li class="hidden help-block">Click "Save" to assign the following teachers.</li>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       end
       resources :periods, shallow: true
       resources :students, only: [:index], shallow: true
+      resources :teachers, only: [:destroy], shallow: true
     end
 
     resources :districts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
       member do
         post :students
         post :set_book
+        post :teachers, controller: :teachers
       end
       resources :periods, shallow: true
       resources :students, only: [:index], shallow: true

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Admin::UsersController do
       'account_id' => admin.account.id,
       'entity_user_id' => admin.entity_user.id,
       'full_name' => 'Administrator',
+      'name' => admin.name,
       'username' => 'admin'
     } ]
 
@@ -29,12 +30,14 @@ RSpec.describe Admin::UsersController do
       'account_id' => admin.account.id,
       'entity_user_id' => admin.entity_user.id,
       'full_name' => 'Administrator',
+      'name' => admin.name,
       'username' => 'admin'
     }, {
       'id' => user.id,
       'account_id' => user.account.id,
       'entity_user_id' => user.entity_user.id,
       'full_name' => 'User One',
+      'name' => user.name,
       'username' => 'student'
     } ]
   end

--- a/spec/feature_js_helper.rb
+++ b/spec/feature_js_helper.rb
@@ -1,0 +1,24 @@
+require 'capybara'
+
+Capybara.javascript_driver = :webkit
+
+# monkey patching ActiveRecord::Base to use the same transaction for all threads
+# http://rubydoc.info/github/jnicklas/capybara/master#Transactions_and_database_setup
+class ActiveRecord::Base
+  mattr_accessor :shared_connection
+  @@shared_connection = nil
+
+  def self.connection
+    @@shared_connection || retrieve_connection
+  end
+end
+
+ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+
+# Helper functions
+
+def autocomplete(selector, with:)
+  page.driver.evaluate_script("$('#{selector}').focus().val('#{with}').keydown();")
+  expect(page).to have_css('.ui-autocomplete .ui-menu-item')
+  page.driver.evaluate_script("$('.ui-autocomplete .ui-menu-item').click()")
+end

--- a/spec/features/admin/assign_teachers_spec.rb
+++ b/spec/features/admin/assign_teachers_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require 'feature_js_helper'
+
+RSpec.describe 'Administration', js: true do
+  before do
+    # Log in as admin
+    admin = FactoryGirl.create(:user_profile, :administrator)
+    stub_current_user(admin)
+
+    # Create a user to add as a teacher
+    FactoryGirl.create(
+      :user_profile, username: 'imateacher', first_name: 'Ima',
+      last_name: 'Teacher', full_name: 'Ima Teacher')
+
+    # Create a course
+    visit admin_courses_path
+    click_link 'Add Course'
+
+    fill_in 'Name', with: 'A Course'
+    click_button 'Save'
+
+    # Edit the course
+    first(:link, 'Edit').click
+
+    # Click on the "Teachers" tab
+    click_link 'Teachers'
+  end
+
+  scenario 'adds a teacher to a course' do
+    # Check that the teacher has not been added yet
+    expect(page).not_to have_css('#teachers td', text: 'imateacher')
+
+    # Search for the user and add the user to the course
+    autocomplete '#course_teacher', with: 'imatea'
+    expect(page).to have_css('.flash_notice', text: 'Teachers updated.')
+
+    # Check that the teacher is now in the list of teachers
+    expect(page).to have_css('#teachers td', text: 'imateacher')
+  end
+
+  scenario 'removes a teacher from a course' do
+    # Search for the user and add the user to the course
+    autocomplete '#course_teacher', with: 'imatea'
+    expect(page).to have_css('.flash_notice', text: 'Teachers updated.')
+
+    # Remove the teacher
+    click_link 'Remove from course'
+    expect(page).to have_css('.flash_notice', text: 'Teacher "Ima Teacher" removed from course.')
+
+    # Check that the teacher is now not in the list of teachers
+    expect(page).not_to have_css('#teachers td', text: 'imateacher')
+  end
+end

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Admin editing a course' do
 
     expect(page).to have_content('Edit Course')
     fill_in 'Name', with: 'Changed'
-    first(:button, 'Save').click
+    click_button 'Save'
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
@@ -28,7 +28,7 @@ RSpec.feature 'Admin editing a course' do
     click_link 'Edit'
 
     select 'School name', from: 'School'
-    first(:button, 'Save').click
+    click_button 'Save'
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('tr td', text: 'School name')

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Admin editing a course' do
 
     expect(page).to have_content('Edit Course')
     fill_in 'Name', with: 'Changed'
-    click_button 'Save'
+    first(:button, 'Save').click
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
@@ -28,7 +28,7 @@ RSpec.feature 'Admin editing a course' do
     click_link 'Edit'
 
     select 'School name', from: 'School'
-    click_button 'Save'
+    first(:button, 'Save').click
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('tr td', text: 'School name')

--- a/spec/subsystems/user_profile/search_profiles_spec.rb
+++ b/spec/subsystems/user_profile/search_profiles_spec.rb
@@ -26,12 +26,14 @@ RSpec.describe UserProfile::SearchProfiles do
       'account_id' => user_2.account.id,
       'entity_user_id' => user_2.entity_user.id,
       'full_name' => 'Stan Dup',
+      'name' => 'Stan Dup',
       'username' => 'teacher'
     }, {
       'id' => user_1.id,
       'account_id' => user_1.account.id,
       'entity_user_id' => user_1.entity_user.id,
       'full_name' => 'Chris Mass',
+      'name' => 'Chris Mass',
       'username' => 'student'
     } ]
   end
@@ -44,12 +46,14 @@ RSpec.describe UserProfile::SearchProfiles do
       'account_id' => user_2.account.id,
       'entity_user_id' => user_2.entity_user.id,
       'full_name' => 'Stan Dup',
+      'name' => 'Stan Dup',
       'username' => 'teacher'
     }, {
       'id' => user_1.id,
       'account_id' => user_1.account.id,
       'entity_user_id' => user_1.entity_user.id,
       'full_name' => 'Chris Mass',
+      'name' => 'Chris Mass',
       'username' => 'student'
     } ]
 
@@ -60,6 +64,7 @@ RSpec.describe UserProfile::SearchProfiles do
       'account_id' => admin.account.id,
       'entity_user_id' => admin.entity_user.id,
       'full_name' => 'Administrator User',
+      'name' => 'Administrator User',
       'username' => 'admin'
     } ]
   end


### PR DESCRIPTION
Close #559.

- Move adding teachers to course into a separate tab
  - Move assign teacher code into the teachers controller
  - Move assign teacher form into a separate tab under edit course

- Fix assign teacher autocomplete to use entity user id

  The user search json `id` field is the `UserProfile::Models::Profile`
  id, the teachers controller is expecting a `Entity::User` id, so change
  assign teacher autocomplete js to use `entity_user_id` field instead.

- Update student roster csv column names on admin edit courses page

- Add notice messages after admin creates or updates periods

- Redirect to the right tab after an action in admin courses edit page

- Change courses index page action from "Students" to "List students"

  The students page doesn't have any edit capabilities so "List students"
  makes it clearer to admin.

- Use user's name in admin assign teacher autocomplete field

  Instead of user's full_name which might be null if it's not explicitly
  set.

  Add "name" to UserProfile::SearchProfiles routine.

- Display assigned teachers in a table on admin edit course page

- Simplify admin assign teacher form

  When admin selects a user from the autocomplete dropdown, the form gets
  submitted and the user is assigned as a teacher.

- Allow admins to remove teachers from a course

- Add feature test for admin assigning teachers to a course

