### PR TITLE
Stats improvements

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -96,8 +96,9 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
     self.task_steps.preload(:tasked).to_a - self.core_task_steps
   end
 
-  def spaced_practice_task_steps
-    self.task_steps.preload(:tasked).to_a.select(&:spaced_practice_group?)
+  def spaced_practice_task_steps(preload_tasked: false)
+    task_steps = preload_tasked ? self.task_steps.preload(:tasked) : self.task_steps
+    task_steps.to_a.select(&:spaced_practice_group?)
   end
 
   def personalized_task_steps

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -87,8 +87,9 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
     page_practice? || chapter_practice? || mixed_practice?
   end
 
-  def core_task_steps
-    self.task_steps.preload(:tasked).to_a.select(&:core_group?)
+  def core_task_steps(preload_tasked: false)
+    task_steps = preload_tasked ? self.task_steps.preload(:tasked) : self.task_steps
+    task_steps.to_a.select(&:core_group?)
   end
 
   def non_core_task_steps

--- a/lib/tasks/demo/demo_base.rb
+++ b/lib/tasks/demo/demo_base.rb
@@ -284,7 +284,7 @@ class DemoBase
       work_step(step, responses[index])
     end
 
-    spaced_practice_task_steps = task.spaced_practice_task_steps
+    spaced_practice_task_steps = task.spaced_practice_task_steps(preload_tasked: true)
 
     spaced_practice_task_steps.each_with_index do |step, index|
       work_step(step, responses[index + core_task_steps.size])

--- a/lib/tasks/demo/demo_base.rb
+++ b/lib/tasks/demo/demo_base.rb
@@ -278,7 +278,7 @@ class DemoBase
          "Continuing: Any tasks that do not have a response will not be worked" ) \
       if responses.count != task.steps_count
 
-    core_task_steps = task.core_task_steps
+    core_task_steps = task.core_task_steps(preload_tasked: true)
 
     core_task_steps.each_with_index do |step, index|
       work_step(step, responses[index])


### PR DESCRIPTION
- Make .preload(:tasked) in Task#core_task_steps optional

  Add argument `preload_tasked` to .preload(:tasked) only if it's necessary

  Towards CalculateTaskPlanStats optimization

- Make .preload(:tasked) in Task#spaced_practice_task_steps optional

  Add argument `preload_tasked` to .preload(:tasked) only if it's necessary

  Towards CalculateTaskPlanStats optimization

- Speed up CalculateTaskPlanStats by eager loading

  Part of #526

  Using the demo rake task to populate the database, running
  `CalculateTaskPlanStats.call(plan: Tasks::Models::TaskPlan.find(1))`
  in `rails console` gives the following improvements:

  master (5938dd5fa) makes 1016 queries and takes about 654ms.

  This branch makes 13 queries and takes about 106ms.
