### PR TITLE
Made BL ex question IDs strings

### DIFF
--- a/app/external/openstax/biglearn/v1/exercise.rb
+++ b/app/external/openstax/biglearn/v1/exercise.rb
@@ -3,6 +3,8 @@ class OpenStax::Biglearn::V1::Exercise
   attr_reader :question_id, :version, :tags
 
   def initialize(question_id:, version: nil, tags: tags)
+    raise IllegalArgument, "`question_id` must be a string" unless question_id.is_a?(String)
+
     tags = [tags].flatten.compact
     tags = tags.collect{|tag| tag.to_s}
 

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -56,7 +56,7 @@ class Content::ImportBook
 
     biglearn_exercises_by_ids = outputs[:exercises].each_with_object({}) do |ex, hash|
       hash[ex.id] = OpenStax::Biglearn::V1::Exercise.new(
-        question_id: ex.number,
+        question_id: ex.number.to_s,
         version: ex.version,
         tags: ex.exercise_tags.collect{ |ex| ex.tag.value }
       )

--- a/spec/controllers/api/v1/practices_controller_spec.rb
+++ b/spec/controllers/api/v1/practices_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
       biglearn_exercises = [exercise_1, exercise_2, exercise_3,
                             exercise_4, exercise_5].collect do |ex|
         OpenStax::Biglearn::V1::Exercise.new(
-          question_id: ex.number,
+          question_id: ex.number.to_s,
           version: ex.version,
           tags: ex.tags.collect{ |tt| tt.value }
         )
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
       OpenStax::Biglearn::V1.add_exercises(biglearn_exercises)
 
       biglearn_pools = pools.collect do |pool|
-        question_ids = pool.exercises.collect(&:number)
+        question_ids = pool.exercises.collect { |ex| ex.number.to_s }
         exercises = biglearn_exercises.select{ |ex| question_ids.include?(ex.question_id) }
         OpenStax::Biglearn::V1::Pool.new(exercises: exercises)
       end


### PR DESCRIPTION
These are the changes we need to fix dev I think, but there are two spec failures that I cannot check right now.

```
Failure/Error: api_post :create,
     StandardError:
       Not enough exercises to build the Practice Widget.

rspec ./spec/controllers/api/v1/practices_controller_spec.rb:62 # Api::V1::PracticesController POST #create returns the practice task data
rspec ./spec/controllers/api/v1/practices_controller_spec.rb:79 # Api::V1::PracticesController POST #create returns exercise URLs
```