### PR TITLE
Change source to sources when creating pools in BigLearn

### DIFF
--- a/app/external/openstax/biglearn/v1/real_client.rb
+++ b/app/external/openstax/biglearn/v1/real_client.rb
@@ -155,13 +155,13 @@ class OpenStax::Biglearn::V1::RealClient
   end
 
   def construct_add_pool_payload(pool)
-    { source: { questions: pool.exercises.collect do |exercise|
+    { sources: [{ questions: pool.exercises.collect do |exercise|
       { question_id: exercise.question_id, version: exercise.version }
-    end } }
+    end }] }
   end
 
   def construct_combine_pools_payload(pools)
-    { source: { pools: pools.collect{ |pl| pl.uuid } } }
+    { sources: [{ pools: pools.collect{ |pl| pl.uuid } }] }
   end
 
   def handle_response(response)


### PR DESCRIPTION
Looking at https://github.com/openstax/biglearn-platform/blob/3c10323abc894de4a7e58c116489cfd98998e4ad/app/tests/api/facts/test_facts_pools.py#L75, I think BigLearn is expecting something like:

```
{ sources: [
    { questions: [
        { question_id: ???, version: ??? },
        { question_id: ???, version: ??? }
    ] }
] }
```