### PR TITLE
Version fixes

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -19,7 +19,13 @@ class Admin::CoursesController < Admin::BaseController
     @periods = entity_course.periods
     @teachers = entity_course.teachers.includes(role: { user: { profile: :account } })
     @ecosystems = Content::ListEcosystems[]
-    @course_ecosystem = entity_course.ecosystems.first
+
+    @course_ecosystem = nil
+    ecosystem_model = entity_course.ecosystems.first
+    return if ecosystem_model.nil?
+
+    ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(ecosystem_model)
+    @course_ecosystem = ::Content::Ecosystem.new(strategy: ecosystem_strategy)
   end
 
   def update

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -48,7 +48,8 @@ class Content::ImportBook
     end
 
     # Need a double reload here for it to work for some reason
-    pages = book.reload.pages(true).eager_load(exercises: {exercise_tags: :tag})
+    # Use preload instead of eager_load here to avoid a memory usage spike
+    pages = book.reload.pages(true).preload(exercises: {exercise_tags: :tag})
     pages = run(:update_page_content, pages: pages, save: false).outputs.pages
     outs = run(:populate_exercise_pools, pages: pages, save: false).outputs
     pages = outs.pages

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -15,7 +15,7 @@ class Content::Models::Exercise < Tutor::SubSystems::BaseModel
   has_many :tasked_exercises, subsystem: :tasks, dependent: :destroy, inverse_of: :exercise
 
   validates :number, presence: true
-  validates :version, presence: true, uniqueness: { scope: :number }
+  validates :version, presence: true
 
   # http://stackoverflow.com/a/7745635
   scope :latest, ->(scope = unscoped) {

--- a/app/subsystems/content/routines/import_exercises.rb
+++ b/app/subsystems/content/routines/import_exercises.rb
@@ -43,8 +43,6 @@ class Content::Routines::ImportExercises
 
     Content::Models::Exercise.import! outputs[:exercises], recursive: true, validate: false
 
-    outputs[:exercises].each do |exercise|
-      exercise.tags.reset
-    end
+    outputs[:exercises].each{ |exercise| exercise.tags.reset }
   end
 end

--- a/app/subsystems/content/routines/import_exercises.rb
+++ b/app/subsystems/content/routines/import_exercises.rb
@@ -41,7 +41,7 @@ class Content::Routines::ImportExercises
       outputs[:exercises] << exercise
     end
 
-    Content::Models::Exercise.import! outputs[:exercises], recursive: true, validate: false
+    Content::Models::Exercise.import! outputs[:exercises], recursive: true
 
     outputs[:exercises].each{ |exercise| exercise.tags.reset }
   end

--- a/app/subsystems/course_content/add_ecosystem_to_course.rb
+++ b/app/subsystems/course_content/add_ecosystem_to_course.rb
@@ -23,16 +23,9 @@ class CourseContent::AddEcosystemToCourse
       strategy = ecosystem_strategy_class.new(course_ecosystem.ecosystem)
       ::Content::Ecosystem.new(strategy: strategy)
     end
-    to_ecosystem = case ecosystem
-    when ::Content::Ecosystem
-      ecosystem
-    else
-      strategy = ecosystem_strategy_class.new(ecosystem)
-      ::Content::Ecosystem.new(strategy: strategy)
-    end
 
     outputs[:ecosystem_map] = ::Content::Map.create!(from_ecosystems: from_ecosystems,
-                                                     to_ecosystem: to_ecosystem,
+                                                     to_ecosystem: ecosystem,
                                                      strategy_class: map_strategy_class)
   end
 

--- a/lib/tasks/demo/biology.yml
+++ b/lib/tasks/demo/biology.yml
@@ -2,7 +2,7 @@
 # The fixture at spec/fixtures/demo-imports/biology.yml must also be updated
 course_name: Biology I
 cnx_book_id: d52e93f4-8653-4273-86da-3850001c0786
-cnx_book_version: 3.3
+cnx_book_version: 3.4
 teacher: cm
 periods:
   - id: p1

--- a/spec/controllers/api/v1/practices_controller_spec.rb
+++ b/spec/controllers/api/v1/practices_controller_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
   context "POST #create" do
     let!(:page) {
       page = FactoryGirl.create :content_page
-      AddEcosystemToCourse[course: course, ecosystem: page.book.ecosystem]
+      ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(page.book.ecosystem)
+      ecosystem = ::Content::Ecosystem.new(strategy: ecosystem_strategy)
+      AddEcosystemToCourse[course: course, ecosystem: ecosystem]
       page
     }
 

--- a/spec/factories/tasks/tasked_task_plan.rb
+++ b/spec/factories/tasks/tasked_task_plan.rb
@@ -27,7 +27,10 @@ FactoryGirl.define do
 
       Content::Routines::PopulateExercisePools[pages: @page.reload]
 
-      AddEcosystemToCourse[course: owner, ecosystem: chapter.book.ecosystem]
+      ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(chapter.book.ecosystem)
+      ecosystem = ::Content::Ecosystem.new(strategy: ecosystem_strategy)
+
+      AddEcosystemToCourse[course: owner, ecosystem: ecosystem]
 
       { page_ids: [@page.id.to_s] }
     end

--- a/spec/routines/reset_practice_widget_spec.rb
+++ b/spec/routines/reset_practice_widget_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe ResetPracticeWidget, type: :routine do
   it 'errors when biglearn does not return enough' do
     course = role.student.course
     page = FactoryGirl.create(:content_page)
-    ecosystem = page.ecosystem
+    ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(page.ecosystem)
+    ecosystem = ::Content::Ecosystem.new(strategy: ecosystem_strategy)
     AddEcosystemToCourse[ecosystem: ecosystem, course: course]
     allow(OpenStax::Biglearn::V1).to receive(:get_projection_exercises) { ['dummy_id'] }
     result = ResetPracticeWidget.call(role: role, exercise_source: :biglearn, page_ids: [page.id])

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -7,6 +7,4 @@ RSpec.describe Content::Models::Exercise, :type => :model do
 
   it { is_expected.to validate_presence_of(:number) }
   it { is_expected.to validate_presence_of(:version) }
-
-  it { is_expected.to validate_uniqueness_of(:version).scoped_to(:number) }
 end

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -104,7 +104,9 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
 
     let!(:course) {
       course = task_plan.owner
-      AddEcosystemToCourse[course: course, ecosystem: chapter.book.ecosystem]
+      ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(chapter.book.ecosystem)
+      ecosystem = ::Content::Ecosystem.new(strategy: ecosystem_strategy)
+      AddEcosystemToCourse[course: course, ecosystem: ecosystem]
       course
     }
     let!(:period) { CreatePeriod[course: course] }

--- a/spec/support/create_student_history.rb
+++ b/spec/support/create_student_history.rb
@@ -18,10 +18,12 @@ class CreateStudentHistory
       puts "=== Set Role##{role.id} history ==="
 
       # practice widgets assign 5 task steps to the role
-      practice_steps = create_practice_widget(role, pages: ecosystem.pages[2 + (i % 2)].id)
+      practice_steps = create_practice_widget(
+        role, pages: ecosystem.chapters[3 - (i % 2)].pages[1].id
+      )
       answer_correctly(practice_steps, 2 + i) # 2 or 3/5
 
-      practice_steps = create_practice_widget(role, pages: ecosystem.pages[5].id)
+      practice_steps = create_practice_widget(role, pages: ecosystem.chapters[3].pages[2].id)
       answer_correctly(practice_steps, 5) # 5/5
 
       practice_steps = create_practice_widget(role, chapters: ecosystem.chapters[3].id)
@@ -85,7 +87,7 @@ class CreateStudentHistory
   end
 
   def create_ireading_task_plan(ecosystem, course, periods)
-    page_ids = ecosystem.pages.from(1).collect{ |pg| pg.id.to_s } # 0 is preface
+    page_ids = ecosystem.pages.collect{ |pg| pg.id.to_s }
     task_plan = FactoryGirl.build(
       :tasks_task_plan,
       owner: course,
@@ -117,7 +119,7 @@ class CreateStudentHistory
   end
 
   def create_homework_task_plan(ecosystem, course, periods)
-    exercise_ids = [ecosystem.exercises.first.id.to_s]
+    exercise_ids = [ecosystem.chapters[2].pages[1].exercises[0].id.to_s]
 
     task_plan = FactoryGirl.build(
       :tasks_task_plan,


### PR DESCRIPTION
- `AddEcosystemToCourse` now only accepts a `Content::Ecosystem`
- Updated bio content to 3.4
- Removed (one) memory spike in import_book.rb
- Reenabled exercise validation that I had forgotten to turn on
- Removed exercise uniqueness validation on `[number, version]` (since exercises are ecosystem-specific now)