### PR TITLE
Migration cleanup and disable ExerciseTag validations

### DIFF
--- a/app/subsystems/content/models/exercise_tag.rb
+++ b/app/subsystems/content/models/exercise_tag.rb
@@ -2,6 +2,10 @@ class Content::Models::ExerciseTag < Tutor::SubSystems::BaseModel
   belongs_to :exercise, inverse_of: :exercise_tags
   belongs_to :tag, inverse_of: :exercise_tags
 
-  validates :exercise, presence: true
-  validates :tag, presence: true, uniqueness: { scope: :content_exercise_id }
+  # These validations are by far the most consuming for all specs and the demo script
+  # They are also enforced by the DB through non-null columns,
+  # foreign key constraints and unique indices
+  # Therefore, we decided to disable them until a bulk validation solution is available
+  # validates :exercise, presence: true
+  # validates :tag, presence: true, uniqueness: { scope: :content_exercise_id }
 end

--- a/db/migrate/00005_create_content_books.rb
+++ b/db/migrate/00005_create_content_books.rb
@@ -2,8 +2,7 @@ class CreateContentBooks < ActiveRecord::Migration
   def change
     create_table :content_books do |t|
       t.resource
-      t.references :content_ecosystem, null: false,
-                                       index: true,
+      t.references :content_ecosystem, null: false, index: true,
                                        foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.string :title, null: false
       t.string :uuid, null: false

--- a/db/migrate/00999_create_course_membership_periods.rb
+++ b/db/migrate/00999_create_course_membership_periods.rb
@@ -1,15 +1,13 @@
 class CreateCourseMembershipPeriods < ActiveRecord::Migration
   def change
     create_table :course_membership_periods do |t|
-      t.references :entity_course, null: false
+      t.references :entity_course, null: false, foreign_key: { on_update: :cascade,
+                                                               on_delete: :cascade }
       t.string :name, null: false
 
       t.timestamps null: false
 
       t.index [:entity_course_id, :name], unique: true
     end
-
-    add_foreign_key :course_membership_periods, :entity_courses, on_update: :cascade,
-                                                                 on_delete: :cascade
   end
 end

--- a/db/migrate/01100_create_role_role_users.rb
+++ b/db/migrate/01100_create_role_role_users.rb
@@ -1,14 +1,14 @@
 class CreateRoleRoleUsers < ActiveRecord::Migration
   def change
     create_table :role_role_users do |t|
-      t.integer :entity_user_id, null: false
-      t.integer :entity_role_id, null: false
+      t.references :entity_user, null: false, foreign_key: { on_update: :cascade,
+                                                             on_delete: :cascade }
+      t.references :entity_role, null: false, foreign_key: { on_update: :cascade,
+                                                             on_delete: :cascade }
       t.timestamps null: false
 
-      t.index [:entity_user_id, :entity_role_id], unique: true, name: 'role_role_users_user_role_uniq'
+      t.index [:entity_user_id, :entity_role_id], unique: true,
+                                                  name: 'role_role_users_user_role_uniq'
     end
-
-     add_foreign_key :role_role_users, :entity_users
-     add_foreign_key :role_role_users, :entity_roles
   end
 end

--- a/db/migrate/01600_create_school_district_schools.rb
+++ b/db/migrate/01600_create_school_district_schools.rb
@@ -2,7 +2,8 @@ class CreateSchoolDistrictSchools < ActiveRecord::Migration
   def change
     create_table :school_district_schools do |t|
       t.string :name, null: false, unique: true
-      t.references :school_district_district, index: true, foreign_key: true
+      t.references :school_district_district, index: true, foreign_key: { on_update: :cascade,
+                                                                          on_delete: :nullify }
 
       t.timestamps null: false
     end

--- a/db/migrate/20140724184630_create_user_profile_profiles.rb
+++ b/db/migrate/20140724184630_create_user_profile_profiles.rb
@@ -1,18 +1,21 @@
 class CreateUserProfileProfiles < ActiveRecord::Migration
   def change
     create_table :user_profile_profiles do |t|
-      t.references :entity_user, null: false
-      t.references :account, null: false
+      t.references :entity_user, null: false, index: { unique: true },
+                                 foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :account, null: false, index: { unique: true }
       t.string :exchange_read_identifier, null: false
       t.string :exchange_write_identifier, null: false
       t.datetime :deleted_at
 
       t.timestamps null: false
 
-      t.index :account_id, unique: true
       t.index :deleted_at
       t.index :exchange_read_identifier, unique: true
       t.index :exchange_write_identifier, unique: true
     end
+
+    add_foreign_key :user_profile_profiles, :openstax_accounts_accounts,
+                    column: :account_id, on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20140724184800_create_user_profile_administrators.rb
+++ b/db/migrate/20140724184800_create_user_profile_administrators.rb
@@ -1,11 +1,9 @@
 class CreateUserProfileAdministrators < ActiveRecord::Migration
   def change
     create_table :user_profile_administrators do |t|
-      t.references :profile, null: false
+      t.references :profile, null: false, index: { unique: true }
 
       t.timestamps null: false
-
-      t.index :profile_id, unique: true
     end
 
     add_foreign_key :user_profile_administrators, :user_profile_profiles,

--- a/db/migrate/20140926165258_create_tasks_task_plans.rb
+++ b/db/migrate/20140926165258_create_tasks_task_plans.rb
@@ -1,7 +1,8 @@
 class CreateTasksTaskPlans < ActiveRecord::Migration
   def change
     create_table :tasks_task_plans do |t|
-      t.references :tasks_assistant, null: false
+      t.references :tasks_assistant, null: false, index: true,
+                                     foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.references :owner, polymorphic: true, null: false
       t.string :type, null: false
       t.string :title, null: false
@@ -13,10 +14,6 @@ class CreateTasksTaskPlans < ActiveRecord::Migration
       t.timestamps null: false
 
       t.index [:owner_id, :owner_type]
-      t.index :tasks_assistant_id
     end
-
-    add_foreign_key :tasks_task_plans, :tasks_assistants, 
-                    on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20140926213212_create_tasks_tasks.rb
+++ b/db/migrate/20140926213212_create_tasks_tasks.rb
@@ -1,8 +1,10 @@
 class CreateTasksTasks < ActiveRecord::Migration
   def change
     create_table :tasks_tasks do |t|
-      t.references :tasks_task_plan
-      t.references :entity_task, null: false
+      t.references :tasks_task_plan, index: true,
+                                     foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :entity_task, null: false, index: { unique: true },
+                                 foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.integer :task_type, null: false
       t.string :title, null: false
       t.text :description
@@ -27,16 +29,9 @@ class CreateTasksTasks < ActiveRecord::Migration
 
       t.timestamps null: false
 
-      t.index :tasks_task_plan_id
-      t.index :entity_task_id
       t.index :task_type
       t.index [:due_at, :opens_at]
       t.index :last_worked_at
     end
-
-    add_foreign_key :tasks_tasks, :tasks_task_plans,
-                    on_update: :cascade, on_delete: :cascade
-    add_foreign_key :tasks_tasks, :entity_tasks,
-                    on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20141021205221_create_tasks_task_steps.rb
+++ b/db/migrate/20141021205221_create_tasks_task_steps.rb
@@ -1,7 +1,8 @@
 class CreateTasksTaskSteps < ActiveRecord::Migration
   def change
     create_table :tasks_task_steps do |t|
-      t.references :tasks_task, null: false
+      t.references :tasks_task, null: false,
+                                foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.references :tasked, polymorphic: true, null: false
       t.integer :number, null: false
       t.datetime :first_completed_at
@@ -16,7 +17,5 @@ class CreateTasksTaskSteps < ActiveRecord::Migration
       t.index [:tasked_id, :tasked_type], unique: true
       t.index [:tasks_task_id, :number], unique: true
     end
-
-    add_foreign_key :tasks_task_steps, :tasks_tasks, on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20141103184649_create_tasks_tasking_plans.rb
+++ b/db/migrate/20141103184649_create_tasks_tasking_plans.rb
@@ -2,7 +2,8 @@ class CreateTasksTaskingPlans < ActiveRecord::Migration
   def change
     create_table :tasks_tasking_plans do |t|
       t.references :target, polymorphic: true, null: false
-      t.references :tasks_task_plan, null: false
+      t.references :tasks_task_plan, null: false, index: true,
+                                     foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.datetime :opens_at, null: false
       t.datetime :due_at, null: false
 
@@ -11,10 +12,6 @@ class CreateTasksTaskingPlans < ActiveRecord::Migration
       t.index [:target_id, :target_type, :tasks_task_plan_id], unique: true,
               name: 'index_tasking_plans_on_t_id_and_t_type_and_t_p_id'
       t.index [:due_at, :opens_at]
-      t.index :tasks_task_plan_id
     end
-
-    add_foreign_key :tasks_tasking_plans, :tasks_task_plans,
-                    on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20141106215530_create_content_tags.rb
+++ b/db/migrate/20141106215530_create_content_tags.rb
@@ -1,7 +1,8 @@
 class CreateContentTags < ActiveRecord::Migration
   def change
     create_table :content_tags do |t|
-      t.references :content_ecosystem, null: false, index: true
+      t.references :content_ecosystem, null: false, index: true,
+                                       foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.string :value, null: false
       t.integer :tag_type, null: false, default: 0
       t.string :name

--- a/db/migrate/20150212223636_create_tasks_course_assistants.rb
+++ b/db/migrate/20150212223636_create_tasks_course_assistants.rb
@@ -1,8 +1,10 @@
 class CreateTasksCourseAssistants < ActiveRecord::Migration
   def change
     create_table :tasks_course_assistants do |t|
-      t.references :entity_course, null: false
-      t.references :tasks_assistant, null: false
+      t.references :entity_course, null: false,
+                                   foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :tasks_assistant, null: false,
+                                     foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.string :tasks_task_plan_type, null: false
       t.text :settings
       t.text :data
@@ -14,10 +16,5 @@ class CreateTasksCourseAssistants < ActiveRecord::Migration
       t.index [:tasks_assistant_id, :entity_course_id],
               name: 'index_tasks_course_assistants_on_assistant_id_and_course_id'
     end
-
-    add_foreign_key :tasks_course_assistants, :entity_courses,
-                    on_update: :cascade, on_delete: :cascade
-    add_foreign_key :tasks_course_assistants, :tasks_assistants,
-                    on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20150218225356_create_content_page_tags.rb
+++ b/db/migrate/20150218225356_create_content_page_tags.rb
@@ -1,18 +1,14 @@
 class CreateContentPageTags < ActiveRecord::Migration
   def change
     create_table :content_page_tags do |t|
-      t.references :content_page, null: false
-      t.references :content_tag, null: false
+      t.references :content_page, null: false,
+                                  foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :content_tag, null: false, index: true,
+                                 foreign_key: { on_update: :cascade, on_delete: :cascade }
 
       t.timestamps null: false
 
       t.index [:content_page_id, :content_tag_id], unique: true
-      t.index :content_tag_id
     end
-
-    add_foreign_key :content_page_tags, :content_pages, on_update: :cascade,
-                                                        on_delete: :cascade
-    add_foreign_key :content_page_tags, :content_tags, on_update: :cascade,
-                                                       on_delete: :cascade
   end
 end

--- a/db/migrate/20150218225408_create_content_exercise_tags.rb
+++ b/db/migrate/20150218225408_create_content_exercise_tags.rb
@@ -1,19 +1,15 @@
 class CreateContentExerciseTags < ActiveRecord::Migration
   def change
     create_table :content_exercise_tags do |t|
-      t.references :content_exercise, null: false
-      t.references :content_tag, null: false
+      t.references :content_exercise, null: false,
+                                      foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :content_tag, null: false, index: true,
+                                 foreign_key: { on_update: :cascade, on_delete: :cascade }
 
       t.timestamps null: false
 
       t.index [:content_exercise_id, :content_tag_id], unique: true,
               name: 'index_content_exercise_tags_on_c_e_id_and_c_t_id'
-      t.index :content_tag_id
     end
-
-    add_foreign_key :content_exercise_tags, :content_exercises,
-                    on_update: :cascade, on_delete: :cascade
-    add_foreign_key :content_exercise_tags, :content_tags,
-                    on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20150420184110_create_content_lo_teks.rb
+++ b/db/migrate/20150420184110_create_content_lo_teks.rb
@@ -8,7 +8,11 @@ class CreateContentLoTeks < ActiveRecord::Migration
       t.index [:lo_id, :teks_id], unique: true, name: 'content_lo_teks_tag_lo_teks_uniq'
     end
 
-    add_foreign_key :content_lo_teks_tags, :content_tags, column: :lo_id
-    add_foreign_key :content_lo_teks_tags, :content_tags, column: :teks_id
+    add_foreign_key :content_lo_teks_tags, :content_tags, column: :lo_id,
+                                                          on_update: :cascade,
+                                                          on_delete: :cascade
+    add_foreign_key :content_lo_teks_tags, :content_tags, column: :teks_id,
+                                                          on_update: :cascade,
+                                                          on_delete: :cascade
   end
 end

--- a/db/migrate/20150505184224_create_tasks_performance_report_exports.rb
+++ b/db/migrate/20150505184224_create_tasks_performance_report_exports.rb
@@ -1,12 +1,16 @@
 class CreateTasksPerformanceReportExports < ActiveRecord::Migration
   def change
     create_table :tasks_performance_report_exports do |t|
-      t.references :entity_course, index: true
-      t.references :entity_role, index: true
+      t.references :entity_course, null: false, index: true,
+                                   foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :entity_role, null: false,
+                                 foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.string :export
+
       t.timestamps
+
+      t.index [:entity_role_id, :entity_course_id],
+              name: 'index_performance_report_exports_on_role_and_course'
     end
-    add_foreign_key :tasks_performance_report_exports, :entity_courses
-    add_foreign_key :tasks_performance_report_exports, :entity_roles
   end
 end

--- a/db/migrate/20150716164846_create_course_membership_enrollments.rb
+++ b/db/migrate/20150716164846_create_course_membership_enrollments.rb
@@ -2,8 +2,10 @@ class CreateCourseMembershipEnrollments < ActiveRecord::Migration
   def change
     create_table :course_membership_enrollments do |t|
       t.references :course_membership_period,
+                   null: false,
                    foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.references :course_membership_student,
+                   null: false,
                    foreign_key: { on_update: :cascade, on_delete: :cascade }
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -159,8 +159,8 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   add_index "course_content_course_ecosystems", ["entity_course_id", "created_at"], name: "course_ecosystems_on_course_id_created_at", using: :btree
 
   create_table "course_membership_enrollments", force: :cascade do |t|
-    t.integer  "course_membership_period_id"
-    t.integer  "course_membership_student_id"
+    t.integer  "course_membership_period_id",  null: false
+    t.integer  "course_membership_student_id", null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
   end
@@ -438,15 +438,15 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   add_index "tasks_course_assistants", ["tasks_assistant_id", "entity_course_id"], name: "index_tasks_course_assistants_on_assistant_id_and_course_id", using: :btree
 
   create_table "tasks_performance_report_exports", force: :cascade do |t|
-    t.integer  "entity_course_id"
-    t.integer  "entity_role_id"
+    t.integer  "entity_course_id", null: false
+    t.integer  "entity_role_id",   null: false
     t.string   "export"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "tasks_performance_report_exports", ["entity_course_id"], name: "index_tasks_performance_report_exports_on_entity_course_id", using: :btree
-  add_index "tasks_performance_report_exports", ["entity_role_id"], name: "index_tasks_performance_report_exports_on_entity_role_id", using: :btree
+  add_index "tasks_performance_report_exports", ["entity_role_id", "entity_course_id"], name: "index_performance_report_exports_on_role_and_course", using: :btree
 
   create_table "tasks_task_plans", force: :cascade do |t|
     t.integer  "tasks_assistant_id",        null: false
@@ -586,7 +586,7 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   end
 
   add_index "tasks_tasks", ["due_at", "opens_at"], name: "index_tasks_tasks_on_due_at_and_opens_at", using: :btree
-  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id", using: :btree
+  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id", unique: true, using: :btree
   add_index "tasks_tasks", ["last_worked_at"], name: "index_tasks_tasks_on_last_worked_at", using: :btree
   add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type", using: :btree
   add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id", using: :btree
@@ -611,6 +611,7 @@ ActiveRecord::Schema.define(version: 20150804002246) do
 
   add_index "user_profile_profiles", ["account_id"], name: "index_user_profile_profiles_on_account_id", unique: true, using: :btree
   add_index "user_profile_profiles", ["deleted_at"], name: "index_user_profile_profiles_on_deleted_at", using: :btree
+  add_index "user_profile_profiles", ["entity_user_id"], name: "index_user_profile_profiles_on_entity_user_id", unique: true, using: :btree
   add_index "user_profile_profiles", ["exchange_read_identifier"], name: "index_user_profile_profiles_on_exchange_read_identifier", unique: true, using: :btree
   add_index "user_profile_profiles", ["exchange_write_identifier"], name: "index_user_profile_profiles_on_exchange_write_identifier", unique: true, using: :btree
 
@@ -619,8 +620,8 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   add_foreign_key "content_exercise_tags", "content_exercises", on_update: :cascade, on_delete: :cascade
   add_foreign_key "content_exercise_tags", "content_tags", on_update: :cascade, on_delete: :cascade
   add_foreign_key "content_exercises", "content_pages", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "content_lo_teks_tags", "content_tags", column: "lo_id"
-  add_foreign_key "content_lo_teks_tags", "content_tags", column: "teks_id"
+  add_foreign_key "content_lo_teks_tags", "content_tags", column: "lo_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_lo_teks_tags", "content_tags", column: "teks_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "content_page_tags", "content_pages", on_update: :cascade, on_delete: :cascade
   add_foreign_key "content_page_tags", "content_tags", on_update: :cascade, on_delete: :cascade
   add_foreign_key "content_pages", "content_chapters", on_update: :cascade, on_delete: :cascade
@@ -630,6 +631,7 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   add_foreign_key "content_pages", "content_pools", column: "content_reading_dynamic_pool_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "content_pages", "content_pools", column: "content_reading_try_another_pool_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "content_pools", "content_ecosystems", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "content_tags", "content_ecosystems", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_content_course_ecosystems", "content_ecosystems", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_content_course_ecosystems", "entity_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_membership_enrollments", "course_membership_periods", on_update: :cascade, on_delete: :cascade
@@ -641,13 +643,13 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   add_foreign_key "course_membership_teachers", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_profile_profiles", "entity_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_profile_profiles", "school_district_schools", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "role_role_users", "entity_roles"
-  add_foreign_key "role_role_users", "entity_users"
-  add_foreign_key "school_district_schools", "school_district_districts"
+  add_foreign_key "role_role_users", "entity_roles", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "role_role_users", "entity_users", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "school_district_schools", "school_district_districts", on_update: :cascade, on_delete: :nullify
   add_foreign_key "tasks_course_assistants", "entity_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_course_assistants", "tasks_assistants", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_performance_report_exports", "entity_courses"
-  add_foreign_key "tasks_performance_report_exports", "entity_roles"
+  add_foreign_key "tasks_performance_report_exports", "entity_courses", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_performance_report_exports", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_task_plans", "tasks_assistants", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_task_steps", "tasks_tasks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_tasked_exercises", "content_exercises", on_update: :cascade, on_delete: :cascade
@@ -658,4 +660,6 @@ ActiveRecord::Schema.define(version: 20150804002246) do
   add_foreign_key "tasks_tasks", "entity_tasks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_tasks", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
   add_foreign_key "user_profile_administrators", "user_profile_profiles", column: "profile_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "user_profile_profiles", "entity_users", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "user_profile_profiles", "openstax_accounts_accounts", column: "account_id", on_update: :cascade, on_delete: :cascade
 end

--- a/spec/subsystems/content/models/exercise_tag_spec.rb
+++ b/spec/subsystems/content/models/exercise_tag_spec.rb
@@ -1,14 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe Content::Models::ExerciseTag, :type => :model do
+RSpec.describe Content::Models::ExerciseTag, type: :model do
   subject { FactoryGirl.create :content_exercise_tag }
 
   it { is_expected.to belong_to(:exercise) }
   it { is_expected.to belong_to(:tag) }
 
-  it { is_expected.to validate_presence_of(:exercise) }
-  it { is_expected.to validate_presence_of(:tag) }
+  # These validations are by far the most consuming for all specs and the demo script
+  # They are also enforced by the DB through non-null columns,
+  # foreign key constraints and unique indices
+  # Therefore, we decided to disable them until a bulk validation solution is available
+  # it { is_expected.to validate_presence_of(:exercise) }
+  # it { is_expected.to validate_presence_of(:tag) }
 
-  it { is_expected.to validate_uniqueness_of(:tag)
-                        .scoped_to(:content_exercise_id) }
+  # it { is_expected.to validate_uniqueness_of(:tag).scoped_to(:content_exercise_id) }
 end

--- a/spec/subsystems/content/models/page_tag_spec.rb
+++ b/spec/subsystems/content/models/page_tag_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Content::Models::PageTag, :type => :model do
+RSpec.describe Content::Models::PageTag, type: :model do
   subject { FactoryGirl.create :content_page_tag }
 
   it { is_expected.to belong_to(:page) }
@@ -9,6 +9,5 @@ RSpec.describe Content::Models::PageTag, :type => :model do
   it { is_expected.to validate_presence_of(:page) }
   it { is_expected.to validate_presence_of(:tag) }
 
-  it { is_expected.to validate_uniqueness_of(:tag)
-                        .scoped_to(:content_page_id) }
+  it { is_expected.to validate_uniqueness_of(:tag).scoped_to(:content_page_id) }
 end


### PR DESCRIPTION
- Includes https://github.com/openstax/tutor-server/pull/591
- Cleans up all the migrations
- Disables validations in ExerciseTag (the DB still enforces them).