### PR TITLE
break Task history ties using TaskPlan created_at

### DIFF
--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -147,7 +147,7 @@ class Tasks::Assistants::HomeworkAssistant
 
     homework_history = tasks.select{|tt| tt.homework?}
                             .reject{|tt| tt == task}
-                            .sort_by{|tt| tt.due_at}
+                            .sort_by{|tt| [tt.due_at, tt.created_at]}
                             .push(task)
                             .reverse
                             .collect{|tt| tt.entity_task}

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -147,7 +147,7 @@ class Tasks::Assistants::HomeworkAssistant
 
     homework_history = tasks.select{|tt| tt.homework?}
                             .reject{|tt| tt == task}
-                            .sort_by{|tt| [tt.due_at, tt.created_at]}
+                            .sort_by{|tt| [tt.due_at, tt.task_plan.created_at]}
                             .push(task)
                             .reverse
                             .collect{|tt| tt.entity_task}

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -171,7 +171,7 @@ class Tasks::Assistants::IReadingAssistant
 
     ireading_history = tasks.select{|tt| tt.reading?}
                             .reject{|tt| tt == task}
-                            .sort_by{|tt| [tt.due_at, tt.created_at]}
+                            .sort_by{|tt| [tt.due_at, tt.task_plan.created_at]}
                             .push(task)
                             .reverse
                             .collect{|tt| tt.entity_task}

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -171,7 +171,7 @@ class Tasks::Assistants::IReadingAssistant
 
     ireading_history = tasks.select{|tt| tt.reading?}
                             .reject{|tt| tt == task}
-                            .sort_by{|tt| tt.due_at}
+                            .sort_by{|tt| [tt.due_at, tt.created_at]}
                             .push(task)
                             .reverse
                             .collect{|tt| tt.entity_task}


### PR DESCRIPTION
This PR breaks ordering ties using Task TaskPlan creation time.