### PR TITLE
dedupe contract list when creating targeted contract

### DIFF
--- a/app/views/admin/targeted_contracts/_form.html.erb
+++ b/app/views/admin/targeted_contracts/_form.html.erb
@@ -6,7 +6,7 @@
       <label class='col-sm-3 control-label'>Contract Name</label>
       <div class='col-sm-9'>
         <%= f.select :contract_name,
-                     options_from_collection_for_select(FinePrint::Contract.all,
+                     options_from_collection_for_select(FinePrint::Contract.published.latest,
                                                         :name,
                                                         :name),
                      class: 'form-control' %>


### PR DESCRIPTION
Previously when selecting the contract for a targeted contract, if there were multiple versions of a contract, you'd see that contract's name once for each version -- since everything in targeted-land is just based on name and not version, this PR just makes sure to use only the latest published contracts in the form.