### PR TITLE
TaskingPlan handling of timezones

### DIFF
--- a/app/representers/api/v1/tasking_plan_representer.rb
+++ b/app/representers/api/v1/tasking_plan_representer.rb
@@ -32,7 +32,7 @@ module Api::V1
              readable: true,
              writeable: true,
              getter: ->(*) { DateTimeUtilities.to_api_s(opens_at) },
-             setter: ->(val, *) { self.opens_at = DateTimeUtilities.opens_at_from_api_s(val) },
+             setter: ->(val, *) { self.opens_at = TaskingPlanRepresenter.opens_at_from_api_s(val) },
              schema_info: {
                required: true
              }
@@ -42,10 +42,46 @@ module Api::V1
              readable: true,
              writeable: true,
              getter: ->(*) { DateTimeUtilities.to_api_s(due_at) },
-             setter: ->(val, *) { self.due_at = DateTimeUtilities.due_at_from_api_s(val) },
+             setter: ->(val, *) { self.due_at = TaskingPlanRepresenter.due_at_from_api_s(val) },
              schema_info: {
                required: true
              }
 
+
+    def self.opens_at_from_api_s(time_str)
+      time_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+      orig_time = time_zone.parse(extract_date_portion(time_str))
+      new_time  = orig_time.nil? ? nil : orig_time.in_time_zone(time_zone).midnight + 1.minute
+      new_time
+    end
+
+    def self.due_at_from_api_s(time_str)
+      time_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+      orig_time = time_zone.parse(extract_date_portion(time_str))
+      new_time  = orig_time.nil? ? nil : orig_time.in_time_zone(time_zone).midnight + 7.hours
+      new_time
+    end
+
+    def self.extract_date_portion(string)
+      results1 = /\b(\d\d\d\d)-(\d\d)-(\d\d)\b/.match(string)
+      results2 = /\b(\d\d\d\d)-(\d\d)-(\d\d)T\d\d:\d\d:\d\d/.match(string)
+      results3 = /\b(\d\d\d\d)(\d\d)(\d\d)\b/.match(string)
+      results4 = /\b(\d\d\d\d)(\d\d)(\d\d)T\d\d:\d\d:\d\d/.match(string)
+
+      captures = [results1, results2, results3, results4].collect(&:to_a).reduce(:+)
+
+      raise "string contains no date portions (#{string})" \
+        if captures.count == 0
+
+      raise "string contains multiple date portions (#{string})" \
+        if captures.count > 4
+
+      year, month, day = captures[1..3]
+
+      date_portion = "#{year}-#{month}-#{day}"
+      date_portion
+    end
+
   end
+
 end

--- a/app/representers/api/v1/tasking_plan_representer.rb
+++ b/app/representers/api/v1/tasking_plan_representer.rb
@@ -32,11 +32,7 @@ module Api::V1
              readable: true,
              writeable: true,
              getter: ->(*) { DateTimeUtilities.to_api_s(opens_at) },
-             setter: ->(val, *) {
-               orig_time = DateTimeUtilities.from_api_s(val)
-               new_time  = orig_time.nil? ? nil : orig_time.in_time_zone.midnight + 1.minute
-               self.opens_at = new_time
-             },
+             setter: ->(val, *) { self.opens_at = DateTimeUtilities.opens_at_from_api_s(val) },
              schema_info: {
                required: true
              }
@@ -46,11 +42,7 @@ module Api::V1
              readable: true,
              writeable: true,
              getter: ->(*) { DateTimeUtilities.to_api_s(due_at) },
-             setter: ->(val, *) {
-               orig_time = DateTimeUtilities.from_api_s(val)
-               new_time  = orig_time.nil? ? nil : orig_time.in_time_zone.midnight + 7.hours
-               self.due_at = new_time
-             },
+             setter: ->(val, *) { self.due_at = DateTimeUtilities.due_at_from_api_s(val) },
              schema_info: {
                required: true
              }

--- a/lib/date_time_utilities.rb
+++ b/lib/date_time_utilities.rb
@@ -5,7 +5,35 @@ module DateTimeUtilities
     time.try(:to_formatted_s, :w3cz)
   end
 
-  def self.from_api_s(time)
-    Chronic.parse(time)
+  def self.opens_at_from_api_s(time_str)
+    time_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+    orig_time = time_zone.parse(extract_date_portion(time_str))
+    new_time  = orig_time.nil? ? nil : orig_time.in_time_zone(time_zone).midnight + 1.minute
+    new_time
+  end
+
+  def self.due_at_from_api_s(time_str)
+    time_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+    orig_time = time_zone.parse(extract_date_portion(time_str))
+    new_time  = orig_time.nil? ? nil : orig_time.in_time_zone(time_zone).midnight + 7.hours
+    new_time
+  end
+
+  def self.extract_date_portion(string)
+    results1 = /\b(\d\d\d\d)-(\d\d)-(\d\d)\b/.match(string)
+    results2 = /\b(\d\d\d\d)(\d\d)(\d\d)\b/.match(string)
+
+    captures = results1.to_a + results2.to_a
+
+    raise "string contains no date portions (#{string})" \
+      if captures.count == 0
+
+    raise "string contains multiple date portions (#{string})" \
+      if captures.count > 4
+
+    year, month, day = captures[1..3]
+
+    date_portion = "#{year}-#{month}-#{day}"
+    date_portion
   end
 end

--- a/lib/date_time_utilities.rb
+++ b/lib/date_time_utilities.rb
@@ -4,36 +4,4 @@ module DateTimeUtilities
   def self.to_api_s(time)
     time.try(:to_formatted_s, :w3cz)
   end
-
-  def self.opens_at_from_api_s(time_str)
-    time_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
-    orig_time = time_zone.parse(extract_date_portion(time_str))
-    new_time  = orig_time.nil? ? nil : orig_time.in_time_zone(time_zone).midnight + 1.minute
-    new_time
-  end
-
-  def self.due_at_from_api_s(time_str)
-    time_zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
-    orig_time = time_zone.parse(extract_date_portion(time_str))
-    new_time  = orig_time.nil? ? nil : orig_time.in_time_zone(time_zone).midnight + 7.hours
-    new_time
-  end
-
-  def self.extract_date_portion(string)
-    results1 = /\b(\d\d\d\d)-(\d\d)-(\d\d)\b/.match(string)
-    results2 = /\b(\d\d\d\d)(\d\d)(\d\d)\b/.match(string)
-
-    captures = results1.to_a + results2.to_a
-
-    raise "string contains no date portions (#{string})" \
-      if captures.count == 0
-
-    raise "string contains multiple date portions (#{string})" \
-      if captures.count > 4
-
-    year, month, day = captures[1..3]
-
-    date_portion = "#{year}-#{month}-#{day}"
-    date_portion
-  end
 end

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -244,7 +244,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
         published_at = task_plan.published_at
         publish_job_uuid = task_plan.publish_job_uuid
 
-        valid_json_hash['tasking_plans'].first['opens_at'] = Time.now
+        valid_json_hash['tasking_plans'].first['opens_at'] = Time.zone.now.yesterday
 
         api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
                               raw_post_data: valid_json_hash.to_json

--- a/spec/lib/date_time_utilities_spec.rb
+++ b/spec/lib/date_time_utilities_spec.rb
@@ -7,11 +7,4 @@ RSpec.describe DateTimeUtilities do
       expect(formatted_time).to eq('2015-08-15T03:07:00.000Z')
     end
   end
-
-  it 'parses tutor API friendly time strings' do
-    Timecop.freeze('Aug 14, 2015 9:07 PM CST') do
-      parsed_time = described_class.from_api_s('2015-08-15T03:07:00.000Z')
-      expect(parsed_time).to eq(Time.current)
-    end
-  end
 end

--- a/spec/representers/api/v1/tasking_plan_representer_spec.rb
+++ b/spec/representers/api/v1/tasking_plan_representer_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
+
+  let!(:tasking_plan) {
+    instance_spy(Tasks::Models::TaskingPlan) do |dbl|
+      # set defaults for represented properties
+      allow(dbl).to receive(:target_id).and_return(nil)
+      allow(dbl).to receive(:target_type).and_return(nil)
+      allow(dbl).to receive(:opens_at).and_return(nil)
+      allow(dbl).to receive(:due_at).and_return(nil)
+    end
+  }
+
+  let(:representation) { ## NOTE: This is lazily-evaluated on purpose!
+    Api::V1::TaskingPlanRepresenter.new(tasking_plan).as_json
+  }
+
+  context "target_id" do
+    it "can be read" do
+      allow(tasking_plan).to receive(:target_id).and_return(12)
+      expect(representation).to include("target_id" => 12.to_s)
+    end
+
+    it "cannot be written (attempts are silently ignored)" do
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"target_id" => 42}.to_json)
+      expect(tasking_plan).to have_received(:target_id=).with('42')
+    end
+  end
+
+  context "target_type" do
+    it "can be read ('CourseMembership::Models::Period' => 'period')" do
+      allow(tasking_plan).to receive(:target_type).and_return('CourseMembership::Models::Period')
+      expect(representation).to include("target_type" => 'period')
+    end
+
+    it "can be read ('Entity::Course' => 'course')" do
+      allow(tasking_plan).to receive(:target_type).and_return('Entity::Course')
+      expect(representation).to include("target_type" => 'course')
+    end
+
+    it "can be written ('period' => 'CourseMembership::Models::Period')" do
+      rep = Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"target_type" => "period"}.to_json)
+      expect(tasking_plan).to have_received(:target_type=).with('CourseMembership::Models::Period')
+    end
+
+    it "can be written ('course' => 'Entity::Course')" do
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"target_type" => "course"}.to_json)
+      expect(tasking_plan).to have_received(:target_type=).with('Entity::Course')
+    end
+  end
+
+  let!(:year_str)           { '2015' }
+  let!(:daylight_month_str) { '06' }
+  let!(:standard_month_str) { '01' }
+  let!(:day_str)            { '04' }
+
+  let!(:format1_daylight_date_str) { "#{year_str}-#{daylight_month_str}-#{day_str}" }
+  let!(:format1_standard_date_str) { "#{year_str}-#{standard_month_str}-#{day_str}" }
+  let!(:format2_daylight_date_str) { "#{year_str}#{daylight_month_str}#{day_str}" }
+  let!(:format2_standard_date_str) { "#{year_str}#{standard_month_str}#{day_str}" }
+
+  let!(:course_timezone)    { ActiveSupport::TimeZone['Central Time (US & Canada)'] }
+  let!(:noncourse_timezone) { ActiveSupport::TimeZone['Pacific Time (US & Canada)'] }
+  let!(:utc_timezone)       { ActiveSupport::TimeZone['UTC'] }
+
+  context "opens_at" do
+
+    let!(:daylight_opens_at) { course_timezone.parse(format1_daylight_date_str).midnight + 1.minute }
+    let!(:standard_opens_at) { course_timezone.parse(format1_standard_date_str).midnight + 1.minute }
+
+    it "can be read (date coerced to String)" do
+      opens_at = Time.zone.now
+      allow(tasking_plan).to receive(:opens_at).and_return(opens_at)
+      expect(representation).to include("opens_at" => DateTimeUtilities::to_api_s(opens_at))
+    end
+
+    it "can be written with string containing date of form YYYY-MM-DD" do
+      test_str = "junk #{format1_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"opens_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+    end
+
+    it "can be written with string containing date of form YYYYMMDD" do
+      test_str = "junk #{format2_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"opens_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+    end
+
+    it "time is adjusted to 12:01am Central" do
+      opens_at = course_timezone.parse("#{standard_opens_at} 15:54:34")
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"opens_at" => opens_at.to_s}.to_json)
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+    end
+
+    it "only date is used; timezone is ignored" do
+      course_timezone_opens_at = course_timezone.parse("#{standard_opens_at} 12:34:56")
+      representer1 =
+        Api::V1::TaskingPlanRepresenter.new(tasking_plan)
+                                    .from_json({"opens_at" => course_timezone_opens_at.to_s}.to_json)
+
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+
+      noncourse_timezone_opens_at = noncourse_timezone.parse("#{standard_opens_at} 16:12:43")
+      representer2 =
+        Api::V1::TaskingPlanRepresenter.new(tasking_plan)
+                                    .from_json({"opens_at" => noncourse_timezone_opens_at.to_s}.to_json)
+
+      expect(representer1['opens_at']).to eq(representer2['opens_at'])
+    end
+  end
+
+  context "due_at" do
+
+    let!(:daylight_due_at) { course_timezone.parse(format1_daylight_date_str).midnight + 7.hours }
+    let!(:standard_due_at) { course_timezone.parse(format1_standard_date_str).midnight + 7.hours }
+
+    it "can be read (date coerced to String)" do
+      due_at = Time.zone.now
+      allow(tasking_plan).to receive(:due_at).and_return(due_at)
+      expect(representation).to include("due_at" => DateTimeUtilities::to_api_s(due_at))
+    end
+
+    it "can be written with string containing date of form YYYY-MM-DD" do
+      test_str = "junk #{format1_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"due_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+    end
+
+    it "can be written with string containing date of form YYYYMMDD" do
+      test_str = "junk #{format2_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"due_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+    end
+
+    it "time is adjusted to 12:01am Central" do
+      due_at = course_timezone.parse("#{standard_due_at} 15:54:34")
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"due_at" => due_at.to_s}.to_json)
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+    end
+
+    it "only date is used; timezone is ignored" do
+      course_timezone_due_at = course_timezone.parse("#{standard_due_at} 12:34:56")
+      representer1 =
+        Api::V1::TaskingPlanRepresenter.new(tasking_plan)
+                                    .from_json({"due_at" => course_timezone_due_at.to_s}.to_json)
+
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+
+      noncourse_timezone_due_at = noncourse_timezone.parse("#{standard_due_at} 16:12:43")
+      representer2 =
+        Api::V1::TaskingPlanRepresenter.new(tasking_plan)
+                                    .from_json({"due_at" => noncourse_timezone_due_at.to_s}.to_json)
+
+      expect(representer1['due_at']).to eq(representer2['due_at'])
+    end
+  end
+end

--- a/spec/representers/api/v1/tasking_plan_representer_spec.rb
+++ b/spec/representers/api/v1/tasking_plan_representer_spec.rb
@@ -88,8 +88,15 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
     end
 
-    it "timezone is ignored" do
-      noncourse_timezone_opens_at = noncourse_timezone.parse("#{standard_date_str}T16:12:43")
+    it "time and timezone are ignored (upper edge)" do
+      noncourse_timezone_opens_at = noncourse_timezone.parse("#{standard_date_str}T23:59:59")
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan)
+                                     .from_json({"opens_at" => noncourse_timezone_opens_at.to_s}.to_json)
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+    end
+
+    it "time and timezone are ignored (lower edge)" do
+      noncourse_timezone_opens_at = noncourse_timezone.parse("#{standard_date_str}T00:00:00")
       Api::V1::TaskingPlanRepresenter.new(tasking_plan)
                                      .from_json({"opens_at" => noncourse_timezone_opens_at.to_s}.to_json)
       expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
@@ -130,8 +137,15 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
     end
 
-    it "only date is used; timezone is ignored" do
-      noncourse_timezone_due_at = noncourse_timezone.parse("#{standard_date_str}T16:12:43")
+    it "time and timezone are ignored (upper edge)" do
+      noncourse_timezone_due_at = noncourse_timezone.parse("#{standard_date_str}T23:59:59")
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan)
+                                     .from_json({"due_at" => noncourse_timezone_due_at.to_s}.to_json)
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+    end
+
+    it "time and timezone are ignored (lower edge)" do
+      noncourse_timezone_due_at = noncourse_timezone.parse("#{standard_date_str}T00:00:00")
       Api::V1::TaskingPlanRepresenter.new(tasking_plan)
                                      .from_json({"due_at" => noncourse_timezone_due_at.to_s}.to_json)
       expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)

--- a/spec/representers/api/v1/tasking_plan_representer_spec.rb
+++ b/spec/representers/api/v1/tasking_plan_representer_spec.rb
@@ -3,12 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
 
   let!(:tasking_plan) {
-    instance_spy(Tasks::Models::TaskingPlan) do |dbl|
-      # set defaults for represented properties
-      allow(dbl).to receive(:target_id).and_return(nil)
-      allow(dbl).to receive(:target_type).and_return(nil)
-      allow(dbl).to receive(:opens_at).and_return(nil)
-      allow(dbl).to receive(:due_at).and_return(nil)
+    instance_spy(Tasks::Models::TaskingPlan).tap do |dbl|
+      ## bug work-around, see:
+      ##   https://github.com/rspec/rspec-rails/issues/1309#issuecomment-118971828
+      allow(dbl).to receive(:as_json).and_return(dbl)
     end
   }
 
@@ -169,8 +167,6 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       representer1 =
         Api::V1::TaskingPlanRepresenter.new(tasking_plan)
                                        .from_json({"due_at" => course_timezone_due_at.to_s}.to_json)
-
-      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
 
       noncourse_timezone_due_at = noncourse_timezone.parse("#{standard_due_at} 16:12:43")
       representer2 =

--- a/spec/representers/api/v1/tasking_plan_representer_spec.rb
+++ b/spec/representers/api/v1/tasking_plan_representer_spec.rb
@@ -57,8 +57,9 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
 
   let!(:format1_daylight_date_str) { "#{year_str}-#{daylight_month_str}-#{day_str}" }
   let!(:format1_standard_date_str) { "#{year_str}-#{standard_month_str}-#{day_str}" }
-  let!(:format2_daylight_date_str) { "#{year_str}#{daylight_month_str}#{day_str}" }
   let!(:format2_standard_date_str) { "#{year_str}#{standard_month_str}#{day_str}" }
+  let!(:format3_standard_date_str) { "#{year_str}-#{standard_month_str}-#{day_str}T14:32:34" }
+  let!(:format4_standard_date_str) { "#{year_str}#{standard_month_str}#{day_str}T14:32:34" }
 
   let!(:course_timezone)    { ActiveSupport::TimeZone['Central Time (US & Canada)'] }
   let!(:noncourse_timezone) { ActiveSupport::TimeZone['Pacific Time (US & Canada)'] }
@@ -87,6 +88,18 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
     end
 
+    it "can be written with string containing date of form YYYY-MM-DDTHH:MM:SS" do
+      test_str = "junk #{format3_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"opens_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+    end
+
+    it "can be written with string containing date of form YYYYMMDDTHH:MM:SS" do
+      test_str = "junk #{format4_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"opens_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
+    end
+
     it "time is adjusted to 12:01am Central" do
       opens_at = course_timezone.parse("#{standard_opens_at} 15:54:34")
       Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"opens_at" => opens_at.to_s}.to_json)
@@ -97,14 +110,14 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       course_timezone_opens_at = course_timezone.parse("#{standard_opens_at} 12:34:56")
       representer1 =
         Api::V1::TaskingPlanRepresenter.new(tasking_plan)
-                                    .from_json({"opens_at" => course_timezone_opens_at.to_s}.to_json)
+                                       .from_json({"opens_at" => course_timezone_opens_at.to_s}.to_json)
 
       expect(tasking_plan).to have_received(:opens_at=).with(standard_opens_at)
 
       noncourse_timezone_opens_at = noncourse_timezone.parse("#{standard_opens_at} 16:12:43")
       representer2 =
         Api::V1::TaskingPlanRepresenter.new(tasking_plan)
-                                    .from_json({"opens_at" => noncourse_timezone_opens_at.to_s}.to_json)
+                                       .from_json({"opens_at" => noncourse_timezone_opens_at.to_s}.to_json)
 
       expect(representer1['opens_at']).to eq(representer2['opens_at'])
     end
@@ -133,6 +146,18 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
     end
 
+    it "can be written with string containing date of form YYYY-MM-DDTHH:MM:SS" do
+      test_str = "junk #{format3_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"due_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+    end
+
+    it "can be written with string containing date of form YYYYMMDDTHH:MM:SS" do
+      test_str = "junk #{format4_standard_date_str} more junk"
+      Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"due_at" => test_str}.to_json)
+      expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
+    end
+
     it "time is adjusted to 12:01am Central" do
       due_at = course_timezone.parse("#{standard_due_at} 15:54:34")
       Api::V1::TaskingPlanRepresenter.new(tasking_plan).from_json({"due_at" => due_at.to_s}.to_json)
@@ -143,14 +168,14 @@ RSpec.describe Api::V1::TaskingPlanRepresenter, type: :representer do
       course_timezone_due_at = course_timezone.parse("#{standard_due_at} 12:34:56")
       representer1 =
         Api::V1::TaskingPlanRepresenter.new(tasking_plan)
-                                    .from_json({"due_at" => course_timezone_due_at.to_s}.to_json)
+                                       .from_json({"due_at" => course_timezone_due_at.to_s}.to_json)
 
       expect(tasking_plan).to have_received(:due_at=).with(standard_due_at)
 
       noncourse_timezone_due_at = noncourse_timezone.parse("#{standard_due_at} 16:12:43")
       representer2 =
         Api::V1::TaskingPlanRepresenter.new(tasking_plan)
-                                    .from_json({"due_at" => noncourse_timezone_due_at.to_s}.to_json)
+                                       .from_json({"due_at" => noncourse_timezone_due_at.to_s}.to_json)
 
       expect(representer1['due_at']).to eq(representer2['due_at'])
     end


### PR DESCRIPTION
See specs for details, but this basically handles all the BE changes needed to ignore/adjust timezones and times when editing `TaskingPlans`.