### PR TITLE
notify devs and log for background job exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'apipie-rails'
 gem 'maruku'
 
 # Lev framework
-gem 'lev', '~> 5.0.0'
+gem 'lev', '~> 6.0.0'
 
 # Ruby dsl for SQL queries
 gem 'squeel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    lev (5.0.0)
+    lev (6.0.0)
       actionpack (>= 3.0)
       active_attr
       activemodel (>= 3.0)
@@ -332,7 +332,7 @@ GEM
       actionpack (>= 3)
       activesupport (>= 3)
       railties (>= 3)
-    loofah (2.0.2)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
@@ -341,7 +341,7 @@ GEM
     mime-types (2.6.1)
     mini_magick (4.2.0)
     mini_portile (0.6.2)
-    minitest (5.7.0)
+    minitest (5.8.0)
     mono_logger (1.1.0)
     multi_json (1.11.1)
     multi_xml (0.5.5)
@@ -437,7 +437,7 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.6)
+    rails-dom-testing (1.0.7)
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
@@ -685,7 +685,7 @@ DEPENDENCIES
   json-schema
   keyword_search
   launchy
-  lev (~> 5.0.0)
+  lev (~> 6.0.0)
   lograge
   maruku
   mini_magick

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,22 @@
+module ActiveJob
+  class Base
+
+    rescue_from(Exception) do |exception|
+      @error_id = "%06d" % SecureRandom.random_number(10**6)
+
+      ExceptionNotifier.notify_exception(
+        exception,
+        data: {
+          error_id: @error_id,
+          message: "A background job exception occurred"
+        }
+      )
+
+      Rails.logger.error {
+        "A background job exception occurred: #{exception.class.name} [#{@error_id}] " +
+        "#{exception.message}\n\n#{exception.backtrace.join("\n")}"
+      }
+    end
+
+  end
+end

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -16,6 +16,8 @@ module ActiveJob
         "A background job exception occurred: #{exception.class.name} [#{@error_id}] " +
         "#{exception.message}\n\n#{exception.backtrace.join("\n")}"
       }
+
+      raise
     end
 
   end


### PR DESCRIPTION
Uses http://edgeguides.rubyonrails.org/active_job_basics.html#exceptions to intercept exceptions so we can send dev notifications and log them.  

Seems like we want something like this -- y'all agree?  Thoughts?

1. Docs talks about doing this in the job concrete class, but should work globally in `ActiveJob::Base`, don't you think?
2. Does doing it globally prevent us from calling it with more specific logic from concrete job classes?
3. For different kinds of exceptions, we could potentially retry the job.