### PR TITLE
Suped-up admin/jobs page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'apipie-rails'
 gem 'maruku'
 
 # Lev framework
-gem 'lev', github: 'lml/lev', branch: 'unprotect-ha-methods' #'~> 6.0.0'
+gem 'lev', github: 'lml/lev' #'~> 6.0.0'
 
 # Ruby dsl for SQL queries
 gem 'squeel'

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'apipie-rails'
 gem 'maruku'
 
 # Lev framework
-gem 'lev', '~> 6.0.0'
+gem 'lev', github: 'lml/lev', branch: 'unprotect-ha-methods' #'~> 6.0.0'
 
 # Ruby dsl for SQL queries
 gem 'squeel'

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'apipie-rails'
 gem 'maruku'
 
 # Lev framework
-gem 'lev', github: 'lml/lev' #'~> 6.0.0'
+gem 'lev', github: 'lml/lev', ref: 'a03a9f10a86b' #'~> 6.0.0'
 
 # Ruby dsl for SQL queries
 gem 'squeel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: git://github.com/lml/lev.git
+  revision: 9992e236f8ee26e7a90885c21221b34edc882a59
+  branch: unprotect-ha-methods
+  specs:
+    lev (6.0.0)
+      actionpack (>= 3.0)
+      active_attr
+      activemodel (>= 3.0)
+      activerecord (>= 3.0)
+      hashie
+      transaction_isolation
+      transaction_retry
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -319,14 +333,6 @@ GEM
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    lev (6.0.0)
-      actionpack (>= 3.0)
-      active_attr
-      activemodel (>= 3.0)
-      activerecord (>= 3.0)
-      hashie
-      transaction_isolation
-      transaction_retry
     libv8 (3.16.14.7)
     lograge (0.3.1)
       actionpack (>= 3)
@@ -685,7 +691,7 @@ DEPENDENCIES
   json-schema
   keyword_search
   launchy
-  lev (~> 6.0.0)
+  lev!
   lograge
   maruku
   mini_magick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: git://github.com/lml/lev.git
   revision: a03a9f10a86b4999230f083e470840812e0dcc12
+  ref: a03a9f10a86b
   specs:
     lev (6.0.0)
       actionpack (>= 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: git://github.com/lml/lev.git
-  revision: 9992e236f8ee26e7a90885c21221b34edc882a59
-  branch: unprotect-ha-methods
+  revision: a03a9f10a86b4999230f083e470840812e0dcc12
   specs:
     lev (6.0.0)
       actionpack (>= 3.0)

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -56,7 +56,13 @@ $(function(){
   $(document).on('click', '.filter_job_status', function(e) {
     var desiredStatus = this.href.replace(/^\S+#/, ''),
         $showRows = $('.' + desiredStatus),
-        $hideRows = $('#jobs tr').not('.' + desiredStatus);
+        $hideRows = $('#jobs tr').not('.' + desiredStatus),
+        $plainTxt = $('<span/>').text(desiredStatus),
+        $prevSpan = $($(this).siblings('span')[0]),
+        prevSpanTxt = $prevSpan.text(),
+        $linkedTxt = $('<a/>').addClass('filter_job_status')
+                              .text(prevSpanTxt)
+                              .attr('href', '#' + prevSpanTxt);
 
     if (desiredStatus === 'all') {
       $showRows = $('#jobs tr');
@@ -66,6 +72,8 @@ $(function(){
       $hideRows = $('.completed');
     }
 
+    $prevSpan.replaceWith($linkedTxt);
+    $(this).replaceWith($plainTxt);
     $showRows.show();
     $hideRows.hide();
   });

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -50,3 +50,20 @@ $(document).ready(function() {
     $('a[href="' + tab + '"]').click();
   }
 });
+
+// === Admin/Jobs === //
+$(function(){
+  $(document).on('click', '#toggle_completed_jobs', function(e) {
+    e.preventDefault();
+
+    $completedJobRows = $('.completed');
+    $completedJobRows.toggle();
+    $verb = $(this).find('span');
+
+    if($completedJobRows.is(':visible')) {
+      $verb.text('Hide');
+    } else {
+      $verb.text('Show');
+    }
+  });
+});

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -76,5 +76,21 @@ $(function(){
     $(this).replaceWith($plainTxt);
     $showRows.show();
     $hideRows.hide();
+  }).on('keyup', '#filter_id', function(e) {
+    var span = $(this).siblings('span')[0];
+
+    if ($(this).val() !== '' && span === undefined) {
+      var placeholder = $(this).attr('placeholder'),
+          $label = $('<span/>').text(placeholder);
+
+      $('#search_by_id').prepend($label);
+    }
+
+    if ($(this).val() === '') {
+      $(span).remove();
+    }
+
+    $('#jobs tbody tr').hide();
+    $("#jobs tbody tr:contains('" + $(this).val() + "')").show();
   });
 });

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -53,17 +53,20 @@ $(document).ready(function() {
 
 // === Admin/Jobs === //
 $(function(){
-  $(document).on('click', '#toggle_completed_jobs', function(e) {
-    e.preventDefault();
+  $(document).on('click', '.filter_job_status', function(e) {
+    var desiredStatus = this.href.replace(/^\S+#/, ''),
+        $showRows = $('.' + desiredStatus),
+        $hideRows = $('#jobs tr').not('.' + desiredStatus);
 
-    $completedJobRows = $('.completed');
-    $completedJobRows.toggle();
-    $verb = $(this).find('span');
-
-    if($completedJobRows.is(':visible')) {
-      $verb.text('Hide');
-    } else {
-      $verb.text('Show');
+    if (desiredStatus === 'all') {
+      $showRows = $('#jobs tr');
+      $hideRows = $();
+    } else if (desiredStatus === 'incomplete') {
+      $showRows = $('#jobs tr').not('.completed');
+      $hideRows = $('.completed');
     }
+
+    $showRows.show();
+    $hideRows.hide();
   });
 });

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -56,7 +56,7 @@ $(function(){
   $(document).on('click', '.filter_job_status', function(e) {
     var desiredStatus = this.href.replace(/^\S+#/, ''),
         $showRows = $('.' + desiredStatus),
-        $hideRows = $('#jobs tr').not('.' + desiredStatus),
+        $hideRows = $('#jobs tbody tr').not('.' + desiredStatus),
         $plainTxt = $('<span/>').text(desiredStatus),
         $prevSpan = $($(this).siblings('span')[0]),
         prevSpanTxt = $prevSpan.text(),
@@ -65,10 +65,10 @@ $(function(){
                               .attr('href', '#' + prevSpanTxt);
 
     if (desiredStatus === 'all') {
-      $showRows = $('#jobs tr');
+      $showRows = $('#jobs tbody tr');
       $hideRows = $();
     } else if (desiredStatus === 'incomplete') {
-      $showRows = $('#jobs tr').not('.completed');
+      $showRows = $('#jobs tbody tr').not('.completed');
       $hideRows = $('.completed');
     }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -8,3 +8,9 @@
 .flash_error {
   color: red;
 }
+
+#jobs {
+  .completed {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -14,3 +14,16 @@
     display: none;
   }
 }
+
+#search_by_id {
+  position: relative;
+  span {
+    display: block;
+    position: absolute;
+    top: -2.3em;
+    left: 1em;
+    background: #4b3725;
+    color: #fff;
+    padding: 0.5em 1em;
+  }
+}

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -4,7 +4,13 @@ module Admin
   class JobsController < BaseController
     def index
       @page_header = "Queued jobs"
-      @jobs = Lev::BackgroundJob.all.paginate(page: params[:page], per_page: 20)
+      @jobs = Lev::BackgroundJob.incomplete.paginate(pagination_options)
+    end
+
+    def all
+      @page_header = "All jobs"
+      @jobs = Lev::BackgroundJob.all.paginate(pagination_options)
+      render :index
     end
 
     def show
@@ -14,6 +20,11 @@ module Admin
       end
 
       @page_header = "#{@job.status.titleize} job : #{@job.id}"
+    end
+
+    private
+    def pagination_options
+      { page: params[:page], per_page: 20 }
     end
   end
 end

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -4,13 +4,7 @@ module Admin
   class JobsController < BaseController
     def index
       @page_header = "Queued jobs"
-      @jobs = Lev::BackgroundJob.incomplete.paginate(pagination_options)
-    end
-
-    def all
-      @page_header = "All jobs"
-      @jobs = Lev::BackgroundJob.all.paginate(pagination_options)
-      render :index
+      @jobs = Lev::BackgroundJob.all
     end
 
     def show
@@ -20,11 +14,6 @@ module Admin
       end
 
       @page_header = "#{@job.status.titleize} job : #{@job.id}"
-    end
-
-    private
-    def pagination_options
-      { page: params[:page], per_page: 20 }
     end
   end
 end

--- a/app/views/admin/jobs/index.html.erb
+++ b/app/views/admin/jobs/index.html.erb
@@ -1,12 +1,21 @@
-Show:
-<%= link_to 'all', '#all', class: 'filter_job_status' %>&nbsp;|
-<span>incomplete</span>&nbsp;|
-<%= link_to 'completed', '#completed', class: 'filter_job_status' %>&nbsp;|
-<%= link_to 'queued', '#queued', class: 'filter_job_status' %>&nbsp;|
-<%= link_to 'working', '#working', class: 'filter_job_status' %>&nbsp;|
-<%= link_to 'failed', '#failed', class: 'filter_job_status' %>&nbsp;|
-<%= link_to 'killed', '#killed', class: 'filter_job_status' %>&nbsp;|
-<%= link_to 'unknown', '#unknown', class: 'filter_job_status' %>
+<div class='row'>
+  <div class='col-xs-7'>
+    Show:
+    <%= link_to 'all', '#all', class: 'filter_job_status' %>&nbsp;|
+    <span>incomplete</span>&nbsp;|
+    <%= link_to 'completed', '#completed', class: 'filter_job_status' %>&nbsp;|
+    <%= link_to 'queued', '#queued', class: 'filter_job_status' %>&nbsp;|
+    <%= link_to 'working', '#working', class: 'filter_job_status' %>&nbsp;|
+    <%= link_to 'failed', '#failed', class: 'filter_job_status' %>&nbsp;|
+    <%= link_to 'killed', '#killed', class: 'filter_job_status' %>&nbsp;|
+    <%= link_to 'unknown', '#unknown', class: 'filter_job_status' %>
+  </div>
+
+  <div id='search_by_id' class='col-xs-5'>
+    <%= text_field_tag :filter_id, nil, placeholder: 'Search by ID, Status, or Progress',
+                                        class: 'form-control' %>
+  </div>
+</div>
 
 <table id='jobs' class="table table-striped">
   <thead>

--- a/app/views/admin/jobs/index.html.erb
+++ b/app/views/admin/jobs/index.html.erb
@@ -1,3 +1,9 @@
+<% if action_name == 'index' %>
+  <%= link_to 'Show completed jobs', all_admin_jobs_path %>
+<% else %>
+  <%= link_to 'Hide completed jobs', admin_jobs_path %>
+<% end %>
+
 <%= will_paginate @jobs %>
 
 <table class="table table-striped">

--- a/app/views/admin/jobs/index.html.erb
+++ b/app/views/admin/jobs/index.html.erb
@@ -1,6 +1,6 @@
 Show:
 <%= link_to 'all', '#all', class: 'filter_job_status' %>&nbsp;|
-<%= link_to 'incomplete', '#incomplete', class: 'filter_job_status' %>&nbsp;|
+<span>incomplete</span>&nbsp;|
 <%= link_to 'completed', '#completed', class: 'filter_job_status' %>&nbsp;|
 <%= link_to 'queued', '#queued', class: 'filter_job_status' %>&nbsp;|
 <%= link_to 'working', '#working', class: 'filter_job_status' %>&nbsp;|

--- a/app/views/admin/jobs/index.html.erb
+++ b/app/views/admin/jobs/index.html.erb
@@ -1,5 +1,12 @@
-<%= link_to '<span>Show</span> completed jobs'.html_safe, '#',
-            id: 'toggle_completed_jobs' %>
+Show:
+<%= link_to 'all', '#all', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'incomplete', '#incomplete', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'completed', '#completed', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'queued', '#queued', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'working', '#working', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'failed', '#failed', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'killed', '#killed', class: 'filter_job_status' %>&nbsp;|
+<%= link_to 'unknown', '#unknown', class: 'filter_job_status' %>
 
 <table id='jobs' class="table table-striped">
   <thead>

--- a/app/views/admin/jobs/index.html.erb
+++ b/app/views/admin/jobs/index.html.erb
@@ -1,12 +1,7 @@
-<% if action_name == 'index' %>
-  <%= link_to 'Show completed jobs', all_admin_jobs_path %>
-<% else %>
-  <%= link_to 'Hide completed jobs', admin_jobs_path %>
-<% end %>
+<%= link_to '<span>Show</span> completed jobs'.html_safe, '#',
+            id: 'toggle_completed_jobs' %>
 
-<%= will_paginate @jobs %>
-
-<table class="table table-striped">
+<table id='jobs' class="table table-striped">
   <thead>
     <tr>
       <th>ID</th>
@@ -17,7 +12,7 @@
 
   <tbody>
     <% @jobs.each do |job| %>
-      <tr>
+      <tr class='<%= job.status %>'>
         <td class='job_id'><%= link_to job.id, admin_job_path(job.id) %></td>
         <td class='job_status'><%= job.status %></td>
         <td class='job_progress'><%= number_to_percentage(job.progress.to_f * 100, precision: 0) %></td>
@@ -25,5 +20,3 @@
     <% end %>
   </tbody>
 </table>
-
-<%= will_paginate @jobs %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,7 +122,9 @@ Rails.application.routes.draw do
 
     resources :licenses
 
-    resources :jobs, only: [:index, :show]
+    resources :jobs, only: [:index, :show] do
+      get :all, on: :collection
+    end
 
     resources :users, except: :destroy do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,9 +122,7 @@ Rails.application.routes.draw do
 
     resources :licenses
 
-    resources :jobs, only: [:index, :show] do
-      get :all, on: :collection
-    end
+    resources :jobs, only: [:index, :show]
 
     resources :users, except: :destroy do
       member do

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -48,6 +48,24 @@ RSpec.feature 'Administration of queued jobs' do
 
     expect(current_path).to eq(admin_job_path(job.id))
     expect(page).to have_css('.job_errors', text: 'bad - awful')
-    expect(page).to have_css('.job_something_spectacular', text: 'For all the good children')
+    expect(page).to have_css('.job_something_spectacular',
+                             text: 'For all the good children')
+  end
+
+  scenario 'completed jobs are hidden' do
+    job.completed!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    expect(page).not_to have_css('.job_id', text: job.id)
+
+    click_link 'Show completed jobs'
+
+    expect(page).to have_css('.job_id', text: job.id)
+
+    click_link 'Hide completed jobs'
+
+    expect(page).not_to have_css('.job_id', text: job.id)
   end
 end

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
+require 'feature_js_helper'
 
-RSpec.feature 'Administration of queued jobs' do
+RSpec.feature 'Administration of queued jobs', :js do
   let(:course) { CreateCourse[name: 'course time'] }
   let(:admin) { FactoryGirl.create(:user_profile, :administrator) }
   let(:user) { Entity::User.create! }
@@ -58,14 +59,12 @@ RSpec.feature 'Administration of queued jobs' do
     visit admin_root_path
     click_link 'Jobs'
 
-    expect(page).not_to have_css('.job_id', text: job.id)
+    expect(page).to have_css('.job_id', visible: false, text: job.id)
 
     click_link 'Show completed jobs'
-
-    expect(page).to have_css('.job_id', text: job.id)
+    expect(page).to have_css('.job_id', visible: true, text: job.id)
 
     click_link 'Hide completed jobs'
-
-    expect(page).not_to have_css('.job_id', text: job.id)
+    expect(page).to have_css('.job_id', visible: false, text: job.id)
   end
 end

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -61,10 +61,81 @@ RSpec.feature 'Administration of queued jobs', :js do
 
     expect(page).not_to have_css('.completed')
 
-    click_link 'Show completed jobs'
+    click_link 'all'
     expect(page).to have_css('.completed')
 
-    click_link 'Hide completed jobs'
+    click_link 'incomplete'
     expect(page).not_to have_css('.completed')
+  end
+
+  scenario 'statuses are filterable' do
+    job.queued!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    click_link 'killed'
+    expect(page).not_to have_css('.queued')
+
+    click_link 'queued'
+    expect(page).to have_css('.queued')
+
+
+    job.working!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    click_link 'killed'
+    expect(page).not_to have_css('.working')
+
+    click_link 'working'
+    expect(page).to have_css('.working')
+
+
+    job.failed!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    click_link 'killed'
+    expect(page).not_to have_css('.failed')
+
+    click_link 'failed'
+    expect(page).to have_css('.failed')
+
+
+    job.killed!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    click_link 'failed'
+    expect(page).not_to have_css('.killed')
+
+    click_link 'killed'
+    expect(page).to have_css('.killed')
+
+
+    job.unknown!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    click_link 'killed'
+    expect(page).not_to have_css('.unknown')
+
+    click_link 'unknown'
+    expect(page).to have_css('.unknown')
+
+
+    job.queued!
+
+    visit admin_root_path
+    click_link 'Jobs'
+
+    click_link 'all'
+    click_link 'incomplete'
+    expect(page).to have_css('.queued')
   end
 end

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -70,72 +70,65 @@ RSpec.feature 'Administration of queued jobs', :js do
 
   scenario 'statuses are filterable' do
     job.queued!
-
-    visit admin_root_path
-    click_link 'Jobs'
+    visit admin_jobs_path
 
     click_link 'killed'
     expect(page).not_to have_css('.queued')
-
     click_link 'queued'
     expect(page).to have_css('.queued')
 
 
     job.working!
-
-    visit admin_root_path
-    click_link 'Jobs'
+    visit admin_jobs_path
 
     click_link 'killed'
     expect(page).not_to have_css('.working')
-
     click_link 'working'
     expect(page).to have_css('.working')
 
 
     job.failed!
-
-    visit admin_root_path
-    click_link 'Jobs'
+    visit admin_jobs_path
 
     click_link 'killed'
     expect(page).not_to have_css('.failed')
-
     click_link 'failed'
     expect(page).to have_css('.failed')
 
 
     job.killed!
-
-    visit admin_root_path
-    click_link 'Jobs'
+    visit admin_jobs_path
 
     click_link 'failed'
     expect(page).not_to have_css('.killed')
-
     click_link 'killed'
     expect(page).to have_css('.killed')
 
 
     job.unknown!
-
-    visit admin_root_path
-    click_link 'Jobs'
+    visit admin_jobs_path
 
     click_link 'killed'
     expect(page).not_to have_css('.unknown')
-
     click_link 'unknown'
     expect(page).to have_css('.unknown')
 
 
     job.queued!
-
-    visit admin_root_path
-    click_link 'Jobs'
+    visit admin_jobs_path
 
     click_link 'all'
     click_link 'incomplete'
     expect(page).to have_css('.queued')
+  end
+
+  scenario 'search by id' do
+    visit admin_jobs_path
+
+    fill_in 'filter_id', with: 'not-here'
+    expect(page).not_to have_css('#jobs tbody tr')
+
+    fill_in 'filter_id', with: 'abc'
+    expect(page).to have_css('#jobs tr', text: 'abc123')
   end
 end

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -125,10 +125,12 @@ RSpec.feature 'Administration of queued jobs', :js do
   scenario 'search by id' do
     visit admin_jobs_path
 
+    expect(page).to have_css('#jobs tbody tr')
+
     fill_in 'filter_id', with: 'not-here'
     expect(page).not_to have_css('#jobs tbody tr')
 
-    fill_in 'filter_id', with: 'abc'
-    expect(page).to have_css('#jobs tr', text: 'abc123')
+    fill_in 'filter_id', with: job.id[4..7] # partial matching works
+    expect(page).to have_css('.job_id', text: job.id)
   end
 end

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -59,12 +59,12 @@ RSpec.feature 'Administration of queued jobs', :js do
     visit admin_root_path
     click_link 'Jobs'
 
-    expect(page).to have_css('.job_id', visible: false, text: job.id)
+    expect(page).not_to have_css('.completed')
 
     click_link 'Show completed jobs'
-    expect(page).to have_css('.job_id', visible: true, text: job.id)
+    expect(page).to have_css('.completed')
 
     click_link 'Hide completed jobs'
-    expect(page).to have_css('.job_id', visible: false, text: job.id)
+    expect(page).not_to have_css('.completed')
   end
 end


### PR DESCRIPTION
* Hides completed jobs by default
* Option to show/hide the jobs
* Searchable by ID
* Filterable by status
* Updates to Lev to support scope-like class methods on `BackgroundJob`