### PR TITLE
Update wonky export xlsx code

### DIFF
--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -62,8 +62,10 @@ module Tasks
 
       def gather_due_dates(data_headings)
         due_dates = data_headings.collect(&:due_at)
+        offset_cells = non_data_headings.map { nil }
+        offset_cells.delete_at(offset_cells.index(nil)) # minus 1 for 'Due Date'
 
-        [italic_text('Due Date')] + due_dates.collect do |due_date|
+        [italic_text('Due Date')] + offset_cells + due_dates.collect do |due_date|
           italic_text(due_date.strftime("%m/%d/%Y"))
         end
       end

--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -134,8 +134,8 @@ module Tasks
         ['First Name', 'Last Name']
       end
 
-      def collect_columns(collection, labels = nil, &block)
-        labels = [labels].flatten.compact
+      def collect_columns(collection, *labels, &block)
+        labels = *labels.flatten.compact
 
         (labels + offset_columns(labels.size) + collection).collect do |item|
           yield(item)

--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -62,8 +62,9 @@ module Tasks
 
       def gather_due_dates(data_headings)
         due_dates = data_headings.collect(&:due_at)
-        offset_cells = non_data_headings.map { nil }
-        offset_cells.delete_at(offset_cells.index(nil)) # minus 1 for 'Due Date'
+        offset_cells = offset_columns.slice!(offset_columns.index(nil), 1)
+          # subtract one cell for 'Due Date'
+          # #slice!(index, length) returns new_ary
 
         [italic_text('Due Date')] + offset_cells + due_dates.collect do |due_date|
           italic_text(due_date.strftime("%m/%d/%Y"))
@@ -79,7 +80,7 @@ module Tasks
       end
 
       def cell_styles(data, worksheet)
-        (non_data_headings.map { nil } + data).map do |d|
+        (offset_columns + data).map do |d|
           worksheet.styles.add_style bg_color: 'FFFF93' if d && d.late
         end
       end
@@ -133,6 +134,10 @@ module Tasks
 
       def non_data_headings
         ['First Name', 'Last Name']
+      end
+
+      def offset_columns
+        non_data_headings.map { nil }
       end
     end
   end

--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -41,7 +41,7 @@ module Tasks
             sheet.add_row(gather_averages(report[:data_headings]))
 
             report.students.each_with_index do |student, row|
-              styles = cell_styles(student.data, sheet)
+              styles = lateness_styles(student.data, sheet)
               sheet.add_row(student_scores(student), style: styles)
               add_late_comments(sheet, student.data, row)
             end
@@ -79,7 +79,7 @@ module Tasks
         (['Average'] + averages).collect { |average| italic_text(average) }
       end
 
-      def cell_styles(data, worksheet)
+      def lateness_styles(data, worksheet)
         (offset_columns + data).map do |d|
           worksheet.styles.add_style bg_color: 'FFFF93' if d && d.late
         end

--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -1,6 +1,8 @@
 module Tasks
   module PerformanceReport
     class ExportXlsx
+      include ActionView::Helpers::DateHelper
+
       lev_routine express_output: :filepath
 
       protected
@@ -85,7 +87,10 @@ module Tasks
         data.each_with_index do |d, col|
           next if d.nil? || !d.late
           ref = "#{('C'..'Z').to_a[col]}#{row + 4}" # forms something like 'D5'
-          sheet.add_comment ref: ref, text: 'Late', author: 'OpenStax', visible: false
+          sheet.add_comment ref: ref,
+            text: "Homework was worked #{time_ago_in_words(d.last_worked_at)} late",
+            author: 'OpenStax',
+            visible: false
         end
       end
 

--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -12,8 +12,8 @@ module Tasks
         Axlsx::Package.new do |axlsx|
           axlsx.use_shared_strings = true # OS X Numbers interoperability
           axlsx.workbook.styles.fonts.first.name = 'Helvetica Neue'
-          create_summary_worksheet(profile.name, axlsx)
           create_data_worksheets(report, axlsx)
+          create_summary_worksheet(profile.name, axlsx)
 
           if axlsx.serialize(filepath)
             outputs.filepath = filepath

--- a/spec/controllers/api/v1/performance_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/performance_reports_controller_spec.rb
@@ -71,23 +71,24 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
 
         expect(response).to have_http_status :success
         resp = response.body_as_hash
+        binding.pry
         expect(resp).to include({
           period_id: course.periods.first.id.to_s,
           data_headings: [
-            { title: 'Homework task plan',
+            { title: 'Homework 2 task plan',
               plan_id: resp[0][:data_headings][0][:plan_id],
               type: 'homework',
               due_at: resp[0][:data_headings][0][:due_at],
-              average: 70.0 },
+              average: 54.16666666666667 },
             { title: 'Reading task plan',
               plan_id: resp[0][:data_headings][1][:plan_id],
               type: 'reading',
               due_at: resp[0][:data_headings][1][:due_at] },
-            { title: 'Homework 2 task plan',
+            { title: 'Homework task plan',
               plan_id: resp[0][:data_headings][2][:plan_id],
               type: 'homework',
               due_at: resp[0][:data_headings][2][:due_at],
-              average: within(0.01).of(54.16) }
+              average: 70.0 }
           ],
           students: [{
             name: 'Student One',
@@ -99,8 +100,8 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 type: 'homework',
                 id: resp[0][:students][0][:data][0][:id],
                 status: 'completed',
-                exercise_count: 6,
-                correct_exercise_count: 6,
+                exercise_count: 4,
+                correct_exercise_count: 3,
                 recovered_exercise_count: 0,
                 due_at: resp[0][:students][0][:data][0][:due_at],
                 last_worked_at: resp[0][:students][0][:data][0][:last_worked_at]
@@ -116,8 +117,8 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 type: 'homework',
                 id: resp[0][:students][0][:data][2][:id],
                 status: 'completed',
-                exercise_count: 4,
-                correct_exercise_count: 3,
+                exercise_count: 6,
+                correct_exercise_count: 6,
                 recovered_exercise_count: 0,
                 due_at: resp[0][:students][0][:data][2][:due_at],
                 last_worked_at: resp[0][:students][0][:data][2][:last_worked_at]
@@ -133,8 +134,8 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 type: 'homework',
                 id: resp[0][:students][1][:data][0][:id],
                 status: 'in_progress',
-                exercise_count: 6,
-                correct_exercise_count: 2,
+                exercise_count: 4,
+                correct_exercise_count: 1,
                 recovered_exercise_count: 0,
                 due_at: resp[0][:students][1][:data][0][:due_at],
                 last_worked_at: resp[0][:students][1][:data][0][:last_worked_at]
@@ -150,8 +151,8 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 type: 'homework',
                 id: resp[0][:students][1][:data][2][:id],
                 status: 'in_progress',
-                exercise_count: 4,
-                correct_exercise_count: 1,
+                exercise_count: 6,
+                correct_exercise_count: 2,
                 recovered_exercise_count: 0,
                 due_at: resp[0][:students][1][:data][2][:due_at],
                 last_worked_at: resp[0][:students][1][:data][2][:last_worked_at]
@@ -161,21 +162,21 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
         }, {
           period_id: course.periods.order(:id).last.id.to_s,
           data_headings: [
-            { title: 'Homework task plan',
+            { title: 'Homework 2 task plan',
               plan_id: resp[1][:data_headings][0][:plan_id],
               type: 'homework',
-              due_at: resp[1][:data_headings][0][:due_at],
-              average: 100.0
+              due_at: resp[1][:data_headings][0][:due_at]
             },
             { title: 'Reading task plan',
               plan_id: resp[1][:data_headings][1][:plan_id],
               type: 'reading',
               due_at: resp[1][:data_headings][1][:due_at]
             },
-            { title: 'Homework 2 task plan',
+            { title: 'Homework task plan',
               plan_id: resp[1][:data_headings][2][:plan_id],
               type: 'homework',
-              due_at: resp[1][:data_headings][2][:due_at]
+              due_at: resp[1][:data_headings][2][:due_at],
+              average: 100.0
             }
           ],
           students: [{
@@ -188,7 +189,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 type: 'homework',
                 id: resp[1][:students][0][:data][0][:id],
                 status: 'not_started',
-                exercise_count: 6,
+                exercise_count: 4,
                 correct_exercise_count: 0,
                 recovered_exercise_count: 0,
                 due_at: resp[1][:students][0][:data][0][:due_at]
@@ -203,7 +204,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 type: 'homework',
                 id: resp[1][:students][0][:data][2][:id],
                 status: 'not_started',
-                exercise_count: 4,
+                exercise_count: 6,
                 correct_exercise_count: 0,
                 recovered_exercise_count: 0,
                 due_at: resp[1][:students][0][:data][2][:due_at]
@@ -219,12 +220,11 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
               {
                 type: 'homework',
                 id: resp[1][:students][1][:data][0][:id],
-                status: 'completed',
-                exercise_count: 6,
-                correct_exercise_count: 6,
+                status: 'not_started',
+                exercise_count: 4,
+                correct_exercise_count: 0,
                 recovered_exercise_count: 0,
-                due_at: resp[1][:students][1][:data][0][:due_at],
-                last_worked_at: resp[1][:students][1][:data][0][:last_worked_at]
+                due_at: resp[1][:students][1][:data][0][:due_at]
               },
               {
                 type: 'reading',
@@ -235,11 +235,12 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
               {
                 type: 'homework',
                 id: resp[1][:students][1][:data][2][:id],
-                status: 'not_started',
-                exercise_count: 4,
-                correct_exercise_count: 0,
+                status: 'completed',
+                exercise_count: 6,
+                correct_exercise_count: 6,
                 recovered_exercise_count: 0,
-                due_at: resp[1][:students][1][:data][2][:due_at]
+                due_at: resp[1][:students][1][:data][2][:due_at],
+                last_worked_at: resp[1][:students][1][:data][2][:last_worked_at]
               }
             ]
           }]

--- a/spec/controllers/api/v1/performance_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/performance_reports_controller_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
 
         expect(response).to have_http_status :success
         resp = response.body_as_hash
-        binding.pry
         expect(resp).to include({
           period_id: course.periods.first.id.to_s,
           data_headings: [


### PR DESCRIPTION
Closes #570 

Fixes #641

![screen shot 2015-09-03 at 10 33 13 am](https://cloud.githubusercontent.com/assets/98936/9661142/671395da-5227-11e5-8740-9bfae010c383.png)

Closes #642

![screen shot 2015-09-04 at 11 14 40 am](https://cloud.githubusercontent.com/assets/98936/9687219/3925815e-52f6-11e5-830b-ef2e7e83fd73.png)

Fixes issue of cell highlighting + commenting reference finding were not aligned for students with multiple late assignments. It was a recursive mutation error on my part.

https://github.com/openstax/tutor-server/pull/637/files#diff-a39789b63cd9e432c33b637155c3695bR90

```ruby
some_loop.with_index do |item, i|
  i += offset_value
end

# vs.

some_loop.with_index do |item, i|
  offset_i = i + offset_value
end
```

Fixes a found issue while debugging the above issue: the averages row was off by one column, just like due dates were. The code for `collecting_columns` is now pretty straightforward:
```ruby
collect_columns(collection, label = nil, &block)
  # ...
end
```

https://github.com/openstax/tutor-server/blob/fix-wonky-perf-export-logic/app/subsystems/tasks/performance_report/export_xlsx.rb#L77

Previously, the above had to be implemented like this:
```ruby
(['Averages'] + offset_columns(1) + gather_averages(data)).collect do # ...

# vs. new and improved

collect_columns(gather_averages(data), 'Average') do # ...

# ^ the offset of columns is inferred by the number of labels passed in :)
```
