### PR TITLE
Handled MalformedCSVError on student import

### DIFF
--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -44,13 +44,19 @@ ActionController::Base.class_exec do
     if notify
       @error_id = "%06d" % SecureRandom.random_number(10**6)
 
+      dns_name = begin
+        Resolv.getname(request.remote_ip)
+      rescue StandardError => e
+        "unknown"
+      end
+
       ExceptionNotifier.notify_exception(
         exception,
         env: request.env,
         data: {
           error_id: @error_id,
           message: "An exception occurred",
-          dns_name: Resolv.getname(request.remote_ip)
+          dns_name: dns_name
         },
         sections: %w(data request session environment backtrace)
       )

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Admin::CoursesController do
 
     let!(:file_1) { fixture_file_upload('files/test_courses_post_students_1.csv', 'text/csv') }
     let!(:file_2) { fixture_file_upload('files/test_courses_post_students_2.csv', 'text/csv') }
+    let!(:file_blankness) { fixture_file_upload('files/test_courses_post_students_blankness.csv', 'text/csv') }
     let!(:incomplete_file) { fixture_file_upload('files/test_courses_post_students_incomplete.csv', 'text/csv') }
 
     it 'adds students to a course period' do
@@ -84,6 +85,15 @@ RSpec.describe Admin::CoursesController do
         'On line 4, password is missing.'
       ])
     end
+
+    it 'gives a nice error and no exception if has funky characters' do
+      expect {
+        post :students, id: physics.id, course: { period: physics_period.id }, student_roster: file_blankness
+      }.not_to raise_error
+
+      expect(flash[:error]).to eq 'Unquoted fields do not allow \r or \n (line 2).'
+    end
+
   end
 
   describe 'GET #edit' do

--- a/spec/fixtures/files/test_courses_post_students_blankness.csv
+++ b/spec/fixtures/files/test_courses_post_students_blankness.csv
@@ -1,0 +1,6 @@
+"first_name","last_name","username","password"
+
+
+"Carol","Burgess","carolb","password"
+"Melissa","Haynes","melissah","PASSword"
+"Alexander","Himmel","alexh","pa$$w0rd"


### PR DESCRIPTION
When the CSV importer freaks out it can raise a `CSV::MalformedCSVError`.  Instead of sending that out to developers, this PR catches it and displays its error message to the admin doing the import.