### PR TITLE
Added exception cause to logs and exception email

### DIFF
--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -1,5 +1,38 @@
 ActionController::Base.class_exec do
 
+  # See https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L453 for error names/symbols
+  EXCEPTION_STATUS_MAP = Hash.new(:internal_server_error).merge({
+    'SecurityTransgression' => :forbidden,
+    'ActiveRecord::RecordNotFound' => :not_found,
+    'ActionController::RoutingError' => :not_found,
+    'ActionController::UnknownController' => :not_found,
+    'AbstractController::ActionNotFound' => :not_found,
+    'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
+    'Apipie::ParamMissing' => :unprocessable_entity,
+    'ActionView::MissingTemplate' => :bad_request,
+  })
+
+  NON_NOTIFYING_EXCEPTIONS = Set.new [
+    'SecurityTransgression',
+    'ActiveRecord::RecordNotFound',
+    'ActionController::RoutingError',
+    'ActionController::UnknownController',
+    'AbstractController::ActionNotFound',
+    'ActionController::InvalidAuthenticityToken',
+    'Apipie::ParamMissing',
+    'ActionView::MissingTemplate'
+  ]
+
+  EXCEPTION_EXTRAS_PROC_MAP = {
+    'OAuth2::Error' => ->(exception) {
+      {
+        headers: exception.response.headers,
+        status: exception.response.status,
+        body: exception.response.body
+      }
+    }
+  }
+
   protect_from_forgery with: :exception
 
   rescue_from Exception, with: :rescue_from_exception
@@ -21,49 +54,50 @@ ActionController::Base.class_exec do
     response.header['X-App-Date'] = Time.now.httpdate
   end
 
-  def get_exception_cause(exception)
+  def get_exception_cause(exception:)
     cause = exception.cause
     return if cause.nil?
 
     {
       class: cause.class.name,
       message: cause.message,
-      cause: get_exception_cause(cause)
+      first_line_of_backtrace: cause.backtrace.first,
+      cause: get_exception_cause(exception: cause)
     }
   end
 
-  def rescue_from_exception(exception)
-    # See https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L453
-    # for error names/symbols
-    @status, notify, extras = case exception
-    when SecurityTransgression
-      [:forbidden, false]
-    when ActiveRecord::RecordNotFound,
-         ActionController::RoutingError,
-         ActionController::UnknownController,
-         AbstractController::ActionNotFound
-      [:not_found, false]
-    when ActionController::InvalidAuthenticityToken,
-         Apipie::ParamMissing
-      [:unprocessable_entity, false]
-    when ActionView::MissingTemplate
-      [:bad_request, false]
-    when OAuth2::Error
-      [
-        :internal_server_error,
-        true,
-        {
-          headers: exception.response.headers,
-          status: exception.response.status,
-          body: exception.response.body
-        }
-      ]
+  def log_exception(exception:, extras: {}, is_cause: false)
+    if is_cause
+      header = 'Exception cause'
+      backtrace = exception.backtrace.first
     else
-      [:internal_server_error, true]
+      header = 'An exception occurred'
+      backtrace = exception.backtrace.join("\n")
     end
 
-    if notify
+    Rails.logger.error {
+      "#{header}: #{exception.class.name} [#{@error_id}] " +
+      "<#{exception.message}> #{extras}\n\n#{exception.backtrace.join("\n")}"
+    }
+
+    cause = exception.cause
+    return if cause.blank?
+
+    log_exception(exception: cause, is_cause: true)
+  end
+
+  def rescue_from_exception(exception)
+    exception_class_name = exception.class.name
+
+    @status = EXCEPTION_STATUS_MAP[exception_class_name]
+
+    unless NON_NOTIFYING_EXCEPTIONS.include?(exception_class_name)
       @error_id = "%06d" % SecureRandom.random_number(10**6)
+
+      extras_proc = EXCEPTION_EXTRAS_PROC_MAP[exception_class_name]
+      extras = (extras_proc.nil? ? {} : extras_proc.call(exception)).inspect
+
+      log_exception(exception: exception, extras: extras)
 
       dns_name = begin
         Resolv.getname(request.remote_ip)
@@ -71,26 +105,20 @@ ActionController::Base.class_exec do
         "unknown"
       end
 
-      extras = (extras || {}).inspect
-
       ExceptionNotifier.notify_exception(
         exception,
         env: request.env,
         data: {
           error_id: @error_id,
-          class: exception.class.name,
+          class: exception_class_name,
           message: exception.message,
-          cause: get_exception_cause(exception),
+          first_line_of_backtrace: exception.backtrace.first,
+          cause: get_exception_cause(exception: exception),
           dns_name: dns_name,
           extras: extras
         },
         sections: %w(data request session environment backtrace)
       )
-
-      Rails.logger.error {
-        "An exception occurred: #{exception.class.name} [#{@error_id}] " +
-        "<#{exception.message}> {#{extras}}\n\n#{exception.backtrace.join("\n")}"
-      }
     end
 
     raise exception if Rails.application.config.consider_all_requests_local

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -21,6 +21,17 @@ ActionController::Base.class_exec do
     response.header['X-App-Date'] = Time.now.httpdate
   end
 
+  def get_exception_cause(exception)
+    cause = exception.cause
+    return if cause.nil?
+
+    {
+      class: cause.class.name,
+      message: cause.message,
+      cause: get_exception_cause(cause)
+    }
+  end
+
   def rescue_from_exception(exception)
     # See https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L453
     # for error names/symbols
@@ -67,7 +78,9 @@ ActionController::Base.class_exec do
         env: request.env,
         data: {
           error_id: @error_id,
+          class: exception.class.name,
           message: exception.message,
+          cause: get_exception_cause(exception),
           dns_name: dns_name,
           extras: extras
         },

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -146,10 +146,10 @@ RSpec.describe ApplicationController, type: :controller do
         raise StandardError, 'Test Wrapped'
       rescue StandardError => exception
         begin
-          raise StandardError, 'Test Wrapper 1', cause: exception
+          raise StandardError, 'Test Wrapper 1'
         rescue StandardError => exception
           begin
-            raise StandardError, 'Test Wrapper 2', cause: exception
+            raise StandardError, 'Test Wrapper 2'
           rescue StandardError => exception
             exception
           end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
-  let!(:controller) {
+  subject(:controller) {
     cc = ApplicationController.new
     cc.response = ActionController::TestResponse.new
     cc
@@ -120,6 +120,128 @@ RSpec.describe ApplicationController, type: :controller do
       controller.send :set_app_date_header
       header_time = Time.parse(controller.response.headers['X-App-Date'])
       expect(header_time).to be_within(1.second).of(t)
+    end
+  end
+
+  context 'rescue_from_exception' do
+    let(:non_notifying_exception) {
+      SecurityTransgression.new('Test Non-notifying').tap{ |ex| ex.set_backtrace([]) }
+    }
+    let(:notifying_exception)     {
+      StandardError.new('Test Notifying').tap{ |ex| ex.set_backtrace([]) }
+    }
+
+    let(:oauth2_headers) { {} }
+    let(:oauth2_status)  { 500 }
+    let(:oauth2_body)    { '' }
+    let(:oauth2_request) {
+      OpenStruct.new(headers: oauth2_headers, status: oauth2_status, body: oauth2_body)
+    }
+    let(:oauth2_exception)     {
+      OAuth2::Error.new(oauth2_request).tap{ |ex| ex.set_backtrace([]) }
+    }
+
+    let(:nested_exception)        {
+      begin
+        raise StandardError, 'Test Wrapped'
+      rescue StandardError => exception
+        begin
+          raise StandardError, 'Test Wrapper 1', cause: exception
+        rescue StandardError => exception
+          begin
+            raise StandardError, 'Test Wrapper 2', cause: exception
+          rescue StandardError => exception
+            exception
+          end
+        end
+      end
+    }
+
+    let(:env) { {} }
+
+    before(:each) do
+      @request = controller.request
+      controller.request = Hashie::Mash.new(env: env)
+    end
+
+    after(:each) do
+      controller.request = @request
+    end
+
+    it 'sends exception emails for notifying exceptions' do
+      expect(ExceptionNotifier).to receive(:notify_exception).once.with(
+        notifying_exception,
+        env: env,
+        data: {
+          error_id: a_kind_of(String),
+          class: 'StandardError',
+          message: 'Test Notifying',
+          cause: nil,
+          dns_name: 'unknown',
+          extras: {}.inspect
+        },
+        sections: %w(data request session environment backtrace)
+      )
+
+      expect{ controller.send :rescue_from_exception, notifying_exception }
+        .to raise_error(notifying_exception)
+    end
+
+    it 'does not send exception email for non-notifying exceptions' do
+      expect(ExceptionNotifier).not_to receive(:notify_exception)
+
+      expect{ controller.send :rescue_from_exception, non_notifying_exception }
+        .to raise_error(non_notifying_exception)
+    end
+
+    it 'displays extra information from OAuth2::Errors' do
+      expect(ExceptionNotifier).to receive(:notify_exception).once.with(
+        oauth2_exception,
+        env: env,
+        data: {
+          error_id: a_kind_of(String),
+          class: 'OAuth2::Error',
+          message: '',
+          cause: nil,
+          dns_name: 'unknown',
+          extras: {
+            headers: oauth2_headers,
+            status: oauth2_status,
+            body: oauth2_body
+          }.inspect
+        },
+        sections: %w(data request session environment backtrace)
+      )
+
+      expect{ controller.send :rescue_from_exception, oauth2_exception }
+        .to raise_error(oauth2_exception)
+    end
+
+    it 'displays nested exceptions' do
+      expect(ExceptionNotifier).to receive(:notify_exception).once.with(
+        nested_exception,
+        env: env,
+        data: {
+          error_id: a_kind_of(String),
+          class: 'StandardError',
+          message: 'Test Wrapper 2',
+          cause: {
+            class: 'StandardError',
+            message: 'Test Wrapper 1',
+            cause: {
+              class: 'StandardError',
+              message: 'Test Wrapped',
+              cause: nil
+            }
+          },
+          dns_name: 'unknown',
+          extras: {}.inspect
+        },
+        sections: %w(data request session environment backtrace)
+      )
+
+      expect{ controller.send :rescue_from_exception, nested_exception }
+        .to raise_error(nested_exception)
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -125,10 +125,14 @@ RSpec.describe ApplicationController, type: :controller do
 
   context 'rescue_from_exception' do
     let(:non_notifying_exception) {
-      SecurityTransgression.new('Test Non-notifying').tap{ |ex| ex.set_backtrace([]) }
+      SecurityTransgression.new('Test Non-notifying').tap do |ex|
+        ex.set_backtrace(['test.rb:42:in `raise!\''])
+      end
     }
     let(:notifying_exception)     {
-      StandardError.new('Test Notifying').tap{ |ex| ex.set_backtrace([]) }
+      StandardError.new('Test Notifying').tap do |ex|
+        ex.set_backtrace(['test.rb:42:in `notify!\''])
+      end
     }
 
     let(:oauth2_headers) { {} }
@@ -138,7 +142,7 @@ RSpec.describe ApplicationController, type: :controller do
       OpenStruct.new(headers: oauth2_headers, status: oauth2_status, body: oauth2_body)
     }
     let(:oauth2_exception)     {
-      OAuth2::Error.new(oauth2_request).tap{ |ex| ex.set_backtrace([]) }
+      OAuth2::Error.new(oauth2_request).tap{ |ex| ex.set_backtrace(['oauth2.rb:42:in `test!\'']) }
     }
 
     let(:nested_exception)        {
@@ -176,6 +180,7 @@ RSpec.describe ApplicationController, type: :controller do
           error_id: a_kind_of(String),
           class: 'StandardError',
           message: 'Test Notifying',
+          first_line_of_backtrace: 'test.rb:42:in `notify!\'',
           cause: nil,
           dns_name: 'unknown',
           extras: {}.inspect
@@ -202,6 +207,7 @@ RSpec.describe ApplicationController, type: :controller do
           error_id: a_kind_of(String),
           class: 'OAuth2::Error',
           message: '',
+          first_line_of_backtrace: 'oauth2.rb:42:in `test!\'',
           cause: nil,
           dns_name: 'unknown',
           extras: {
@@ -225,12 +231,15 @@ RSpec.describe ApplicationController, type: :controller do
           error_id: a_kind_of(String),
           class: 'StandardError',
           message: 'Test Wrapper 2',
+          first_line_of_backtrace: a_kind_of(String),
           cause: {
             class: 'StandardError',
             message: 'Test Wrapper 1',
+            first_line_of_backtrace: a_kind_of(String),
             cause: {
               class: 'StandardError',
               message: 'Test Wrapped',
+              first_line_of_backtrace: a_kind_of(String),
               cause: nil
             }
           },


### PR DESCRIPTION
- Exception causes are now printed in logs and emails, if present
- First line of backtrace added to main exception and cause
- Specs