### PR TITLE
(Some) Role cleanup

### DIFF
--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -10,6 +10,9 @@ class CollectCourseInfo
   uses_routine GetTeacherNames,
                translations: { outputs: { type: :verbatim } },
                as: :get_teacher_names
+  uses_routine GetUserCourses,
+               translations: { outputs: { type: :verbatim } },
+               as: :get_courses
   uses_routine GetUserCourseRoles,
                translations: { outputs: { type: :verbatim } },
                as: :get_course_roles
@@ -32,12 +35,8 @@ class CollectCourseInfo
     profiles = if course
                  CourseProfile::Models::Profile.where(entity_course_id: course.id) || []
                elsif user
-                 CourseProfile::Models::Profile.all.select do |p|
-                   run(:is_student, user: user, course: p.course)
-                       .outputs.user_is_course_student ||
-                   run(:is_teacher, user: user, course: p.course)
-                       .outputs.user_is_course_teacher
-                 end
+                 courses = run(:get_courses, user: user).outputs.courses
+                 CourseProfile::Models::Profile.where(entity_course_id: courses.collect(&:id))
                else
                  CourseProfile::Models::Profile.all
                end

--- a/app/routines/get_user_course_roles.rb
+++ b/app/routines/get_user_course_roles.rb
@@ -18,12 +18,14 @@ class GetUserCourseRoles
 
   protected
 
-  def exec(course:, user:, types: :any)
-    run(:get_user_roles, user)
-    run(:get_course_roles, course: course, types: types)
+  def exec(course:, user:, types: :any, include_inactive_students: false)
+    user_roles = run(:get_user_roles, user).outputs.roles
+    course_roles = run(:get_course_roles, course: course,
+                                          types: types,
+                                          include_inactive_students: include_inactive_students)
+                     .outputs.roles
 
     # Intersect the results from above
-    outputs[:roles] = outputs["[:get_user_roles, :roles]"] &
-                      outputs["[:get_course_roles, :roles]"]
+    outputs[:roles] = user_roles & course_roles
   end
 end

--- a/app/subsystems/course_membership/get_course_roles.rb
+++ b/app/subsystems/course_membership/get_course_roles.rb
@@ -7,7 +7,9 @@ class CourseMembership::GetCourseRoles
 
   protected
 
-  def exec(course:, types: :any)
-    run(:get_period_roles, periods: course.periods, types: types)
+  def exec(course:, types: :any, include_inactive_students: false)
+    run(:get_period_roles, periods: course.periods,
+                           types: types,
+                           include_inactive_students: include_inactive_students)
   end
 end

--- a/app/subsystems/course_membership/get_period_roles.rb
+++ b/app/subsystems/course_membership/get_period_roles.rb
@@ -4,7 +4,7 @@ class CourseMembership::GetPeriodRoles
   ROLE_TYPES = [:student, :teacher, :any]
 
   protected
-  def exec(periods:, types: :any)
+  def exec(periods:, types: :any, include_inactive_students: false)
     periods = [periods].flatten.uniq
     types = [types].flatten.uniq
 
@@ -15,7 +15,9 @@ class CourseMembership::GetPeriodRoles
     outputs[:roles] = types.collect do |type|
       case type
       when :student
-        periods.collect(&:student_roles)
+        periods.collect do |period|
+          period.student_roles(include_inactive_students: include_inactive_students)
+        end
       when :teacher
         periods.collect(&:teacher_roles)
       else

--- a/app/subsystems/course_membership/get_role_courses.rb
+++ b/app/subsystems/course_membership/get_role_courses.rb
@@ -8,7 +8,7 @@ class CourseMembership::GetRoleCourses
 
   protected
 
-  def exec(roles:, types: :any)
+  def exec(roles:, types: :any, include_inactive_students: false)
     types = [types].flatten.compact
     types = [:student, :teacher] if types.include?(:any)
 
@@ -17,7 +17,10 @@ class CourseMembership::GetRoleCourses
     courses = []
 
     if types.include?(:student)
-      courses += Entity::Course.joins{students}.where{students.entity_role_id.in role_ids}
+      courses_as_student = Entity::Course.joins{students}.where{students.entity_role_id.in role_ids}
+      courses_as_student = courses_as_student.where(students: { inactive_at: nil }) \
+        unless include_inactive_students
+      courses += courses_as_student
     end
 
     if types.include?(:teacher)

--- a/spec/routines/choose_course_role_spec.rb
+++ b/spec/routines/choose_course_role_spec.rb
@@ -109,12 +109,25 @@ describe ChooseCourseRole do
     end
 
     context "and the role is a course student and the user is a teacher" do
-      subject {
-        ChooseCourseRole.call(user: teacher, course: course, role_id: student_role.id)
-      }
+      context "and the student is active" do
+        subject {
+          ChooseCourseRole.call(user: teacher, course: course, role_id: student_role.id)
+        }
 
-      it "returns the provided role" do
-        expect(subject.outputs.role).to eq(student_role)
+        it "returns the provided role" do
+          expect(subject.outputs.role).to eq(student_role)
+        end
+      end
+
+      context "and the student is inactive" do
+        subject do
+          student_role.student.inactivate.save!
+          ChooseCourseRole.call(user: teacher, course: course, role_id: student_role.id)
+        end
+
+        it "returns the provided role" do
+          expect(subject.outputs.role).to eq(student_role)
+        end
       end
     end
 

--- a/spec/routines/collect_course_info_spec.rb
+++ b/spec/routines/collect_course_info_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe CollectCourseInfo, type: :routine do
+  let!(:user_1)    { Entity::User.create! }
+  let!(:user_2)    { Entity::User.create! }
+
+  let!(:role_1)    { FactoryGirl.create :entity_role, user: user_1 }
+  let!(:role_2)    { FactoryGirl.create :entity_role, user: user_2 }
+
+  let!(:course_1) { FactoryGirl.create(:course_profile_profile).course }
+  let!(:course_2) { FactoryGirl.create(:course_profile_profile).course }
+
+  let!(:student_1) { FactoryGirl.create :course_membership_student, role: role_1, course: course_1 }
+  let!(:student_2) { FactoryGirl.create :course_membership_student, role: role_2, course: course_2 }
+
+  context "when a course is given" do
+    it "returns information about the course" do
+      result = described_class[course: course_1]
+      expect(result).to contain_exactly(
+        {
+          id: course_1.id,
+          name: course_1.profile.name,
+          school_name: course_1.profile.school_name
+        }
+      )
+    end
+  end
+
+  context "when a user is given" do
+    it "returns information about the user's active courses" do
+      result = described_class[user: user_1]
+      expect(result).to contain_exactly(
+        {
+          id: course_1.id,
+          name: course_1.profile.name,
+          school_name: course_1.profile.school_name
+        }
+      )
+    end
+  end
+
+  context "when neither is given" do
+    it "returns information about all courses" do
+      result = described_class[]
+      expect(result).to contain_exactly(
+        {
+          id: course_1.id,
+          name: course_1.profile.name,
+          school_name: course_1.profile.school_name
+        },
+        {
+          id: course_2.id,
+          name: course_2.profile.name,
+          school_name: course_2.profile.school_name
+        }
+      )
+    end
+  end
+end

--- a/spec/routines/get_user_courses_spec.rb
+++ b/spec/routines/get_user_courses_spec.rb
@@ -32,4 +32,26 @@ RSpec.describe GetUserCourses, :type => :routine do
     expect(courses).to contain_exactly(course_1, course_3)
   end
 
+  it 'does not return courses where the user is an inactive student' do
+    user   = Entity::User.create!
+    course_1 = Entity::Course.create!
+    course_1_period = CreatePeriod[course: course_1]
+    course_2 = Entity::Course.create!
+    course_3 = Entity::Course.create!
+    course_3_period = CreatePeriod[course: course_3]
+
+    AddUserAsCourseTeacher[user: user, course: course_2]
+    AddUserAsPeriodStudent[user: user, period: course_3_period]
+    AddUserAsPeriodStudent[user: user, period: course_1_period]
+
+    course_3_role = user.roles.joins(:student)
+                              .where(student: { entity_course_id: course_3.id })
+                              .first!
+    course_3_role.student.inactivate.save!
+
+    courses = GetUserCourses[user: user, types: :student]
+
+    expect(courses).to eq [course_1]
+  end
+
 end

--- a/spec/subsystems/course_membership/get_role_courses_spec.rb
+++ b/spec/subsystems/course_membership/get_role_courses_spec.rb
@@ -46,4 +46,10 @@ describe CourseMembership::GetRoleCourses do
     expect(courses).to contain_exactly(course_1, course_3)
   end
 
+  it 'does not find courses where the role is an inactive student' do
+    role_b.student.inactivate.save!
+    courses = described_class[roles: [role_a, role_b], types: [:student]]
+    expect(courses).to contain_exactly(course_1)
+  end
+
 end


### PR DESCRIPTION
- Teachers can now impersonate dropped students.
- Courses where the user is a dropped student should no longer be displayed for selection.

Solves https://www.pivotaltracker.com/story/show/103137354
Solves https://github.com/openstax/tutor-server/issues/638