### PR TITLE
Set the default cache store to Redis (initializer did not work)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,15 @@ module Tutor
     # Temporary fix until we update openstax_api
     # to include this for JSON responses
     ActiveSupport.escape_html_entities_in_json = false
+
+    # Set the default cache store to Redis
+    # This setting cannot be set from an initializer
+    # See https://github.com/rails/rails/issues/10908
+    redis_secrets = secrets['redis']
+    config.cache_store = :redis_store, {
+      url: redis_secrets['url'],
+      namespace: redis_secrets['namespaces']['cache'],
+      expires_in: 90.minutes
+    }
   end
 end

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-secrets = Rails.application.secrets['redis']
-
-Rails.application.config.cache_store = :redis_store, {
-  url: secrets['url'],
-  namespace: secrets['namespaces']['cache'],
-  expires_in: 90.minutes
-}


### PR DESCRIPTION
You can verify this fix works because `Rails.cache` in the console is an instance of the Redis cache class after the fix.