### PR TITLE
Improved teacher learning guide performance some more

### DIFF
--- a/app/subsystems/content/map.rb
+++ b/app/subsystems/content/map.rb
@@ -45,12 +45,15 @@ module Content
       end
     end
 
-    # Returns an array of ::Content::Page's that correspond to the given array of
-    # ::Content::Exercises, mapped to the to_ecosystem
+    # Returns a hash that maps the given ::Content::Exercises' ids
+    # to ::Content::Pages in the to_ecosystem
     def map_exercises_to_pages(exercises:)
       ex_arr = verify_and_return [exercises].flatten.compact, klass: ::Content::Exercise
-      verify_and_return @strategy.map_exercises_to_pages(exercises: ex_arr),
-                        klass: ::Content::Page, error: ::Content::StrategyError
+      map = verify_and_return @strategy.map_exercises_to_pages(exercises: ex_arr),
+                              klass: Hash, error: ::Content::StrategyError
+      verify_and_return map.keys, klass: Integer, error: ::Content::StrategyError
+      verify_and_return map.values, klass: ::Content::Page, error: ::Content::StrategyError
+      map
     end
 
     def valid?

--- a/app/subsystems/content/strategies/generated/map.rb
+++ b/app/subsystems/content/strategies/generated/map.rb
@@ -77,7 +77,7 @@ module Content
 
           all_map = map_exercises_to_pages(exercises: all_exercises)
 
-          # The hash returned has all exercises given as keys
+          # The hash returned has all given exercise ids as keys
           # All values in the hash are ::Content::Page's from the to_ecosystem
           @valid = Set.new(all_map.keys) == Set.new(all_exercises.collect(&:id)) && \
                    Set.new(all_map.values).subset?(Set.new(@to_ecosystem.pages))

--- a/app/subsystems/content/strategies/generated/map.rb
+++ b/app/subsystems/content/strategies/generated/map.rb
@@ -26,53 +26,61 @@ module Content
         def initialize(from_ecosystems:, to_ecosystem:)
           @from_ecosystems = from_ecosystems
           @to_ecosystem = to_ecosystem
+
+          @page_id_to_page_map = to_ecosystem.pages.each_with_object({}) do |page, hash|
+            hash[page.id] = page
+          end
+          @exercise_id_to_page_map = {}
         end
 
         def map_exercises_to_pages(exercises:)
-          all_pages = @to_ecosystem.pages
-          page_map = all_pages.each_with_object({}) do |page, hash|
-            hash[page.id] = page
-          end
-
           exercise_ids = exercises.collect(&:id)
+          mapped_exercises = @exercise_id_to_page_map.slice(*exercise_ids)
+          unmapped_exercise_ids = exercise_ids - mapped_exercises.keys
 
-          content_exercises = Content::Models::Exercise
-                                .joins(tags: :same_value_tags)
-                                .where(id: exercise_ids,
-                                       tags: {
-                                         content_ecosystem_id: @from_ecosystems.collect(&:id),
-                                         tag_type: Content::Models::Tag::OBJECTIVE_TAG_TYPES,
-                                         same_value_tags: {
-                                           content_ecosystem_id: @to_ecosystem.id,
-                                           tag_type: Content::Models::Tag::OBJECTIVE_TAG_TYPES,
-                                         }
-                                       })
-                                .preload(tags: {same_value_tags: :pages})
-          exercise_map = content_exercises.each_with_object({}) do |content_exercise, hash|
+          return mapped_exercises if unmapped_exercise_ids.empty?
+
+          unmapped_content_exercises = Content::Models::Exercise
+            .joins(tags: :same_value_tags)
+            .where(id: unmapped_exercise_ids,
+                   tags: {
+                     content_ecosystem_id: @from_ecosystems.collect(&:id),
+                     tag_type: Content::Models::Tag::OBJECTIVE_TAG_TYPES,
+                     same_value_tags: {
+                       content_ecosystem_id: @to_ecosystem.id,
+                       tag_type: Content::Models::Tag::OBJECTIVE_TAG_TYPES,
+                     }
+                   })
+            .preload(tags: {same_value_tags: :pages})
+
+          @exercise_id_to_page_map = unmapped_content_exercises
+            .each_with_object(@exercise_id_to_page_map) do |content_exercise, hash|
+
             objective_tags = content_exercise.tags.select{ |tag| tag.lo? || tag.aplo? }
             tags_across_ecosystems = objective_tags.collect(&:same_value_tags).flatten
                                                    .select{ |tag| tag.lo? || tag.aplo? }
             content_pages = tags_across_ecosystems.collect{ |tag| tag.pages }.flatten.uniq
-            ecosystem_pages = content_pages.collect{ |cp| page_map[cp.id] }.compact
+            ecosystem_pages = content_pages.collect{ |cp| @page_id_to_page_map[cp.id] }.compact
 
             # We only allow each exercise to map to 1 page
             hash[content_exercise.id] = ecosystem_pages.size == 1 ? ecosystem_pages.first : nil
+
           end
 
-          exercise_ids.collect{ |exercise_id| exercise_map[exercise_id] }
+          mapped_exercises.merge(@exercise_id_to_page_map.slice(*unmapped_exercise_ids))
         end
 
         def valid?
           return @valid unless @valid.nil?
 
-          all_exercises = @from_ecosystems.collect{ |es| es.exercises }.flatten
+          all_exercises = @from_ecosystems.flat_map(&:exercises)
 
           all_map = map_exercises_to_pages(exercises: all_exercises)
 
-          # The array returned has the same size as the input array
-          # All elements in the array are ::Content::Page's from the to_ecosystem
-          @valid = all_map.size == all_exercises.size && \
-                   Set.new(all_map).subset?(Set.new(@to_ecosystem.pages))
+          # The hash returned has all exercises given as keys
+          # All values in the hash are ::Content::Page's from the to_ecosystem
+          @valid = Set.new(all_map.keys) == Set.new(all_exercises.collect(&:id)) && \
+                   Set.new(all_map.values).subset?(Set.new(@to_ecosystem.pages))
         end
 
       end

--- a/lib/course_guide_methods.rb
+++ b/lib/course_guide_methods.rb
@@ -16,10 +16,10 @@ module CourseGuideMethods
       strategy = ::Content::Strategies::Direct::Exercise.new(content_exercise)
       ::Content::Exercise.new(strategy: strategy)
     end
-    exercise_pages = ecosystems_map.map_exercises_to_pages(exercises: exercises)
+    exercise_id_to_page_map = ecosystems_map.map_exercises_to_pages(exercises: exercises)
 
-    tasked_exercises.each_with_index.each_with_object({}) do |(tasked_exercise, index), hash|
-      page = exercise_pages[index]
+    tasked_exercises.each_with_object({}) do |tasked_exercise, hash|
+      page = exercise_id_to_page_map[tasked_exercise.content_exercise_id]
       hash[page] ||= []
       hash[page] << tasked_exercise
     end

--- a/spec/factories/content/pages.rb
+++ b/spec/factories/content/pages.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :content_page, class: '::Content::Models::Page' do
-    url { Faker::Internet.url }
     association :chapter, factory: :content_chapter
+    url { Faker::Internet.url }
     title { Faker::Lorem.words(3) }
     content { Faker::Lorem.paragraphs(2) }
     uuid { SecureRandom.uuid }

--- a/spec/factories/content/tags.rb
+++ b/spec/factories/content/tags.rb
@@ -2,8 +2,9 @@ FactoryGirl.define do
   factory :content_tag, class: '::Content::Models::Tag' do
     association :ecosystem, factory: :content_ecosystem
 
-    value { SecureRandom.hex }
-    name { Faker::Lorem.word }
+    value       { SecureRandom.hex }
+    name        { Faker::Lorem.word }
     description { Faker::Lorem.paragraph }
+    tag_type    { :generic }
   end
 end

--- a/spec/subsystems/content/strategies/generated/map_spec.rb
+++ b/spec/subsystems/content/strategies/generated/map_spec.rb
@@ -122,14 +122,29 @@ module Content
 
         it 'can map from_ecosystems exercise ids to to_ecosystem pages' do
           mapping = map.map_exercises_to_pages(exercises: [
-            old_exercise, new_exercise, another_old_exercise, another_new_exercise
+            old_exercise, new_exercise
           ])
           [old_exercise, new_exercise].each do |exercise|
             expect(mapping[exercise.id]).to eq new_exercise.page
           end
 
+          mapping_2 = map.map_exercises_to_pages(exercises: [
+            another_old_exercise, another_new_exercise
+          ])
           [another_old_exercise, another_new_exercise].each do |exercise|
-            expect(mapping[exercise.id]).to eq another_new_exercise.page
+            expect(mapping_2[exercise.id]).to eq another_new_exercise.page
+          end
+
+          # Try again to see that we get the same results with the cached mapping
+          mapping_3 = map.map_exercises_to_pages(exercises: [
+            old_exercise, new_exercise, another_old_exercise, another_new_exercise
+          ])
+          [old_exercise, new_exercise].each do |exercise|
+            expect(mapping_3[exercise.id]).to eq new_exercise.page
+          end
+
+          [another_old_exercise, another_new_exercise].each do |exercise|
+            expect(mapping_3[exercise.id]).to eq another_new_exercise.page
           end
         end
 

--- a/spec/subsystems/content/strategies/generated/map_spec.rb
+++ b/spec/subsystems/content/strategies/generated/map_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+module Content
+  module Strategies
+    module Generated
+      RSpec.describe Map do
+        let!(:old_content_exercise)         { FactoryGirl.create :content_exercise }
+        let!(:new_content_exercise)         { FactoryGirl.create :content_exercise }
+
+        let!(:another_old_content_chapter)  {
+          FactoryGirl.create :content_chapter, book: old_content_exercise.book
+        }
+        let!(:another_old_content_page)     {
+          FactoryGirl.create :content_page, chapter: another_old_content_chapter
+        }
+        let!(:another_old_content_exercise) {
+          FactoryGirl.create :content_exercise, page: another_old_content_page
+        }
+        let!(:another_old_content_page_2)   {
+          FactoryGirl.create :content_page, chapter: old_content_exercise.chapter
+        }
+
+        let!(:another_new_content_chapter)  {
+          FactoryGirl.create :content_chapter, book: new_content_exercise.book
+        }
+        let!(:another_new_content_page)     {
+          FactoryGirl.create :content_page, chapter: another_new_content_chapter
+        }
+        let!(:another_new_content_exercise) {
+          FactoryGirl.create :content_exercise, page: another_new_content_page
+        }
+        let!(:another_new_content_page_2)   {
+          FactoryGirl.create :content_page, chapter: new_content_exercise.chapter
+        }
+
+        let!(:old_lo_tag)                   {
+          FactoryGirl.create :content_tag, ecosystem: old_content_exercise.ecosystem,
+                                           tag_type: :lo,
+                                           value: 'lo01'
+        }
+        let!(:old_exercise_tag)             {
+          FactoryGirl.create :content_exercise_tag, exercise: old_content_exercise,
+                                                    tag: old_lo_tag
+        }
+        let!(:old_page_tag)                 {
+          FactoryGirl.create :content_page_tag, page: old_content_exercise.page,
+                                                tag: old_lo_tag
+        }
+
+        let!(:new_lo_tag)                   {
+          FactoryGirl.create :content_tag, ecosystem: new_content_exercise.ecosystem,
+                                           tag_type: :lo,
+                                           value: 'lo01'
+        }
+        let!(:new_exercise_tag)             {
+          FactoryGirl.create :content_exercise_tag, exercise: new_content_exercise,
+                                                    tag: new_lo_tag
+        }
+        let!(:new_page_tag)                 {
+          FactoryGirl.create :content_page_tag, page: new_content_exercise.page,
+                                                tag: new_lo_tag
+        }
+
+        let!(:another_old_lo_tag)           {
+          FactoryGirl.create :content_tag, ecosystem: old_content_exercise.ecosystem,
+                                           tag_type: :lo,
+                                           value: 'lo02'
+        }
+        let!(:another_old_exercise_tag)     {
+          FactoryGirl.create :content_exercise_tag, exercise: another_old_content_exercise,
+                                                    tag: another_old_lo_tag
+        }
+        let!(:another_old_page_tag)         {
+          FactoryGirl.create :content_page_tag, page: another_old_content_exercise.page,
+                                                tag: another_old_lo_tag
+        }
+
+        let!(:another_new_lo_tag)           {
+          FactoryGirl.create :content_tag, ecosystem: new_content_exercise.ecosystem,
+                                           tag_type: :lo,
+                                           value: 'lo02'
+        }
+        let!(:another_new_exercise_tag)     {
+          FactoryGirl.create :content_exercise_tag, exercise: another_new_content_exercise,
+                                                    tag: another_new_lo_tag
+        }
+        let!(:another_new_page_tag)         {
+          FactoryGirl.create :content_page_tag, page: another_new_content_exercise.page,
+                                                tag: another_new_lo_tag
+        }
+
+        let!(:old_exercise)                 {
+          model = old_content_exercise
+          strategy = ::Content::Strategies::Direct::Exercise.new(model)
+          ::Content::Exercise.new(strategy: strategy)
+        }
+        let!(:new_exercise)                 {
+          model = new_content_exercise
+          strategy = ::Content::Strategies::Direct::Exercise.new(model)
+          ::Content::Exercise.new(strategy: strategy)
+        }
+
+        let!(:old_ecosystem)                { old_exercise.page.chapter.book.ecosystem }
+        let!(:new_ecosystem)                { new_exercise.page.chapter.book.ecosystem }
+
+        let!(:another_old_exercise)         {
+          model = another_old_content_exercise
+          strategy = ::Content::Strategies::Direct::Exercise.new(model)
+          ::Content::Exercise.new(strategy: strategy)
+        }
+        let!(:another_new_exercise)         {
+          model = another_new_content_exercise
+          strategy = ::Content::Strategies::Direct::Exercise.new(model)
+          ::Content::Exercise.new(strategy: strategy)
+        }
+
+        subject(:map)                       {
+          Content::Map.create!(from_ecosystems: [old_ecosystem, new_ecosystem],
+                               to_ecosystem: new_ecosystem,
+                               strategy_class: described_class)
+        }
+
+        it 'can map from_ecosystems exercise ids to to_ecosystem pages' do
+          mapping = map.map_exercises_to_pages(exercises: [
+            old_exercise, new_exercise, another_old_exercise, another_new_exercise
+          ])
+          [old_exercise, new_exercise].each do |exercise|
+            expect(mapping[exercise.id]).to eq new_exercise.page
+          end
+
+          [another_old_exercise, another_new_exercise].each do |exercise|
+            expect(mapping[exercise.id]).to eq another_new_exercise.page
+          end
+        end
+
+        it 'knows if it is valid or not' do
+          # The ecosystems are identical, so we can map both ways
+          expect(map).to be_valid
+          reverse_map = Content::Map.create!(from_ecosystems: [old_ecosystem, new_ecosystem],
+                                             to_ecosystem: old_ecosystem,
+                                             strategy_class: described_class)
+          expect(reverse_map).to be_valid
+
+          # Pretend lo02 and its page were added only in the new ecosystem
+          another_old_lo_tag.exercises.first.destroy
+          another_old_lo_tag.pages.first.destroy
+          another_old_lo_tag.destroy
+
+          # Rewrap the old ecosystem so we pick up the changes
+          modified_old_strategy = Content::Strategies::Direct::Ecosystem.new(
+            another_old_lo_tag.ecosystem
+          )
+          modified_old_ecosystem = Content::Ecosystem.new(strategy: modified_old_strategy)
+
+          # We can still map forward, but the reverse map is now invalid
+          modified_map = Content::Map.create!(
+            from_ecosystems: [modified_old_ecosystem, new_ecosystem],
+            to_ecosystem: new_ecosystem,
+            strategy_class: described_class
+          )
+          expect(modified_map).to be_valid
+          reverse_modified_map = Content::Map.create(
+            from_ecosystems: [modified_old_ecosystem, new_ecosystem],
+            to_ecosystem: modified_old_ecosystem,
+            strategy_class: described_class
+          )
+          expect(reverse_modified_map).not_to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Reuse ecosystem mappings already computed across periods
- Map now returns a hash that maps exercise ids to pages for convenience