### PR TITLE
Trouble flag

### DIFF
--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -17,18 +17,9 @@ module Api::V1::Courses
                type: String,
                readable: true,
                writeable: false
-
     end
 
     class Plan < Base
-
-      property :trouble,
-               as: :is_trouble,
-               readable: true,
-               writeable: false,
-               getter: lambda{|*| false },
-               schema_info: { type: 'boolean' }
-
       property :type,
                type: String,
                readable: true,
@@ -62,11 +53,9 @@ module Api::V1::Courses
                  readable: true,
                  writeable: false,
                  decorator: Api::V1::TaskingPlanRepresenter
-
     end
 
     class TaskBase < Base
-
       property :opens_at,
                type: String,
                readable: true,
@@ -199,7 +188,6 @@ module Api::V1::Courses
              readable: true,
              writeable: false,
              decorator: Course
-
 
   end
 

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -20,6 +20,14 @@ module Api::V1::Courses
     end
 
     class Plan < Base
+
+      property :trouble,
+               as: :is_trouble,
+               readable: true,
+               writeable: false,
+               getter: lambda{|*| false },
+               schema_info: { type: 'boolean' }
+
       property :type,
                type: String,
                readable: true,

--- a/app/representers/api/v1/tasks/stats/page_representer.rb
+++ b/app/representers/api/v1/tasks/stats/page_representer.rb
@@ -52,6 +52,12 @@ module Api::V1
                  readable: true,
                  decorator: self
 
+        property :trouble,
+                 as: :is_trouble,
+                 readable: true,
+                 writeable: false,
+                 schema_info: { type: 'boolean' }
+
       end
     end
   end

--- a/app/representers/api/v1/tasks/stats/stat_representer.rb
+++ b/app/representers/api/v1/tasks/stats/stat_representer.rb
@@ -51,6 +51,13 @@ module Api::V1
                    writable: false,
                    decorator: Api::V1::Tasks::Stats::PageRepresenter
 
+        property :trouble,
+                 as: :is_trouble,
+                 readable: true,
+                 writeable: false,
+                 getter: lambda{|*| false },
+                 schema_info: { type: 'boolean' }
+
       end
     end
   end

--- a/app/representers/api/v1/tasks/stats/stat_representer.rb
+++ b/app/representers/api/v1/tasks/stats/stat_representer.rb
@@ -55,7 +55,6 @@ module Api::V1
                  as: :is_trouble,
                  readable: true,
                  writeable: false,
-                 getter: lambda{|*| false },
                  schema_info: { type: 'boolean' }
 
       end

--- a/app/routines/calculate_task_plan_stats.rb
+++ b/app/routines/calculate_task_plan_stats.rb
@@ -131,7 +131,9 @@ class CalculateTaskPlanStats
 
         spaced_pages: generate_page_stats_for_task_steps(
                         period_tasks.collect{ |t| t.spaced_practice_task_steps }
-                      )
+                      ),
+
+        trouble: false
       )
     end
   end

--- a/app/routines/calculate_task_plan_stats.rb
+++ b/app/routines/calculate_task_plan_stats.rb
@@ -50,10 +50,15 @@ class CalculateTaskPlanStats
     end.flatten.uniq
 
     correct_count = completed.count{ |te| te.is_correct? }
+    incorrect_count = completed.length - correct_count
+
+    trouble = (incorrect_count > correct_count) && (completed.size > 0.25*tasked_exercises.size)
+
     stats = {
       student_count: some_completed_role_ids.length,
       correct_count: correct_count,
-      incorrect_count: completed.length - correct_count
+      incorrect_count: incorrect_count,
+      trouble: trouble
     }
     stats[:exercises] = exercise_stats_for_tasked_exercises(tasked_exercises) if @details
     stats
@@ -112,6 +117,13 @@ class CalculateTaskPlanStats
       tt.taskings.first.try(:period) || no_period
     end
     grouped_tasks.collect do |period, period_tasks|
+      current_page_stats = generate_page_stats_for_task_steps(
+                             period_tasks.collect{ |t| t.core_task_steps }
+                           )
+      spaced_page_stats = generate_page_stats_for_task_steps(
+                            period_tasks.collect{ |t| t.spaced_practice_task_steps }
+                          )
+
       Hashie::Mash.new(
         period_id: period.id,
 
@@ -125,15 +137,11 @@ class CalculateTaskPlanStats
 
         partially_complete_count: period_tasks.count(&:in_progress?),
 
-        current_pages: generate_page_stats_for_task_steps(
-                         period_tasks.collect{ |t| t.core_task_steps }
-                       ),
+        current_pages: current_page_stats,
 
-        spaced_pages: generate_page_stats_for_task_steps(
-                        period_tasks.collect{ |t| t.spaced_practice_task_steps }
-                      ),
+        spaced_pages: spaced_page_stats,
 
-        trouble: false
+        trouble: (current_page_stats + spaced_page_stats).any?{ |page_stats| page_stats[:trouble] }
       )
     end
   end

--- a/spec/representers/api/v1/task_plan_with_detailed_stats_representer_spec.rb
+++ b/spec/representers/api/v1/task_plan_with_detailed_stats_representer_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Api::V1::TaskPlanWithDetailedStatsRepresenter, type: :representer
             "correct_count"   => 1,
             "incorrect_count" => 1,
             "chapter_section" => [1, 1],
+            "is_trouble" => false,
             "exercises" => a_collection_containing_exactly(
               {
                 "content" => a_kind_of(Hash),
@@ -81,8 +82,10 @@ RSpec.describe Api::V1::TaskPlanWithDetailedStatsRepresenter, type: :representer
             "correct_count"   => 0,
             "incorrect_count" => 0,
             "chapter_section" => [1, 1],
+            "is_trouble" => false,
             "exercises" => a_kind_of(Array)
-          )
+          ),
+          "is_trouble" => false
         }
       ]
     )

--- a/spec/representers/api/v1/task_plan_with_stats_representer_spec.rb
+++ b/spec/representers/api/v1/task_plan_with_stats_representer_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Api::V1::TaskPlanWithStatsRepresenter, type: :representer, speed:
               "student_count"   => 0,
               "correct_count"   => 0,
               "incorrect_count" => 0,
-              "chapter_section" => [1, 1]
+              "chapter_section" => [1, 1],
+              "is_trouble" => false
             )
           ),
           "spaced_pages" => a_collection_containing_exactly(
@@ -41,9 +42,11 @@ RSpec.describe Api::V1::TaskPlanWithStatsRepresenter, type: :representer, speed:
               "student_count"   => 0,
               "correct_count"   => 0,
               "incorrect_count" => 0,
-              "chapter_section" => [1, 1]
+              "chapter_section" => [1, 1],
+              "is_trouble" => false
             )
-          )
+          ),
+          "is_trouble" => false
         }
       ]
     )

--- a/spec/routines/calculate_task_plan_stats_spec.rb
+++ b/spec/routines/calculate_task_plan_stats_spec.rb
@@ -32,11 +32,13 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.total_count).to eq(@task_plan.tasks.length)
       expect(stats.first.complete_count).to eq(0)
       expect(stats.first.partially_complete_count).to eq(0)
+      expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages[0]
       expect(page.student_count).to eq(0) # no students have worked yet
       expect(page.incorrect_count).to eq(0)
       expect(page.correct_count).to eq(0)
+      expect(page.trouble).to eq false
 
       spaced_page = stats.first.spaced_pages[0]
       expect(spaced_page).to eq page
@@ -86,6 +88,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to be_nil
       expect(stats.first.complete_count).to eq(0)
       expect(stats.first.partially_complete_count).to eq(1)
+      expect(stats.first.trouble).to eq false
 
       first_task.task_steps.each do |ts|
         MarkTaskStepCompleted.call(task_step: ts) unless ts.completed?
@@ -95,6 +98,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to eq (0)
       expect(stats.first.complete_count).to eq(1)
       expect(stats.first.partially_complete_count).to eq(0)
+      expect(stats.first.trouble).to eq false
 
       last_task = tasks.last
       MarkTaskStepCompleted.call(task_step: last_task.task_steps.first)
@@ -102,6 +106,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to eq (0)
       expect(stats.first.complete_count).to eq(1)
       expect(stats.first.partially_complete_count).to eq(1)
+      expect(stats.first.trouble).to eq false
     end
 
   end
@@ -123,18 +128,21 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to eq (100)
       expect(stats.first.complete_count).to eq(1)
       expect(stats.first.partially_complete_count).to eq(0)
+      expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
       expect(page['title']).to eq("Newton's First Law of Motion: Inertia")
       expect(page['student_count']).to eq(1) # num students with completed task steps
       expect(page['correct_count']).to eq(2)
       expect(page['incorrect_count']).to eq(0)
+      expect(page['trouble']).to eq false
 
       spaced_page = stats.first.spaced_pages.first
       expect(spaced_page['title']).to eq("Newton's First Law of Motion: Inertia")
       expect(spaced_page['student_count']).to eq(1)
       expect(spaced_page['correct_count']).to eq(2)
       expect(spaced_page['incorrect_count']).to eq(0)
+      expect(spaced_page['trouble']).to eq false
 
       second_task = tasks.second
       second_task.task_steps.each{ |ts|
@@ -148,6 +156,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to eq (50)
       expect(stats.first.complete_count).to eq(2)
       expect(stats.first.partially_complete_count).to eq(0)
+      expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
       expect(page['title']).to eq("Newton's First Law of Motion: Inertia")
@@ -155,6 +164,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(page['correct_count']).to eq(2)
       expect(page['incorrect_count']).to eq(2)
       expect(page['chapter_section']).to eq([1, 1])
+      expect(page['trouble']).to eq false
 
       spaced_page = stats.first.spaced_pages.first
       expect(spaced_page['title']).to eq("Newton's First Law of Motion: Inertia")
@@ -162,6 +172,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(spaced_page['correct_count']).to eq(2)
       expect(spaced_page['incorrect_count']).to eq(2)
       expect(spaced_page['chapter_section']).to eq([1, 1])
+      expect(spaced_page['trouble']).to eq false
 
       third_task = tasks.third
       third_task.task_steps.each{ |ts|
@@ -176,6 +187,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to eq (67)
       expect(stats.first.complete_count).to eq(3)
       expect(stats.first.partially_complete_count).to eq(0)
+      expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
       expect(page['title']).to eq("Newton's First Law of Motion: Inertia")
@@ -183,6 +195,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(page['correct_count']).to eq(4)
       expect(page['incorrect_count']).to eq(2)
       expect(page['chapter_section']).to eq([1, 1])
+      expect(page['trouble']).to eq false
 
       spaced_page = stats.first.spaced_pages.first
       expect(spaced_page['title']).to eq("Newton's First Law of Motion: Inertia")
@@ -190,6 +203,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(spaced_page['correct_count']).to eq(4)
       expect(spaced_page['incorrect_count']).to eq(2)
       expect(spaced_page['chapter_section']).to eq([1, 1])
+      expect(spaced_page['trouble']).to eq false
 
       fourth_task = tasks.fourth
       fourth_task.task_steps.each{ |ts|
@@ -204,6 +218,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(stats.first.mean_grade_percent).to eq (75)
       expect(stats.first.complete_count).to eq(4)
       expect(stats.first.partially_complete_count).to eq(0)
+      expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
       expect(page['title']).to eq("Newton's First Law of Motion: Inertia")
@@ -211,6 +226,7 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(page['correct_count']).to eq(6)
       expect(page['incorrect_count']).to eq(2)
       expect(page['chapter_section']).to eq([1, 1])
+      expect(page['trouble']).to eq false
 
       spaced_page = stats.first.spaced_pages.first
       expect(spaced_page['title']).to eq("Newton's First Law of Motion: Inertia")
@@ -218,6 +234,136 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       expect(spaced_page['correct_count']).to eq(6)
       expect(spaced_page['incorrect_count']).to eq(2)
       expect(spaced_page['chapter_section']).to eq([1, 1])
+      expect(spaced_page['trouble']).to eq false
+    end
+
+    # This test assumes that all of these tasks have the same numbers of steps,
+    # which is true at least for now
+    it "sets trouble to true if >50% incorrect and >25% completed" do
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq false
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq false
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq false
+
+      tasks = @task_plan.tasks.to_a
+      tasks.first(2).each do |task|
+        task.task_steps.each do |ts|
+          if ts.tasked.exercise?
+            ts.tasked.free_response = 'a sentence not explaining anything'
+            ts.tasked.save!
+          end
+          MarkTaskStepCompleted.call(task_step: ts)
+        end
+      end
+
+      # Only 25% done: no trouble
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq false
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq false
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq false
+
+      tasks.third.task_steps.each do |ts|
+        if ts.tasked.exercise?
+          ts.tasked.free_response = 'a sentence not explaining anything'
+          ts.tasked.save!
+        end
+        MarkTaskStepCompleted.call(task_step: ts)
+      end
+
+      # Over 25% done: trouble
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq true
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq true
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq true
+
+      tasks[3..4].each do |task|
+        task.task_steps.each do |ts|
+          if ts.tasked.exercise?
+            ts.tasked.answer_id = ts.tasked.correct_answer_id
+            ts.tasked.free_response = 'a sentence explaining all the things'
+            ts.tasked.save!
+          end
+          MarkTaskStepCompleted.call(task_step: ts)
+        end
+      end
+
+      # 40% correct: still trouble
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq true
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq true
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq true
+
+      tasks[5].task_steps.each do |ts|
+        if ts.tasked.exercise?
+          ts.tasked.answer_id = ts.tasked.correct_answer_id
+          ts.tasked.free_response = 'a sentence explaining all the things'
+          ts.tasked.save!
+        end
+        MarkTaskStepCompleted.call(task_step: ts)
+      end
+
+      # 50% correct: no more trouble
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq false
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq false
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq false
+
+      tasks[6].task_steps.each do |ts|
+        if ts.tasked.exercise?
+          ts.tasked.free_response = 'a sentence not explaining anything'
+          ts.tasked.save!
+        end
+        MarkTaskStepCompleted.call(task_step: ts)
+      end
+
+      # 3 out of 7 correct: trouble again
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq true
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq true
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq true
+
+      tasks[7].task_steps.each do |ts|
+        if ts.tasked.exercise?
+          ts.tasked.answer_id = ts.tasked.correct_answer_id
+          ts.tasked.free_response = 'a sentence explaining all the things'
+          ts.tasked.save!
+        end
+        MarkTaskStepCompleted.call(task_step: ts)
+      end
+
+      # 50% correct: no more trouble
+      stats = CalculateTaskPlanStats.call(plan: @task_plan.reload).outputs.stats
+      expect(stats.first.trouble).to eq false
+
+      page = stats.first.current_pages.first
+      expect(page.trouble).to eq false
+
+      spaced_page = stats.first.spaced_pages.first
+      expect(spaced_page.trouble).to eq false
     end
 
     it "returns detailed stats if :details is true" do
@@ -452,11 +598,13 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
         expect(stats.first.total_count).to eq(@task_plan.tasks.length/2)
         expect(stats.first.complete_count).to eq(0)
         expect(stats.first.partially_complete_count).to eq(0)
+        expect(stats.first.trouble).to eq false
 
         page = stats.first.current_pages[0]
         expect(page.student_count).to eq(0)
         expect(page.incorrect_count).to eq(0)
         expect(page.correct_count).to eq(0)
+        expect(page.trouble).to eq false
 
         spaced_page = stats.first.spaced_pages[0]
         expect(spaced_page).to eq page
@@ -465,11 +613,13 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
         expect(stats.second.total_count).to eq(@task_plan.tasks.length/2)
         expect(stats.second.complete_count).to eq(0)
         expect(stats.second.partially_complete_count).to eq(0)
+        expect(stats.second.trouble).to eq false
 
         page = stats.second.current_pages[0]
         expect(page.student_count).to eq(0)
         expect(page.incorrect_count).to eq(0)
         expect(page.correct_count).to eq(0)
+        expect(page.trouble).to eq false
 
         spaced_page = stats.second.spaced_pages[0]
         expect(spaced_page).to eq page
@@ -484,11 +634,13 @@ describe CalculateTaskPlanStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
         expect(stats.first.total_count).to eq(@task_plan.tasks.length)
         expect(stats.first.complete_count).to eq(0)
         expect(stats.first.partially_complete_count).to eq(0)
+        expect(stats.first.trouble).to eq false
 
         page = stats.first.current_pages[0]
         expect(page.student_count).to eq(0)
         expect(page.incorrect_count).to eq(0)
         expect(page.correct_count).to eq(0)
+        expect(page.trouble).to eq false
 
         spaced_page = stats.first.spaced_pages[0]
         expect(spaced_page).to eq page


### PR DESCRIPTION
- Shows up on assignment stats page, for each period in the entire assignment
- Also visible for each page in the assignment (but currently that would probably not be used by the FE)
- Trouble if >50% incorrect and >25% problems worked (completed)
- Added specs