### PR TITLE
Add unique_learner_count to the Performance Forecast API

### DIFF
--- a/app/external/openstax/biglearn/v1/fake_client.rb
+++ b/app/external/openstax/biglearn/v1/fake_client.rb
@@ -85,7 +85,8 @@ class OpenStax::Biglearn::V1::FakeClient
         ],
         confidence_interval_interpretation: confidence,
         sample_size: samples,
-        sample_size_interpretation: 'above'
+        sample_size_interpretation: 'above',
+        unique_learner_count: roles.size
       }
     end
   end

--- a/app/external/openstax/biglearn/v1/real_client.rb
+++ b/app/external/openstax/biglearn/v1/real_client.rb
@@ -186,7 +186,8 @@ class OpenStax::Biglearn::V1::RealClient
         ],
         confidence_interval_interpretation: interpretation['confidence'],
         sample_size: confidence['sample_size'],
-        sample_size_interpretation: interpretation['threshold']
+        sample_size_interpretation: interpretation['threshold'],
+        unique_learner_count: confidence['unique_learner_count']
       }
 
       Rails.cache.write(cache_key, clue_hash, expires_in: CLUE_CACHE_DURATION)

--- a/app/representers/api/v1/clue_representer.rb
+++ b/app/representers/api/v1/clue_representer.rb
@@ -57,5 +57,14 @@ module Api::V1
                description: "Returns 'above' or 'below' depending on if the sample size is above or below an internal threshold"
              }
 
+    property :unique_learner_count,
+             type: Integer,
+             readable: true,
+             writeable: false,
+             schema_info: {
+               required: true,
+               description: "The number of learners that contributed to the data points considered"
+             }
+
   end
 end

--- a/spec/external/openstax/biglearn/v1/fake_client_spec.rb
+++ b/spec/external/openstax/biglearn/v1/fake_client_spec.rb
@@ -71,14 +71,12 @@ module OpenStax::Biglearn
       end
 
       it 'returns a well-formatted array of clues' do
-        user = User::CreateUser.call(
-          username: SecureRandom.hex
-        ).outputs.user
-        role = Role::CreateUserRole[user]
+        user = User::CreateUser.call(username: SecureRandom.hex).outputs.user
+        roles = [Role::CreateUserRole[user]]
         pools = [pool_1, pool_2]
         pool_uuids = pools.collect(&:uuid)
 
-        clues = client.get_clues(roles: role, pools: pools)
+        clues = client.get_clues(roles: roles, pools: pools)
         expect(clues.keys.size).to eq pools.size
 
         clues.each do |pool_uuid, clue|

--- a/spec/external/openstax/biglearn/v1/real_client_spec.rb
+++ b/spec/external/openstax/biglearn/v1/real_client_spec.rb
@@ -97,7 +97,8 @@ module OpenStax::Biglearn
         confidence_interval: [ 0.0, 1.0 ],
         confidence_interval_interpretation: "bad",
         sample_size: 0,
-        sample_size_interpretation: "below"
+        sample_size_interpretation: "below",
+        unique_learner_count: 0
       }
     }
     let!(:pool_2_clue) {
@@ -107,7 +108,8 @@ module OpenStax::Biglearn
         confidence_interval: [ 0.8, 1.0 ],
         confidence_interval_interpretation: "good",
         sample_size: 100,
-        sample_size_interpretation: "above"
+        sample_size_interpretation: "above",
+        unique_learner_count: 50
       }
     }
 

--- a/spec/routines/get_student_guide_spec.rb
+++ b/spec/routines/get_student_guide_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe GetStudentGuide, type: :routine do
         "confidence_interval" => kind_of(Array),
         "confidence_interval_interpretation" => kind_of(String),
         "sample_size" => kind_of(Integer),
-        "sample_size_interpretation" => kind_of(String)
+        "sample_size_interpretation" => kind_of(String),
+        "unique_learner_count" => kind_of(Integer)
       },
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)],
@@ -92,7 +93,8 @@ RSpec.describe GetStudentGuide, type: :routine do
         "confidence_interval" => kind_of(Array),
         "confidence_interval_interpretation" => kind_of(String),
         "sample_size" => kind_of(Integer),
-        "sample_size_interpretation" => kind_of(String)
+        "sample_size_interpretation" => kind_of(String),
+        "unique_learner_count" => kind_of(Integer)
       },
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)]

--- a/spec/routines/get_teacher_guide_spec.rb
+++ b/spec/routines/get_teacher_guide_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe GetTeacherGuide, type: :routine do
         "confidence_interval" => kind_of(Array),
         "confidence_interval_interpretation" => kind_of(String),
         "sample_size" => kind_of(Integer),
-        "sample_size_interpretation" => kind_of(String)
+        "sample_size_interpretation" => kind_of(String),
+        "unique_learner_count" => kind_of(Integer)
       },
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)],
@@ -87,7 +88,8 @@ RSpec.describe GetTeacherGuide, type: :routine do
         "confidence_interval" => kind_of(Array),
         "confidence_interval_interpretation" => kind_of(String),
         "sample_size" => kind_of(Integer),
-        "sample_size_interpretation" => kind_of(String)
+        "sample_size_interpretation" => kind_of(String),
+        "unique_learner_count" => kind_of(Integer)
       },
       "practice_count"=>0,
       "page_ids"=>[kind_of(Integer)],
@@ -108,7 +110,8 @@ RSpec.describe GetTeacherGuide, type: :routine do
                          "confidence_interval" => kind_of(Array),
                          "confidence_interval_interpretation" => kind_of(String),
                          "sample_size" => kind_of(Integer),
-                         "sample_size_interpretation" => kind_of(String)
+                         "sample_size_interpretation" => kind_of(String),
+                         "unique_learner_count" => kind_of(Integer)
                        },
                        "practice_count"=>0,
                        "page_ids"=>[kind_of(Integer)])
@@ -126,7 +129,8 @@ RSpec.describe GetTeacherGuide, type: :routine do
                          "confidence_interval" => kind_of(Array),
                          "confidence_interval_interpretation" => kind_of(String),
                          "sample_size" => kind_of(Integer),
-                         "sample_size_interpretation" => kind_of(String)
+                         "sample_size_interpretation" => kind_of(String),
+                         "unique_learner_count" => kind_of(Integer)
                        },
                        "practice_count"=>0,
                        "page_ids"=>[kind_of(Integer)])


### PR DESCRIPTION
- Pass the `unique_learner_count` from Biglearn to the FE
- Updated specs