### PR TITLE
Document creating the ox-tutur db user as a superuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ Or using homebrew on OSX
 
 Once installed, create a user and database.  By default Tutor will expect a database named 'ox_tutor_{dev,test}' owned by user 'ox_tutor' who has a password 'ox_tutor_secret_password'.  These can be overridden by setting environmental variables in your ~/.bash_profile or ~/.zshenv.  See the config/database.yml for details.
 
-`createuser --createdb --pwprompt ox_tutor`
+`createuser --superuser --pwprompt ox_tutor`
 
 And then create the development and test databases:
 
 `createdb --username ox_tutor ox_tutor_dev`
 
 `createdb --username ox_tutor ox_tutor_test`
+
+Once Tutor is up and running the database superuser role can be safely removed from the user. It is only needed to create and configure the tutor databases.  To remove it, log into the database:
+
+`psql -Uox_tutor ox_tutor_dev`
+
+and then run command: `alter user ox_tutor nosuperuser;`
+
+Exit the psql database shell by typeing `\q` and hitting enter.
 
 ## Configuring database for Development and Testing
 


### PR DESCRIPTION
That way the migrations can install the hstore extension and perform any other configuration that may be needed.