### PR TITLE
More CLUe fixes

### DIFF
--- a/app/external/openstax/biglearn/v1/real_client.rb
+++ b/app/external/openstax/biglearn/v1/real_client.rb
@@ -8,8 +8,8 @@ class OpenStax::Biglearn::V1::RealClient
   # At least one pool will always be sent in each request, regardless of this value
   # Setting this value too low will make requests slower.
   # Setting this value too high will cause timeouts.
-  # Default is 250 (for example, 25 students and 10 pools on each request)
-  CLUE_MAX_POOL_STUDENT_PRODUCT = 250
+  # Default is 100 (for example, 25 students and 4 pools on each request)
+  CLUE_MAX_POOL_STUDENT_PRODUCT = 100
 
   def initialize(biglearn_configuration)
     @server_url   = biglearn_configuration.server_url

--- a/app/routines/update_clues.rb
+++ b/app/routines/update_clues.rb
@@ -44,7 +44,7 @@ class UpdateClues
     end
 
     role_ids_to_worked_exercises_map = worked_tasked_exercises
-                                         .each_with_object({}) do |tasked_exercise, hash|
+                                         .find_each.each_with_object({}) do |tasked_exercise, hash|
       model = tasked_exercise.exercise
       strategy = Content::Strategies::Direct::Exercise.new(model)
       exercise = Content::Exercise.new(strategy: strategy)


### PR DESCRIPTION
- Use find_each to prevent going OOM when too many exercises
- Reduce max request size in case load balancer decides to send all requests to the same server...