### PR TITLE
Fixing sporadic Exchange communication error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,11 +108,12 @@ gem 'pg'
 # Lorem Ipsum
 gem 'faker'
 
-# Key-value store for caching and job queuing
+# Key-value store for caching
 gem 'redis-rails'
 
 # Background job queueing
-gem 'resque', '~> 1.24.1'
+gem 'delayed_job_active_record'
+gem 'daemons'
 
 # Type coercion for Representable
 gem 'virtus'
@@ -213,9 +214,6 @@ end
 group :test do
   # Fake in-memory Redis for testing
   gem 'fakeredis'
-
-  # Resque in test mode
-  gem 'resque_spec'
 
   gem 'shoulda-matchers', require: false
   gem 'capybara-webkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,11 @@ GEM
     debugger-ruby_core_source (1.3.8)
     deep_cloneable (2.1.1)
       activerecord (>= 3.1.0, < 5.0.0)
+    delayed_job (4.1.1)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.1.0)
+      activerecord (>= 3.0, < 5)
+      delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
@@ -349,7 +354,6 @@ GEM
     mini_magick (4.2.0)
     mini_portile (0.6.2)
     minitest (5.8.0)
-    mono_logger (1.1.0)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -429,8 +433,6 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
-    rack-protection (1.5.3)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     railroady (1.3.0)
@@ -478,8 +480,6 @@ GEM
     redis-activesupport (4.0.0)
       activesupport (~> 4)
       redis-store (~> 1.1.0)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
     redis-rack (1.5.0)
       rack (~> 1.5)
       redis-store (~> 1.1.0)
@@ -497,17 +497,6 @@ GEM
       uber (~> 0.0.7)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    resque (1.24.1)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.2)
-      sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
-    resque_spec (0.16.0)
-      resque (>= 1.19.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
-      rspec-mocks (>= 3.0.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -563,10 +552,6 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sinatra (1.4.6)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     slop (3.6.0)
     sortability (0.0.3)
       rails
@@ -630,8 +615,6 @@ GEM
     validates_timeliness (3.0.14)
       timeliness (~> 0.3.6)
     vcr (2.9.3)
-    vegas (0.1.11)
-      rack (>= 1.0.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -681,8 +664,10 @@ DEPENDENCIES
   coffee-rails-source-maps
   compass-rails
   coveralls
+  daemons
   database_cleaner
   deep_cloneable
+  delayed_job_active_record
   dotenv-rails
   factory_girl_rails
   faker
@@ -720,8 +705,6 @@ DEPENDENCIES
   rails-html-sanitizer (~> 1.0)
   redis-rails
   remotipart
-  resque (~> 1.24.1)
-  resque_spec
   rspec-collection_matchers
   rspec-rails
   sass-rails (~> 5.0.0)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ behavior is to do this and then only switch to a `true` setting if you need to d
 
 ## Background Jobs
 
-Tutor in production runs background jobs using resque and redis.  In the development environment, however, background jobs are run "inline", i.e. not in the background.  To actually run these jobs in the background in the development environment, set the environment variable `USE_REAL_BACKGROUND_JOBS` to `true`.
+Tutor in production runs background jobs using delayed_job.  In the development environment, however, background jobs are run "inline", i.e. not in the background.  To actually run these jobs in the background in the development environment, start the delayed_job daemon and set the environment variable `USE_REAL_BACKGROUND_JOBS` to `true`.
 
 ## Bullet
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,5 +35,3 @@ Rails.application.load_tasks
 if Rails.env.development?
   Dir.glob('lib/sprint/*.rake').each { |r| load r }
 end
-
-require 'resque/tasks'

--- a/app/routines/send_tasked_exercise_answer_to_exchange.rb
+++ b/app/routines/send_tasked_exercise_answer_to_exchange.rb
@@ -1,0 +1,25 @@
+class SendTaskedExerciseAnswerToExchange
+
+  lev_routine
+
+  protected
+
+  def exec(tasked_exercise:)
+    # Currently assuming only one question per tasked_exercise (see also correct_answer_id)
+    # Also assuming no group tasks
+    identifier = tasked_exercise.identifiers.first
+    url = tasked_exercise.url
+    # "trial" is set to only "1" for now. When multiple
+    # attempts are supported, it will be incremented to indicate the attempt #
+    trial = 1
+    answer_id = tasked_exercise.answer_id
+
+    OpenStax::Exchange.record_multiple_choice_answer(identifier, url, trial, answer_id)
+
+    grade = tasked_exercise.is_correct? ? 1 : 0
+    grader = 'tutor'
+
+    OpenStax::Exchange.record_grade(identifier, url, trial, grade, grader)
+  end
+
+end

--- a/app/routines/send_tasked_exercise_answer_to_exchange.rb
+++ b/app/routines/send_tasked_exercise_answer_to_exchange.rb
@@ -13,9 +13,8 @@ class SendTaskedExerciseAnswerToExchange
     # Currently assuming no group tasks
     identifier = identifiers.first
 
-    # "trial" is set to only "1" for now. When multiple
-    # attempts are supported, it will be incremented to indicate the attempt #
-    trial = 1
+    # "trial" is currently set to the id of the task_step being answered
+    trial = tasked_exercise.task_step.id.to_s
 
     # Currently assuming only one question per tasked_exercise (see also correct_answer_id)
     answer_id = tasked_exercise.answer_id

--- a/app/routines/send_tasked_exercise_answer_to_exchange.rb
+++ b/app/routines/send_tasked_exercise_answer_to_exchange.rb
@@ -5,13 +5,19 @@ class SendTaskedExerciseAnswerToExchange
   protected
 
   def exec(tasked_exercise:)
-    # Currently assuming only one question per tasked_exercise (see also correct_answer_id)
-    # Also assuming no group tasks
-    identifier = tasked_exercise.identifiers.first
     url = tasked_exercise.url
+    roles = tasked_exercise.task_step.task.taskings.collect{ |t| t.role }
+    users = Role::GetUsersForRoles[roles]
+    identifiers = users.collect{ |user| user.exchange_write_identifier }
+
+    # Currently assuming no group tasks
+    identifier = identifiers.first
+
     # "trial" is set to only "1" for now. When multiple
     # attempts are supported, it will be incremented to indicate the attempt #
     trial = 1
+
+    # Currently assuming only one question per tasked_exercise (see also correct_answer_id)
     answer_id = tasked_exercise.answer_id
 
     OpenStax::Exchange.record_multiple_choice_answer(identifier, url, trial, answer_id)

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -18,7 +18,7 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   end
 
   def handle_task_step_completion!
-    SendTaskedExerciseAnswerToExchange[]
+    SendTaskedExerciseAnswerToExchange[tasked_exercise: self]
   end
 
   def has_correctness?
@@ -83,19 +83,6 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   end
 
   protected
-
-  def roles
-    task_step.task.taskings.collect{ |t| t.role }
-  end
-
-  def identifiers
-    users = Role::GetUsersForRoles[roles]
-    users.collect{ |user| user.exchange_write_identifier }
-  end
-
-  def trial
-    task_step.id.to_s
-  end
 
   def free_response_provided
     errors.add(:free_response, 'is required') \

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -18,18 +18,7 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   end
 
   def handle_task_step_completion!
-    # TODO: Do this somewhere else, it does not belong here
-
-    # Currently assuming only one question per tasked_exercise, see also correct_answer_id
-    # Also assuming no group tasks
-    question = questions.first
-    # "trial" is set to only "1" for now. When multiple
-    # attempts are supported, it will be incremented to indicate the attempt #
-    OpenStax::Exchange.record_multiple_choice_answer(identifiers.first, url, trial, answer_id)
-
-    grade = is_correct? ? 1 : 0
-    grader = 'tutor'
-    OpenStax::Exchange.record_grade(identifiers.first, url, trial, grade, grader)
+    SendTaskedExerciseAnswerToExchange[]
   end
 
   def has_correctness?

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -18,7 +18,7 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
   end
 
   def handle_task_step_completion!
-    SendTaskedExerciseAnswerToExchange[tasked_exercise: self]
+    SendTaskedExerciseAnswerToExchange.perform_later(tasked_exercise: self)
   end
 
   def has_correctness?

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module Tutor
       namespace: redis_secrets['namespaces']['cache'],
       expires_in: 90.minutes
     }
+
+    # Use delayed_job for background jobs
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,10 +50,4 @@ Rails.application.configure do
       Bullet.bullet_logger = true # tail -f log/bullet.log
     end
   end
-
-  # Use fake "background" jobs by default
-  # (real background jobs require redis and cache_classes = true or some entity autoload fix)
-  use_real_background_jobs = EnvUtilities.load_boolean(name: 'USE_REAL_BACKGROUND_JOBS',
-                                                       default: false)
-  config.active_job.queue_adapter = use_real_background_jobs ? :resque : :inline
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Send email to developers when users encounter exceptions
-  config.active_job.queue_adapter = :resque
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,4 @@ Rails.application.configure do
   WebMock.allow_net_connect!
 
   OpenStax::Cnx::V1.set_archive_url_base(url: 'https://archive-staging-tutor.cnx.org/contents/')
-
-  config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,23 @@
+# Defaults:
+# Delayed::Worker.destroy_failed_jobs = true
+# Delayed::Worker.sleep_delay = 5
+# Delayed::Worker.max_attempts = 25
+# Delayed::Worker.max_run_time = 4.hours
+# Delayed::Worker.read_ahead = 5
+# Delayed::Worker.default_queue_name = nil
+# Delayed::Worker.delay_jobs = true
+# Delayed::Worker.raise_signal_exceptions = false
+# Delayed::Worker.logger = Rails.logger
+
+# Keep failed jobs for later inspection
+Delayed::Worker.destroy_failed_jobs = false
+
+# Should be longer than the longest background job (that actually uses this gem)
+Delayed::Worker.max_run_time = 10.minutes
+
+# Allows us to use this gem in tests instead of setting the ActiveJob adapter to :inline
+Delayed::Worker.delay_jobs = Rails.env.production? || (
+                               Rails.env.development? && \
+                               EnvUtilities.load_boolean(name: 'USE_REAL_BACKGROUND_JOBS',
+                                                         default: false)
+                             )

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -13,7 +13,7 @@
 Delayed::Worker.destroy_failed_jobs = false
 
 # Should be longer than the longest background job (that actually uses this gem)
-Delayed::Worker.max_run_time = 10.minutes
+Delayed::Worker.max_run_time = Rails.application.secrets['background_worker_timeout']
 
 # Allows us to use this gem in tests instead of setting the ActiveJob adapter to :inline
 Delayed::Worker.delay_jobs = Rails.env.production? || (

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,4 +1,0 @@
-# Be sure to restart your server when you modify this file.
-secrets = Rails.application.secrets['redis']
-
-Resque.redis = Addressable::URI.join(secrets['url'], secrets['namespaces']['resque']).to_s

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -14,6 +14,7 @@ development:
   js_url: <%= ENV["JS_URL"] || 'http://localhost:8000/dist/tutor.js' %>
   css_url: <%= ENV["CSS_URL"] || 'http://localhost:8000/dist/tutor.css' %>
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
+  background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   ga_tracking_code: ''
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
@@ -56,6 +57,7 @@ test:
   js_url: <%= ENV["JS_URL"] || 'http://localhost:8000/dist/tutor.js' %>
   css_url: <%= ENV["CSS_URL"] || 'http://localhost:8000/dist/tutor.css' %>
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
+  background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   ga_tracking_code: ''
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
@@ -101,6 +103,7 @@ production:
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
   exception_recipients: <%= ENV["EXCEPTION_RECIPIENTS"] %>
   mail_site_url: <%= ENV["MAIL_SITE_URL"] %>
+  background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   ga_tracking_code: 'UA-XXXXXXX-1'
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -20,7 +20,6 @@ development:
     namespaces:
       cache: <%= ENV["REDIS_NAMESPACES_CACHE"] || 'cache' %>
       settings: <%= ENV["REDIS_NAMESPACES_SETTINGS"] || 'settings' %>
-      resque: <%= ENV["REDIS_NAMESPACES_RESQUE"] || 'resque' %>
       lev: <%= ENV["REDIS_NAMESPACES_LEV"] || 'lev' %>
   environment_name: 'dev'
   exception:
@@ -63,7 +62,6 @@ test:
     namespaces:
       cache: <%= ENV["REDIS_NAMESPACES_CACHE"] || 'cache' %>
       settings: <%= ENV["REDIS_NAMESPACES_SETTINGS"] || 'settings' %>
-      resque: <%= ENV["REDIS_NAMESPACES_RESQUE"] || 'resque' %>
       lev: <%= ENV["REDIS_NAMESPACES_LEV"] || 'lev' %>
   environment_name: 'test'
   exception:
@@ -109,7 +107,6 @@ production:
     namespaces:
       cache: <%= ENV["REDIS_NAMESPACES_CACHE"] || 'cache' %>
       settings: <%= ENV["REDIS_NAMESPACES_SETTINGS"] || 'settings' %>
-      resque: <%= ENV["REDIS_NAMESPACES_RESQUE"] || 'resque' %>
       lev: <%= ENV["REDIS_NAMESPACES_LEV"] || 'lev' %>
   environment_name: 'production'
   exception:

--- a/db/migrate/20151009223317_create_delayed_jobs.rb
+++ b/db/migrate/20151009223317_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151008154744) do
+ActiveRecord::Schema.define(version: 20151009223317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -217,6 +217,22 @@ ActiveRecord::Schema.define(version: 20151008154744) do
   add_index "course_profile_profiles", ["entity_course_id"], name: "index_course_profile_profiles_on_entity_course_id", unique: true, using: :btree
   add_index "course_profile_profiles", ["name"], name: "index_course_profile_profiles_on_name", using: :btree
   add_index "course_profile_profiles", ["school_district_school_id"], name: "index_course_profile_profiles_on_school_district_school_id", using: :btree
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "entity_courses", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/lib/tasks/demo/demo_base.rb
+++ b/lib/tasks/demo/demo_base.rb
@@ -143,6 +143,9 @@ class DemoBase
       # Start a new process
       # Threading does not work well with MRI due to the GIL
       fork do
+        # Reconnect to Redis (demo work now uses jobs to send info to Exchange)
+        Lev.configuration.job_store.reconnect
+
         if transaction
           ActiveRecord::Base.transaction do
             yield *process_args[process_index]

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
   let(:user_token) { FactoryGirl.create(:doorkeeper_access_token, resource_owner_id: user.id) }
   let(:admin_token) { FactoryGirl.create(:doorkeeper_access_token, resource_owner_id: admin.id) }
 
-  before(:all) { Lev.configuration.job_store.clear }
+  before(:all) do
+    @original_job_store = Lev.configuration.job_store
+    Lev.configuration.job_store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  after(:all)  { Lev.configuration.job_store = @original_job_store }
 
   before do
     stub_const 'TestRoutine', Class.new

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
   let(:user_token) { FactoryGirl.create(:doorkeeper_access_token, resource_owner_id: user.id) }
   let(:admin_token) { FactoryGirl.create(:doorkeeper_access_token, resource_owner_id: admin.id) }
 
+  before(:all) { Lev.configuration.job_store.clear }
+
   before do
     stub_const 'TestRoutine', Class.new
     TestRoutine.class_eval {

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -18,11 +18,11 @@ RSpec.feature 'Administration of queued jobs', :js do
   let(:job) { Lev::BackgroundJob.all.last }
 
   before(:all) do
-    ActiveJob::Base.queue_adapter = :resque
+    Delayed::Worker.delay_jobs = true
   end
 
   after(:all) do
-    ActiveJob::Base.queue_adapter = :inline
+    Delayed::Worker.delay_jobs = false
   end
 
   before(:each) do

--- a/spec/features/customer_service/queued_jobs_spec.rb
+++ b/spec/features/customer_service/queued_jobs_spec.rb
@@ -18,11 +18,11 @@ RSpec.feature 'Viewing queued jobs as Customer Service', :js do
   let(:job) { Lev::BackgroundJob.all.last }
 
   before(:all) do
-    ActiveJob::Base.queue_adapter = :resque
+    Delayed::Worker.delay_jobs = true
   end
 
   after(:all) do
-    ActiveJob::Base.queue_adapter = :inline
+    Delayed::Worker.delay_jobs = false
   end
 
   before(:each) do

--- a/spec/routines/mark_task_step_completed_spec.rb
+++ b/spec/routines/mark_task_step_completed_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe MarkTaskStepCompleted, type: :routine do
   # end
 
   it 'can mark an exercise step as completed' do
-    allow(tasked_exercise).to receive(:identifiers).and_return([42])
+    expect_any_instance_of(tasked_exercise.class).to receive(:handle_task_step_completion!)
+
     result = MarkTaskStepCompleted.call(task_step: tasked_exercise.task_step)
     expect(result.errors).to be_empty
     expect(tasked_exercise.task_step).to be_completed

--- a/spec/routines/reset_practice_widget_spec.rb
+++ b/spec/routines/reset_practice_widget_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ResetPracticeWidget, type: :routine do
   end
 
   it 'clears incomplete steps from previous practice widgets' do
-    MarkTaskStepCompleted[task_step: practice_task.task.task_steps.first]
+    Hacks::AnswerExercise[task_step: practice_task.task.task_steps.first, is_correct: false]
     practice_task_2 = ResetPracticeWidget[role: role, exercise_source: :fake, page_ids: []]
     expect(practice_task_2).to be_persisted
     expect(practice_task.task.task_steps.reload.size).to eq 1

--- a/spec/routines/send_tasked_exercise_answer_to_exchange_spec.rb
+++ b/spec/routines/send_tasked_exercise_answer_to_exchange_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SendTaskedExerciseAnswerToExchange, type: :routine do
+  let!(:tasked_exercise)    { FactoryGirl.create(:tasks_tasked_exercise, free_response: 'abc') }
+
+  let(:exchange_identifier) { 42 }
+  let(:answer_id)           { tasked_exercise.correct_answer_id }
+  let(:free_response)
+
+  it 'records answers and grade in exchange when the task_step is completed' do
+    roles = tasked_exercise.task_step.task.taskings.collect{ |tasking| tasking.role }
+    users = Role::GetUsersForRoles[roles]
+    users.each{ |user| allow(user).to receive(:identifier).and_return(exchange_identifier) }
+
+    tasked_exercise.answer_id = answer_id
+    expect(OpenStax::Exchange).to receive(:record_multiple_choice_answer)
+                                    .with(exchange_identifier,
+                                          tasked_exercise.url,
+                                          tasked_exercise.task_step.id.to_s,
+                                          answer_id)
+    expect(OpenStax::Exchange).to receive(:record_grade)
+                                    .with(exchange_identifier,
+                                          tasked_exercise.url,
+                                          tasked_exercise.task_step.id.to_s,
+                                          1,
+                                          'tutor')
+    described_class[tasked_exercise: tasked_exercise]
+  end
+end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Tasks::Models::TaskedExercise, :type => :model do
+RSpec.describe Tasks::Models::TaskedExercise, type: :model do
   it { is_expected.to validate_presence_of(:content) }
 
   let!(:hash) { OpenStax::Exercises::V1.fake_client.new_exercise_hash }
@@ -71,25 +71,10 @@ RSpec.describe Tasks::Models::TaskedExercise, :type => :model do
     expect { tasked_exercise.save! }.to change{ tasked_exercise.task_step.task.cache_key }
   end
 
-  it 'records answers and grade in exchange when the task_step is completed' do
-    roles = [Entity::Role.create!]
-    exchange_identifier = 42
-    correct_answer_id = tasked_exercise.correct_answer_id
-    allow(tasked_exercise).to receive(:roles).and_return(roles)
-    allow(tasked_exercise).to receive(:identifiers).and_return([exchange_identifier])
-    tasked_exercise.free_response = 'abc'
-    tasked_exercise.answer_id = correct_answer_id
-    expect(OpenStax::Exchange).to receive(:record_multiple_choice_answer)
-                                    .with(exchange_identifier,
-                                          tasked_exercise.url,
-                                          tasked_exercise.task_step.id.to_s,
-                                          correct_answer_id)
-    expect(OpenStax::Exchange).to receive(:record_grade)
-                                    .with(exchange_identifier,
-                                          tasked_exercise.url,
-                                          tasked_exercise.task_step.id.to_s,
-                                          1,
-                                          'tutor')
+  it 'calls SendTaskedExerciseAnswerToExchange when completed' do
+    expect(SendTaskedExerciseAnswerToExchange).to(
+      receive(:[]).with(tasked_exercise: tasked_exercise)
+    )
     tasked_exercise.handle_task_step_completion!
   end
 end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     expect(SendTaskedExerciseAnswerToExchange).to(
       receive(:perform_later).with(tasked_exercise: tasked_exercise)
     )
+    tasked_exercise.free_response = 'abc'
+    tasked_exercise.answer_id = tasked_exercise.answer_ids.last
     tasked_exercise.handle_task_step_completion!
+  end
+
+  it 'does not call SendTaskedExerciseAnswerToExchange when attributes are missing' do
+    expect(SendTaskedExerciseAnswerToExchange).not_to receive(:perform_later)
+    tasked_exercise.handle_task_step_completion!
+    expect(Set.new tasked_exercise.errors).to eq Set.new [[:free_response, 'is required'],
+                                                          [:answer_id, 'is required']]
   end
 end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
 
   it 'calls SendTaskedExerciseAnswerToExchange when completed' do
     expect(SendTaskedExerciseAnswerToExchange).to(
-      receive(:[]).with(tasked_exercise: tasked_exercise)
+      receive(:perform_later).with(tasked_exercise: tasked_exercise)
     )
     tasked_exercise.handle_task_step_completion!
   end

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -105,10 +105,11 @@ class SetupPerformanceReportData
 
     # User 1 completed the reading task plan
     student_1_tasks[1].core_task_steps.each do |ts|
-      MarkTaskStepCompleted[task_step: ts]
+      ts.exercise? ? Hacks::AnswerExercise[task_step: ts, is_correct: false] : \
+                     MarkTaskStepCompleted[task_step: ts]
     end
     student_1_tasks[1].reload.non_core_task_steps.each do |ts|
-      MarkTaskStepCompleted[task_step: ts]
+      Hacks::AnswerExercise[task_step: ts, is_correct: false]
     end
 
     # User 1 answered 3 correct, 1 incorrect in 2nd homework


### PR DESCRIPTION
- **Switched the ActiveJob backend to DelayedJob**
- Moved code to send TaskedExercise answers to Exchange to a routine
- Make routine run as a background job
- Specs

DelayedJob pros and cons

Pros:
- DelayedJob has retry built-in (though Resque has a perfectly fine plugin, it requires you to run an extra scheduler process)
- DelayedJob uses the DB, which we actually backup
- DelayedJob would write the job inside the transaction, so the worker wouldn't see it until the transaction is done

Cons:
- More DB access by DelayedJob's polling (one extra query per worker per 5 seconds).