### PR TITLE
WIP Load JS API from accounts for FE use

### DIFF
--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -1,2 +1,3 @@
 //= require jquery
 //= require bootstrap-sprockets
+//= require 'home/accounts'

--- a/app/assets/javascripts/home/accounts.coffee
+++ b/app/assets/javascripts/home/accounts.coffee
@@ -1,0 +1,20 @@
+$(document).ready ->
+
+  return if OxAccount.isLoggedIn()
+
+  $('#login.btn').on 'click', (ev)->
+    ev.preventDefault()
+    $(ev.target).addClass('btn-loading')
+    displayLogin ->
+      $(ev.target).removeClass('btn-loading')
+
+displayLogin = (cb) ->
+
+  OxAccount.onAvailable ->
+    OxAccount.on('login', (ev, user) ->
+      # Not 100% sure of the best action here.
+      # For now we just trigger a reload which will redirect to app.
+      # Might be better to display a short message saying "login successfull" or something
+      window.location.reload()
+    )
+    OxAccount.displayLogin().then(cb)

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -276,6 +276,26 @@ header {
   box-shadow: 0 0 20px rgba(0,0,0,.4);
 }
 
+.btn-loading {
+  &:before{
+    @extend .glyphicon;
+    @extend .glyphicon-refresh ;
+    margin-right: 0.5rem;
+    animation: spin 1s infinite linear;
+    -webkit-animation: spin2 1s infinite linear;
+  }
+}
+
+@keyframes spin {
+    from { transform: scale(1) rotate(0deg); }
+    to { transform: scale(1) rotate(360deg); }
+}
+
+@-webkit-keyframes spin2 {
+    from { -webkit-transform: rotate(0deg); }
+    to { -webkit-transform: rotate(360deg); }
+}
+
 /*-------------------------------------------------------------
                    FOOTER STYLES
 ---------------------------------------------------------------*/

--- a/app/controllers/remote_controller.rb
+++ b/app/controllers/remote_controller.rb
@@ -1,0 +1,13 @@
+class RemoteController < ApplicationController
+
+  skip_before_filter :authenticate_user!, only: :loader
+
+  skip_before_action :verify_authenticity_token, only: :loader
+
+  def loader
+    respond_to do |format|
+      format.js
+    end
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,7 @@ module ApplicationHelper
     request.host == 'tutor.openstax.org'
   end
 
+  def accounts_access_script_url
+    Rails.application.secrets.openstax['accounts']['url'] + '/assets/ox-account.js'
+  end
 end

--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -4,6 +4,7 @@
   <title>OpenStax Tutor</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel='stylesheet' href='<%= Rails.application.secrets[:css_url] %>' />
+  <%= javascript_include_tag accounts_access_script_url %>
   <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='<%= Rails.application.secrets[:js_url] %>' async></script>
   <%= csrf_meta_tags %>

--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -4,7 +4,7 @@
   <title>OpenStax Tutor</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel='stylesheet' href='<%= Rails.application.secrets[:css_url] %>' />
-  <%= javascript_include_tag accounts_access_script_url %>
+  <%= javascript_include_tag remote_js_loader_url  %>
   <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='<%= Rails.application.secrets[:js_url] %>' async></script>
   <%= csrf_meta_tags %>

--- a/app/views/remote/loader.js.erb
+++ b/app/views/remote/loader.js.erb
@@ -1,0 +1,223 @@
+window.OxAccount = (window.OxAccount || {});
+
+OxAccount.isAvailable = function(){
+   // use jquery as a sentinel since it's loaded dynamically
+   return !!window.OxAccount.$;
+}
+OxAccount.serverAddress = function(){
+  if (this._serverAddress){
+      return this._serverAddress;
+  }
+  var scriptTags = document.querySelectorAll('script');
+  for (var i=0; i<scriptTags.length; i++){
+    var matchesSelf = scriptTags[i].src.match(/(.*)\/remote\/v1.js$/);
+    if (matchesSelf){
+      return this._serverAddress = matchesSelf[ matchesSelf.length-1 ];
+    }
+  }
+  return '';
+}
+
+<% if current_user.is_anonymous? %>
+OxAccount.current_user = false;
+<% else -%>
+OxAccount.current_user = <%=raw Api::V1::UserRepresenter.new(current_user).to_json %>;
+<% end %>
+
+window.OxAccount.onAvailable = function(callback, scope){
+  finished = function(){ callback.call(scope||OxAccount, !!window.OxAccount.$); };
+  if ( this.isAvailable() )
+     return finished();
+  this._lazyLoad.js( this.serverAddress() + '/assets/remote-access.js', finished );
+}
+
+window.OxAccount._lazyLoad = (function (doc) {
+  var env,
+  head,
+  pending = {},
+  pollCount = 0,
+  queue = {css: [], js: []},
+  items = [],
+  styleSheets = doc.styleSheets;
+
+  function createNode(name, attrs) {
+    var node = doc.createElement(name), attr;
+
+    for (attr in attrs) {
+      if (attrs.hasOwnProperty(attr)) {
+        node.setAttribute(attr, attrs[attr]);
+      }
+    }
+
+    return node;
+  }
+
+  function finish(type) {
+    var p = pending[type],
+        callback,
+        urls;
+
+    if (p) {
+      callback = p.callback;
+      urls     = p.urls;
+
+      urls.shift();
+      pollCount = 0;
+
+      if (!urls.length) {
+        callback && callback.call(p.context, p.obj);
+        pending[type] = null;
+        queue[type].length && load(type);
+      }
+    }
+  }
+
+  function getEnv() {
+    var ua = navigator.userAgent;
+
+    env = {
+      async: doc.createElement('script').async === true
+    };
+
+    (env.webkit = /AppleWebKit\//.test(ua))
+      || (env.ie = /MSIE|Trident/.test(ua))
+      || (env.opera = /Opera/.test(ua))
+      || (env.gecko = /Gecko\//.test(ua))
+      || (env.unknown = true);
+  }
+
+
+  function load(type, urls, callback, obj, context) {
+    var _finish = function () { finish(type); },
+        isCSS   = type === 'css',
+        nodes   = [],
+        i, len, node, p, pendingUrls, url;
+
+    env || getEnv();
+
+    if (urls) {
+      urls = typeof urls === 'string' ? [urls] : urls.concat();
+      urls = urls.filter(function(url) {
+        return items.indexOf(url) == -1;
+      });
+      if (urls.length == 0)
+        return callback()
+      items = items.concat(urls);
+      if (isCSS || env.async || env.gecko || env.opera) {
+
+        queue[type].push({
+          urls    : urls,
+          callback: callback,
+          obj     : obj,
+          context : context
+        });
+      } else {
+        for (i = 0, len = urls.length; i < len; ++i) {
+          queue[type].push({
+            urls    : [urls[i]],
+            callback: i === len - 1 ? callback : null, // callback is only added to the last URL
+            obj     : obj,
+            context : context
+          });
+        }
+      }
+    }
+
+    if (pending[type] || !(p = pending[type] = queue[type].shift())) {
+      return;
+    }
+
+    head || (head = doc.head || doc.getElementsByTagName('head')[0]);
+    pendingUrls = p.urls.concat();
+
+    for (i = 0, len = pendingUrls.length; i < len; ++i) {
+      url = pendingUrls[i];
+
+      if (isCSS) {
+          node = env.gecko ? createNode('style') : createNode('link', {
+            href: url,
+            rel : 'stylesheet'
+          });
+      } else {
+        node = createNode('script', {src: url});
+        node.async = false;
+      }
+
+      node.className = 'lazyload';
+      node.setAttribute('charset', 'utf-8');
+
+      if (env.ie && !isCSS && 'onreadystatechange' in node && !('draggable' in node)) {
+        node.onreadystatechange = function () {
+          if (/loaded|complete/.test(node.readyState)) {
+            node.onreadystatechange = null;
+            _finish();
+          }
+        };
+      } else if (isCSS && (env.gecko || env.webkit)) {
+        if (env.webkit) {
+          p.urls[i] = node.href; // resolve relative URLs (or polling won't work)
+          pollWebKit();
+        } else {
+          node.innerHTML = '@import "' + url + '";';
+          pollGecko(node);
+        }
+      } else {
+        node.onload = node.onerror = _finish;
+      }
+
+      nodes.push(node);
+    }
+
+    for (i = 0, len = nodes.length; i < len; ++i) {
+      head.appendChild(nodes[i]);
+    }
+  }
+  function pollGecko(node) {
+    var hasRules;
+    try {
+      hasRules = !!node.sheet.cssRules;
+    } catch (ex) {
+      pollCount += 1;
+
+      if (pollCount < 200) {
+        setTimeout(function () { pollGecko(node); }, 50);
+      } else {
+        hasRules && finish('css');
+      }
+      return;
+    }
+    finish('css');
+  }
+  function pollWebKit() {
+    var css = pending.css, i;
+    if (css) {
+      i = styleSheets.length;
+      while (--i >= 0) {
+        if (styleSheets[i].href === css.urls[0]) {
+          finish('css');
+          break;
+        }
+      }
+      pollCount += 1;
+      if (css) {
+        if (pollCount < 200) {
+          setTimeout(pollWebKit, 50);
+        } else {
+          finish('css');
+        }
+      }
+    }
+  }
+
+  return {
+
+    css: function (urls, callback, obj, context) {
+      load('css', urls, callback, obj, context);
+    },
+
+    js: function (urls, callback, obj, context) {
+      load('js', urls, callback, obj, context);
+    }
+
+  };
+})(this.document);

--- a/app/views/remote/loader.js.erb
+++ b/app/views/remote/loader.js.erb
@@ -1,28 +1,27 @@
 window.OxAccount = (window.OxAccount || {});
 
-OxAccount.isAvailable = function(){
-   // use jquery as a sentinel since it's loaded dynamically
-   return !!window.OxAccount.$;
-}
-OxAccount.serverAddress = function(){
-  if (this._serverAddress){
-      return this._serverAddress;
-  }
-  var scriptTags = document.querySelectorAll('script');
-  for (var i=0; i<scriptTags.length; i++){
-    var matchesSelf = scriptTags[i].src.match(/(.*)\/remote\/v1.js$/);
-    if (matchesSelf){
-      return this._serverAddress = matchesSelf[ matchesSelf.length-1 ];
-    }
-  }
-  return '';
-}
-
 <% if current_user.is_anonymous? %>
 OxAccount.current_user = false;
 <% else -%>
 OxAccount.current_user = <%=raw Api::V1::UserRepresenter.new(current_user).to_json %>;
 <% end %>
+
+// Ideally we could use the openstax_accounts.login_path helper
+// But it returns as just http://<host>:<port>/login, when it needs to be /accounts/login
+OxAccount.login_path = '<%= "#{request.protocol}#{request.host}:#{request.port}/accounts/login" %>';
+
+OxAccount.isAvailable = function(){
+   // use jquery as a sentinel since it's loaded dynamically
+   return !!window.OxAccount.$;
+}
+
+OxAccount.serverAddress = function(){
+  return "<%= Rails.application.secrets.openstax['accounts']['url'] %>";
+}
+
+OxAccount.isLoggedIn = function(){
+  return !!OxAccount.current_user;
+}
 
 window.OxAccount.onAvailable = function(callback, scope){
   finished = function(){ callback.call(scope||OxAccount, !!window.OxAccount.$); };

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -6,9 +6,7 @@
   <% unless is_real_production_site? # Keep google away from -dev etc %>
     <meta name="robots" content="noindex">
   <% end %>
-
-  <%= javascript_include_tag remote_js_loader_url(format: :js)  %>
-
+  <%= javascript_include_tag remote_js_loader_url  %>
   <meta http-equiv="content-type" content="text/html; charset=UTF8" />
   <%= render 'layouts/meta' %>
   <%= stylesheet_link_tag 'home', media: 'all' %>

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -6,7 +6,7 @@
   <% unless is_real_production_site? # Keep google away from -dev etc %>
     <meta name="robots" content="noindex">
   <% end %>
-
+  <%= javascript_include_tag accounts_access_script_url %>
   <meta http-equiv="content-type" content="text/html; charset=UTF8" />
   <%= render 'layouts/meta' %>
   <%= stylesheet_link_tag 'home', media: 'all' %>

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -37,7 +37,7 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse navbar-right navbar-ex1-collapse">
         <ul class="nav navbar-nav links">
-          <li><%= link_to 'Login', openstax_accounts.login_path, class: 'btn' %></li>
+          <li><%= link_to 'Login', openstax_accounts.login_path, id: 'login', class: 'btn' %></li>
           <li><a href="http://openstaxtutor.zendesk.com" target="_blank">Help</a></li>
         </ul>
         <a class="navbar-brand-rice" href="http://www.rice.edu" target="_blank"></a>

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -6,7 +6,9 @@
   <% unless is_real_production_site? # Keep google away from -dev etc %>
     <meta name="robots" content="noindex">
   <% end %>
-  <%= javascript_include_tag accounts_access_script_url %>
+
+  <%= javascript_include_tag remote_js_loader_url(format: :js)  %>
+
   <meta http-equiv="content-type" content="text/html; charset=UTF8" />
   <%= render 'layouts/meta' %>
   <%= stylesheet_link_tag 'home', media: 'all' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
   mount OpenStax::Accounts::Engine, at: "/accounts"
   mount FinePrint::Engine => "/fine_print"
 
+  # Intended to eventually move to openstax_accounts gem
+  get '/accounts/remote/v1', :to => 'remote#loader', :as=>'remote_js_loader'
+
   use_doorkeeper
 
   apipie


### PR DESCRIPTION
Goes along with https://github.com/openstax/accounts/pull/202 and https://github.com/openstax/tutor-js/pull/810


In order to test logins you need a real accounts instance configured with the above PR and it's oath linked to tutor-server.  Accounts stubbing must also be turned off in `secrets.yml`

![screen shot 2015-10-15 at 9 35 17 am](https://cloud.githubusercontent.com/assets/79566/10518174/c24b020c-7325-11e5-88a4-3a1a35074557.png)
