### PR TITLE
WIP: Provide "metadata" for courses

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
   def index
     OSU::AccessPolicy.require_action_allowed!(:index, current_api_user, Entity::Course)
     courses_info = CollectCourseInfo[user: current_human_user,
-                                     with: [:roles, :periods, :ecosystem]]
+                                     with: [:roles, :periods, :ecosystem, :metadata]]
     respond_with courses_info, represent_with: Api::V1::CoursesRepresenter
   end
 
@@ -34,7 +34,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
     # we can gather extra information
     course_info = CollectCourseInfo[course: course,
                                     user: current_human_user,
-                                    with: [:roles, :periods, :ecosystem]].first
+                                    with: [:roles, :periods, :ecosystem, :metadata]].first
     respond_with course_info, represent_with: Api::V1::CourseRepresenter
   end
 

--- a/app/helpers/webview_helper.rb
+++ b/app/helpers/webview_helper.rb
@@ -5,7 +5,7 @@ module WebviewHelper
     {
       user: Api::V1::UserRepresenter.new(current_user),
       courses: Api::V1::CoursesRepresenter.new(
-        CollectCourseInfo[user: current_user, with: [:roles, :periods, :ecosystem]]
+        CollectCourseInfo[user: current_user, with: [:roles, :periods, :ecosystem, :metadata]]
       )
     }
   end

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -27,6 +27,18 @@ module Api::V1
               required: false
              }
 
+    property :metadata,
+             type: String,
+             readable: true,
+             writeable: false,
+             if: ->(*) { respond_to?(:metadata) },
+             getter: ->(*) { metadata },
+             schema_info: {
+              description: "Metadata for the course, if available.",
+              required: false
+             }
+
+
     collection :roles,
                extend: Api::V1::RoleRepresenter,
                readable: true,

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -22,6 +22,9 @@ class CollectCourseInfo
   uses_routine GetCourseEcosystem,
                translations: { outputs: { type: :verbatim } },
                as: :get_course_ecosystem
+  uses_routine GetCourseMetadata,
+               translations: { outputs: { type: :verbatim } },
+               as: :get_course_metadata
 
   protected
 
@@ -61,6 +64,8 @@ class CollectCourseInfo
         set_periods_on_courses
       when :ecosystem
         set_ecosystem_on_courses
+      when :metadata
+        set_metadata_on_courses
       end
     end
   end
@@ -92,6 +97,13 @@ class CollectCourseInfo
     outputs.courses.each do |course|
       routine = run(:get_course_ecosystem, course: Entity::Course.find(course.id))
       course.ecosystem = routine.outputs.ecosystem
+    end
+  end
+
+  def set_metadata_on_courses
+    outputs.courses.each do |course|
+      routine = run(:get_course_metadata, course: Entity::Course.find(course.id))
+      course.metadata = routine.outputs.metadata
     end
   end
 

--- a/app/routines/get_course_metadata.rb
+++ b/app/routines/get_course_metadata.rb
@@ -1,0 +1,15 @@
+class GetCourseMetadata
+  lev_routine express_output: :metadata
+
+  protected
+
+  def mapping
+    @@mapping ||=
+      YAML.load_file(Rails.root.join('config', 'book-metadata-mapping.yml'))
+  end
+
+  def exec(course:, strategy_class: Content::Strategies::Direct::Ecosystem)
+    ecosystem = GetCourseEcosystem[course: course, strategy_class: strategy_class]
+    outputs[:metadata] = mapping[ecosystem.books.first.uuid]
+  end
+end

--- a/app/subsystems/course_content/get_course_ecosystems.rb
+++ b/app/subsystems/course_content/get_course_ecosystems.rb
@@ -5,6 +5,7 @@ class CourseContent::GetCourseEcosystems
 
   def exec(course:, strategy_class: Content::Strategies::Direct::Ecosystem)
     course_ecosystems = CourseContent::Models::CourseEcosystem.where(course: course.id)
+
     outputs[:ecosystems] = course_ecosystems.collect do |ce|
       content_ecosystem = ce.ecosystem
       strategy = strategy_class.new(ce.ecosystem)

--- a/app/subsystems/course_content/get_course_metadata.rb
+++ b/app/subsystems/course_content/get_course_metadata.rb
@@ -1,0 +1,13 @@
+class GetCourseMetadata
+  lev_routine express_output: :metadata
+
+  uses_routine GetCourseEcosystem, as: :get_course_ecosystem
+
+  protected
+
+  def exec(course:, strategy_class: Content::Strategies::Direct::Ecosystem)
+
+    ecosystem = get_course_ecosystem[course: course, strategy_class: strategy_class]
+    debugger
+  end
+end

--- a/config/book-metadata-mapping.yml
+++ b/config/book-metadata-mapping.yml
@@ -1,0 +1,15 @@
+# This file contains a mapping between a books UUID and the type of content it contains
+# The information is used to indicate to the FE how courses that use the book should be styled
+# Read
+
+# Concept coach derived copy
+7ce75839-d694-4bdf-be1f-ec330b083735:
+  type: 'physics'
+
+# HS Biology
+d52e93f4-8653-4273-86da-3850001c0786:
+  type: 'biology'
+
+# HS Physics
+334f8b61-30eb-4475-8e05-5260a4866b4b:
+  type: 'physics'


### PR DESCRIPTION
The goal of this is to provide the FE information to style courses with.  Right now it's just using the first word of the course name, which is far from ideal.  This adds a `config/book-metadata-mapping.yml` file which contains a book UUID -> type mapping.

This isn't ideal either but I think it's the "simplest thing that could possibly work".  I chatted with the content folks in an attempt to find built-in field on the book's JSON that we get the information from, and we came to the conclusion that there really wasn't anything that would work other than just the UUID.  All the other fields can and do vary to much between books.

Two ways I could see to improve this would be to either:
  * Read the YAML file when the book is imported and store the information on the books model.  That's not really much better to me because it's storing information in the db over and over for no real reason.

  * Alter the ecosystem admin screen to include a drop-down to set the type from a pre-vetted list.  The demo scripts could supply it along with their yaml.  **I think this is the better way to go**, but wanted to run it by others before I did that.
