### PR TITLE
Ecosystem import job

### DIFF
--- a/app/controllers/admin/ecosystems_controller.rb
+++ b/app/controllers/admin/ecosystems_controller.rb
@@ -1,6 +1,9 @@
 class Admin::EcosystemsController < Admin::BaseController
   def index
     @ecosystems = Content::ListEcosystems[]
+    @incomplete_jobs = Lev::BackgroundJob.incomplete.select do |job|
+      job.respond_to?(:ecosystem_import_url)
+    end
   end
 
   def import

--- a/app/controllers/admin/ecosystems_controller.rb
+++ b/app/controllers/admin/ecosystems_controller.rb
@@ -18,6 +18,9 @@ class Admin::EcosystemsController < Admin::BaseController
         book_cnx_id: params[:cnx_id],
         tag_generator: Marshal.dump(ConceptCoach::TagGenerator.new(params[:cc_tag]))
       )
+      job = Lev::BackgroundJob.find(job_id)
+      import_url = OpenStax::Cnx::V1.url_for(params[:cnx_id])
+      job.save(ecosystem_import_url: import_url)
       flash[:notice] = 'Ecosystem import job queued.'
     end
     redirect_to admin_ecosystems_path

--- a/app/controllers/admin/ecosystems_controller.rb
+++ b/app/controllers/admin/ecosystems_controller.rb
@@ -14,11 +14,11 @@ class Admin::EcosystemsController < Admin::BaseController
     archive_url = params[:archive_url].present? ? params[:archive_url] : @default_archive_url
 
     OpenStax::Cnx::V1.with_archive_url(url: archive_url) do
-      ecosystem = FetchAndImportBookAndCreateEcosystem[
+      job_id = FetchAndImportBookAndCreateEcosystem.perform_later(
         book_cnx_id: params[:cnx_id],
-        tag_generator: ConceptCoach::TagGenerator.new(params[:cc_tag])
-      ]
-      flash[:notice] = "Ecosystem \"#{ecosystem.title}\" imported."
+        tag_generator: Marshal.dump(ConceptCoach::TagGenerator.new(params[:cc_tag]))
+      )
+      flash[:notice] = 'Ecosystem import job queued.'
     end
     redirect_to admin_ecosystems_path
   end

--- a/app/routines/fetch_and_import_book_and_create_ecosystem.rb
+++ b/app/routines/fetch_and_import_book_and_create_ecosystem.rb
@@ -11,6 +11,7 @@ class FetchAndImportBookAndCreateEcosystem
   def exec(book_cnx_id:, ecosystem_title: nil, exercise_uids: nil, tag_generator: nil)
     cnx_book = OpenStax::Cnx::V1.book(id: book_cnx_id)
     eco_title ||= "#{cnx_book.title} (#{cnx_book.uuid}@#{cnx_book.version}) - #{Time.now.utc}"
+    tag_generator = Marshal.load(tag_generator) if tag_generator.is_a?(String)
     outputs[:ecosystem] = Content::Ecosystem.create!(title: eco_title)
     run(:import_book, cnx_book: cnx_book,
                       ecosystem: outputs[:ecosystem],

--- a/app/views/admin/ecosystems/index.html.erb
+++ b/app/views/admin/ecosystems/index.html.erb
@@ -3,3 +3,7 @@
 <%= render partial: 'manager/ecosystems/index', locals: { ecosystems: @ecosystems } %>
 
 <%= link_to 'Import a new Ecosystem', import_admin_ecosystems_path, class: 'btn btn-primary' %>
+
+<% unless @incomplete_jobs.empty? %>
+  <%= render partial: 'manager/ecosystems/incomplete', locals: { incomplete_jobs: @incomplete_jobs } %>
+<% end %>

--- a/app/views/admin/ecosystems/index.html.erb
+++ b/app/views/admin/ecosystems/index.html.erb
@@ -1,9 +1,31 @@
 <% @page_header = 'Ecosystems' %>
 
-<%= render partial: 'manager/ecosystems/index', locals: { ecosystems: @ecosystems } %>
+<ul class="nav nav-tabs" role="tablist">
+  <li role="presentation" class="active">
+    <a href="#main" aria-controls="main" role="tab" data-toggle="tab">
+      List of Books
+    </a>
+  </li>
+  <% unless @incomplete_jobs.empty? %>
+    <li role="presentation">
+      <a href="#incomplete" aria-controls="main" role="tab" data-toggle="tab">
+        Incomplete Imports
+      </a>
+    </li>
+  <% end %>
+</ul>
 
-<%= link_to 'Import a new Ecosystem', import_admin_ecosystems_path, class: 'btn btn-primary' %>
 
-<% unless @incomplete_jobs.empty? %>
-  <%= render partial: 'manager/ecosystems/incomplete', locals: { incomplete_jobs: @incomplete_jobs } %>
-<% end %>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="main">
+    <%= render partial: 'manager/ecosystems/index', locals: { ecosystems: @ecosystems } %>
+
+    <%= link_to 'Import a new Ecosystem', import_admin_ecosystems_path, class: 'btn btn-primary' %>
+  </div>
+
+  <% unless @incomplete_jobs.empty? %>
+    <div role="tabpanel" class="tab-pane" id="incomplete">
+      <%= render partial: 'manager/ecosystems/incomplete', locals: { incomplete_jobs: @incomplete_jobs } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/manager/ecosystems/_incomplete.html.erb
+++ b/app/views/manager/ecosystems/_incomplete.html.erb
@@ -1,5 +1,3 @@
-<h2>Incomplete Ecosystem Imports</h2>
-
 <table class="table table-striped">
   <thead>
     <tr>
@@ -17,3 +15,5 @@
     </tr>
   <% end %>
 </table>
+
+<p><strong>Note:</strong> This table does not automatically refresh.</p>

--- a/app/views/manager/ecosystems/_incomplete.html.erb
+++ b/app/views/manager/ecosystems/_incomplete.html.erb
@@ -1,0 +1,19 @@
+<h2>Incomplete Ecosystem Imports</h2>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Job ID</th>
+      <th>Status</th>
+      <th>Link to Archive</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% incomplete_jobs.each do |job| %>
+    <tr>
+      <td><%= link_to(job.id, admin_job_path(job.id)) %></td>
+      <td><%= job.status %></td>
+      <td><%= link_to(job.ecosystem_import_url, job.ecosystem_import_url, target: '_blank') %></td>
+    </tr>
+  <% end %>
+</table>

--- a/spec/features/admin/manage_ecosystems_spec.rb
+++ b/spec/features/admin/manage_ecosystems_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe 'Administration', speed: :slow, vcr: VCR_OPTS do
     fill_in 'Book CNX id', with: '93e2b09d-261c-4007-a987-0b3062fe154b@4.4'
     click_button 'Import'
 
-    expect(page).to have_css('.flash_notice', text: 'Ecosystem "Physics (93e2b09d-261c-4007-a987-0b3062fe154b@4.4)')
-    expect(page).to have_css('.flash_notice', text: '" imported.')
+    expect(page).to have_css('.flash_notice', text: 'Ecosystem import job queued.')
     expect(page).to have_css('td', text: 'Physics')
     expect(page).to have_css('td', text: '93e2b09d-261c-4007-a987-0b3062fe154b')
     expect(page).to have_css('td', text: '4.4')


### PR DESCRIPTION
- Use background job for admin ecosystem importing textbook

  Use `Marshal.dump` when passing in the tag_generator to
  `FetchAndImportBookAndCreateEcosystem`.  An instance of the concept
  coach tag generator cannot be used in background jobs:

  ```Unsupported argument type: ConceptCoach::TagGenerator```

- Store the book url with the ecosystem import background job


- Display incomplete ecosystem import jobs on admin ecosystems page

  Display job id (with link to the job details page), job status and link
  to the book in archive.

- Change ecosystems index page to use tabs

  "List of Books" and "Incomplete Imports".

  Add note to "Incomplete Imports" table to say that the table does not
  automatically refresh.

