### PR TITLE
Adds stubbed endpoint for getting a concept coach task

### DIFF
--- a/app/controllers/api/v1/cc/tasks_controller.rb
+++ b/app/controllers/api/v1/cc/tasks_controller.rb
@@ -1,0 +1,75 @@
+class Api::V1::Cc::TasksController < Api::V1::ApiController
+
+  resource_description do
+    api_versions "v1"
+    short_description 'Represents a concept coach task'
+    description <<-EOS
+      see `/api/tasks`
+    EOS
+  end
+
+  ###############################################################
+  # show
+  ###############################################################
+
+  api :GET, 'cc/tasks/:cnx_book_id/:cnx_page_id', 'Gets the Concept Coach Task for the given CNX page'
+  description <<-EOS
+    The `cnx_book_id` and `cnx_page_id` should not contain version information.
+    #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
+  EOS
+  def show
+    # THIS IS JUST A HACKED STUBBED IMPLEMENTATION!!
+
+    # Real implementation should, among other things:
+    #   1) Error out if the user isn't in a course with the provided book/page ID
+    #   2) return 4xx error if IDs contain versions, e.g. UUID@42
+
+    if current_human_user.nil? || current_human_user.is_anonymous?
+      head :forbidden
+    elsif params[:cnx_book_id].blank? || params[:cnx_page_id].blank?
+      head :unprocessable_entity
+    else
+      # Instead of really attaching a task to a user, store it in the session (hack)
+      hash = Digest::SHA1.hexdigest(
+        current_human_user.id.to_s +
+        params[:cnx_book_id] +
+        params[:cnx_page_id]
+      )[0..7]
+
+      task_id = session[hash.to_sym]
+
+      task = task_id.nil? ?
+               create_fake_concept_coach_task :
+               Tasks::Models::Task.find(task_id)
+
+      session[hash.to_sym] = task.id
+
+      respond_with task, represent_with: Api::V1::TaskRepresenter
+    end
+  end
+
+  protected
+
+  def create_fake_concept_coach_task
+    task =  Tasks::BuildTask[
+              task_type: :concept_coach,
+              title: 'Dummy task title',
+              description: 'Dummy task description',
+              opens_at: 1000.days.ago,
+              feedback_at: 1000.days.ago]
+
+    3.times do
+      content_exercise = FactoryGirl.create(:content_exercise)
+      strategy = ::Content::Strategies::Direct::Exercise.new(content_exercise)
+      exercise = ::Content::Exercise.new(strategy: strategy)
+
+      step = Tasks::Models::TaskStep.new(task: task)
+      step.tasked = TaskExercise[exercise: exercise, task_step: step]
+      task.task_steps << step
+    end
+
+    task.save!
+    task
+  end
+
+end

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -4,7 +4,7 @@ require_relative '../placeholder_strategies/i_reading_personalized'
 class Tasks::Models::Task < Tutor::SubSystems::BaseModel
   enum task_type: [:homework, :reading, :chapter_practice,
                    :page_practice, :mixed_practice, :external,
-                   :event, :extra]
+                   :event, :extra, :concept_coach]
 
   belongs_to :task_plan, inverse_of: :tasks
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,10 @@ Rails.application.routes.draw do
       end
     end
 
+    namespace 'cc' do
+      get 'tasks/:cnx_book_id/:cnx_page_id', to: 'tasks#show', as: :task
+    end
+
     get 'user/courses', to: 'courses#index', as: :courses
 
     resources :guides, path: 'courses', only: [] do

--- a/spec/requests/api/v1/cc/get_tasks_spec.rb
+++ b/spec/requests/api/v1/cc/get_tasks_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+describe "Get CC Tasks", type: :request, api: true, version: :v1 do
+
+  let!(:application)     { FactoryGirl.create :doorkeeper_application }
+  let!(:user_1)          {
+    profile = FactoryGirl.create(:user_profile)
+    strategy = User::Strategies::Direct::User.new(profile)
+    User::User.new(strategy: strategy)
+  }
+  let!(:user_1_token)    { FactoryGirl.create :doorkeeper_access_token,
+                                              application: application,
+                                              resource_owner_id: user_1.id }
+
+  let!(:user_2)          {
+    profile = FactoryGirl.create(:user_profile)
+    strategy = User::Strategies::Direct::User.new(profile)
+    User::User.new(strategy: strategy)
+  }
+  let!(:user_2_token)    { FactoryGirl.create :doorkeeper_access_token,
+                                              application: application,
+                                              resource_owner_id: user_2.id }
+
+  let!(:anon_user)        { User::User.anonymous }
+  let!(:anon_user_token) { FactoryGirl.create :doorkeeper_access_token,
+                                              application: application,
+                                              resource_owner_id: anon_user.id }
+
+  let!(:userless_token)  { FactoryGirl.create :doorkeeper_access_token, application: application }
+
+  def get_route(cnx_book_id:, cnx_page_id:)
+    "/api/cc/tasks/#{cnx_book_id}/#{cnx_page_id}"
+  end
+
+  describe "#show" do
+    it "should create on first request and not again" do
+      expect{
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), user_1_token)
+      }.to change{Tasks::Models::Task.count}.by(1)
+
+      cc_task = Tasks::Models::Task.order{created_at.desc}.first
+
+      expect(response.code).to eq '200'
+      expect(response.body_as_hash).to include(id: cc_task.id.to_s)
+      expect(response.body_as_hash).to include(title: cc_task.title)
+      expect(response.body_as_hash).to have_key(:steps)
+      expect(response.body_as_hash[:steps].length).to eq 3
+
+      expect{
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), user_1_token)
+      }.to change{Tasks::Models::Task.count}.by(0)
+
+      expect(response.body_as_hash).to include(id: cc_task.id.to_s)
+    end
+
+    it 'gets different tasks for different users' do
+      expect{
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), user_1_token)
+      }.to change{Tasks::Models::Task.count}.by(1)
+
+      cc_task = Tasks::Models::Task.order{created_at.desc}.first
+      expect(response.body_as_hash).to include(id: cc_task.id.to_s)
+
+      expect{
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), user_2_token)
+      }.to change{Tasks::Models::Task.count}.by(1)
+
+      cc_task2 = Tasks::Models::Task.order{created_at.desc}.first
+      expect(response.body_as_hash).to include(id: cc_task2.id.to_s)
+
+      expect(cc_task2.id).not_to eq cc_task.id
+    end
+
+    it 'returns 403 when user is anonymous' do
+      expect {
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), anon_user_token)
+      }.to change{Tasks::Models::Task.count}.by(0)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 403 when user is not a human' do
+      expect {
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), userless_token)
+      }.to change{Tasks::Models::Task.count}.by(0)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+end


### PR DESCRIPTION
* Hit `/api/cc/tasks/CNX_COLLECTION_UUID/CNX_MODULE_UUID` and you'll get back a `Task` with normal task JSON.  
*The task will have three exercises each with fake content.  
* The UUIDs don't need to be real (can hit `/api/cc/tasks/foo/bar` if you want) for now, but later will need to be real UUIDs without version info.  
* If you hit the same endpoint twice, the first time the CC task will be generated anew and returned.  The second time you'll get back the task you got the first time (it is lazily created on the first call).  
* Different users calling the same endpoint will get different tasks.  
* This stub stores the task ID in the session now for a given user/UUID combination, so it will likely not survive logouts (can't remember exactly how brutal we are to the session on logout).  
* Some errors will be returned (e.g. 403 if not logged in, 422 if don't provide right args), but not all errors implemented yet (e.g. we don't check that the UUIDs match an ecosystem/course/student, etc).
* The task JSON is what you've seen before (with a different type).  In the real implementation there will be some new fields, and possibly some fields removed (TBD).

cc @openstax/tutor-fe-dev 