### PR TITLE
Skip all the pages at the book level when importing a book

### DIFF
--- a/app/subsystems/content/routines/import_book_part.rb
+++ b/app/subsystems/content/routines/import_book_part.rb
@@ -52,7 +52,10 @@ class Content::Routines::ImportBookPart
       chapter_tracker.advance!
     else
       cnx_book_part.parts.each do |part|
-        raise "Unexpected class #{part.class}" unless part.is_a?(OpenStax::Cnx::V1::BookPart)
+        # skip all the pages at the book level
+        next if cnx_book_part.is_root && part.is_a?(OpenStax::Cnx::V1::Page)
+
+        raise "Unexpected class #{part.class}" unless part.is_a?(OpenStax::Cnx::V1::BookPart) rescue debugger
 
         outs = run(:import_book_part,
                    cnx_book_part: part,

--- a/lib/openstax/cnx/v1/book.rb
+++ b/lib/openstax/cnx/v1/book.rb
@@ -49,7 +49,7 @@ module OpenStax::Cnx::V1
     end
 
     def root_book_part
-      @root_book_part ||= BookPart.new(hash: tree)
+      @root_book_part ||= BookPart.new(hash: tree, is_root: true)
     end
 
     def visit(visitor:, depth: 0)

--- a/lib/openstax/cnx/v1/book_part.rb
+++ b/lib/openstax/cnx/v1/book_part.rb
@@ -1,11 +1,12 @@
 module OpenStax::Cnx::V1
   class BookPart
 
-    def initialize(hash: {})
+    def initialize(hash: {}, is_root: false)
       @hash = hash
+      @is_root = is_root
     end
 
-    attr_reader :hash
+    attr_reader :hash, :is_root
 
     def title
       @title ||= hash.fetch('title') { |key|


### PR DESCRIPTION
To fix this error when running the `rake demo` script:

```
Starting book import for Concept Coach 185cbf87-c72e-48f5-b51e-f14f21b5eabd@9.87 from https://archive.cnx.org/contents/.

rake aborted!

Unexpected class OpenStax::Cnx::V1::Page
```

That is because the book
https://archive.cnx.org/contents/185cbf87-c72e-48f5-b51e-f14f21b5eabd@9.87.html
has preface and appendix pages that are not in a chapter.