### PR TITLE
Default the demo import URL to value from secrets

### DIFF
--- a/lib/tasks/demo/content_configuration.rb
+++ b/lib/tasks/demo/content_configuration.rb
@@ -53,7 +53,7 @@ class ContentConfiguration
   end
 
   def url_base
-    @configuration.url_base || OpenStax::Cnx::V1.archive_url_base
+    @configuration.url_base || Rails.application.secrets.openstax['cnx']['archive_url']
   end
 
   def assignments


### PR DESCRIPTION
Previously it was default to whatever it had been set to. Which was then
overwritten when a book was imported and would be invalid for following books. 

Caused a bug when the concept coach book with a custom url was imported in the middle. Following books would fail because they'd all use the custom url