### PR TITLE
Remove main User module from module path

### DIFF
--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -2,7 +2,7 @@ module User
   module Models
     class Profile < Tutor::SubSystems::BaseModel
 
-      wrapped_by User::Strategies::Direct::User
+      wrapped_by Strategies::Direct::User
 
       belongs_to :account, class_name: "OpenStax::Accounts::Account", subsystem: 'none'
 


### PR DESCRIPTION
Believe this is the root cause of Rails code reloading failures.  When the path's fixed up it seems to work fine now.

