### PR TITLE
Add API for patching courses

### DIFF
--- a/app/access_policies/course_access_policy.rb
+++ b/app/access_policies/course_access_policy.rb
@@ -7,7 +7,7 @@ class CourseAccessPolicy
       requestor.is_human? && \
       (UserIsCourseStudent[user: requestor, course: course] || \
        UserIsCourseTeacher[user: requestor, course: course])
-    when :export, :roster, :add_period
+    when :export, :roster, :add_period, :update
       requestor.is_human? && UserIsCourseTeacher[user: requestor, course: course]
     else
       false

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -38,6 +38,23 @@ class Api::V1::CoursesController < Api::V1::ApiController
     respond_with course_info, represent_with: Api::V1::CourseRepresenter
   end
 
+  api :PATCH, '/courses/:course_id', 'Update course details'
+  description <<-EOS
+    Update course details and return information about the updated course
+    #{json_schema(Api::V1::CourseRepresenter, include: :readable)}
+  EOS
+  def update
+    course = Entity::Course.find(params[:id])
+    OSU::AccessPolicy.require_action_allowed!(:update, current_api_user, course)
+
+    # Use CollectCourseInfo instead of just representing the entity course so
+    # we can gather extra information
+    course_info = CollectCourseInfo[course: course,
+                                    user: current_human_user,
+                                    with: [:roles, :periods, :ecosystem]].first
+    respond_with course_info, represent_with: Api::V1::CourseRepresenter
+  end
+
   api :GET, '/courses/:course_id/tasks', 'Gets all course tasks assigned to the role holder making the request'
   description <<-EOS
     #{json_schema(Api::V1::TaskSearchRepresenter, include: :readable)}

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -47,12 +47,16 @@ class Api::V1::CoursesController < Api::V1::ApiController
     course = Entity::Course.find(params[:id])
     OSU::AccessPolicy.require_action_allowed!(:update, current_api_user, course)
 
+    UpdateCourse.call(params[:id], { name: params[:course][:name] })
+
     # Use CollectCourseInfo instead of just representing the entity course so
     # we can gather extra information
     course_info = CollectCourseInfo[course: course,
                                     user: current_human_user,
                                     with: [:roles, :periods, :ecosystem]].first
-    respond_with course_info, represent_with: Api::V1::CourseRepresenter
+    respond_with course_info, represent_with: Api::V1::CourseRepresenter,
+                              location: nil,
+                              responder: ResponderWithPutContent
   end
 
   api :GET, '/courses/:course_id/tasks', 'Gets all course tasks assigned to the role holder making the request'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :courses, only: [:show] do
+    resources :courses, only: [:show, :update] do
       member do
         get 'dashboard(/role/:role_id)', action: :dashboard
         get 'plans'

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -229,7 +229,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
       it 'renames the course' do
         api_patch :update, user_1_token, parameters: { id: course.id,
                                                        course: { name: 'Renamed' } }
-        # TODO assert the course has been renamed
+        expect(course.reload.name).to eq 'Renamed'
+        expect(response.body_as_hash[:name]).to eq 'Renamed'
       end
     end
   end

--- a/spec/routines/update_course_spec.rb
+++ b/spec/routines/update_course_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe UpdateCourse do
+  let!(:course) { CreateCourse[name: 'A course'] }
+
+  it 'updates the course name' do
+    UpdateCourse.call(course.id, { name: 'Physics' })
+    expect(course.reload.name).to eq 'Physics'
+  end
+end

--- a/spec/subsystems/course_profile/update_profile_spec.rb
+++ b/spec/subsystems/course_profile/update_profile_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe CourseProfile::UpdateProfile do
+  let!(:course) { CreateCourse[name: 'A course'] }
+
+  it 'updates the course name' do
+    CourseProfile::UpdateProfile.call(course.id, { name: 'Physics' })
+    expect(course.reload.name).to eq 'Physics'
+  end
+end


### PR DESCRIPTION

- Add stub API for patching courses

  The API currently only checks that the user has permission to call the
  API, the course details are not updated.

- Add spec for CourseProfile::UpdateProfile


- Add spec UpdateCourse routine


- Add API for patching courses (name change only for now)

