### PR TITLE
Support fetching cc exercises via CORS

### DIFF
--- a/app/controllers/api/v1/cc/tasks_controller.rb
+++ b/app/controllers/api/v1/cc/tasks_controller.rb
@@ -1,5 +1,8 @@
 class Api::V1::Cc::TasksController < Api::V1::ApiController
 
+  after_filter :set_cors_headers
+  skip_before_action :verify_authenticity_token, only: :show
+
   resource_description do
     api_versions "v1"
     short_description 'Represents a concept coach task'
@@ -24,6 +27,11 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
     #   1) Error out if the user isn't in a course with the provided book/page ID
     #   2) return 4xx error if IDs contain versions, e.g. UUID@42
 
+    # FIXME
+    # OpenstaxAPI calls User::User.where().first which fails since User::User is a proxy and lacks .where
+    # https://github.com/openstax/openstax_api/pull/36
+    # current_human_user = User::User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+
     if current_human_user.nil? || current_human_user.is_anonymous?
       head :forbidden
     elsif params[:cnx_book_id].blank? || params[:cnx_page_id].blank?
@@ -40,23 +48,25 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
 
       task = task_id.nil? ?
                create_fake_concept_coach_task :
-               Tasks::Models::Task.find(task_id)
+               ::Tasks::Models::Task.find(task_id)
 
       session[hash.to_sym] = task.id
 
-      respond_to do |format|
-        format.js do
-          render :json => Api::V1::TaskRepresenter.new(task).to_json, :callback => params[:callback]
-        end
-      end
-
+      respond_with task, represent_with: Api::V1::TaskRepresenter
     end
+  end
+
+  # requested by an OPTIONS request type
+  def cors_preflight_check
+    set_cors_headers
+    headers['Access-Control-Max-Age'] = '1728000'
+    render :text => '', :content_type => 'text/plain'
   end
 
   protected
 
   def create_fake_concept_coach_task
-    task =  Tasks::BuildTask[
+    task =  ::Tasks::BuildTask[
               task_type: :concept_coach,
               title: 'Dummy task title',
               description: 'Dummy task description',
@@ -77,4 +87,20 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
     task
   end
 
+  def set_cors_headers
+    headers['Access-Control-Allow-Origin']   = validated_cors_origin
+    headers['Access-Control-Allow-Methods']  = 'POST, PUT, DELETE, GET, OPTIONS'
+    headers['Access-Control-Request-Method'] = '*'
+    headers['Access-Control-Allow-Credentials'] = 'true'
+    headers['Access-Control-Allow-Headers']  = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+  end
+
+  def validated_cors_origin
+    origin = request.headers["HTTP_ORIGIN"]
+    return '' if origin.blank?
+    Rails.application.secrets.cc_origins.each do | host |
+      return origin if origin.match(/^#{host}/)
+    end
+    '' # an empty string will disallow any access
+  end
 end

--- a/app/controllers/api/v1/cc/tasks_controller.rb
+++ b/app/controllers/api/v1/cc/tasks_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Cc::TasksController < Api::V1::ApiController
 
-  after_filter :set_cors_headers
+  before_filter :set_cors_headers
   skip_before_action :verify_authenticity_token, only: :show
 
   resource_description do
@@ -27,11 +27,6 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
     #   1) Error out if the user isn't in a course with the provided book/page ID
     #   2) return 4xx error if IDs contain versions, e.g. UUID@42
 
-    # FIXME
-    # OpenstaxAPI calls User::User.where().first which fails since User::User is a proxy and lacks .where
-    # https://github.com/openstax/openstax_api/pull/36
-    # current_human_user = User::User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
-
     if current_human_user.nil? || current_human_user.is_anonymous?
       head :forbidden
     elsif params[:cnx_book_id].blank? || params[:cnx_page_id].blank?
@@ -57,10 +52,9 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
   end
 
   # requested by an OPTIONS request type
-  def cors_preflight_check
-    set_cors_headers
+  def cors_preflight_check # the other CORS headers are set by the before_filter
     headers['Access-Control-Max-Age'] = '1728000'
-    render :text => '', :content_type => 'text/plain'
+    render text: '', :content_type => 'text/plain'
   end
 
   protected
@@ -89,7 +83,7 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
 
   def set_cors_headers
     headers['Access-Control-Allow-Origin']   = validated_cors_origin
-    headers['Access-Control-Allow-Methods']  = 'POST, PUT, DELETE, GET, OPTIONS'
+    headers['Access-Control-Allow-Methods']  = 'GET, OPTIONS' # PUT/POST will be added when tasks are created
     headers['Access-Control-Request-Method'] = '*'
     headers['Access-Control-Allow-Credentials'] = 'true'
     headers['Access-Control-Allow-Headers']  = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'

--- a/app/controllers/api/v1/cc/tasks_controller.rb
+++ b/app/controllers/api/v1/cc/tasks_controller.rb
@@ -44,7 +44,12 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
 
       session[hash.to_sym] = task.id
 
-      respond_with task, represent_with: Api::V1::TaskRepresenter
+      respond_to do |format|
+        format.js do
+          render :json => Api::V1::TaskRepresenter.new(task).to_json, :callback => params[:callback]
+        end
+      end
+
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,8 @@ Rails.application.routes.draw do
 
     namespace 'cc' do
       get 'tasks/:cnx_book_id/:cnx_page_id', to: 'tasks#show', as: :task
+      # ConceptCoach loads via CORS and needs to handle preflight OPTIONS requests
+      match "*path", to: "tasks#cors_preflight_check", via: [:options]
     end
 
     get 'user/courses', to: 'courses#index', as: :courses

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -16,8 +16,9 @@ development:
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
   background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   cc_origins: # list of url prefixes allowed to access concept coach resources via CORS
-    - http://localhost:3001/
-    - http://10.0.2.2:4567/ # middleman test site accessed via virtualbox vm
+    - http://localhost:3001 # Tutor dev server
+    - http://localhost:9000 # Concept Coach dev server
+    - http://10.0.2.2:9000  # 10.0.2.2 is the default IP for accessing local resources from inside a virtualbox VM
   ga_tracking_code: ''
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -15,6 +15,9 @@ development:
   css_url: <%= ENV["CSS_URL"] || 'http://localhost:8000/dist/tutor.css' %>
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
   background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
+  cc_origins: # list of url prefixes allowed to access concept coach resources via CORS
+    - http://localhost:3001 # NOTE - IE11 doesn't treat differning ports as a cross origin request
+    - http://nathan.stitt.org # there's a test site at http://nathan.stitt.org/ox/
   ga_tracking_code: ''
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
@@ -105,6 +108,8 @@ production:
   mail_site_url: <%= ENV["MAIL_SITE_URL"] %>
   background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   ga_tracking_code: 'UA-XXXXXXX-1'
+  cc_origins: # list of url prefixes allowed to access concept coach resources via CORS
+     - https://cnx.org/
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
     namespaces:

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -16,8 +16,8 @@ development:
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
   background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   cc_origins: # list of url prefixes allowed to access concept coach resources via CORS
-    - http://localhost:3001 # NOTE - IE11 doesn't treat differning ports as a cross origin request
-    - http://nathan.stitt.org # there's a test site at http://nathan.stitt.org/ox/
+    - http://localhost:3001/
+    - http://10.0.2.2:4567/ # middleman test site accessed via virtualbox vm
   ga_tracking_code: ''
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
@@ -62,6 +62,8 @@ test:
   timecop_enable: <%= ENV["TIMECOP_ENABLE"] %>
   background_worker_timeout: <%= ENV["BACKGROUND_WORKER_TIMEOUT"] || 15.minutes %>
   ga_tracking_code: ''
+  cc_origins: # list of url prefixes allowed to access concept coach resources via CORS
+    - http://localhost:3001/
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
     namespaces:

--- a/spec/cassettes/Content_Analyst/imports_a_book_without_explicit_archive_url.yml
+++ b/spec/cassettes/Content_Analyst/imports_a_book_without_explicit_archive_url.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:41 GMT
+      - Fri, 30 Oct 2015 22:34:56 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -186,7 +186,7 @@ http_interactions:
         {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor", "title": "",
         "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:35 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:37 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/4e40d43d-cfee-412e-919c-facccdf0535d@3
@@ -208,7 +208,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:42 GMT
+      - Fri, 30 Oct 2015 22:34:57 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -330,7 +330,7 @@ http_interactions:
         "HSPhysics", "suffix": null, "firstname": "Tutor", "title": "", "fullname":
         "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:35 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:38 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/0e58aa87-2e09-40a7-8bf3-269b2fa16509@9
@@ -352,7 +352,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:42 GMT
+      - Fri, 30 Oct 2015 22:34:57 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -866,7 +866,7 @@ http_interactions:
         "publisher": {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor",
         "title": "", "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:35 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:38 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/3005b86b-d993-4048-aff0-500256001f42@7
@@ -888,7 +888,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:42 GMT
+      - Fri, 30 Oct 2015 22:34:57 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1763,7 +1763,7 @@ http_interactions:
         "HSPhysics", "suffix": null, "firstname": "Tutor", "title": "", "fullname":
         "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:35 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:39 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/1bb611e9-0ded-48d6-a107-fbb9bd900851@2
@@ -1785,7 +1785,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:42 GMT
+      - Fri, 30 Oct 2015 22:34:58 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1882,7 +1882,7 @@ http_interactions:
         {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor", "title": "",
         "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:35 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:39 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/95e61258-2faf-41d4-af92-f62e1414175a@4
@@ -1904,7 +1904,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:42 GMT
+      - Fri, 30 Oct 2015 22:34:58 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2204,7 +2204,7 @@ http_interactions:
         "publisher": {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor",
         "title": "", "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:35 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:39 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/640e3e84-09a5-4033-b2a7-b7fe5ec29dc6@4
@@ -2226,7 +2226,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:42 GMT
+      - Fri, 30 Oct 2015 22:34:58 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2648,7 +2648,7 @@ http_interactions:
         {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor", "title": "",
         "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:36 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:40 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/548a8717-71e1-4d65-80f0-7b8c6ed4b4c0@3
@@ -2670,7 +2670,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:43 GMT
+      - Fri, 30 Oct 2015 22:34:59 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3237,7 +3237,7 @@ http_interactions:
         "publisher": {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor",
         "title": "", "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:36 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:40 GMT
 - request:
     method: get
     uri: https://archive-staging-tutor.cnx.org/contents/dbc79576-8c66-41d2-929a-74bcd036a1df@4
@@ -3259,7 +3259,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Mon, 26 Oct 2015 23:06:43 GMT
+      - Fri, 30 Oct 2015 22:34:59 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3960,10 +3960,10 @@ http_interactions:
         "publisher": {"surname": "HSPhysics", "suffix": null, "firstname": "Tutor",
         "title": "", "fullname": "Tutor HSPhysics", "id": "tutor_hsphysics"}}]}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:36 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:40 GMT
 - request:
     method: get
-    uri: https://exercises-dev.openstax.org/api/exercises?q=tag:4e40d43d-cfee-412e-919c-facccdf0535d,0e58aa87-2e09-40a7-8bf3-269b2fa16509,k12phys-ch03-s01-lo01,k12phys-ch03-s01-lo02,3005b86b-d993-4048-aff0-500256001f42,k12phys-ch03-s02-lo01,k12phys-ch03-s02-lo02,1bb611e9-0ded-48d6-a107-fbb9bd900851,95e61258-2faf-41d4-af92-f62e1414175a,k12phys-ch04-s01-lo01,k12phys-ch04-s01-lo02,640e3e84-09a5-4033-b2a7-b7fe5ec29dc6,k12phys-ch04-s02-lo01,k12phys-ch04-s02-lo02,548a8717-71e1-4d65-80f0-7b8c6ed4b4c0,k12phys-ch04-s03-lo01,k12phys-ch04-s03-lo02,dbc79576-8c66-41d2-929a-74bcd036a1df,k12phys-ch04-s04-lo01,k12phys-ch04-s04-lo02
+    uri: https://exercises-dev.openstax.org/api/exercises?q=tag:%22cnxmod:4e40d43d-cfee-412e-919c-facccdf0535d,cnxmod:0e58aa87-2e09-40a7-8bf3-269b2fa16509,k12phys-ch03-s01-lo01,k12phys-ch03-s01-lo02,cnxmod:3005b86b-d993-4048-aff0-500256001f42,k12phys-ch03-s02-lo01,k12phys-ch03-s02-lo02,cnxmod:1bb611e9-0ded-48d6-a107-fbb9bd900851,cnxmod:95e61258-2faf-41d4-af92-f62e1414175a,k12phys-ch04-s01-lo01,k12phys-ch04-s01-lo02,cnxmod:640e3e84-09a5-4033-b2a7-b7fe5ec29dc6,k12phys-ch04-s02-lo01,k12phys-ch04-s02-lo02,cnxmod:548a8717-71e1-4d65-80f0-7b8c6ed4b4c0,k12phys-ch04-s03-lo01,k12phys-ch04-s03-lo02,cnxmod:dbc79576-8c66-41d2-929a-74bcd036a1df,k12phys-ch04-s04-lo01,k12phys-ch04-s04-lo02%22
     body:
       encoding: US-ASCII
       string: ''
@@ -3982,7 +3982,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 26 Oct 2015 22:56:45 GMT
+      - Fri, 30 Oct 2015 22:24:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -4004,12 +4004,12 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Set-Cookie:
-      - _exercises_session=a0YreHhmSlNDc09tZEFsajBPb1RXR1BQdzJWVHUzdTlGNGliUWxnd2lORHp1SjZQN2FJRVk2TTRRWmlIakt5N2xaRU1rUVlFdzhxMWlqWnRVQUNTQXc9PS0tT0lvbzhST0RNL1R5ZHBnTkQ1UlhpUT09--19b35d7630cefcd7097f89178d33757bc4c82b57;
+      - _exercises_session=UndvNk0zQ3I1UGJrcUFPaUhkYnk4Y1c5TkxpakhuOXN2WkVITGJyaHBYaGhIWElqRVR0UThXTm11QWY3ZWZ2RGcrNlA1amkzQVZheGtPOG11S2Q5YVE9PS0tRXZkOGhjVTFDV0gvMlZBR1loWEtVZz09--d0057be668f459d6fd0cb660749cdc3c8812ab39;
         path=/; HttpOnly
       X-Request-Id:
-      - 561f9837-ed72-4cd4-8fd5-862d3c93f83c
+      - 08b0413e-1801-4e45-af4d-8a8e12f44010
       X-Runtime:
-      - '7.766114'
+      - '6.392383'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains
     body:
@@ -15536,5 +15536,5 @@ http_interactions:
         bnRzIjpbXSwiZm9ybWF0cyI6WyJmcmVlLXJlc3BvbnNlIiwibXVsdGlwbGUt
         Y2hvaWNlIl0sImNvbWJvX2Nob2ljZXMiOltdfV19XX0=
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 22:56:45 GMT
+  recorded_at: Fri, 30 Oct 2015 22:24:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/requests/api/v1/cc/get_tasks_spec.rb
+++ b/spec/requests/api/v1/cc/get_tasks_spec.rb
@@ -76,6 +76,35 @@ describe "Get CC Tasks", type: :request, api: true, version: :v1 do
       }.to change{Tasks::Models::Task.count}.by(0)
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'sets cors headers' do
+        api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), user_1_token)
+        expect(response.headers.keys).to include(
+                                           'Access-Control-Allow-Origin',
+                                           'Access-Control-Allow-Methods',
+                                           'Access-Control-Request-Method',
+                                           'Access-Control-Allow-Headers',
+                                           'Access-Control-Allow-Credentials'
+                                         )
+    end
+
+    it 'returns blank allow-origin if given one doesnt match' do
+      api_get(get_route(cnx_book_id: 'foo', cnx_page_id: 'bar'), user_1_token)
+      expect(response).to have_http_status(:success)
+      expect(response.headers['Access-Control-Allow-Origin']).to eq('')
+    end
+
+    it "should reply to a CORS OPTIONS request" do
+      origin = Rails.application.secrets.cc_origins.first + '/foo/bar'
+      # It's difficult to test an OPTIONS request
+      # reset and __send__ hacks from https://github.com/rspec/rspec-rails/issues/925
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', '/api/cc/tasks/1/1.json', nil, \
+        {'HTTP_ORIGIN' => origin, 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'}
+      expect(response.headers['Access-Control-Allow-Origin']).to eq(origin)
+      expect(response.headers['Access-Control-Allow-Methods']).to eq('GET, OPTIONS')
+    end
+
   end
 
 end


### PR DESCRIPTION
Since IE 11 supports CORS I'd suggest this is the way to go unless we really, really need to support IE 10.

One braindead thing that IE 11 does is that it doesn't treat requests to the same host but different ports as a cross-site request.  That means you can't test by just changing the ports on localhost :(

I've setup a proper test page at: http://nathan.stitt.org/ox/