### PR TITLE
Use stored ecosystems import job ids instead of filtering all bg jobs

### DIFF
--- a/app/subsystems/content/models/ecosystem_job.rb
+++ b/app/subsystems/content/models/ecosystem_job.rb
@@ -1,0 +1,15 @@
+module Content
+  module Models
+    class EcosystemJob < Tutor::SubSystems::BaseModel
+      scope :incomplete, -> { where(completed: false) }
+
+      def self.update_status
+        incomplete.each do |ecosystem_job|
+          job_id = ecosystem_job.import_job_uuid
+          job = Lev::BackgroundJob.find(job_id)
+          ecosystem_job.update_attributes(completed: true) if job.completed?
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20151028012241_create_content_ecosystem_jobs.rb
+++ b/db/migrate/20151028012241_create_content_ecosystem_jobs.rb
@@ -1,0 +1,8 @@
+class CreateContentEcosystemJobs < ActiveRecord::Migration
+  def change
+    create_table :content_ecosystem_jobs do |t|
+      t.string :import_job_uuid, null: false
+      t.boolean :completed, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151023175052) do
+ActiveRecord::Schema.define(version: 20151028012241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,11 @@ ActiveRecord::Schema.define(version: 20151023175052) do
 
   add_index "content_chapters", ["content_book_id", "number"], name: "index_content_chapters_on_content_book_id_and_number", unique: true, using: :btree
   add_index "content_chapters", ["title"], name: "index_content_chapters_on_title", using: :btree
+
+  create_table "content_ecosystem_jobs", force: :cascade do |t|
+    t.string  "import_job_uuid",                 null: false
+    t.boolean "completed",       default: false
+  end
 
   create_table "content_ecosystems", force: :cascade do |t|
     t.string   "title",      null: false


### PR DESCRIPTION
It was making the ecosystems page very slow to load because we were
looping through all the background jobs to look for incomplete ecosystem
import jobs.
