### PR TITLE
Prevent homework spaced practice pages from being used for further SP

### DIFF
--- a/app/routines/get_history.rb
+++ b/app/routines/get_history.rb
@@ -23,12 +23,15 @@ class GetHistory
       Content::Ecosystem.new(strategy: strategy)
     end
 
-    outputs[:exercises] = tasks.collect do |task|
+    tasked_exercises_array = tasks.collect do |task|
       # Handle 0-ago spaced practice
-      tasked_exercises = task.persisted? ? \
-                           task.tasked_exercises : \
-                           task.task_steps.select(&:exercise?).collect(&:tasked)
+      task.persisted? ? task.tasked_exercises : \
+                        task.task_steps.select(&:exercise?).collect(&:tasked)
+    end
 
+    outputs[:tasked_exercises] = tasked_exercises_array
+
+    outputs[:exercises] = tasked_exercises_array.collect do |tasked_exercises|
       tasked_exercises.collect do |tasked_exercise|
         model = tasked_exercise.exercise
         strategy = Content::Strategies::Direct::Exercise.new(model)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -244,8 +244,8 @@ ActiveRecord::Schema.define(version: 20151028163225) do
     t.string   "timezone",                    default: "Central Time (US & Canada)", null: false
     t.datetime "created_at",                                                         null: false
     t.datetime "updated_at",                                                         null: false
-    t.string   "catalog_offering_identifier"
     t.boolean  "is_concept_coach",                                                   null: false
+    t.string   "catalog_offering_identifier"
   end
 
   add_index "course_profile_profiles", ["entity_course_id"], name: "index_course_profile_profiles_on_entity_course_id", unique: true, using: :btree


### PR DESCRIPTION
This issue does not happen in readings because we read the page_ids from the teacher settings.