### PR TITLE
Allow teachers to change the opens_at and due_at

### DIFF
--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -6,6 +6,16 @@ class PropagateTaskPlanUpdates
 
   def exec(task_plan:)
     task_plan.tasks.update_all(title: task_plan.title, description: task_plan.description)
+
+    # For now we only handle tasking_plans that point to periods
+    task_plan.tasking_plans.each do |tasking_plan|
+      period = tasking_plan.target
+      next unless period.is_a?(CourseMembership::Models::Period)
+
+      task_plan.tasks.joins(:taskings).where(taskings: { course_membership_period_id: period.id })
+                     .update_all(opens_at: tasking_plan.opens_at, due_at: tasking_plan.due_at)
+    end
+
     task_plan.tasks.reset
   end
 

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -12,8 +12,12 @@ class PropagateTaskPlanUpdates
       period = tasking_plan.target
       next unless period.is_a?(CourseMembership::Models::Period)
 
+      feedback_at = task_plan.type == 'homework' ? tasking_plan.due_at : Time.now
+
       task_plan.tasks.joins(:taskings).where(taskings: { course_membership_period_id: period.id })
-                     .update_all(opens_at: tasking_plan.opens_at, due_at: tasking_plan.due_at)
+                     .update_all(opens_at: tasking_plan.opens_at,
+                                 due_at: tasking_plan.due_at,
+                                 feedback_at: feedback_at)
     end
 
     task_plan.tasks.reset

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -10,7 +10,8 @@ class PropagateTaskPlanUpdates
     # For now we only handle tasking_plans that point to periods
     task_plan.tasking_plans.each do |tasking_plan|
       period = tasking_plan.target
-      next unless period.is_a?(CourseMembership::Models::Period)
+      raise 'Cannot propagate plan changes for plan not assigned to a period' \
+        unless period.is_a?(CourseMembership::Models::Period)
 
       feedback_at = task_plan.type == 'homework' ? tasking_plan.due_at : Time.now
 


### PR DESCRIPTION
For assignments past the open date

QA will need to test that this change did not break publishing etc.