### PR TITLE
Start and end handlers for iframe login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'openstax_exchange', '~> 0.2.1'
 gem 'chronic'
 
 # API versioning and documentation
-gem 'openstax_api', '~> 5.5.5'
+gem 'openstax_api', '~> 6.0.0'
 gem 'apipie-rails'
 gem 'maruku'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (2.2.1)
+    doorkeeper (3.0.1)
       railties (>= 3.2)
     dotenv (2.0.1)
     dotenv-rails (2.0.1)
@@ -314,7 +314,7 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.6)
       tilt
-    hashie (3.4.2)
+    hashie (3.4.3)
     highline (1.6.21)
     hike (1.2.3)
     htmlentities (4.3.3)
@@ -353,7 +353,7 @@ GEM
     mime-types (2.6.2)
     mini_magick (4.2.0)
     mini_portile (0.6.2)
-    minitest (5.8.0)
+    minitest (5.8.2)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -390,7 +390,7 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_api (5.5.5)
+    openstax_api (6.0.0)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
       lev (>= 1.0.0)
@@ -406,7 +406,7 @@ GEM
     openstax_rescue_from (1.5.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 5.0)
-    openstax_utilities (4.2.1)
+    openstax_utilities (4.2.2)
       keyword_search
       lev
       rails (>= 3.1)
@@ -493,9 +493,7 @@ GEM
       redis (>= 2.2)
     ref (1.0.5)
     remotipart (1.2.1)
-    representable (2.2.2)
-      multi_json
-      nokogiri
+    representable (2.3.0)
       uber (~> 0.0.7)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
@@ -503,7 +501,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    roar (1.0.1)
+    roar (1.0.3)
       representable (>= 2.0.1, <= 3.0.0)
     roar-rails (1.0.1)
       actionpack
@@ -599,7 +597,7 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uber (0.0.13)
+    uber (0.0.15)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -689,7 +687,7 @@ DEPENDENCIES
   newrelic_rpm
   nifty-generators
   openstax_accounts (~> 6.1.3)
-  openstax_api (~> 5.5.5)
+  openstax_api (~> 6.0.0)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.5.0)
   openstax_utilities (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (3.0.1)
+    doorkeeper (2.2.1)
       railties (>= 3.2)
     dotenv (2.0.1)
     dotenv-rails (2.0.1)
@@ -314,7 +314,7 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.6)
       tilt
-    hashie (3.4.3)
+    hashie (3.4.2)
     highline (1.6.21)
     hike (1.2.3)
     htmlentities (4.3.3)
@@ -353,7 +353,7 @@ GEM
     mime-types (2.6.2)
     mini_magick (4.2.0)
     mini_portile (0.6.2)
-    minitest (5.8.2)
+    minitest (5.8.0)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -406,7 +406,7 @@ GEM
     openstax_rescue_from (1.5.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 5.0)
-    openstax_utilities (4.2.2)
+    openstax_utilities (4.2.1)
       keyword_search
       lev
       rails (>= 3.1)
@@ -493,7 +493,9 @@ GEM
       redis (>= 2.2)
     ref (1.0.5)
     remotipart (1.2.1)
-    representable (2.3.0)
+    representable (2.2.2)
+      multi_json
+      nokogiri
       uber (~> 0.0.7)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
@@ -501,7 +503,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    roar (1.0.3)
+    roar (1.0.1)
       representable (>= 2.0.1, <= 3.0.0)
     roar-rails (1.0.1)
       actionpack
@@ -597,7 +599,7 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uber (0.0.15)
+    uber (0.0.13)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -67,12 +67,7 @@ class AuthController < ApplicationController
   end
 
   def validated_cors_origin
-    origin = request.headers["HTTP_ORIGIN"]
-    return '' if origin.blank?
-    Rails.application.secrets.cc_origins.each do | host |
-      return origin if origin.match(%r{^#{host}})
-    end
-    '' # an empty string will disallow any access
+    OpenStax::Api.configuration.validate_cors_origin[ request ] ? request.headers["HTTP_ORIGIN"] : ''
   end
 
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -5,8 +5,11 @@ class AuthController < ApplicationController
   # iframe_start doesn't need to clear the headers since doesn't render, it only redirects
   before_filter :allow_iframe_access, only: :iframe_finish
 
+  #before_filter :forbid_access
   # these should always return 200 response regardless of login status
-  skip_before_filter :authenticate_user!, only: [:status, :cors_preflight_check]
+  skip_before_filter :authenticate_user!, only: [:status, :cors_preflight_check, :iframe_start, :iframe_finish]
+
+
 
   # Since these endpoints are loaded from foreign sites via cors or iframe, CRSF tokens can't be used
   skip_before_action :verify_authenticity_token
@@ -22,11 +25,13 @@ class AuthController < ApplicationController
   end
 
   def iframe_start
+    head :forbidden and return if current_user.is_anonymous?
     session[:accounts_return_to] = after_iframe_authentication_url
-    redirect_to openstax_accounts.login_url(host_only:false)
+    redirect_to openstax_accounts.login_url #(host_only:false)
   end
 
   def iframe_finish
+    head :forbidden and return if current_user.is_anonymous?
     # the view will deliver the status data using postMessage out of the iframe
     @status = user_status_update
   end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,20 +1,18 @@
 class AuthController < ApplicationController
 
-  before_filter :set_cors_headers
+  before_filter :set_cors_headers, only: [:status, :cors_preflight_check]
 
-  # this endpoint should always return 200 response regardless of login status
+  # iframe_start doesn't need to clear the headers since doesn't render, it only redirects
+  before_filter :allow_iframe_access, only: :iframe_finish
+
+  # these should always return 200 response regardless of login status
   skip_before_filter :authenticate_user!, only: [:status, :cors_preflight_check]
-  # Since it's loaded from foreign sites via cors, CRSF tokens can't be used
-  skip_before_action :verify_authenticity_token, only: [:status, :cors_preflight_check]
+
+  # Since these endpoints are loaded from foreign sites via cors or iframe, CRSF tokens can't be used
+  skip_before_action :verify_authenticity_token
 
   def status
-    body = strategy.authorize.body.slice('access_token')
-    body[:current_user] = if current_user.is_anonymous?
-                            false
-                          else
-                            Api::V1::UserRepresenter.new(current_user)
-                          end
-    render json: body
+    render json: user_status_update
   end
 
   # requested by an OPTIONS request type
@@ -23,7 +21,34 @@ class AuthController < ApplicationController
     render text: '', :content_type => 'text/plain'
   end
 
+  def iframe_start
+    session[:accounts_return_to] = after_iframe_authentication_url
+    redirect_to openstax_accounts.login_url(host_only:false)
+  end
+
+  def iframe_finish
+    # the view will deliver the status data using postMessage out of the iframe
+    @status = user_status_update
+  end
+
   private
+
+  def user_status_update
+    status = strategy.authorize.body.slice('access_token')
+    unless current_user.is_anonymous?
+      status[:current_user] = Api::V1::UserRepresenter.new(current_user)
+    end
+    status[:endpoints] = {
+      login: openstax_accounts.login_url,
+      iframe_login: authenticate_via_iframe_url,
+      accounts_iframe: Rails.application.secrets.openstax['accounts']['url'] + "/remote/iframe"
+    }
+    status
+  end
+
+  def allow_iframe_access
+    response.headers.except! 'X-Frame-Options'
+  end
 
   def set_cors_headers
     headers['Access-Control-Allow-Origin']   = validated_cors_origin

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,18 +1,19 @@
 class AuthController < ApplicationController
 
+  # Unlike other controllers, these cors headers allows cookies via the
+  # Access-Control-Allow-Credentials header
   before_filter :set_cors_headers, only: [:status, :cors_preflight_check]
 
-  # iframe_start doesn't need to clear the headers since doesn't render, it only redirects
+  # Allow accessing iframe methods from inside an iframe
   before_filter :allow_iframe_access, only: [:iframe_start, :iframe_finish]
 
-  #before_filter :forbid_access
-  # these should always return 200 response regardless of login status
-  skip_before_filter :authenticate_user!, only: [:status, :cors_preflight_check, :iframe_start, :iframe_finish]
+  # Methods handle returning login status differently than the standard authenticate_user! filter
+  skip_before_filter :authenticate_user!,
+                     only: [:status, :cors_preflight_check, :iframe_start, :iframe_finish]
 
-
-
-  # Since these endpoints are loaded from foreign sites via cors or iframe, CRSF tokens can't be used
-  skip_before_action :verify_authenticity_token
+  # CRSF tokens can't be used since these endpoints are loaded from foreign sites via cors or iframe
+  skip_before_action :verify_authenticity_token,
+                     only: [:status, :cors_preflight_check, :iframe_start,:iframe_finish]
 
   def status
     render json: user_status_update

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -3,7 +3,7 @@ class AuthController < ApplicationController
   before_filter :set_cors_headers, only: [:status, :cors_preflight_check]
 
   # iframe_start doesn't need to clear the headers since doesn't render, it only redirects
-  before_filter :allow_iframe_access, only: :iframe_finish
+  before_filter :allow_iframe_access, only: [:iframe_start, :iframe_finish]
 
   #before_filter :forbid_access
   # these should always return 200 response regardless of login status
@@ -25,9 +25,13 @@ class AuthController < ApplicationController
   end
 
   def iframe_start
-    head :forbidden and return if current_user.is_anonymous?
-    session[:accounts_return_to] = after_iframe_authentication_url
-    redirect_to openstax_accounts.login_url #(host_only:false)
+    if current_user.is_anonymous?
+      session[:accounts_return_to] = after_iframe_authentication_url
+      redirect_to openstax_accounts.login_url #(host_only:false)
+    else
+      @status = user_status_update
+      render action: :iframe_finish
+    end
   end
 
   def iframe_finish

--- a/app/views/auth/iframe_finish.html.erb
+++ b/app/views/auth/iframe_finish.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      var msg = <%=raw json_escape @status.to_json %>;
+      window.parent.postMessage(JSON.stringify({data: { onLogin: msg}}), msg.endpoints.accounts_iframe);
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/config/initializers/openstax_api.rb
+++ b/config/initializers/openstax_api.rb
@@ -3,6 +3,11 @@ OpenStax::Api.configure do |config|
   config.current_user_method = 'current_user'
   config.routing_error_app = lambda { |env|
     [404, {"Content-Type" => 'application/json'}, ['']] }
+  config.validate_cors_origin = lambda{ |request|
+    Rails.application.secrets.cc_origins.any? do | origin |
+      /^#{origin}/.match(request.headers["HTTP_ORIGIN"])
+    end
+  }
 end
 
 # Override the human_user method so it can properly return a User::User

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ Rails.application.routes.draw do
   # Fetch user information and a doorkeepr access token via a CORS request from whitelisted hosts
   get '/auth/status', :to => 'auth#status'
   match "/auth/status", to: "auth#cors_preflight_check", via: [:options]
+  # Relay user tokens inside an iframe.
+  get '/auth/iframe/start', :to => 'auth#iframe_start',  as: 'authenticate_via_iframe'
+  get '/auth/iframe/finish',:to => 'auth#iframe_finish', as: 'after_iframe_authentication'
+
+
 
   api :v1, default: true do
     resources :jobs, only: [:index, :show]

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe AuthController, type: :controller do
 
   context "as an non-signed in user" do
 
-    it 'disallows access to iframe start' do
+    it 'allows access to iframe start and redirects to accounts' do
       get :iframe_start
-      expect(session[:accounts_return_to]).to be_nil
-      expect(response).to have_http_status(:forbidden)
+      expect(session[:accounts_return_to]).to eq(after_iframe_authentication_url)
+      expect(response).to redirect_to(controller.openstax_accounts.login_url)
     end
 
     it 'disallows access to iframe finish' do
@@ -22,11 +22,12 @@ RSpec.describe AuthController, type: :controller do
   context "as an signed in user" do
     render_views
 
-    it 'allows access to iframe start and then redirects' do
+    it 'allows access to iframe start and simply renders status info' do
       controller.sign_in user
       get :iframe_start
-      expect(session[:accounts_return_to]).to eq(after_iframe_authentication_url)
-      expect(response).to redirect_to(controller.openstax_accounts.login_url)
+      expect(session[:accounts_return_to]).to be_nil
+      expect(assigns(:status)).not_to be_nil
+      expect(response.body).to include('window.parent.postMessage')
     end
 
     it 'allows access to iframe finish and sets status info' do

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe AuthController, type: :controller do
+
+  let(:user)        { FactoryGirl.create(:user) }
+
+  context "as an non-signed in user" do
+
+    it 'disallows access to iframe start' do
+      get :iframe_start
+      expect(session[:accounts_return_to]).to be_nil
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'disallows access to iframe finish' do
+      get :iframe_finish
+      expect(response).to have_http_status(:forbidden)
+    end
+
+  end
+
+  context "as an signed in user" do
+    render_views
+
+    it 'allows access to iframe start and then redirects' do
+      controller.sign_in user
+      get :iframe_start
+      expect(session[:accounts_return_to]).to eq(after_iframe_authentication_url)
+      expect(response).to redirect_to(controller.openstax_accounts.login_url)
+    end
+
+    it 'allows access to iframe finish and sets status info' do
+      controller.sign_in user
+      get :iframe_finish
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:status)).not_to be_nil
+      expect(response.body).to include('window.parent.postMessage')
+    end
+
+  end
+
+end

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -26,16 +26,16 @@ describe "Get authentication status", type: :request, version: :v1 do
       expect(response.body_as_hash).to match(
                                          :access_token => token,
                                          :endpoints => {
-                                           :login=>a_string_starting_with("http://"),
-                                           :iframe_login=>a_string_starting_with("http://"),
-                                           :accounts_iframe=>a_string_starting_with("http://")
+                                           :login=>a_string_starting_with("http"),
+                                           :iframe_login=>a_string_starting_with("http"),
+                                           :accounts_iframe=>a_string_starting_with("http")
                                          },
                                          :current_user => {
                                            :name=>user.name,
                                            :is_admin=>false,
                                            :is_customer_service=>false,
                                            :is_content_analyst=>false,
-                                           :profile_url=>a_string_starting_with("http://")
+                                           :profile_url=>a_string_starting_with("http")
                                          })
     end
 

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -13,7 +13,7 @@ describe "Get authentication status", type: :request, version: :v1 do
       stub_current_user(anon_user)
       get("/auth/status")
       expect(response).to have_http_status(:ok)
-      expect(response.body_as_hash).to eq({current_user: false})
+      expect(response.body_as_hash.stringify_keys.keys).not_to include('current_user')
     end
 
     it 'returns a token and current_user when user is logged in' do
@@ -25,12 +25,17 @@ describe "Get authentication status", type: :request, version: :v1 do
       token = Doorkeeper::AccessToken.find_by(resource_owner_id: user.id).token
       expect(response.body_as_hash).to match(
                                          :access_token => token,
+                                         :endpoints => {
+                                           :login=>a_string_starting_with("http://"),
+                                           :iframe_login=>a_string_starting_with("http://"),
+                                           :accounts_iframe=>a_string_starting_with("http://")
+                                         },
                                          :current_user => {
                                            :name=>user.name,
                                            :is_admin=>false,
                                            :is_customer_service=>false,
                                            :is_content_analyst=>false,
-                                           :profile_url=>a_string_starting_with("http")
+                                           :profile_url=>a_string_starting_with("http://")
                                          })
     end
 


### PR DESCRIPTION
This allows Tutor to set the return point once login completes and then relay the access token back to the iframe once the completion page is loaded

