### PR TITLE
Fix #788 - prevent trying to read a nil student roster file

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -31,15 +31,15 @@ class Admin::CoursesController < Admin::BaseController
 
   def students
     handle_with(Admin::CoursesStudents, success: -> {
-      add_students(@handler_result.outputs.period,
-                   @handler_result.outputs.users_attributes)
       flash[:notice] = 'Student roster has been uploaded.'
-      redirect_to edit_admin_course_path(params[:id], anchor: 'roster')
     },
     failure: -> {
-      flash[:error] = @handler_result.errors.collect(&:message).compact
-      redirect_to edit_admin_course_path(params[:id], anchor: 'roster')
+      flash[:error] = ['Error uploading student roster'] +
+                        @handler_result.errors.collect(&:message).flatten
+
     })
+
+    redirect_to edit_admin_course_path(params[:id], anchor: 'roster')
   end
 
   def set_ecosystem
@@ -87,22 +87,5 @@ class Admin::CoursesController < Admin::BaseController
 
   def get_schools
     @schools = SchoolDistrict::ListSchools[]
-  end
-
-  def add_students(period, users_attributes)
-    users_attributes.each do |user_attributes|
-      user = find_or_create(user_attributes)
-      AddUserAsPeriodStudent.call(period: period, user: user)
-    end
-  end
-
-  def find_or_create(user)
-    username = user['username']
-    first_name = user['first_name']
-    last_name = user['last_name']
-    User::FindOrCreateUser[username: user['username'],
-                           password: user['password'],
-                           first_name: first_name,
-                           last_name: last_name]
   end
 end

--- a/app/handlers/admin/courses_students.rb
+++ b/app/handlers/admin/courses_students.rb
@@ -1,0 +1,41 @@
+class Admin::CoursesStudents
+  lev_handler
+
+  protected
+  def authorized?; true; end
+
+  def handle
+    outputs.period = CourseMembership::Models::Period.find(params[:course][:period])
+    outputs.users_attributes = []
+
+    if params[:student_roster].blank?
+      fatal_error(code: :no_file_attached, message: 'You must attach a file to upload.')
+    end
+
+    begin
+      csv_reader = CSV.new(params[:student_roster].read, headers: true)
+
+      csv_reader.each do |row|
+        outputs.users_attributes << row
+
+        unless row['username'].present?
+          nonfatal_error(code: :username_missing,
+                      message: "On line #{csv_reader.lineno}, username is missing.")
+        end
+
+        unless row['password'].present?
+          nonfatal_error(code: :password_missing,
+                      message: "On line #{csv_reader.lineno}, password is missing.")
+        end
+      end
+    rescue CSV::MalformedCSVError => e
+      nonfatal_error(code: :malformed_csv, message: e.message)
+    end
+
+    if errors.any?
+      errors.insert(0, Lev::Error.new(code: :error_uploading,
+                                      message: 'Error uploading student roster'))
+      fatal_error(code: :fatal_errors)
+    end
+  end
+end

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -104,7 +104,15 @@ RSpec.describe Admin::CoursesController, type: :controller do
         post :students, id: physics.id, course: { period: physics_period.id }, student_roster: file_blankness
       }.not_to raise_error
 
-      expect(flash[:error]).to eq 'Unquoted fields do not allow \r or \n (line 2).'
+      expect(flash[:error]).to include 'Unquoted fields do not allow \r or \n (line 2).'
+    end
+
+    it 'gives a nice error if the file is blank' do
+      expect {
+        post :students, id: physics.id, course: { period: physics_period.id }
+      }.not_to raise_error
+
+      expect(flash[:error]).to include 'You must attach a file to upload.'
     end
 
   end

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -53,14 +53,27 @@ RSpec.describe Admin::CoursesController, type: :controller do
     let!(:biology) { CreateCourse[name: 'Biology'] }
     let!(:biology_period) { CreatePeriod[course: biology, name: '3rd'] }
 
-    let!(:file_1) { fixture_file_upload('files/test_courses_post_students_1.csv', 'text/csv') }
-    let!(:file_2) { fixture_file_upload('files/test_courses_post_students_2.csv', 'text/csv') }
-    let!(:file_blankness) { fixture_file_upload('files/test_courses_post_students_blankness.csv', 'text/csv') }
-    let!(:incomplete_file) { fixture_file_upload('files/test_courses_post_students_incomplete.csv', 'text/csv') }
+    let!(:file_1) do
+      fixture_file_upload('files/test_courses_post_students_1.csv', 'text/csv')
+    end
+
+    let!(:file_2) do
+      fixture_file_upload('files/test_courses_post_students_2.csv', 'text/csv')
+    end
+
+    let!(:file_blankness) do
+      fixture_file_upload('files/test_courses_post_students_blankness.csv', 'text/csv')
+    end
+
+    let!(:incomplete_file) do
+      fixture_file_upload('files/test_courses_post_students_incomplete.csv', 'text/csv')
+    end
 
     it 'adds students to a course period' do
       expect {
-        post :students, id: physics.id, course: { period: physics_period.id }, student_roster: file_1
+        post :students, id: physics.id,
+                        course: { period: physics_period.id },
+                        student_roster: file_1
       }.to change { OpenStax::Accounts::Account.count }.by(3)
       expect(flash[:notice]).to eq('Student roster has been uploaded.')
 
@@ -73,11 +86,15 @@ RSpec.describe Admin::CoursesController, type: :controller do
 
     it 'reuses existing users for existing usernames' do
       expect {
-        post :students, id: physics.id, course: { period: physics_period.id }, student_roster: file_1
+        post :students, id: physics.id,
+                        course: { period: physics_period.id },
+                        student_roster: file_1
       }.to change { OpenStax::Accounts::Account.count }.by(3)
 
       expect {
-        post :students, id: biology.id, course: { period: biology_period.id }, student_roster: file_2
+        post :students, id: biology.id,
+                        course: { period: biology_period.id },
+                        student_roster: file_2
       }.to change { OpenStax::Accounts::Account.count }.by(1) # 2 in file but 1 reused
 
       # Carol B should be in both courses
@@ -88,7 +105,9 @@ RSpec.describe Admin::CoursesController, type: :controller do
 
     it 'does not add any students if username or password is missing' do
       expect {
-        post :students, id: physics.id, course: { period: physics_period.id }, student_roster: incomplete_file
+        post :students, id: physics.id,
+                        course: { period: physics_period.id },
+                        student_roster: incomplete_file
       }.to change { OpenStax::Accounts::Account.count }.by(0)
       expect(flash[:error]).to eq([
         'Error uploading student roster',
@@ -101,7 +120,9 @@ RSpec.describe Admin::CoursesController, type: :controller do
 
     it 'gives a nice error and no exception if has funky characters' do
       expect {
-        post :students, id: physics.id, course: { period: physics_period.id }, student_roster: file_blankness
+        post :students, id: physics.id,
+                        course: { period: physics_period.id },
+                        student_roster: file_blankness
       }.not_to raise_error
 
       expect(flash[:error]).to include 'Unquoted fields do not allow \r or \n (line 2).'
@@ -114,7 +135,6 @@ RSpec.describe Admin::CoursesController, type: :controller do
 
       expect(flash[:error]).to include 'You must attach a file to upload.'
     end
-
   end
 
   describe 'GET #edit' do


### PR DESCRIPTION
Moved the `courses#students` code off into the `Admin::CoursesStudents` handler