### PR TITLE
Mount routes from api engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'openstax_exchange', '~> 0.2.1'
 gem 'chronic'
 
 # API versioning and documentation
-gem 'openstax_api', '~> 6.0.0'
+gem 'openstax_api', '~> 6.0.1'
 gem 'apipie-rails'
 gem 'maruku'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_api (6.0.0)
+    openstax_api (6.0.1)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
       lev (>= 1.0.0)
@@ -710,7 +710,7 @@ DEPENDENCIES
   nifty-generators
   openstax_accounts (~> 6.1.4)
   omniauth-salesforce
-  openstax_api (~> 6.0.0)
+  openstax_api (~> 6.0.1)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.5.0)
   openstax_utilities (~> 4.2.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get 'terms', to: 'terms#index'
 
   mount OpenStax::Accounts::Engine, at: "/accounts"
+  mount OpenStax::Api::Engine, at: '/'
   mount FinePrint::Engine => "/fine_print"
 
   use_doorkeeper


### PR DESCRIPTION


Goes along with https://github.com/openstax/openstax_api/pull/38
Needed by https://github.com/openstax/concept-coach/pull/9 so it can send a POST to the course registration end point