### PR TITLE
protect against missing cc origins

### DIFF
--- a/config/initializers/openstax_api.rb
+++ b/config/initializers/openstax_api.rb
@@ -4,7 +4,7 @@ OpenStax::Api.configure do |config|
   config.routing_error_app = lambda { |env|
     [404, {"Content-Type" => 'application/json'}, ['']] }
   config.validate_cors_origin = lambda{ |request|
-    Rails.application.secrets.cc_origins.any? do | origin |
+    (Rails.application.secrets.cc_origins || []).any? do | origin |
       /^#{origin}/.match(request.headers["HTTP_ORIGIN"])
     end
   }


### PR DESCRIPTION
Protects against "undefined method `any?' for nil:NilClass" when `cc_origins` secret not set.

Probably not going to happen much more b/c of recent updates to deployment scripts, but hey...

@Dantemss can review/merge or close if not something we want.