### PR TITLE
Logout support for concept coach

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -34,7 +34,7 @@ class AuthController < ApplicationController
       redirect_to_login_url
     else
       @status = user_status_update
-      @iframe_origin = stubbed_auth? ? session[:parent] : @status[:endpoints][:accounts_iframe]
+      @iframe_origin = stubbed_auth? ? session[:parent] || '*' : @status[:endpoints][:accounts_iframe]
     end
   end
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -73,7 +73,7 @@ class AuthController < ApplicationController
 
   def set_cors_headers
     headers['Access-Control-Allow-Origin']   = validated_cors_origin
-    headers['Access-Control-Allow-Methods']  = 'GET, OPTIONS, DELETE' # No PUT/POST access
+    headers['Access-Control-Allow-Methods']  = 'GET, OPTIONS' # No PUT/POST/DELETE access
     headers['Access-Control-Request-Method'] = '*'
     headers['Access-Control-Allow-Credentials'] = 'true'
     headers['Access-Control-Allow-Headers']  = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -49,9 +49,6 @@ class AuthController < ApplicationController
 
   private
 
-  def accounts_url_to(page)
-  end
-
   def stubbed_auth?
     OpenStax::Accounts.configuration.enable_stubbing?
   end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -4,18 +4,18 @@ class AuthController < ApplicationController
 
   # Unlike other controllers, these cors headers allows cookies via the
   # Access-Control-Allow-Credentials header
-  before_filter :set_cors_headers, only: [:status, :cors_preflight_check]
+  before_filter :set_cors_headers, only: [:status, :cors_preflight_check, :logout]
 
   # Allow accessing iframe methods from inside an iframe
   before_filter :allow_iframe_access, only: [:iframe]
 
   # Methods handle returning login status differently than the standard authenticate_user! filter
   skip_before_filter :authenticate_user!,
-                     only: [:status, :cors_preflight_check, :iframe]
+                     only: [:status, :cors_preflight_check, :iframe, :logout]
 
   # CRSF tokens can't be used since these endpoints are loaded from foreign sites via cors or iframe
   skip_before_action :verify_authenticity_token,
-                     only: [:status, :cors_preflight_check, :iframe]
+                     only: [:status, :cors_preflight_check, :iframe, :logout]
 
   layout false
 
@@ -35,6 +35,15 @@ class AuthController < ApplicationController
     else
       @status = user_status_update
       @iframe_origin = stubbed_auth? ? session[:parent] : @status[:endpoints][:accounts_iframe]
+    end
+  end
+
+  def logout
+    if current_user.is_anonymous?
+      render status: :forbidden, text: 'You must be logged in to logout'
+    else
+      sign_out!
+      render json: { logout: true }
     end
   end
 
@@ -61,7 +70,7 @@ class AuthController < ApplicationController
 
   def set_cors_headers
     headers['Access-Control-Allow-Origin']   = validated_cors_origin
-    headers['Access-Control-Allow-Methods']  = 'GET, OPTIONS' # No PUT/POST access
+    headers['Access-Control-Allow-Methods']  = 'GET, OPTIONS, DELETE' # No PUT/POST access
     headers['Access-Control-Request-Method'] = '*'
     headers['Access-Control-Allow-Credentials'] = 'true'
     headers['Access-Control-Allow-Headers']  = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,10 +33,9 @@ Rails.application.routes.draw do
   scope 'auth', controller: 'auth' do
     scope to: 'auth#cors_preflight_check', via: [:options] do
       match 'status'
-      match 'logout'
     end
     get 'status'
-    delete 'logout'
+    get 'logout', as: 'logout_via_iframe'
     # Relay user tokens inside an iframe.
     get 'iframe', as: 'authenticate_via_iframe'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,11 +28,15 @@ Rails.application.routes.draw do
 
   apipie
 
-  # Fetch user information and logging in remotely
+
+  # Fetch user information and log in/out in remotely
   scope 'auth', controller: 'auth' do
-    # Request user info and doorkeeper access token via a CORS request
+    scope to: 'auth#cors_preflight_check', via: [:options] do
+      match 'status'
+      match 'logout'
+    end
     get 'status'
-    match 'status', to: 'auth#cors_preflight_check', via: [:options]
+    delete 'logout'
     # Relay user tokens inside an iframe.
     get 'iframe', as: 'authenticate_via_iframe'
   end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe AuthController, type: :controller do
       expect(response.body).to include('window.parent.postMessage')
     end
 
+    it 'can sign out' do
+      controller.sign_in user
+      get :logout
+      expect(session[:account_id]).to be_nil
+      expect(response).to redirect_to(authenticate_via_iframe_url)
+    end
+
     it 'requires agreeing to terms' do
       controller.sign_in new_user
       get :iframe

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -66,7 +66,7 @@ describe "Get authentication status", type: :request, version: :v1 do
       integration_session.__send__ :process, 'OPTIONS', '/auth/status', nil, \
         {'HTTP_ORIGIN' => origin, 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'}
       expect(response.headers['Access-Control-Allow-Origin']).to eq(origin)
-      expect(response.headers['Access-Control-Allow-Methods']).to eq('GET, OPTIONS')
+      expect(response.headers['Access-Control-Allow-Methods']).to eq('GET, OPTIONS, DELETE')
     end
 
   end

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -26,6 +26,8 @@ describe "Get authentication status", type: :request, version: :v1 do
       expect(response.body_as_hash).to match(
                                          :access_token => token,
                                          :endpoints => {
+                                           :is_stubbed=>true,
+                                           :iframe_logout=>a_string_starting_with("http"),
                                            :login=>a_string_starting_with("http"),
                                            :iframe_login=>a_string_starting_with("http"),
                                            :accounts_iframe=>a_string_starting_with("http")

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -68,7 +68,7 @@ describe "Get authentication status", type: :request, version: :v1 do
       integration_session.__send__ :process, 'OPTIONS', '/auth/status', nil, \
         {'HTTP_ORIGIN' => origin, 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'}
       expect(response.headers['Access-Control-Allow-Origin']).to eq(origin)
-      expect(response.headers['Access-Control-Allow-Methods']).to eq('GET, OPTIONS, DELETE')
+      expect(response.headers['Access-Control-Allow-Methods']).to eq('GET, OPTIONS')
     end
 
   end


### PR DESCRIPTION
I see three ways we can accomplish logout for concept coach

1) Via a special CORS request to a controller with the appropriate OPTIONS and headers.  Our existing auth one is already setup to do so.  Thats what this PR implements.

2) Extend the existing `sessions` controller's `delete` action to be reachable via CORS. Since that lives in the accounts gem, I'm not sure we want to do so for all uses.

3) Use an iframe proxy method.  That seems a bit complex but might be more secure.

After playing with #1 and #2 I'm afraid they're not going to work because CORS will not follow redirects.  

We could work around this by logging out of tutor and then replying with a `next_url` parameter that CC would then load on accounts, or just loading the logout inside the iframe.  That'd require opening CORS up on accounts though. 

Given that, I think it's probably better to just logout inside the iframe. A nice side effect of this is that the login page is then immediately shown so a new session can be started from there.

https://github.com/openstax/accounts/pull/210 goes along with this.