### PR TITLE
Update openstax_rescue_from to 1.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
     openstax_exchange (0.2.1)
       hashie
       oauth2 (>= 0.5.0)
-    openstax_rescue_from (1.5.0)
+    openstax_rescue_from (1.6.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 5.0)
     openstax_utilities (4.2.1)
@@ -712,7 +712,7 @@ DEPENDENCIES
   openstax_accounts (~> 6.1.4)
   openstax_api (~> 6.0.2)
   openstax_exchange (~> 0.2.1)
-  openstax_rescue_from (~> 1.5.0)
+  openstax_rescue_from (~> 1.6.0)
   openstax_utilities (~> 4.2.0)
   parallel_tests
   paranoia (~> 2.1.3)


### PR DESCRIPTION
The outdated `openstax_rescue_from` line is causing errors in deployment:
```
stdout: You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.


```