### PR TITLE
Include teacher names as part of enrollment request

### DIFF
--- a/app/representers/api/v1/enrollment/period_with_course_representer.rb
+++ b/app/representers/api/v1/enrollment/period_with_course_representer.rb
@@ -1,4 +1,24 @@
 module Api::V1::Enrollment
+
+  class Teacher < Roar::Decorator
+    include Roar::JSON
+
+    property :name,
+             readable: true,
+             writeable: false,
+             type: String
+
+    property :first_name,
+             readable: true,
+             writeable: false,
+             type: String
+
+    property :last_name,
+             readable: true,
+             writeable: false,
+             type: String
+  end
+
   class PeriodWithCourseRepresenter < Roar::Decorator
 
     include Roar::JSON
@@ -18,6 +38,12 @@ module Api::V1::Enrollment
                readable: true,
                writeable: false,
                schema_info: { required: true }
+
+      collection :teachers,
+                 readable: true,
+                 getter: ->(*) { teacher_roles.map{|role| role} },
+                 writeable: false,
+                 decorator: Teacher
     end
 
     nested :period do


### PR DESCRIPTION
Will enable concept coach to display the teacher name as part of the enrollment confirmation