### PR TITLE
Locked down omniauth-oauth2 because the latest version breaks Accounts login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'openstax_utilities', '~> 4.2.0'
 # Cron job scheduling
 gem 'whenever'
 
+# Talks to Accounts (latest version is broken)
+gem 'omniauth-oauth2', '~> 1.3.1'
+
 # OpenStax Accounts integration
 gem 'openstax_accounts', '~> 6.1.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -708,6 +708,7 @@ DEPENDENCIES
   mini_magick
   newrelic_rpm
   nifty-generators
+  omniauth-oauth2 (~> 1.3.1)
   omniauth-salesforce
   openstax_accounts (~> 6.1.4)
   openstax_api (~> 6.0.2)


### PR DESCRIPTION
See comments on https://github.com/intridea/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f