### PR TITLE
Redirect logging out CC users to cc.openstax.org/logout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'openstax_utilities', '~> 4.2.0'
 gem 'whenever'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', github: 'openstax/accounts-rails', ref: '6e6fe06b'
+gem 'openstax_accounts', '~> 6.2.0'
 
 # OpenStax Exchange integration
 gem 'openstax_exchange', '~> 0.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'openstax_utilities', '~> 4.2.0'
 gem 'whenever'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', '~> 6.1.4'
+gem 'openstax_accounts', github: 'openstax/accounts-rails', ref: '6e6fe06b'
 
 # OpenStax Exchange integration
 gem 'openstax_exchange', '~> 0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,25 +13,6 @@ GIT
       transaction_retry
 
 GIT
-  remote: git://github.com/openstax/accounts-rails.git
-  revision: 6e6fe06befb04b9b8863ee7c639b46c4ddc46001
-  ref: 6e6fe06b
-  specs:
-    openstax_accounts (6.2.0)
-      action_interceptor (>= 1.0)
-      keyword_search (>= 1.0.0)
-      lev (>= 2.2.1)
-      oauth2 (>= 0.5.0)
-      omniauth (>= 1.1)
-      omniauth-oauth2 (>= 1.1)
-      openstax_api (>= 3.1.0)
-      openstax_utilities (>= 4.1.0)
-      rails (>= 4.1)
-      representable (>= 2.0)
-      roar (>= 1.0)
-      squeel (>= 0.5.0)
-
-GIT
   remote: https://github.com/maddijoyce/active_force
   revision: 9695896f576ea850d6ca60fb7b8af9c0dd07e8ea
   ref: 9695896f5
@@ -422,6 +403,19 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
+    openstax_accounts (6.2.0)
+      action_interceptor (>= 1.0)
+      keyword_search (>= 1.0.0)
+      lev (>= 2.2.1)
+      oauth2 (>= 0.5.0)
+      omniauth (>= 1.1)
+      omniauth-oauth2 (>= 1.1)
+      openstax_api (>= 3.1.0)
+      openstax_utilities (>= 4.1.0)
+      rails (>= 4.1)
+      representable (>= 2.0)
+      roar (>= 1.0)
+      squeel (>= 0.5.0)
     openstax_api (6.0.2)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
@@ -727,7 +721,7 @@ DEPENDENCIES
   newrelic_rpm
   nifty-generators
   omniauth-salesforce
-  openstax_accounts!
+  openstax_accounts (~> 6.2.0)
   openstax_api (~> 6.0.2)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,25 @@ GIT
       transaction_retry
 
 GIT
+  remote: git://github.com/openstax/accounts-rails.git
+  revision: 6e6fe06befb04b9b8863ee7c639b46c4ddc46001
+  ref: 6e6fe06b
+  specs:
+    openstax_accounts (6.2.0)
+      action_interceptor (>= 1.0)
+      keyword_search (>= 1.0.0)
+      lev (>= 2.2.1)
+      oauth2 (>= 0.5.0)
+      omniauth (>= 1.1)
+      omniauth-oauth2 (>= 1.1)
+      openstax_api (>= 3.1.0)
+      openstax_utilities (>= 4.1.0)
+      rails (>= 4.1)
+      representable (>= 2.0)
+      roar (>= 1.0)
+      squeel (>= 0.5.0)
+
+GIT
   remote: https://github.com/maddijoyce/active_force
   revision: 9695896f576ea850d6ca60fb7b8af9c0dd07e8ea
   ref: 9695896f5
@@ -403,7 +422,6 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_accounts (6.1.4)
     openstax_api (6.0.2)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
@@ -709,7 +727,7 @@ DEPENDENCIES
   newrelic_rpm
   nifty-generators
   omniauth-salesforce
-  openstax_accounts (~> 6.1.4)
+  openstax_accounts!
   openstax_api (~> 6.0.2)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.6.0)

--- a/app/controllers/webview_controller.rb
+++ b/app/controllers/webview_controller.rb
@@ -9,7 +9,11 @@ class WebviewController < ApplicationController
   before_filter :require_contracts, only: :index
 
   def home
-    redirect_to dashboard_path unless current_user.is_anonymous?
+    if params[:cc] == "1"
+      redirect_to 'http://cc.openstax.org'
+    elsif current_user.is_signed_in?
+      redirect_to dashboard_path
+    end
   end
 
   def index

--- a/app/subsystems/user/user.rb
+++ b/app/subsystems/user/user.rb
@@ -110,6 +110,10 @@ module User
       !!@strategy.is_application?
     end
 
+    def is_signed_in?
+      !is_anonymous?
+    end
+
     def is_anonymous?
       !!@strategy.is_anonymous?
     end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,6 +19,7 @@ require 'type_verification'
 require 'tagger'
 require 'unique_tokenable'
 require 'url_generator'
+require 'logout_redirect_chooser'
 
 %w(
   biglearn

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -12,6 +12,7 @@ OpenStax::Accounts.configure do |config|
   config.enable_stubbing = stub
   config.logout_via = :delete
   config.account_user_mapper = MapUsersAccounts
+  config.logout_redirect_url = ->(request) { LogoutRedirectChooser.new(request.url).choose }
 end
 
 OpenStax::Accounts::ApplicationController.class_exec do

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -12,7 +12,9 @@ OpenStax::Accounts.configure do |config|
   config.enable_stubbing = stub
   config.logout_via = :delete
   config.account_user_mapper = MapUsersAccounts
-  config.logout_redirect_url = ->(request) { LogoutRedirectChooser.new(request.url).choose }
+  config.logout_redirect_url = ->(request) {
+    LogoutRedirectChooser.new(request.url).choose(default: config.default_logout_redirect_url)
+  }
 end
 
 OpenStax::Accounts::ApplicationController.class_exec do

--- a/lib/logout_redirect_chooser.rb
+++ b/lib/logout_redirect_chooser.rb
@@ -7,27 +7,12 @@ class LogoutRedirectChooser
     @url = request_url
   end
 
-  def choose(default: nil)
+  def choose(default:)
     if url_indicates_concept_coach?
-      cc_redirect_url
+      URI.join(default, "?cc=1").to_s
     else
       default
     end
-  end
-
-  def cc_redirect_url
-    subdomain = uri.host.split('.')[0]
-
-    suffix = case subdomain
-             when /localhost/
-               "-localhost"
-             when /-(\w+)/
-               "-" + $1
-             else
-               ""
-             end
-
-    "http://cc.openstax.org/logout#{suffix}"
   end
 
   private

--- a/lib/logout_redirect_chooser.rb
+++ b/lib/logout_redirect_chooser.rb
@@ -1,0 +1,52 @@
+# Based on a request, choose where to redirect folks who are logging out (or
+# return nil if some outside default redirect should be used)
+
+class LogoutRedirectChooser
+
+  def initialize(request_url)
+    @url = request_url
+  end
+
+  def choose(default: nil)
+    if url_indicates_concept_coach?
+      cc_redirect_url
+    else
+      default
+    end
+  end
+
+  def cc_redirect_url
+    subdomain = uri.host.split('.')[0]
+
+    suffix = case subdomain
+             when /localhost/
+               "-localhost"
+             when /-(\w+)/
+               "-" + $1
+             else
+               ""
+             end
+
+    "http://cc.openstax.org/logout#{suffix}"
+  end
+
+  private
+
+  def url_indicates_concept_coach?
+    @url.match(/\/ConceptCoach\//i) ||
+    to_bool(query_hash['cc'])
+  end
+
+  def query_hash
+    uri.query.nil? ? {} : URI::decode_www_form(uri.query).to_h
+  end
+
+  def uri
+    @uri ||= URI.parse(@url)
+  end
+
+  def to_bool(boolean_thing)
+    ActiveRecord::Type::Boolean.new.type_cast_from_user(boolean_thing)
+  end
+
+end

--- a/spec/controllers/webview_controller_spec.rb
+++ b/spec/controllers/webview_controller_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe WebviewController, type: :controller do
       expect(response).to have_http_status(:found)
       expect(response).to redirect_to(dashboard_path)
     end
+
+    it 'redirect to CC landing page when param set' do
+      get :home, cc: "1"
+      expect(response).to redirect_to('http://cc.openstax.org')
+    end
   end
 
   describe 'GET *anything' do

--- a/spec/lib/logout_redirect_chooser_spec.rb
+++ b/spec/lib/logout_redirect_chooser_spec.rb
@@ -2,64 +2,31 @@ require 'rails_helper'
 
 RSpec.describe LogoutRedirectChooser do
 
-  it "computes the CC redirect for the dev env" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor-dev.openstax.org/blah/blah-qa").cc_redirect_url
-    ).to eq "http://cc.openstax.org/logout-dev"
-  end
+  let!(:default) { "http://accounts.openstax.org/logout/" }
+  let!(:cc_logout) { default + "?cc=1" }
 
-  it "computes the CC redirect for the qa env" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor-qa.openstax.org/blah/blah-qa").cc_redirect_url
-    ).to eq "http://cc.openstax.org/logout-qa"
-  end
-
-  it "computes the CC redirect for the staging env" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor-staging.openstax.org/blah/blah-dev").cc_redirect_url
-    ).to eq "http://cc.openstax.org/logout-staging"
-  end
-
-  it "computes the CC redirect for the production env" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor.openstax.org/blah/blah-qa").cc_redirect_url
-    ).to eq "http://cc.openstax.org/logout"
-  end
-
-  it "computes the CC redirect for the localhost env" do
-    expect(
-      LogoutRedirectChooser.new("http://localhost:3001/blah/blah-qa").cc_redirect_url
-    ).to eq "http://cc.openstax.org/logout-localhost"
+  def choose_for(url)
+    LogoutRedirectChooser.new(url).choose(default: default)
   end
 
   it "returns the CC redirect when the request URL has conceptcoach in it" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor.openstax.org/conCepTcoacH/blah-qa").choose
-    ).to eq "http://cc.openstax.org/logout"
+    expect(choose_for("http://tutor.openstax.org/conCepTcoacH/blah-qa")).to eq cc_logout
   end
 
   it "returns the CC redirect when the request URL has a truthy 'cc' param" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa?cc=1").choose
-    ).to eq "http://cc.openstax.org/logout"
+    expect(choose_for("http://tutor.openstax.org/yadda/blah-qa?cc=1")).to eq cc_logout
   end
 
   it "returns the default when the request URL has a falsy 'cc' param" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa?cc=false").choose(default: 42)
-    ).to eq 42
+    expect(choose_for("http://tutor.openstax.org/yadda/blah-qa?cc=false")).to eq default
   end
 
-  it "returns the nil when there's no CC-ness to the URL" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa?howdy=false").choose()
-    ).to eq nil
+  it "returns the default when there's no CC-ness to the URL" do
+    expect(choose_for("http://tutor.openstax.org/yadda/blah-qa?howdy=false")).to eq default
   end
 
-  it "returns the nil when there's no CC-ness to the URL (and no params)" do
-    expect(
-      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa").choose()
-    ).to eq nil
+  it "returns the default when there's no CC-ness to the URL (and no params)" do
+    expect(choose_for("http://tutor.openstax.org/yadda/blah-qa")).to eq default
   end
 
 end

--- a/spec/lib/logout_redirect_chooser_spec.rb
+++ b/spec/lib/logout_redirect_chooser_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe LogoutRedirectChooser do
+
+  it "computes the CC redirect for the dev env" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor-dev.openstax.org/blah/blah-qa").cc_redirect_url
+    ).to eq "http://cc.openstax.org/logout-dev"
+  end
+
+  it "computes the CC redirect for the qa env" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor-qa.openstax.org/blah/blah-qa").cc_redirect_url
+    ).to eq "http://cc.openstax.org/logout-qa"
+  end
+
+  it "computes the CC redirect for the staging env" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor-staging.openstax.org/blah/blah-dev").cc_redirect_url
+    ).to eq "http://cc.openstax.org/logout-staging"
+  end
+
+  it "computes the CC redirect for the production env" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor.openstax.org/blah/blah-qa").cc_redirect_url
+    ).to eq "http://cc.openstax.org/logout"
+  end
+
+  it "computes the CC redirect for the localhost env" do
+    expect(
+      LogoutRedirectChooser.new("http://localhost:3001/blah/blah-qa").cc_redirect_url
+    ).to eq "http://cc.openstax.org/logout-localhost"
+  end
+
+  it "returns the CC redirect when the request URL has conceptcoach in it" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor.openstax.org/conCepTcoacH/blah-qa").choose
+    ).to eq "http://cc.openstax.org/logout"
+  end
+
+  it "returns the CC redirect when the request URL has a truthy 'cc' param" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa?cc=1").choose
+    ).to eq "http://cc.openstax.org/logout"
+  end
+
+  it "returns the default when the request URL has a falsy 'cc' param" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa?cc=false").choose(default: 42)
+    ).to eq 42
+  end
+
+  it "returns the nil when there's no CC-ness to the URL" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa?howdy=false").choose()
+    ).to eq nil
+  end
+
+  it "returns the nil when there's no CC-ness to the URL (and no params)" do
+    expect(
+      LogoutRedirectChooser.new("http://tutor.openstax.org/yadda/blah-qa").choose()
+    ).to eq nil
+  end
+
+end

--- a/spec/lib/openstax/accounts/configuration_spec.rb
+++ b/spec/lib/openstax/accounts/configuration_spec.rb
@@ -13,14 +13,7 @@ RSpec.describe OpenStax::Accounts::Configuration do
     cc_fake_request = OpenStruct.new(url: "http://tutor.openstax.org/ConCEptCoach/blah")
     expect(
       OpenStax::Accounts.configuration.logout_redirect_url(cc_fake_request)
-    ).to eq "http://cc.openstax.org/logout"
-  end
-
-  it 'gives a concept coach logout URL when the request comes from CC for a non-production env' do
-    cc_fake_request = OpenStruct.new(url: "http://tutor-qa.openstax.org/blah?cc=1")
-    expect(
-      OpenStax::Accounts.configuration.logout_redirect_url(cc_fake_request)
-    ).to eq "http://cc.openstax.org/logout-qa"
+    ).to eq OpenStax::Accounts.configuration.default_logout_redirect_url + "?cc=1"
   end
 
 end

--- a/spec/lib/openstax/accounts/configuration_spec.rb
+++ b/spec/lib/openstax/accounts/configuration_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe OpenStax::Accounts::Configuration do
+
+  it 'gives a the normal accounts logout URL when the request does NOT comes from CC' do
+    non_cc_fake_request = OpenStruct.new(url: "http://tutor.openstax.org/madness/blah")
+    expect(
+      OpenStax::Accounts.configuration.logout_redirect_url(non_cc_fake_request)
+    ).to eq OpenStax::Accounts.configuration.default_logout_redirect_url
+  end
+
+  it 'gives a concept coach logout URL when the request comes from CC' do
+    cc_fake_request = OpenStruct.new(url: "http://tutor.openstax.org/ConCEptCoach/blah")
+    expect(
+      OpenStax::Accounts.configuration.logout_redirect_url(cc_fake_request)
+    ).to eq "http://cc.openstax.org/logout"
+  end
+
+  it 'gives a concept coach logout URL when the request comes from CC for a non-production env' do
+    cc_fake_request = OpenStruct.new(url: "http://tutor-qa.openstax.org/blah?cc=1")
+    expect(
+      OpenStax::Accounts.configuration.logout_redirect_url(cc_fake_request)
+    ).to eq "http://cc.openstax.org/logout-qa"
+  end
+
+end

--- a/spec/requests/concept_coach_logout_spec.rb
+++ b/spec/requests/concept_coach_logout_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe "Concept Coach teacher logout", type: :request do
+  let(:user)        { FactoryGirl.create(:user) }
+
+  it "redirects to cc.openstax.org when the request is a CC one" do
+    stub_current_user(user)
+    host! 'tutor-blah.openstax.org'
+    delete("/accounts/logout?cc=1")
+    expect(response).to redirect_to("http://cc.openstax.org/logout-blah")
+  end
+
+  it "redirects to accounts when the request is NOT a CC one" do
+    stub_current_user(user)
+    host! 'tutor-blah.openstax.org'
+    delete("/accounts/logout")
+    expect(response).to redirect_to(OpenStax::Accounts.configuration.default_logout_redirect_url)
+  end
+end

--- a/spec/requests/concept_coach_logout_spec.rb
+++ b/spec/requests/concept_coach_logout_spec.rb
@@ -2,18 +2,21 @@ require "rails_helper"
 
 describe "Concept Coach teacher logout", type: :request do
   let(:user)        { FactoryGirl.create(:user) }
+  let!(:default) { OpenStax::Accounts.configuration.default_logout_redirect_url }
 
   it "redirects to cc.openstax.org when the request is a CC one" do
     stub_current_user(user)
+    allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) { false }
     host! 'tutor-blah.openstax.org'
     delete("/accounts/logout?cc=1")
-    expect(response).to redirect_to("http://cc.openstax.org/logout-blah")
+    expect(response).to redirect_to(default + "?cc=1")
   end
 
   it "redirects to accounts when the request is NOT a CC one" do
     stub_current_user(user)
+    allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) { false }
     host! 'tutor-blah.openstax.org'
     delete("/accounts/logout")
-    expect(response).to redirect_to(OpenStax::Accounts.configuration.default_logout_redirect_url)
+    expect(response).to redirect_to(default)
   end
 end


### PR DESCRIPTION
Uses updates in https://github.com/openstax/accounts-rails/pull/43 to redirect logging out CC users to a variant of cc.openstax.org/logout, which will in turn redirect the Accounts logout URL to complete the signout.  By redirecting via the cc.openstax.org site, Accounts will redirect back to cc.openstax.org when it completes the logout process (which we want).

Once https://github.com/openstax/accounts-rails/pull/43 is merged, we can update this PR's gemfile to point to the new accounts-rails version.
