### PR TITLE
Update Salesforce course stats / add global settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,6 +149,10 @@ gem 'omniauth-salesforce'
 # Fork that supports Ruby >= 2.1
 gem 'active_force', git: 'https://github.com/maddijoyce/active_force', ref: '9695896f5'
 
+# Global settings
+gem 'rails-settings-cached', '~> 0.4.0'
+gem 'rails-settings-ui'
+
 group :development, :test do
   # Get env variables from .env file
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,9 +325,20 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.6)
       tilt
+    haml-rails (0.9.0)
+      actionpack (>= 4.0.1)
+      activesupport (>= 4.0.1)
+      haml (>= 4.0.6, < 5.0)
+      html2haml (>= 1.0.1)
+      railties (>= 4.0.1)
     hashie (3.4.2)
     highline (1.6.21)
     hike (1.2.3)
+    html2haml (2.0.0)
+      erubis (~> 2.7.0)
+      haml (~> 4.0.0)
+      nokogiri (~> 1.6.0)
+      ruby_parser (~> 3.5)
     htmlentities (4.3.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -488,6 +499,12 @@ GEM
       ruby-graphviz (~> 1.0.4)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails-settings-cached (0.4.6)
+      rails (>= 4.2.0)
+    rails-settings-ui (0.5.0)
+      haml-rails
+      i18n
+      rails (>= 3.0)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -740,6 +757,8 @@ DEPENDENCIES
   rails (= 4.2.4)
   rails-erd
   rails-html-sanitizer (~> 1.0)
+  rails-settings-cached (~> 0.4.0)
+  rails-settings-ui
   redis-rails
   remotipart
   restforce

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -18,7 +18,7 @@ module Admin
 
     def import_courses
       outputs = ImportSalesforceCourses.call(
-        run_on_test_data_only: !params[:use_real_data]
+        include_real_salesforce_data: params[:use_real_data]
       ).outputs
 
       flash[:notice] = "Of #{outputs.num_failures + outputs.num_successes} candidate records in Salesforce, " +

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -27,5 +27,14 @@ module Admin
       redirect_to admin_salesforce_path
     end
 
+    def update_salesforce
+      outputs = UpdateSalesforceStats.call
+
+      flash[:notice] = "Ran on #{outputs[:num_records]} record(s); " +
+                       "updated #{outputs[:num_updates]} record(s); #{outputs[:num_errors]} error(s) occurred."
+
+      redirect_to admin_salesforce_path
+    end
+
   end
 end

--- a/app/routines/import_salesforce_courses.rb
+++ b/app/routines/import_salesforce_courses.rb
@@ -17,7 +17,7 @@ class ImportSalesforceCourses
 
     candidate_sf_records.each do |candidate|
       create_course_for_candidate(candidate)
-      candidate.save if candidate.changed?
+      candidate.save_if_changed
     end
   end
 
@@ -70,6 +70,7 @@ class ImportSalesforceCourses
     candidate.created_at = course.created_at.iso8601
     candidate.num_students = 0
     candidate.num_teachers = 0
+    candidate.num_sections = 0
     candidate.teacher_join_url = UrlGenerator.new.join_course_url(course.teacher_join_token)
 
     run(:set_ecosystem, course: course, ecosystem: offering.ecosystem)

--- a/app/routines/import_salesforce_courses.rb
+++ b/app/routines/import_salesforce_courses.rb
@@ -30,9 +30,8 @@ class ImportSalesforceCourses
 
     (@include_real_salesforce_data_preference.present? ?
       @include_real_salesforce_data_preference :
-      GlobalSettings.import_real_salesforce_courses || false)
-    &&
-    Rails.application.secrets['salesforce'].allow_use_of_real_data
+      GlobalSettings.import_real_salesforce_courses || false) &&
+    Rails.application.secrets['salesforce']['allow_use_of_real_data']
   end
 
   def candidate_sf_records

--- a/app/routines/import_salesforce_courses.rb
+++ b/app/routines/import_salesforce_courses.rb
@@ -12,8 +12,14 @@ class ImportSalesforceCourses
     outputs.num_successes = 0
   end
 
-  def exec(run_on_test_data_only: true)
-    @run_on_test_data_only = run_on_test_data_only
+  def exec(include_real_salesforce_data: nil)
+    # The "include real" parameter to this routine is used if set; if not set,
+    # fall back to the GlobalSettings value.  If that not set, don't import real
+
+    @include_real_salesforce_data =
+      include_real_salesforce_data.present? ?
+        include_real_salesforce_data :
+        GlobalSettings.import_real_salesforce_courses || false
 
     candidate_sf_records.each do |candidate|
       create_course_for_candidate(candidate)
@@ -27,7 +33,7 @@ class ImportSalesforceCourses
       course_id: nil
     }
 
-    if @run_on_test_data_only
+    if !@include_real_salesforce_data
       search_criteria[:school] = 'Denver University'
       Rails.logger.info { "Starting Salesforce course import using test data only" }
     end

--- a/app/routines/update_salesforce_stats.rb
+++ b/app/routines/update_salesforce_stats.rb
@@ -1,0 +1,44 @@
+class UpdateSalesforceStats
+
+  def self.call
+    attached_records = Salesforce::AttachedRecord.all
+
+    num_records = attached_records.count
+    num_errors = 0
+
+    attached_records.each do |attached_record|
+      begin
+        record = attached_record.record
+        attached_to = attached_record.attached_to
+
+        case record
+        when Salesforce::Remote::ClassSize
+          update_class_size_stats(record, attached_to)
+        end
+
+      rescue Exception => e
+        num_errors += 1
+        record.error = "Unable to update stats #{e.message}"
+        OpenStax::RescueFrom.perform_rescue(e)
+      end
+
+      begin
+        record.save_if_changed
+      rescue Exception => e
+        num_errors += 1
+        OpenStax::RescueFrom.perform_rescue(e)
+      end
+    end
+
+    Rails.logger.info {
+      "UpdateSalesforceStats ran for #{num_records} record(s); #{num_errors} error(s) occurred."
+    }
+  end
+
+  def self.update_class_size_stats(class_size, course)
+    class_size.num_teachers = CourseMembership::GetTeachers[course].count
+    class_size.num_students = CourseMembership::GetCourseRoles[course: course, types: :student].count
+    class_size.num_sections = CourseMembership::GetCoursePeriods[course: course].count
+  end
+
+end

--- a/app/routines/update_salesforce_stats.rb
+++ b/app/routines/update_salesforce_stats.rb
@@ -21,13 +21,17 @@ class UpdateSalesforceStats
 
       rescue Exception => e
         num_errors += 1
-        record.error = "Unable to update stats #{e.message}"
+        record.error = "Unable to update stats: #{e.message}" if record.present?
         OpenStax::RescueFrom.perform_rescue(e)
       end
 
       begin
-        num_updates += 1 if record.changed?
-        record.save_if_changed
+        if record.present?
+          if record.changed?
+            record.save
+            num_updates +=1
+          end
+        end
       rescue Exception => e
         num_errors += 1
         OpenStax::RescueFrom.perform_rescue(e)
@@ -35,7 +39,8 @@ class UpdateSalesforceStats
     end
 
     Rails.logger.info {
-      "UpdateSalesforceStats ran for #{num_records} record(s); Made #{num_updates} update(s);#{num_errors} error(s) occurred."
+      "UpdateSalesforceStats ran for #{num_records} record(s); Made #{num_updates} " +
+      "update(s);#{num_errors} error(s) occurred."
     }
 
     {num_records: num_records, num_errors: num_errors, num_updates: num_updates}

--- a/app/routines/update_salesforce_stats.rb
+++ b/app/routines/update_salesforce_stats.rb
@@ -1,10 +1,13 @@
 class UpdateSalesforceStats
 
+  # not a routine!
+
   def self.call
     attached_records = Salesforce::AttachedRecord.all
 
     num_records = attached_records.count
     num_errors = 0
+    num_updates = 0
 
     attached_records.each do |attached_record|
       begin
@@ -23,6 +26,7 @@ class UpdateSalesforceStats
       end
 
       begin
+        num_updates += 1 if record.changed?
         record.save_if_changed
       rescue Exception => e
         num_errors += 1
@@ -31,8 +35,10 @@ class UpdateSalesforceStats
     end
 
     Rails.logger.info {
-      "UpdateSalesforceStats ran for #{num_records} record(s); #{num_errors} error(s) occurred."
+      "UpdateSalesforceStats ran for #{num_records} record(s); Made #{num_updates} update(s);#{num_errors} error(s) occurred."
     }
+
+    {num_records: num_records, num_errors: num_errors, num_updates: num_updates}
   end
 
   def self.update_class_size_stats(class_size, course)

--- a/app/subsystems/course_membership/get_teachers.rb
+++ b/app/subsystems/course_membership/get_teachers.rb
@@ -1,5 +1,5 @@
 class CourseMembership::GetTeachers
-  lev_routine
+  lev_routine express_output: :teachers
 
   protected
 

--- a/app/subsystems/salesforce/attached_record.rb
+++ b/app/subsystems/salesforce/attached_record.rb
@@ -5,6 +5,10 @@ module Salesforce
 
     self.strategy_class = ::Salesforce::Strategies::Direct::AttachedRecord
 
+    def self.all
+      verify_and_return strategy_class.all, klass: self, error: StrategyError
+    end
+
     def record
       @strategy.record
     end

--- a/app/subsystems/salesforce/models/attached_record.rb
+++ b/app/subsystems/salesforce/models/attached_record.rb
@@ -7,6 +7,29 @@ module Salesforce
       validates :tutor_gid, presence: true
       validates :salesforce_class_name, presence: true
       validates :salesforce_id, presence: true
+
+      def salesforce_class
+        salesforce_class_name.constantize
+      end
+
+      attr_writer :salesforce_object
+
+      def salesforce_object
+        @salesforce_object ||= salesforce_class.find(salesforce_id)
+      end
+
+      def self.load_salesforce_objects
+        all.group_by(&:salesforce_class_name).each do |salesforce_class_name, one_class_models|
+          salesforce_class = salesforce_class_name.constantize
+          salesforce_ids = one_class_models.map(&:salesforce_id)
+          salesforce_objects = salesforce_class.where(id: salesforce_ids).all.index_by(&:id)
+
+          one_class_models.each do |model|
+            model.salesforce_object = salesforce_objects[model.salesforce_id]
+          end
+        end.values.flatten
+      end
+
     end
   end
 end

--- a/app/subsystems/salesforce/remote/class_size.rb
+++ b/app/subsystems/salesforce/remote/class_size.rb
@@ -6,6 +6,7 @@ class Salesforce::Remote::ClassSize < ActiveForce::SObject
   field :created_at,                from: "Tutor_Created_Date__c", as: :datetime
   field :num_students,              from: "Student_using_Tutor__c", as: :int
   field :num_teachers,              from: "Active_Teachers__c", as: :int
+  field :num_sections,              from: "Number_of_Sections__c", as: :int
   field :teacher_join_url,          from: "Teacher_Join_URL__c"
   field :error,                     from: "Tutor_Error__c"
   field :book_name,                 from: "Book_Name__c"

--- a/app/subsystems/salesforce/strategies/direct/attached_record.rb
+++ b/app/subsystems/salesforce/strategies/direct/attached_record.rb
@@ -9,8 +9,8 @@ module Salesforce
         class << self
           alias_method :entity_all, :all
           def all
-            entity_all.collect do |entity|
-              ::Salesforce::AttachedRecord.new(strategy: entity)
+            Salesforce::Models::AttachedRecord.all.load_salesforce_objects.collect do |entity|
+              ::Salesforce::AttachedRecord.new(strategy: entity.wrap)
             end
           end
 
@@ -21,11 +21,11 @@ module Salesforce
         end
 
         def record
-          repository.salesforce_class_name.constantize.find(repository.salesforce_id)
+          repository.salesforce_object
         end
 
         def attached_to
-          GlobalID::Locator.locate repository.tutor_gid
+          @attached_to ||= GlobalID::Locator.locate repository.tutor_gid
         end
 
       end

--- a/app/views/admin/salesforce/index.html.erb
+++ b/app/views/admin/salesforce/index.html.erb
@@ -27,6 +27,10 @@
 
 <p>Use the button below to trigger an import of courses from Salesforce.  For each Class Size object within Salesforce that are approved for a Concept Coach course but that don't yet have such a course, a course will be created and information written back to the Salesforce record.  If the operation is unsuccessful, an error will be written to the Salesforce record.</p>
 
+<p><i>This action is called automatically on
+   <a href="https://github.com/openstax/tutor-server/blob/master/config/schedule.rb">the schedule shown here.</a>
+</i></p>
+
 <%= form_tag(admin_salesforce_import_courses_path, method: :post, style: 'margin: 30px 0') do %>
 
   <div class="checkbox">
@@ -39,3 +43,17 @@
 
   <%= submit_tag 'Import Courses', class: 'btn btn-primary' %>
 <% end %>
+
+<hr/>
+
+<h3>Update Salesforce Stats</h3>
+
+<p>Use the button below to trigger an update of Salesforce statistics from the latest data in Tutor.  This will only update SF records for which Tutor records have been created (either via a manual or scheduled call to the import functionality above).</p>
+
+<%= form_tag(admin_salesforce_update_salesforce_path, method: :put, style: 'margin: 30px 0') do %>
+  <%= submit_tag 'Update Salesforce', class: 'btn btn-primary' %>
+<% end %>
+
+<p><i>This action is called automatically on
+   <a href="https://github.com/openstax/tutor-server/blob/master/config/schedule.rb">the schedule shown here.</a>
+</i></p>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -68,6 +68,8 @@
 
             <li><%= link_to 'Salesforce', admin_salesforce_path %></li>
 
+            <li><%= link_to 'Settings', admin_rails_settings_ui_path %></li>
+
             <% if Timecop.enabled? %>
               <li><%= link_to 'Time Travel', admin_timecop_path %></li>
             <% end %>
@@ -89,6 +91,7 @@
 
     <div class="container">
       <div class="page-header">
+        <% @page_header = "Global Settings" if current_page?(admin_rails_settings_ui.settings_url) %>
         <h1><%= @page_header %></h1>
       </div>
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,6 +19,7 @@ require 'tagger'
 require 'unique_tokenable'
 require 'url_generator'
 require 'logout_redirect_chooser'
+require 'global_settings'
 
 %w(
   biglearn

--- a/config/initializers/active_force.rb
+++ b/config/initializers/active_force.rb
@@ -14,4 +14,11 @@ module ActiveForce
     end
   end
 
+  class SObject
+    # Save that precious SF API call count!
+    def save_if_changed
+      save if changed?
+    end
+  end
+
 end

--- a/config/initializers/global_settings.rb
+++ b/config/initializers/global_settings.rb
@@ -1,0 +1,3 @@
+# See https://github.com/huacnlee/rails-settings-cached
+
+GlobalSettings.defaults[:import_real_salesforce_courses] = false

--- a/config/initializers/rails_settings_ui.rb
+++ b/config/initializers/rails_settings_ui.rb
@@ -1,0 +1,16 @@
+require 'rails-settings-ui'
+
+#= Application-specific
+#
+# # You can specify a controller for RailsSettingsUi::ApplicationController to inherit from:
+RailsSettingsUi.parent_controller = 'Admin::BaseController' # default: '::ApplicationController'
+#
+# # Render RailsSettingsUi inside a custom layout (set to 'application' to use app layout, default is RailsSettingsUi's own layout)
+# RailsSettingsUi::ApplicationController.layout 'admin'
+
+RailsSettingsUi.settings_class = "GlobalSettings"
+
+Rails.application.config.to_prepare do
+  # If you use a *custom layout*, make route helpers available to RailsSettingsUi:
+  RailsSettingsUi.inline_main_app_routes!
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,8 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  settings:
+    attributes:
+      import_real_salesforce_courses:
+        name: 'Import real Salesforce courses?'
+        help_block: 'Unchecked: limits to Denver University'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+
   root 'webview#home'
 
   get '/dashboard', to: 'webview#index'
@@ -188,6 +189,8 @@ Rails.application.routes.draw do
       delete :destroy_user
       post :import_courses
     end
+
+    mount RailsSettingsUi::Engine, at: 'settings'
   end
 
   match '/auth/salesforce/callback', to: 'admin/salesforce#callback',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
       get '', action: :index
       delete :destroy_user
       post :import_courses
+      put :update_salesforce
     end
 
     mount RailsSettingsUi::Engine, at: 'settings'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,3 +8,11 @@ end
 every 1.day, at: '3:00 AM' do
   rake 'openstax:biglearn:clues:update:all'
 end
+
+every 1.hour do
+  runner "ImportSalesforceCourses.call()"
+end
+
+every 1.day, at: '2:00 AM' do
+  runner "UpdateSalesforceStats.call"
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,7 +10,7 @@ every 1.day, at: '3:00 AM' do
 end
 
 every 1.hour do
-  runner "ImportSalesforceCourses.call()"
+  runner "ImportSalesforceCourses.call"
 end
 
 every 1.day, at: '2:00 AM' do

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -25,6 +25,7 @@ development:
   salesforce:
     consumer_key: <%= ENV["SALESFORCE_CONSUMER_KEY"] %>
     consumer_secret: <%= ENV["SALESFORCE_CONSUMER_SECRET"] %>
+    allow_use_of_real_data: false
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
     namespaces:
@@ -75,6 +76,7 @@ test:
   salesforce:
     consumer_key: <%= ENV["SALESFORCE_CONSUMER_KEY"] %>
     consumer_secret: <%= ENV["SALESFORCE_CONSUMER_SECRET"] %>
+    allow_use_of_real_data: false
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
     namespaces:
@@ -127,6 +129,7 @@ production:
   salesforce:
     consumer_key: <%= ENV["SALESFORCE_CONSUMER_KEY"] %>
     consumer_secret: <%= ENV["SALESFORCE_CONSUMER_SECRET"] %>
+    allow_use_of_real_data: false
   redis:
     url: <%= ENV["REDIS_URL"] || 'redis://localhost:6379/0' %>
     namespaces:

--- a/db/migrate/20151121171035_create_settings.rb
+++ b/db/migrate/20151121171035_create_settings.rb
@@ -1,0 +1,17 @@
+class CreateSettings < ActiveRecord::Migration
+  def self.up
+    create_table :settings do |t|
+      t.string  :var,        null: false
+      t.text    :value,      null: true
+      t.integer :thing_id,   null: true
+      t.string  :thing_type, null: true, limit: 30
+      t.timestamps
+    end
+
+    add_index :settings, %i(thing_type thing_id var), unique: true
+  end
+
+  def self.down
+    drop_table :settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -488,6 +488,17 @@ ActiveRecord::Schema.define(version: 20151124165753) do
 
   add_index "school_district_schools", ["school_district_district_id"], name: "index_school_district_schools_on_school_district_district_id", using: :btree
 
+  create_table "settings", force: :cascade do |t|
+    t.string   "var",                   null: false
+    t.text     "value"
+    t.integer  "thing_id"
+    t.string   "thing_type", limit: 30
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "settings", ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true, using: :btree
+
   create_table "tasks_assistants", force: :cascade do |t|
     t.string   "name",            null: false
     t.string   "code_class_name", null: false

--- a/lib/global_settings.rb
+++ b/lib/global_settings.rb
@@ -1,0 +1,3 @@
+# Part of https://github.com/huacnlee/rails-settings-cached
+
+class GlobalSettings < RailsSettings::CachedSettings; end

--- a/spec/controllers/admin/salesforce_controller_spec.rb
+++ b/spec/controllers/admin/salesforce_controller_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe Admin::SalesforceController do
     it 'receives the call and formats the flash' do
       expect(ImportSalesforceCourses)
         .to receive(:call)
-        .with(run_on_test_data_only: true)
+        .with(include_real_salesforce_data: false)
 
       allow(ImportSalesforceCourses)
         .to receive(:call)
-        .with(run_on_test_data_only: true)
+        .with(include_real_salesforce_data: false)
         .and_return(
           Hashie::Mash.new({outputs: {num_failures: 1, num_successes: 2}})
         )

--- a/spec/routines/import_salesforce_courses_spec.rb
+++ b/spec/routines/import_salesforce_courses_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ImportSalesforceCourses, type: :routine do
 
-  it 'restricts to Denver University when asked to run on test data only' do
+  it 'restricts to Denver University when asked to not run on real data' do
     allow(Salesforce::Remote::ClassSize).to receive(:where).and_return([])
 
     expect(Salesforce::Remote::ClassSize).to receive(:where).with(
@@ -11,10 +11,10 @@ RSpec.describe ImportSalesforceCourses, type: :routine do
       school: 'Denver University'
     )
 
-    ImportSalesforceCourses[run_on_test_data_only: true]
+    ImportSalesforceCourses[include_real_salesforce_data: false]
   end
 
-  it 'does not restrict to Denver University when not asked to run on test data only' do
+  it 'does not restrict to Denver University when told to include real data' do
     allow(Salesforce::Remote::ClassSize).to receive(:where).and_return([])
 
     expect(Salesforce::Remote::ClassSize).to receive(:where).with(
@@ -22,7 +22,7 @@ RSpec.describe ImportSalesforceCourses, type: :routine do
       course_id: nil
     )
 
-    ImportSalesforceCourses[run_on_test_data_only: false]
+    ImportSalesforceCourses[include_real_salesforce_data: true]
   end
 
   it 'errors when the book name does not match an offering in tutor' do

--- a/spec/routines/import_salesforce_courses_spec.rb
+++ b/spec/routines/import_salesforce_courses_spec.rb
@@ -14,8 +14,22 @@ RSpec.describe ImportSalesforceCourses, type: :routine do
     ImportSalesforceCourses[include_real_salesforce_data: false]
   end
 
+  it 'restricts to Denver University when told to include real data but global secrets flag false' do
+    allow(Salesforce::Remote::ClassSize).to receive(:where).and_return([])
+    allow(Rails.application.secrets.salesforce).to receive(:[]).with('allow_use_of_real_data').and_return false
+
+    expect(Salesforce::Remote::ClassSize).to receive(:where).with(
+      concept_coach_approved: true,
+      course_id: nil,
+      school: 'Denver University'
+    )
+
+    ImportSalesforceCourses[include_real_salesforce_data: true]
+  end
+
   it 'does not restrict to Denver University when told to include real data' do
     allow(Salesforce::Remote::ClassSize).to receive(:where).and_return([])
+    allow(Rails.application.secrets.salesforce).to receive(:[]).with('allow_use_of_real_data').and_return true
 
     expect(Salesforce::Remote::ClassSize).to receive(:where).with(
       concept_coach_approved: true,

--- a/spec/routines/update_salesforce_stats_spec.rb
+++ b/spec/routines/update_salesforce_stats_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe UpdateSalesforceStats, type: :routine do
+
+  it 'updates a record on the happy stubbed path' do
+    attached_record = OpenStruct.new(
+      record: OpenStruct.new(changed?: true, save_if_changed: nil),
+      attached_to: nil
+    )
+    allow(Salesforce::AttachedRecord).to receive(:all).and_return([attached_record])
+
+    outputs = UpdateSalesforceStats.call
+
+    expect(outputs[:num_records]).to eq 1
+    expect(outputs[:num_errors]).to eq 0
+    expect(outputs[:num_updates]).to eq 1
+  end
+
+  it 'does not update unchanged records' do
+    attached_record = OpenStruct.new(
+      record: OpenStruct.new(changed?: false, save_if_changed: nil),
+      attached_to: nil
+    )
+    allow(Salesforce::AttachedRecord).to receive(:all).and_return([attached_record])
+
+    outputs = UpdateSalesforceStats.call
+
+    expect(outputs[:num_records]).to eq 1
+    expect(outputs[:num_errors]).to eq 0
+    expect(outputs[:num_updates]).to eq 0
+  end
+
+  it 'handles exceptions in the update section' do
+    attached_record = OpenStruct.new(
+      record: OpenStruct.new(changed?: false, save_if_changed: nil),
+      attached_to: nil
+    )
+    allow(attached_record).to receive(:attached_to).and_raise "boom"
+    allow(Salesforce::AttachedRecord).to receive(:all).and_return([attached_record])
+
+    outputs = rescuing_exceptions do
+      UpdateSalesforceStats.call
+    end
+
+    expect(outputs[:num_records]).to eq 1
+    expect(outputs[:num_errors]).to eq 1
+    expect(outputs[:num_updates]).to eq 0
+    expect(attached_record.record.error).to eq "Unable to update stats: boom"
+  end
+
+  it 'handles exceptions in the save section' do
+    attached_record = OpenStruct.new(
+      record: OpenStruct.new(changed?: nil, save_if_changed: nil),
+      attached_to: nil
+    )
+    allow(attached_record.record).to receive(:changed?).and_raise "boom"
+    allow(Salesforce::AttachedRecord).to receive(:all).and_return([attached_record])
+
+    outputs = rescuing_exceptions do
+      UpdateSalesforceStats.call
+    end
+
+    expect(outputs[:num_records]).to eq 1
+    expect(outputs[:num_errors]).to eq 1
+    expect(outputs[:num_updates]).to eq 0
+    expect(attached_record.record.error).to eq nil
+  end
+
+end

--- a/spec/subsystems/course_membership/get_teachers_spec.rb
+++ b/spec/subsystems/course_membership/get_teachers_spec.rb
@@ -34,6 +34,10 @@ describe CourseMembership::GetTeachers do
       expect(result.outputs.teachers.size).to eq(1)
       expect(result.outputs.teachers).to include(target_role)
     end
+
+    it "also works when called expressly" do
+      expect(CourseMembership::GetTeachers[target_course]).to include(target_role)
+    end
   end
 
   context "when there are multiple teachers for the given course" do


### PR DESCRIPTION
DONE:

* Added a cron job for updating Salesforce course stats nightly
* Updated `Salesforce::AttachedRecord` to load all remote data in one API query instead of N.
* Initial SF import and subsequent updates now update the "num sections" field.
* Add a global settings feature for efficiently storing/setting/retrieving site-wide settings (see screenshot below, uses https://github.com/huacnlee/rails-settings-cached and https://github.com/accessd/rails-settings-ui.  Put a "import real SF courses" setting here so we can control what happens from the cron job that imports from SF. (screenshot below)

![image](https://cloud.githubusercontent.com/assets/1001691/11319960/079d5612-903f-11e5-9cfd-82c5b9d826a8.png)