### PR TITLE
Make UUID on ecosystem list more accessible

### DIFF
--- a/app/views/manager/ecosystems/_listing.html.erb
+++ b/app/views/manager/ecosystems/_listing.html.erb
@@ -1,10 +1,12 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th class="col-md-2">Book Title</th>
-      <th class="col-md-2">Import Date</th>
-      <th class="col-md-4">UUID @ Version (link to archive)</th>
-      <th class="col-md-4">Comments</th>
+      <th>Book Title</th>
+      <th>Comments</th>
+      <th>Book Version</th>
+      <th>Import Date</th>
+      <th>Link to Archive</th>
+      <th>Book UUID</th>
     </tr>
   </thead>
   <tbody>
@@ -13,9 +15,18 @@
 
     <tr>
       <td><%= book.title %></td>
-      <td><small><%= ecosystem.imported_at %></small></td>
-      <td><small><%= link_to "#{book.uuid} @ #{book.version}", book.url, target: '_blank'%></small></td>
       <td><%= ecosystem.comments %></td>
+      <td><%= book.version %></td>
+      <td><%= ecosystem.imported_at %></td>
+      <td><%= link_to 'Archive', book.url, target: '_blank',
+                                           class: 'btn btn-xs btn-primary' %></td>
+      <td><%= link_to 'Show UUID', '#', role: 'button',
+                                        tabindex: 0,
+                                        data: { toggle: 'popover',
+                                                placement: 'top',
+                                                content: book.uuid,
+                                                container: 'body' },
+                                        class: 'btn btn-xs btn-secondary' %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/manager/ecosystems/_listing.html.erb
+++ b/app/views/manager/ecosystems/_listing.html.erb
@@ -1,12 +1,10 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Book Title</th>
-      <th>Comments</th>
-      <th>Book Version</th>
-      <th>Import Date</th>
-      <th>Link to Archive</th>
-      <th>Book UUID</th>
+      <th class="col-md-2">Book Title</th>
+      <th class="col-md-2">Import Date</th>
+      <th class="col-md-4">UUID @ Version (link to archive)</th>
+      <th class="col-md-4">Comments</th>
     </tr>
   </thead>
   <tbody>
@@ -15,19 +13,9 @@
 
     <tr>
       <td><%= book.title %></td>
+      <td><small><%= ecosystem.imported_at %></small></td>
+      <td><small><%= link_to "#{book.uuid} @ #{book.version}", book.url, target: '_blank'%></small></td>
       <td><%= ecosystem.comments %></td>
-      <td><%= book.version %></td>
-      <td><%= ecosystem.imported_at %></td>
-      <td><%= link_to 'Archive', book.url, target: '_blank',
-                                           class: 'btn btn-xs btn-primary' %></td>
-      <td><%= link_to 'Show UUID', '#', role: 'button',
-                                        tabindex: 0,
-                                        data: { toggle: 'popover',
-                                                trigger: 'focus',
-                                                placement: 'top',
-                                                content: book.uuid,
-                                                container: 'body' },
-                                        class: 'btn btn-xs btn-secondary' %></td>
     </tr>
   <% end %>
   </tbody>


### PR DESCRIPTION
The UUID was in a popover that went away whenever clicked on (so UUID couldn't be copied).  @gregfitch reported this.  

This PR changes the table to always show the UUID:

![image](https://cloud.githubusercontent.com/assets/1001691/11330569/21c57a46-9162-11e5-8fd9-bb3196ce48da.png)

If @gregfitch just wants the popover to stick, all we have to do is remove the `trigger: 'focus'` attribute from the source.  @gregfitch it is up to you.  If you like the new look, feel free to merge this PR.  If you want it the other way, let me know.