### PR TITLE
Attempts to fix duplicate CC tasks

### DIFF
--- a/app/routines/get_concept_coach.rb
+++ b/app/routines/get_concept_coach.rb
@@ -8,10 +8,6 @@ class GetConceptCoach
     translations: { outputs: { type: :verbatim } },
     as: :create_cc_task
 
-  uses_routine Tasks::CreateTasking,
-    translations: { outputs: { type: :verbatim } },
-    as: :create_tasking
-
   uses_routine AddSpyInfo, as: :add_spy_info
 
   uses_routine GetHistory, as: :get_history
@@ -96,12 +92,10 @@ class GetConceptCoach
     related_content_array = exercises.collect{ |ex| ex.page.related_content }
 
     # Create the new concept coach task, and put the exercises into steps
-    run(:create_cc_task, page: page, exercises: exercises,
+    run(:create_cc_task, role: role, page: page, exercises: exercises,
                          related_content_array: related_content_array)
 
     run(:add_spy_info, to: outputs.task, from: [ecosystem, history.tasks])
-
-    run(:create_tasking, role: role, task: outputs.task.entity_task, period: role.student.period)
 
     outputs.entity_task = outputs.task.entity_task
   end

--- a/app/subsystems/tasks/create_concept_coach_task.rb
+++ b/app/subsystems/tasks/create_concept_coach_task.rb
@@ -7,9 +7,13 @@ module Tasks
       translations: { outputs: { type: :verbatim } },
       as: :build_task
 
+    uses_routine Tasks::CreateTasking,
+      translations: { outputs: { type: :verbatim } },
+      as: :create_tasking
+
     protected
 
-    def exec(page:, exercises:, related_content_array: [])
+    def exec(role:, page:, exercises:, related_content_array: [])
       # In a multi-web server environment, it is possible for one server to create
       # the cc task and another to request it very quickly and if the server
       # times are not completely sync'd the request can be reject because the task
@@ -37,8 +41,10 @@ module Tasks
 
       outputs.task.save!
 
+      run(:create_tasking, role: role, task: outputs.task.entity_task, period: role.student.period)
+
       outputs.concept_coach_task = Tasks::Models::ConceptCoachTask.create!(
-        task: outputs.task.entity_task, content_page_id: page.id
+        content_page_id: page.id, entity_role_id: role.id, task: outputs.task.entity_task
       )
     end
 

--- a/app/subsystems/tasks/get_concept_coach_task.rb
+++ b/app/subsystems/tasks/get_concept_coach_task.rb
@@ -5,7 +5,8 @@ class Tasks::GetConceptCoachTask
 
   def exec(role:, page:)
     outputs[:entity_task] = Tasks::Models::ConceptCoachTask
-      .where(content_page_id: page.id, entity_role_id: role.id)
+      .joins(:page)
+      .where(page: { uuid: page.uuid }, entity_role_id: role.id)
       .lock.take.try(:task)
   end
 end

--- a/app/subsystems/tasks/get_concept_coach_task.rb
+++ b/app/subsystems/tasks/get_concept_coach_task.rb
@@ -5,8 +5,7 @@ class Tasks::GetConceptCoachTask
 
   def exec(role:, page:)
     outputs[:entity_task] = Tasks::Models::ConceptCoachTask
-      .joins(task: :taskings)
-      .where(content_page_id: page.id, task: { taskings: { entity_role_id: role.id } })
-      .take.try(:task)
+      .where(content_page_id: page.id, entity_role_id: role.id)
+      .lock.take.try(:task)
   end
 end

--- a/app/subsystems/tasks/models/concept_coach_task.rb
+++ b/app/subsystems/tasks/models/concept_coach_task.rb
@@ -4,11 +4,12 @@ module Tasks::Models
     CORE_EXERCISES_COUNT = 4
     SPACED_EXERCISES_MAP = [[2, 1], [4, 1], [nil, 1]]
 
-    belongs_to :task, subsystem: :entity
-    belongs_to :page, subsystem: :content
+    belongs_to :page,    subsystem: :content
+    belongs_to :role,    subsystem: :entity
+    belongs_to :task,    subsystem: :entity
 
-    validates :task, presence: true, uniqueness: true
     validates :page, presence: true
-
+    validates :role, presence: true, uniqueness: { scope: :content_page_id }
+    validates :task, presence: true, uniqueness: true
   end
 end

--- a/app/subsystems/tasks/models/concept_coach_task.rb
+++ b/app/subsystems/tasks/models/concept_coach_task.rb
@@ -11,5 +11,14 @@ module Tasks::Models
     validates :page, presence: true
     validates :role, presence: true, uniqueness: { scope: :content_page_id }
     validates :task, presence: true, uniqueness: true
+    validate :same_role
+
+    protected
+
+    def same_role
+      return if task.nil? || task.taskings.map(&:role).include?(role)
+      errors.add(:role, 'must match the role the task is assigned to')
+      false
+    end
   end
 end

--- a/app/subsystems/tasks/models/concept_coach_task.rb
+++ b/app/subsystems/tasks/models/concept_coach_task.rb
@@ -4,9 +4,9 @@ module Tasks::Models
     CORE_EXERCISES_COUNT = 4
     SPACED_EXERCISES_MAP = [[2, 1], [4, 1], [nil, 1]]
 
-    belongs_to :page,    subsystem: :content
-    belongs_to :role,    subsystem: :entity
-    belongs_to :task,    subsystem: :entity
+    belongs_to :page, subsystem: :content
+    belongs_to :role, subsystem: :entity
+    belongs_to :task, subsystem: :entity
 
     validates :page, presence: true
     validates :role, presence: true, uniqueness: { scope: :content_page_id }

--- a/db/migrate/20151124165753_add_role_to_tasks_concept_coach_tasks.rb
+++ b/db/migrate/20151124165753_add_role_to_tasks_concept_coach_tasks.rb
@@ -1,0 +1,20 @@
+class AddRoleToTasksConceptCoachTasks < ActiveRecord::Migration
+  def change
+    add_reference :tasks_concept_coach_tasks, :entity_role,
+                  foreign_key: { on_update: :cascade, on_delete: :cascade }
+
+    reversible do |direction|
+      direction.up do
+        Tasks::Models::ConceptCoachTask.unscoped.find_each do |cc_task|
+          cc_task.role = cc_task.task.taskings.first.role
+          cc_task.save!
+        end
+
+        change_column_null :tasks_concept_coach_tasks, :entity_role_id, false
+      end
+    end
+
+    add_index :tasks_concept_coach_tasks, [:entity_role_id, :content_page_id],
+              unique: true, name: 'index_tasks_concept_coach_tasks_on_e_r_id_and_c_p_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151103171830) do
+ActiveRecord::Schema.define(version: 20151124165753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -503,9 +503,11 @@ ActiveRecord::Schema.define(version: 20151103171830) do
     t.integer  "content_page_id", null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.integer  "entity_role_id",  null: false
   end
 
   add_index "tasks_concept_coach_tasks", ["content_page_id"], name: "index_tasks_concept_coach_tasks_on_content_page_id", using: :btree
+  add_index "tasks_concept_coach_tasks", ["entity_role_id", "content_page_id"], name: "index_tasks_concept_coach_tasks_on_e_r_id_and_c_p_id", unique: true, using: :btree
   add_index "tasks_concept_coach_tasks", ["entity_task_id"], name: "index_tasks_concept_coach_tasks_on_entity_task_id", unique: true, using: :btree
 
   create_table "tasks_course_assistants", force: :cascade do |t|
@@ -755,6 +757,7 @@ ActiveRecord::Schema.define(version: 20151103171830) do
   add_foreign_key "role_role_users", "user_profiles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "school_district_schools", "school_district_districts", on_update: :cascade, on_delete: :nullify
   add_foreign_key "tasks_concept_coach_tasks", "content_pages", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_concept_coach_tasks", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_concept_coach_tasks", "entity_tasks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_course_assistants", "entity_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_course_assistants", "tasks_assistants", on_update: :cascade, on_delete: :cascade

--- a/spec/factories/tasks/concept_coach_tasks.rb
+++ b/spec/factories/tasks/concept_coach_tasks.rb
@@ -1,6 +1,11 @@
 FactoryGirl.define do
   factory :tasks_concept_coach_task, class: '::Tasks::Models::ConceptCoachTask' do
-    association :task, factory: :entity_task
     association :page, factory: :content_page
+    association :role, factory: :entity_role
+    association :task, factory: :entity_task
+
+    after(:build) do |cc_task, evaluator|
+      cc_task.task.taskings << Tasks::Models::Tasking.new(role: cc_task.role, task: cc_task.task)
+    end
   end
 end

--- a/spec/subsystems/tasks/create_concept_coach_task_spec.rb
+++ b/spec/subsystems/tasks/create_concept_coach_task_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe Tasks::CreateConceptCoachTask, type: :routine do
+  let!(:user)             { FactoryGirl.create :user }
+  let!(:period)           { FactoryGirl.create :course_membership_period }
+  let!(:role)             { AddUserAsPeriodStudent[user: user, period: period] }
   let!(:page_model)       { FactoryGirl.create :content_page }
   let!(:page)             { Content::Page.new(strategy: page_model.wrap) }
 
@@ -20,7 +23,7 @@ RSpec.describe Tasks::CreateConceptCoachTask, type: :routine do
 
   it 'creates a task containing the given exercises in the proper order' do
     task = nil
-    expect{ task = described_class[page: page, exercises: exercises] }.to(
+    expect{ task = described_class[role: role, page: page, exercises: exercises] }.to(
       change{ Tasks::Models::Task.count }.by(1)
     )
     expect(task.concept_coach?).to eq true
@@ -29,11 +32,13 @@ RSpec.describe Tasks::CreateConceptCoachTask, type: :routine do
 
   it 'creates a ConceptCoachTask object' do
     task = nil
-    expect{ task = described_class[page: page, exercises: exercises] }.to(
+    expect{ task = described_class[role: role, page: page, exercises: exercises] }.to(
       change{ Tasks::Models::ConceptCoachTask.count }.by(1)
     )
     cc_task = Tasks::Models::ConceptCoachTask.order(:created_at).last
-    expect(cc_task.task).to eq task.entity_task
     expect(cc_task.page).to eq page_model
+    expect(cc_task.role).to eq role
+    expect(cc_task.task).to eq task.entity_task
+    expect(task.taskings.first.role).to eq role
   end
 end

--- a/spec/subsystems/tasks/get_concept_coach_task_spec.rb
+++ b/spec/subsystems/tasks/get_concept_coach_task_spec.rb
@@ -4,17 +4,13 @@ require 'vcr_helper'
 RSpec.describe Tasks::GetConceptCoachTask, type: :routine do
   let!(:concept_coach_task) { FactoryGirl.create :tasks_concept_coach_task }
 
-  let!(:role)               { Entity::Role.create! }
+  let!(:role)               { concept_coach_task.role }
   let!(:another_role)       { Entity::Role.create! }
 
   let!(:page)               { Content::Page.new(strategy: concept_coach_task.page.wrap) }
   let!(:another_page)       do
     page_model = FactoryGirl.create :content_page
     Content::Page.new(strategy: page_model.wrap)
-  end
-
-  let!(:tasking)            do
-    FactoryGirl.create :tasks_tasking, role: role, task: concept_coach_task.task
   end
 
   context 'with an existing ConceptCoachTask' do

--- a/spec/subsystems/tasks/models/concept_coach_task_spec.rb
+++ b/spec/subsystems/tasks/models/concept_coach_task_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.describe Tasks::Models::ConceptCoachTask, type: :model do
   subject(:concept_coach_task) { FactoryGirl.create(:tasks_concept_coach_task) }
 
-  it { is_expected.to belong_to(:task) }
   it { is_expected.to belong_to(:page) }
+  it { is_expected.to belong_to(:role) }
+  it { is_expected.to belong_to(:task) }
 
-  it { is_expected.to validate_presence_of(:task) }
   it { is_expected.to validate_presence_of(:page) }
+  it { is_expected.to validate_presence_of(:role) }
+  it { is_expected.to validate_presence_of(:task) }
 
+  it { is_expected.to validate_uniqueness_of(:role).scoped_to(:content_page_id) }
   it { is_expected.to validate_uniqueness_of(:task) }
 end
-

--- a/spec/subsystems/tasks/models/concept_coach_task_spec.rb
+++ b/spec/subsystems/tasks/models/concept_coach_task_spec.rb
@@ -13,4 +13,12 @@ RSpec.describe Tasks::Models::ConceptCoachTask, type: :model do
 
   it { is_expected.to validate_uniqueness_of(:role).scoped_to(:content_page_id) }
   it { is_expected.to validate_uniqueness_of(:task) }
+
+  it 'requires the role to match the role the task is assigned to' do
+    concept_coach_task.task.taskings.first.role = Entity::Role.create!
+    expect(concept_coach_task).not_to be_valid
+    expect(concept_coach_task.errors.first).to(
+      eq [:role, 'must match the role the task is assigned to']
+    )
+  end
 end


### PR DESCRIPTION
- Adds a (required) reference to a role in concept_coach_task and a unique index.
- Does a select for update when trying to read the concept_coach_task before creation.