### PR TITLE
GetConceptCoach now errors out if the page requested has no exercises

### DIFF
--- a/app/controllers/api/v1/cc/tasks_controller.rb
+++ b/app/controllers/api/v1/cc/tasks_controller.rb
@@ -21,6 +21,7 @@ class Api::V1::Cc::TasksController < Api::V1::ApiController
       invalid_book
       invalid_page
       not_a_cc_student
+      page_has_no_exercises
     #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
   EOS
   def show

--- a/app/routines/get_concept_coach.rb
+++ b/app/routines/get_concept_coach.rb
@@ -39,6 +39,11 @@ class GetConceptCoach
       Tasks::Models::ConceptCoachTask::CORE_EXERCISES_COUNT, pool, all_worked_exercises
     )
 
+    if core_exercises.empty?
+      outputs.valid_book_urls = ecosystem.books.map(&:url)
+      fatal_error(code: :page_has_no_exercises)
+    end
+
     current_exercise_numbers = core_exercises.map(&:number)
     ecosystems_map = {}
 
@@ -126,8 +131,9 @@ class GetConceptCoach
     page_model = page_models.order(:created_at).last
 
     if page_model.blank?
-      valid_books = Content::Models::Book.where(content_ecosystem_id: ecosystem_id_role_map.keys)
-                                         .to_a
+      valid_books = Content::Models::Book.where(
+        content_ecosystem_id: ecosystem_id_role_map.keys
+      ).to_a
       valid_book_with_cnx_book_id = valid_books.select{ |book| book.uuid == cnx_book_id }.first
 
       if !valid_book_with_cnx_book_id.nil?

--- a/spec/controllers/api/v1/cc/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/cc/tasks_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Api::V1::Cc::TasksController, type: :controller, api: true, versi
         expect(cc_task2.id).not_to eq cc_task.id
       end
 
-      it 'should return 422 with code :invalid_book if the book is invalid' do
+      it 'should return 422 with code invalid_book if the book is invalid' do
         expect{ api_call(@user_1_token, cnx_book_id: 'invalid') }.not_to(
           change{ Tasks::Models::Task.count }
         )
@@ -141,13 +141,24 @@ RSpec.describe Api::V1::Cc::TasksController, type: :controller, api: true, versi
         expect(body[:valid_books]).to eq [@book.url]
       end
 
-      it 'should return 422 with code :invalid_page if the page is invalid' do
+      it 'should return 422 with code invalid_page if the page is invalid' do
         expect{ api_call(@user_1_token, cnx_page_id: 'invalid') }.not_to(
           change{ Tasks::Models::Task.count }
         )
         expect(response).to have_http_status(:unprocessable_entity)
         body = response.body_as_hash
         expect(body[:errors].map{ |error| error[:code] }).to eq ['invalid_page']
+        expect(body[:valid_books]).to eq [@book.url]
+      end
+
+      it 'should return 422 with code page_has_no_exercises if the page has no exercises' do
+        page = FactoryGirl.create :content_page, chapter: @book.chapters.first
+        expect{ api_call(@user_1_token, cnx_page_id: page.uuid) }.not_to(
+          change{ Tasks::Models::Task.count }
+        )
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = response.body_as_hash
+        expect(body[:errors].map{ |error| error[:code] }).to eq ['page_has_no_exercises']
         expect(body[:valid_books]).to eq [@book.url]
       end
     end

--- a/spec/routines/get_concept_coach_spec.rb
+++ b/spec/routines/get_concept_coach_spec.rb
@@ -199,7 +199,8 @@ it 'should create a new task for a different page and properly assign spaced pra
     end
 
     it 'returns an error if the page has no exercises' do
-      page = FactoryGirl.create :content_page, chapter: @book.chapters.first
+      chapter_model = Content::Models::Chapter.find(@book.chapters.first.id)
+      page = FactoryGirl.create :content_page, chapter: chapter_model
       result = nil
       expect{ result = described_class.call(
         user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: page.uuid

--- a/spec/routines/get_concept_coach_spec.rb
+++ b/spec/routines/get_concept_coach_spec.rb
@@ -197,6 +197,16 @@ it 'should create a new task for a different page and properly assign spaced pra
       expect(result.errors.map(&:code)).to eq [:invalid_page]
       expect(result.outputs.valid_book_urls).to eq [@book.url]
     end
+
+    it 'returns an error if the page has no exercises' do
+      page = FactoryGirl.create :content_page, chapter: @book.chapters.first
+      result = nil
+      expect{ result = described_class.call(
+        user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: page.uuid
+      ) }.not_to change{ Tasks::Models::ConceptCoachTask.count }
+      expect(result.errors.map(&:code)).to eq [:page_has_no_exercises]
+      expect(result.outputs.valid_book_urls).to eq [@book.url]
+    end
   end
 
 end


### PR DESCRIPTION
code: "page_has_no_exercises"