### PR TITLE
Made job error JSON work

### DIFF
--- a/app/representers/api/v1/error_representer.rb
+++ b/app/representers/api/v1/error_representer.rb
@@ -1,7 +1,7 @@
 module Api::V1
   class ErrorRepresenter < Roar::Decorator
 
-    include Roar::JSON
+    include Representable::JSON::Hash
     include Representable::Coercion
 
     property :is_fatal,

--- a/spec/representers/api/v1/error_representer_spec.rb
+++ b/spec/representers/api/v1/error_representer_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ErrorRepresenter, type: :representer do
+  let!(:exception_error) {
+    {
+      "is_fatal"=>true,
+      "code"=>"exception",
+      "message"=>"undefined local variable or method `name' for #<Tasks::GetCcPerformanceReport:0x007f5fff1a7f00>",
+      "data"=>"blah blah"
+    }
+  }
+
+  it 'handles hash errors (errors are hashes)' do
+    expect{
+      described_class.new(exception_error).to_hash
+    }.not_to raise_error
+  end
+
+end

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       expect(entity_task.taskings.count).to eq(1)
     end
     expected_roles = taskee_users.collect{ |taskee| Role::GetDefaultUserRole[taskee] }
-    expect(entity_tasks.collect{|t| t.taskings.first.role}).to eq expected_roles
+    expect(entity_tasks.collect{|t| t.taskings.first.role}).to match_array expected_roles
 
     ## it "assigns the correct number of exercises"
     entity_tasks.each do |entity_task|


### PR DESCRIPTION
Didn't work previously b/c the properties were inside a hash -- led to exceptions like:

```
A NoMethodError occurred in jobs#show:

  undefined method `is_fatal' for #<Hash:0x007ff4fb4e6450>
  app/controllers/api/v1/jobs_controller.rb:32:in `show'
```