### PR TITLE
Include comments in ecosystem's representation

### DIFF
--- a/app/representers/api/v1/ecosystem_representer.rb
+++ b/app/representers/api/v1/ecosystem_representer.rb
@@ -9,6 +9,10 @@ module Api::V1
              readable: true,
              schema_info: { required: true }
 
+    property :comments,
+             type: String,
+             readable: true
+
     collection :books,
                readable: true,
                writable: false,

--- a/spec/factories/content/books.rb
+++ b/spec/factories/content/books.rb
@@ -12,7 +12,9 @@ FactoryGirl.define do
 
     after(:build) do |book, evaluator|
       book.ecosystem ||= FactoryGirl.build(
-        :content_ecosystem, title: "#{evaluator.title} (#{evaluator.uuid}@#{evaluator.version})"
+        :content_ecosystem,
+        comments: Faker::Lorem.words(2),
+        title: "#{evaluator.title} (#{evaluator.uuid}@#{evaluator.version})"
       )
     end
 

--- a/spec/representers/api/v1/ecosystem_representer_spec.rb
+++ b/spec/representers/api/v1/ecosystem_representer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V1::EcosystemRepresenter, type: :representer do
   it 'can represent an ecosystem' do
     expect(represented).to eq({
       'id' => book.ecosystem.id,
+      'comments' => book.ecosystem.comments,
       'books' => [{
         'id'      => book.id,
         'uuid'    => book.uuid,


### PR DESCRIPTION
The QA view needs to display the ecosystem comments on the book selection menu so they can tell the different books apart.