### PR TITLE
Replaced default static error pages with branded pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ doc
 
 # Ignore profiling logs from Pilfer
 pilfer.log
+
+# Ignore asset stuff
+public/assets/**

--- a/Gemfile
+++ b/Gemfile
@@ -153,6 +153,10 @@ gem 'active_force', git: 'https://github.com/maddijoyce/active_force', ref: '969
 gem 'rails-settings-cached', '~> 0.4.0'
 gem 'rails-settings-ui'
 
+# Nicely-styled static error pages
+gem 'error_page_assets'
+gem 'render_anywhere', :require => false
+
 group :development, :test do
   # Get env variables from .env file
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
     dotenv-rails (2.0.1)
       dotenv (= 2.0.1)
     equalizer (0.0.11)
+    error_page_assets (0.3)
     erubis (2.7.0)
     eventmachine (1.0.7)
     exception_notification (4.1.1)
@@ -536,6 +537,8 @@ GEM
       redis (>= 2.2)
     ref (1.0.5)
     remotipart (1.2.1)
+    render_anywhere (0.0.12)
+      rails (>= 3.0.7)
     representable (2.2.2)
       multi_json
       nokogiri
@@ -720,6 +723,7 @@ DEPENDENCIES
   deep_cloneable
   delayed_job_active_record
   dotenv-rails
+  error_page_assets
   factory_girl_rails
   faker
   fakeredis
@@ -761,6 +765,7 @@ DEPENDENCIES
   rails-settings-ui
   redis-rails
   remotipart
+  render_anywhere
   restforce
   rspec-collection_matchers
   rspec-rails

--- a/app/assets/html/404.html.erb
+++ b/app/assets/html/404.html.erb
@@ -1,0 +1,5 @@
+<%=
+  require 'error_page_builder'
+  ErrorPageBuilder.build(code: 404,
+                         heading: 'We couldn\'t find what you were looking for.')
+%>

--- a/app/assets/html/422.html.erb
+++ b/app/assets/html/422.html.erb
@@ -1,0 +1,5 @@
+<%=
+  require 'error_page_builder'
+  ErrorPageBuilder.build(code: 422,
+                         heading: 'The change you were trying to make was rejected.')
+%>

--- a/app/assets/html/500.html.erb
+++ b/app/assets/html/500.html.erb
@@ -1,0 +1,5 @@
+<%=
+  require 'error_page_builder'
+  ErrorPageBuilder.build(code: 500,
+                         heading: 'An unexpected error occurred!')
+%>

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -187,6 +187,25 @@ header {
 
 }
 
+.static-error {
+  width: 800px;
+  margin: 30px auto;
+
+  .logo {
+    height: 60px;
+    background: image-url("OS-Horiz-TM-CMYK.svg") no-repeat;
+  }
+
+  h1 {
+    margin: 30px 0;
+    font-size: 30px;
+  }
+
+  .no-css-message {
+    display: none; // hide this message when CSS available
+  }
+}
+
 /*-------------------------------------------------------------
                     BUTTON STYLES
 ---------------------------------------------------------------*/

--- a/app/views/layouts/static_error.html.erb
+++ b/app/views/layouts/static_error.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title><%= code %> error - OpenStax</title>
+    <%= stylesheet_link_tag 'application', :media => 'all', :digest => true %>
+  </head>
+  <body>
+    <div class='static-error'>
+      <div class='no-css-message'>To see this page properly styled, precompile assets</div>
+      <div class='logo'></div>
+      <section id="error">
+        <h1><%= heading %></h1>
+        This is a <%= code %> error.  Please <%= link_to "contact support", "https://openstaxtutor.zendesk.com/" %> if you need assistance or <%= link_to "return to the home page", root_path %>.
+      </section>
+    </div>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module Tutor
 
     # add app/assets/fonts to the asset path
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
+    config.assets.paths << Rails.root.join("app", "assets", "html")
 
     # For not swallowing errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true

--- a/lib/error_page_builder.rb
+++ b/lib/error_page_builder.rb
@@ -1,0 +1,11 @@
+require 'render_anywhere'
+
+class ErrorPageBuilder
+  include RenderAnywhere
+
+  def self.build(code:, heading:)
+    new.render template: 'layouts/static_error',
+               layout: false,
+               locals: {code: code, heading: heading}
+  end
+end

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,19 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body>
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>404 error - OpenStax</title>
+    <link rel="stylesheet" media="all" href="/assets/application-66c895bd088f581310ab38c136117852.css?body=1" digest="true" />
+  </head>
+  <body>
+    <div class='static-error'>
+      <div class='no-css-message'>To see this page properly styled, precompile assets</div>
+      <div class='logo'></div>
+      <section id="error">
+        <h1>We couldn&#39;t find what you were looking for.</h1>
+        This is a 404 error.  Please <a href="https://openstaxtutor.zendesk.com/">contact support</a> if you need assistance or <a href="/">return to the home page</a>.
+      </section>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>
+

--- a/public/422.html
+++ b/public/422.html
@@ -1,67 +1,19 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>The change you wanted was rejected (422)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body>
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>422 error - OpenStax</title>
+    <link rel="stylesheet" media="all" href="/assets/application-66c895bd088f581310ab38c136117852.css?body=1" digest="true" />
+  </head>
+  <body>
+    <div class='static-error'>
+      <div class='no-css-message'>To see this page properly styled, precompile assets</div>
+      <div class='logo'></div>
+      <section id="error">
+        <h1>The change you were trying to make was rejected.</h1>
+        This is a 422 error.  Please <a href="https://openstaxtutor.zendesk.com/">contact support</a> if you need assistance or <a href="/">return to the home page</a>.
+      </section>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>
+

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,19 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body>
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>500 error - OpenStax</title>
+    <link rel="stylesheet" media="all" href="/assets/application-66c895bd088f581310ab38c136117852.css?body=1" digest="true" />
+  </head>
+  <body>
+    <div class='static-error'>
+      <div class='no-css-message'>To see this page properly styled, precompile assets</div>
+      <div class='logo'></div>
+      <section id="error">
+        <h1>An unexpected error occurred!</h1>
+        This is a 500 error.  Please <a href="https://openstaxtutor.zendesk.com/">contact support</a> if you need assistance or <a href="/">return to the home page</a>.
+      </section>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>
+


### PR DESCRIPTION
I just couldn't take it anymore.  I replaced Rails' boilerplate (and IMO not very professional for a site like ours) staticly-served error pages with OpenStax branded ones.

Replaced

![image](https://cloud.githubusercontent.com/assets/1001691/11517167/e2801b84-983c-11e5-8656-e0761dbfa32f.png)

With

![image](https://cloud.githubusercontent.com/assets/1001691/11517153/b7a3986e-983c-11e5-80ef-5a31dac27e22.png)

in a way that is easy to maintain and keep consistent across error types.  Note that these pages are seen when there's an error that isn't caught by our normal exception machinery.

Closes #632 