### PR TITLE
Copyright year adapts and add Terms link to footer

### DIFF
--- a/app/views/layouts/_copyright_terms.html.erb
+++ b/app/views/layouts/_copyright_terms.html.erb
@@ -1,0 +1,3 @@
+&copy; <%= year = Time.now.year; 2015 == year ? "2015" : "2015&ndash;#{year}".html_safe %> <a href="http://www.rice.edu" target="_blank">Rice University</a> &middot; <%= link_to "Terms", terms_path %>
+
+

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer>
   <div class="container">
     <div class="row">
-      <p style="padding-left:0">&copy; 2015 <a href="http://www.rice.edu" target="_blank">Rice University</a></p>
+      <p style="padding-left:0"><%= render 'layouts/copyright_terms' %></p>
     </div>
   </div>
 </footer>

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -72,7 +72,7 @@
 <footer>
   <div class="container">
     <div class="row">
-      <p>&copy; 2015 <a href="http://www.rice.edu" target="_blank">Rice University</a></p>
+      <p><%= render 'layouts/copyright_terms' %></p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Adds a "Terms" link next to the copyright notice (goes to https://tutor.openstax.org/terms):

![image](https://cloud.githubusercontent.com/assets/1001691/11539439/ede36b6c-98db-11e5-8cd1-e56674e99313.png)

Also makes the copyright year adaptive so when 2016 hits it will look like:

![image](https://cloud.githubusercontent.com/assets/1001691/11539481/1d3f8f30-98dc-11e5-9ddf-f974f066452b.png)

@jason-holmes can you bless this?