### PR TITLE
Fix uniqueness exceptions for creating CC tasks

### DIFF
--- a/app/routines/get_concept_coach.rb
+++ b/app/routines/get_concept_coach.rb
@@ -1,6 +1,6 @@
 class GetConceptCoach
 
-  lev_routine express_output: :entity_task
+  lev_routine express_output: :entity_task, transaction: :serializable
 
   uses_routine Tasks::GetConceptCoachTask, as: :get_cc_task
 


### PR DESCRIPTION
When testing locally, it seems that making the transaction serializable does it... Hopefully won't affect performance too badly?