### PR TITLE
Let configure webview URL base for demo classes

### DIFF
--- a/lib/tasks/demo/configurations/concept-coach.yml
+++ b/lib/tasks/demo/configurations/concept-coach.yml
@@ -3,6 +3,7 @@ is_concept_coach: true
 cnx_book_id: f10533ca-f803-490d-b935-88899941197f
 cnx_book_version: 3.1
 url_base: https://archive.cnx.org/contents/
+webview_url_base: https://demo.cnx.org/contents/
 catalog_offering_salesforce_book_name: Biology
 catalog_offering_is_concept_coach: true
 teachers:

--- a/lib/tasks/demo/configurations/ludicrous.yml
+++ b/lib/tasks/demo/configurations/ludicrous.yml
@@ -3,6 +3,7 @@ is_concept_coach: true
 cnx_book_id: 185cbf87-c72e-48f5-b51e-f14f21b5eabd
 cnx_book_version: 9.87
 url_base: https://archive.cnx.org/contents/
+webview_url_base: https://demo.cnx.org/contents/
 catalog_offering_salesforce_book_name: Biology
 catalog_offering_is_concept_coach: true
 teachers:

--- a/lib/tasks/demo/configurations/small/base
+++ b/lib/tasks/demo/configurations/small/base
@@ -1,5 +1,6 @@
 is_concept_coach: true
 url_base: https://archive.cnx.org/contents/
+webview_url_base: https://demo.cnx.org/contents/
 catalog_offering_is_concept_coach: true
 periods:
   - id: p1

--- a/lib/tasks/demo/content_configuration.rb
+++ b/lib/tasks/demo/content_configuration.rb
@@ -55,6 +55,10 @@ class ContentConfiguration
     @configuration.url_base || Rails.application.secrets.openstax['cnx']['archive_url']
   end
 
+  def webview_url_base
+    @configuration.webview_url_base
+  end
+
   def assignments
     @configuration.assignments || []
   end

--- a/lib/tasks/demo/demo_base.rb
+++ b/lib/tasks/demo/demo_base.rb
@@ -109,7 +109,7 @@ class DemoBase
         salesforce_book_name: content.catalog_offering_salesforce_book_name,
         appearance_code: content.catalog_offering_salesforce_book_name,
         description: content.course_name,
-        webview_url: content.url_base + content.cnx_book,
+        webview_url: (content.webview_url_base || content.url_base.sub(/archive\./,'')) + content.cnx_book,
         pdf_url: content.url_base.sub(%r{contents/$}, 'exports/') + content.cnx_book + '.pdf',
         is_concept_coach: content.catalog_offering_is_concept_coach,
         content_ecosystem_id: ecosystem.id


### PR DESCRIPTION
Previously, the webview URL for demo courses pointed to archive.  This PR makes demo webview_urls use a configurable base, and if not present likely defaults to 'https://cnx.org/contents/'.

@nathanstitt please review.