### PR TITLE
Improve SF cron logging; notify for SF cron exceptions

### DIFF
--- a/app/routines/import_salesforce_courses.rb
+++ b/app/routines/import_salesforce_courses.rb
@@ -119,7 +119,7 @@ class ImportSalesforceCourses
   end
 
   def log(&block)
-    Rails.logger.info { "[#{class.name}] #{block.call}" }
+    Rails.logger.info { "[ImportSalesforceCourses] #{block.call}" }
   end
 
 end

--- a/app/routines/import_salesforce_courses.rb
+++ b/app/routines/import_salesforce_courses.rb
@@ -13,12 +13,19 @@ class ImportSalesforceCourses
   end
 
   def exec(include_real_salesforce_data: nil)
+    log { "Starting." }
+
     @include_real_salesforce_data_preference = include_real_salesforce_data
 
     candidate_sf_records.each do |candidate|
       create_course_for_candidate(candidate)
       candidate.save_if_changed
     end
+
+    log {
+      "#{outputs.num_failures + outputs.num_successes} candidate record(s); " +
+      "#{outputs.num_successes} success(es) and #{outputs.num_failures} failure(s)."
+    }
   end
 
   def include_real_salesforce_data?
@@ -42,7 +49,7 @@ class ImportSalesforceCourses
 
     if !include_real_salesforce_data?
       search_criteria[:school] = 'Denver University'
-      Rails.logger.info { "Starting Salesforce course import using test data only" }
+      log { "Using test data only." }
     end
 
     Salesforce::Remote::ClassSize.where(search_criteria)
@@ -91,7 +98,7 @@ class ImportSalesforceCourses
     # Remember the candidate obj ID so we can write stats later
     run(:attach_record, record: candidate, to: course)
 
-    Rails.logger.info {
+    log {
       "Created course '#{course.name}' (#{course.id}) based on Salesforce record " +
       "#{candidate.id} using offering '#{offering.identifier}' (#{offering.id}) " +
       "and ecosystem '#{offering.ecosystem.title}'."
@@ -108,6 +115,11 @@ class ImportSalesforceCourses
   def error!(candidate, message)
     candidate.error = message
     outputs.num_failures += 1
+    log { "Error! candidate: #{candidate.id}; message: #{message}." }
+  end
+
+  def log(&block)
+    Rails.logger.info { "[#{class.name}] #{block.call}" }
   end
 
 end

--- a/app/routines/update_salesforce_stats.rb
+++ b/app/routines/update_salesforce_stats.rb
@@ -3,6 +3,8 @@ class UpdateSalesforceStats
   # not a routine!
 
   def self.call
+    log { "Starting." }
+
     attached_records = Salesforce::AttachedRecord.all
 
     num_records = attached_records.count
@@ -38,9 +40,9 @@ class UpdateSalesforceStats
       end
     end
 
-    Rails.logger.info {
-      "UpdateSalesforceStats ran for #{num_records} record(s); Made #{num_updates} " +
-      "update(s);#{num_errors} error(s) occurred."
+    log {
+      "Ran for #{num_records} record(s); Made #{num_updates} " +
+      "update(s); #{num_errors} error(s) occurred."
     }
 
     {num_records: num_records, num_errors: num_errors, num_updates: num_updates}
@@ -50,6 +52,10 @@ class UpdateSalesforceStats
     class_size.num_teachers = CourseMembership::GetTeachers[course].count
     class_size.num_students = CourseMembership::GetCourseRoles[course: course, types: :student].count
     class_size.num_sections = CourseMembership::GetCoursePeriods[course: course].count
+  end
+
+  def log(&block)
+    Rails.logger.info { "[#{class.name}] #{block.call}" }
   end
 
 end

--- a/app/routines/update_salesforce_stats.rb
+++ b/app/routines/update_salesforce_stats.rb
@@ -54,8 +54,8 @@ class UpdateSalesforceStats
     class_size.num_sections = CourseMembership::GetCoursePeriods[course: course].count
   end
 
-  def log(&block)
-    Rails.logger.info { "[#{class.name}] #{block.call}" }
+  def self.log(&block)
+    Rails.logger.info { "[UpdateSalesforceStats] #{block.call}" }
   end
 
 end

--- a/app/subsystems/salesforce/remote/real_client.rb
+++ b/app/subsystems/salesforce/remote/real_client.rb
@@ -1,8 +1,13 @@
+class SalesforceUserMissing < StandardError; end
+
 class Salesforce::Remote::RealClient < Restforce::Data::Client
 
   def initialize
     user = Salesforce::Models::User.first
-    raise IllegalState, "a salesforce user must be set!" if user.nil?
+    if user.nil?
+      Rails.logger.error { "The Salesforce client was requested but no user is available." }
+      raise SalesforceUserMissing
+    end
     secrets = secrets = Rails.application.secrets['salesforce']
     super(oauth_token: user.oauth_token,
           refresh_token: user.refresh_token,

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -20,6 +20,7 @@ require 'unique_tokenable'
 require 'url_generator'
 require 'logout_redirect_chooser'
 require 'global_settings'
+require 'openstax_rescue_from_this'
 
 %w(
   biglearn

--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -24,7 +24,17 @@ end
 #                                         notify: true,
 #                                         extras: ->(e) { {} })
 #
-OpenStax::RescueFrom.register_exception('InvalidTeacherJoinToken',
-                                       message: 'You are trying to join a class as a teacher, but the information you provided is either out of date or does not correspond to an existing course.',
-                                       status: :not_found,
-                                       notify: false)
+
+OpenStax::RescueFrom.register_exception(
+  'InvalidTeacherJoinToken',
+  message: 'You are trying to join a class as a teacher, but the information you provided ' +
+           'is either out of date or does not correspond to an existing course.',
+  status: :not_found,
+  notify: false
+)
+
+OpenStax::RescueFrom.register_exception(
+  'SalesforceUserMissing',
+  # only notify when real data involved (only time it really needs admin attention)
+  notify: secrets['salesforce']['allow_use_of_real_data']
+)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,9 +10,9 @@ every 1.day, at: '3:00 AM' do
 end
 
 every 1.hour do
-  runner "ImportSalesforceCourses.call"
+  runner "OpenStax::RescueFrom.this{ ImportSalesforceCourses.call }"
 end
 
 every 1.day, at: '2:00 AM' do
-  runner "UpdateSalesforceStats.call"
+  runner "OpenStax::RescueFrom.this{ UpdateSalesforceStats.call }"
 end

--- a/lib/openstax_rescue_from_this.rb
+++ b/lib/openstax_rescue_from_this.rb
@@ -1,0 +1,17 @@
+# For places where openstax_rescue_from isn't automatically used (e.g. cron
+# 'runner' calls), this wrapper is a quick way to handle exceptions with
+# openstax_rescue_from.
+#
+# Usage:
+#
+#   OpenStax::RescueFrom.this{ SomeCodeHereThatCanRaise }
+
+module OpenStax::RescueFrom
+  def self.this
+    begin
+      yield
+    rescue Exception => e
+      perform_rescue(e)
+    end
+  end
+end

--- a/spec/subsystems/salesforce/remote/real_client_spec.rb
+++ b/spec/subsystems/salesforce/remote/real_client_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Salesforce::Remote::RealClient do
+
+  it 'raises when there is no SF user' do
+    allow(Salesforce::Models::User).to receive(:first) { nil }
+    expect{ Salesforce::Remote::RealClient.new }.to raise_error(SalesforceUserMissing)
+  end
+
+end


### PR DESCRIPTION
Salesforce cron jobs are getting called but not doing anything.  This PR adds more logging to help figure out what's going on.  It also adds our exception processing machinery to the cron job calls; previously, any exceptions were not being rescued and notified.