### PR TITLE
Assign already published task_plans to moved students in the background

### DIFF
--- a/app/subsystems/course_membership/add_enrollment.rb
+++ b/app/subsystems/course_membership/add_enrollment.rb
@@ -3,8 +3,6 @@ class CourseMembership::AddEnrollment
 
   lev_routine
 
-  uses_routine ReassignPublishedPeriodTaskPlans, as: :reassign_period_task_plans
-
   protected
 
   def exec(period:, student:)
@@ -17,6 +15,6 @@ class CourseMembership::AddEnrollment
     student.activate.save! unless student.active?
     outputs[:student] = student
 
-    run(:reassign_period_task_plans, period: period)
+    ReassignPublishedPeriodTaskPlans.perform_later(period: period.to_model)
   end
 end


### PR DESCRIPTION
Well that was easy...

Closes https://github.com/openstax/tutor-server/issues/717