### PR TITLE
Make whenever runner command use rbenv exec bundle exec

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,7 @@
-set :bundle_command, ENV['BUNDLE_COMMAND'] || 'bundle exec'
+bundle_command = ENV['BUNDLE_COMMAND'] || 'bundle exec'
+
+set :bundle_command, bundle_command
+set :runner_command, "#{bundle_command} rails runner"
 
 every 1.minute do
   rake 'openstax:accounts:sync:all'


### PR DESCRIPTION
Whenever's cron jobs for "runner"s were using the binstubs instead of `rbenv exec bundle exec blah`.  The runners were then dying immediately.  

This change should generate:

```
/bin/bash -l -c 'cd /home/osttutor/src/tutor-ffd9f1b && /usr/local/bin/rbenv exec bundle exec rails runner -e production '\''OpenStax::RescueFrom.this{ ImportSalesforceCourses.call }'\'''
```

which works and logs as expected.  Will need to check it works after deploy to dev.

cc @cnuber 