### PR TITLE
Redirect to homepage if not iframed

### DIFF
--- a/app/views/auth/iframe.html.erb
+++ b/app/views/auth/iframe.html.erb
@@ -4,9 +4,20 @@
     <title></title>
     <script>
       var msg = <%=raw json_escape @status.to_json %>;
-      window.parent.postMessage( JSON.stringify({
-        sourceWindowName: 'OxAccountIframe', data: { onLogin: msg}
-      }), '<%= @iframe_origin %>' );
+      var isFramed = false;
+      try { // IE can block access to window.top
+        isFramed = window.self != window.top;
+      }
+      catch(e){
+        isFramed = true;  // failed to read window.top
+      }
+      if (isFramed){
+        window.parent.postMessage( JSON.stringify({
+          sourceWindowName: 'OxAccountIframe', data: { onLogin: msg}
+        }), '<%= @iframe_origin %>' );
+      } else {
+        window.location.href = '/';  // redirect to home page
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
While this case should never occur, it still seems to at times.

The iframe page should only be called from the CC iframe.  Sometimes other users seem to end up on it. When they do they're presented with a blank page.  This attempts to at least do something useful and redirect to the homepage in that case.