### PR TITLE
Add validated return_to's on login URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'whenever'
 gem 'omniauth-oauth2', '~> 1.3.1'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', '~> 6.2.0'
+gem 'openstax_accounts', '~> 6.3.0'
 
 # OpenStax Exchange integration
 gem 'openstax_exchange', '~> 0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_accounts (6.2.0)
+    openstax_accounts (6.3.0)
       action_interceptor (>= 1.0)
       keyword_search (>= 1.0.0)
       lev (>= 2.2.1)
@@ -745,7 +745,7 @@ DEPENDENCIES
   nifty-generators
   omniauth-oauth2 (~> 1.3.1)
   omniauth-salesforce
-  openstax_accounts (~> 6.2.0)
+  openstax_accounts (~> 6.3.0)
   openstax_api (~> 6.1.3)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.6.0)

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -5,11 +5,12 @@ secrets = Rails.application.secrets['openstax']['accounts']
 # By default, stub unless in the production environment
 stub = secrets['stub'].nil? ? !Rails.env.production? : secrets['stub']
 
-APPROVED_HOST_REGEXES = [
-  /.*openstax\.org$/,
-  /.*cnx\.org$/,
-  /localhost$/,
+approved_host_regexes = [
+  /openstax\.org\z/,
+  /cnx\.org\z/,
 ]
+
+approved_host_regexes.push(/localhost\z/) if !Rails.env.production?
 
 OpenStax::Accounts.configure do |config|
   config.openstax_application_id = secrets['client_id']
@@ -24,7 +25,7 @@ OpenStax::Accounts.configure do |config|
   config.return_to_url_approver = ->(url) {
     begin
       uri = Addressable::URI.parse(url)
-      APPROVED_HOST_REGEXES.any?{|regex| regex.match(uri.host)}
+      approved_host_regexes.any?{|regex| regex.match(uri.host)}
     rescue
       false
     end

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -5,6 +5,12 @@ secrets = Rails.application.secrets['openstax']['accounts']
 # By default, stub unless in the production environment
 stub = secrets['stub'].nil? ? !Rails.env.production? : secrets['stub']
 
+APPROVED_HOST_REGEXES = [
+  /.*openstax\.org$/,
+  /.*cnx\.org$/,
+  /localhost$/,
+]
+
 OpenStax::Accounts.configure do |config|
   config.openstax_application_id = secrets['client_id']
   config.openstax_application_secret = secrets['secret']
@@ -14,6 +20,14 @@ OpenStax::Accounts.configure do |config|
   config.account_user_mapper = MapUsersAccounts
   config.logout_redirect_url = ->(request) {
     LogoutRedirectChooser.new(request.url).choose(default: config.default_logout_redirect_url)
+  }
+  config.return_to_url_approver = ->(url) {
+    begin
+      uri = Addressable::URI.parse(url)
+      APPROVED_HOST_REGEXES.any?{|regex| regex.match(uri.host)}
+    rescue
+      false
+    end
   }
 end
 

--- a/spec/requests/login_return_to_spec.rb
+++ b/spec/requests/login_return_to_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "Login with explicit return_to", type: :request do
+  let(:user)        { FactoryGirl.create(:user) }
+
+  good_return_tos = %w(http://www.cnx.org?blah http://localhost:3001 http://openstax.org)
+
+  good_return_tos.each do |good_return_to|
+    it "stores '#{good_return_to}'return_to redirect after login for approved return_tos" do
+      stub_current_user(user)
+      allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) { false }
+      host! 'tutor-blah.openstax.org'
+      get("/accounts/login?return_to=#{good_return_to}")
+      expect(session["accounts_return_to"]).to eq good_return_to
+    end
+  end
+
+  it "does not store return_to redirect after login for non-approved return_tos" do
+    stub_current_user(user)
+    allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) { false }
+    host! 'tutor-blah.openstax.org'
+    get("/accounts/login?return_to=http://www.openstax.org.spamsite.net")
+    expect(session["accounts_return_to"]).to eq nil
+  end
+end

--- a/spec/requests/login_return_to_spec.rb
+++ b/spec/requests/login_return_to_spec.rb
@@ -15,11 +15,15 @@ describe "Login with explicit return_to", type: :request do
     end
   end
 
-  it "does not store return_to redirect after login for non-approved return_tos" do
-    stub_current_user(user)
-    allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) { false }
-    host! 'tutor-blah.openstax.org'
-    get("/accounts/login?return_to=http://www.openstax.org.spamsite.net")
-    expect(session["accounts_return_to"]).to eq nil
+  bad_return_tos = %w(http://www.openstax.org.spamsite.net http://www.openstax.org%0Aspamsite.net)
+
+  bad_return_tos.each do |bad_return_to|
+    it "does not store '#{bad_return_to}' return_to redirect after login for non-approved return_tos" do
+      stub_current_user(user)
+      allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) { false }
+      host! 'tutor-blah.openstax.org'
+      get("/accounts/login?return_to=#{bad_return_to}")
+      expect(session["accounts_return_to"]).to eq nil
+    end
   end
 end


### PR DESCRIPTION
URLs with hosts of `cnx.org`, `openstax.org`, and `localhost` are now accepted as `return_to` arguments on the login URL.  After login, Tutor will redirect to those URLs.  Any other `return_to` values will be ignored.

This is a backup way to login for CC, CNX.