### PR TITLE
Blow up on invalid TaskPlan content

### DIFF
--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -12,7 +12,9 @@ class Tasks::Assistants::HomeworkAssistant
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1,
+          "uniqueItems": true
         },
         "exercises_count_dynamic": {
           "type": "integer",

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -11,7 +11,9 @@ class Tasks::Assistants::IReadingAssistant
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
       },
       "additionalProperties": false

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -60,7 +60,7 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
     if settings['exercise_ids'].present?
       exercises_ecosystem = Content::Ecosystem.find_by_exercise_ids(*settings['exercise_ids'])
       if exercises_ecosystem != ecosystem_wrapper
-        errors.add(:settings, '- Invalid exercises selected.')
+        errors.add(:settings, '- Invalid exercises selected')
         return_value = false
       end
     end
@@ -68,7 +68,7 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
     if settings['page_ids'].present?
       pages_ecosystem = Content::Ecosystem.find_by_page_ids(*settings['page_ids'])
       if pages_ecosystem != ecosystem_wrapper
-        errors.add(:settings, '- Invalid pages selected.')
+        errors.add(:settings, '- Invalid pages selected')
         return_value = false
       end
     end

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -9,14 +9,6 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
   let!(:teacher)   { FactoryGirl.create(:user) }
   let!(:student)   { FactoryGirl.create(:user) }
 
-  let!(:page)      { FactoryGirl.create :content_page }
-  let!(:task_plan) { FactoryGirl.build(:tasks_task_plan,
-                                       owner: course,
-                                       assistant: get_assistant(course: course,
-                                                                task_plan_type: 'reading'),
-                                       settings: { page_ids: [page.id.to_s] },
-                                       type: 'reading',
-                                       num_tasking_plans: 0) }
   let!(:tasking_plan) { FactoryGirl.create :tasks_tasking_plan,
                                            task_plan: task_plan,
                                            target: period.to_model,
@@ -27,8 +19,17 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
                                                   owner: course,
                                                   assistant: get_assistant(course: course,
                                                                            task_plan_type: 'reading'),
-                                                  settings: { page_ids: [page.id.to_s] },
                                                   published_at: Time.now) }
+  let!(:ecosystem) { published_task_plan.ecosystem }
+  let!(:page)      { ecosystem.pages.first }
+  let!(:task_plan) { FactoryGirl.build(:tasks_task_plan,
+                                       owner: course,
+                                       assistant: get_assistant(course: course,
+                                                                task_plan_type: 'reading'),
+                                       content_ecosystem_id: ecosystem.id,
+                                       settings: { page_ids: [page.id.to_s] },
+                                       type: 'reading',
+                                       num_tasking_plans: 0) }
 
   let!(:unaffiliated_teacher) { FactoryGirl.create(:user) }
 

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -60,6 +60,7 @@ describe CalculateTaskStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
       task_plan = FactoryGirl.create(
         :tasks_task_plan,
         owner: course,
+        ecosystem: page.ecosystem,
         settings: { 'page_ids' => [page.id.to_s] },
         assistant: get_assistant(course: course, task_plan_type: 'reading')
       )

--- a/spec/routines/get_history_spec.rb
+++ b/spec/routines/get_history_spec.rb
@@ -5,7 +5,7 @@ describe GetHistory, type: :routine do
     DatabaseCleaner.start
 
     homework_assistant = FactoryGirl.create(
-          :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
+      :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
     )
 
     period = FactoryGirl.create :course_membership_period
@@ -23,6 +23,7 @@ describe GetHistory, type: :routine do
       :tasked_task_plan, owner: course,
                          type: 'homework',
                          assistant: homework_assistant,
+                         ecosystem: pages_1.first.ecosystem,
                          settings: { 'exercise_ids' => homework_exercises_1.map{ |ex| ex.id.to_s },
                                      'exercises_count_dynamic' => 2 }
     )
@@ -35,6 +36,7 @@ describe GetHistory, type: :routine do
       :tasked_task_plan, owner: course,
                          type: 'homework',
                          assistant: homework_assistant,
+                         ecosystem: pages_2.first.ecosystem,
                          settings: { 'exercise_ids' => homework_exercises_2.map{ |ex| ex.id.to_s },
                                      'exercises_count_dynamic' => 3 }
     )
@@ -47,6 +49,7 @@ describe GetHistory, type: :routine do
       :tasked_task_plan, owner: course,
                          type: 'homework',
                          assistant: homework_assistant,
+                         ecosystem: pages_3.first.ecosystem,
                          settings: { 'exercise_ids' => homework_exercises_3.map{ |ex| ex.id.to_s },
                                      'exercises_count_dynamic' => 4 }
     )

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -26,7 +26,7 @@ class SetupPerformanceReportData
     end
 
     # Exclude introduction pages b/c they don't have LOs
-    page_ids = Content::Models::Page.where{title != "Introduction"}.map(&:id)
+    page_ids = ecosystem.pages.select{ |page| page.title != "Introduction" }.map(&:id)
 
     reading_taskplan = Tasks::Models::TaskPlan.new(
       title: 'Reading task plan',
@@ -52,7 +52,7 @@ class SetupPerformanceReportData
       assistant: homework_assistant,
       content_ecosystem_id: ecosystem.id,
       settings: {
-        exercise_ids: Content::Models::Exercise.first(5).collect(&:id).map(&:to_s),
+        exercise_ids: ecosystem.exercises.first(5).collect(&:id).map(&:to_s),
         exercises_count_dynamic: 2
       }
     )
@@ -72,7 +72,7 @@ class SetupPerformanceReportData
       assistant: homework_assistant,
       content_ecosystem_id: ecosystem.id,
       settings: {
-        exercise_ids: Content::Models::Exercise.last(2).collect(&:id).map(&:to_s),
+        exercise_ids: ecosystem.exercises.last(2).collect(&:id).map(&:to_s),
         exercises_count_dynamic: 2
       }
     )
@@ -92,7 +92,7 @@ class SetupPerformanceReportData
       assistant: homework_assistant,
       content_ecosystem_id: ecosystem.id,
       settings: {
-        exercise_ids: Content::Models::Exercise.first(5).collect(&:id).map(&:to_s),
+        exercise_ids: ecosystem.exercises.first(5).collect(&:id).map(&:to_s),
         exercises_count_dynamic: 2
       }
     )


### PR DESCRIPTION
- TaskPlans now fail to validate if all page_ids and exercise_ids don't belong to the TaskPlan's ecosystem
- TaskPlans now fail to validate if there are no page_ids (reading) or exercise_ids (homework)
- Specs