### PR TITLE
Don't redirect to accounts on logout if stubbed

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -45,9 +45,9 @@ class AuthController < ApplicationController
     sign_out!
     unless stubbed_auth?
       redirect_to OpenStax::Utilities.generate_url(
-            OpenStax::Accounts.configuration.openstax_accounts_url,
-            "logout", parent: params[:parent]
-          )
+                    OpenStax::Accounts.configuration.openstax_accounts_url,
+                    "logout", parent: params[:parent]
+                  )
     end
   end
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -43,11 +43,12 @@ class AuthController < ApplicationController
 
   def logout
     sign_out!
-    redirect_to stubbed_auth? ? authenticate_via_popup_url :
-                  OpenStax::Utilities.generate_url(
-                    OpenStax::Accounts.configuration.openstax_accounts_url,
-                    "logout", parent: params[:parent]
-                  )
+    unless stubbed_auth?
+      redirect_to OpenStax::Utilities.generate_url(
+            OpenStax::Accounts.configuration.openstax_accounts_url,
+            "logout", parent: params[:parent]
+          )
+    end
   end
 
   private

--- a/app/views/auth/logout.html.erb
+++ b/app/views/auth/logout.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+    <script>
+      window.parent.postMessage( JSON.stringify({'data': {'logoutComplete': true}}), '<%= params[:parent] %>' );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
I missed the stubbed accounts scenario earlier.  In that case Tutor just needs to logout and relay the logout message.