### PR TITLE
Add throttled endpoint for FE logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,6 +160,9 @@ gem 'render_anywhere', :require => false
 # Add P3P headers for IE
 gem 'p3p'
 
+# API throttling
+gem 'rack-attack'
+
 group :development, :test do
   # Get env variables from .env file
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,6 +475,8 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
+    rack-attack (4.3.1)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     railroady (1.3.0)
@@ -760,6 +762,7 @@ DEPENDENCIES
   pry-rails
   pry-stack_explorer
   quiet_assets
+  rack-attack
   railroady
   rails (= 4.2.4)
   rails-erd

--- a/app/controllers/api/v1/log_controller.rb
+++ b/app/controllers/api/v1/log_controller.rb
@@ -43,7 +43,7 @@ class Api::V1::LogController < Api::V1::ApiController
     else
       message = entry_params.message[0..MAX_LOG_LENGTH]
 
-      Rails.logger.log(level, message)
+      Rails.logger.log(level, "(ext) #{message}")
       head :created
     end
   end

--- a/app/controllers/api/v1/log_controller.rb
+++ b/app/controllers/api/v1/log_controller.rb
@@ -1,0 +1,51 @@
+class Api::V1::LogController < Api::V1::ApiController
+
+  LOG_LEVELS = {
+    "unknown" => Logger::UNKNOWN,
+    "fatal" => Logger::FATAL,
+    "error" => Logger::ERROR,
+    "warn" => Logger::WARN,
+    "info" => Logger::INFO,
+    "debug" => Logger::DEBUG
+  }
+
+  MAX_LOG_LENGTH = 1000
+
+  resource_description do
+    api_versions "v1"
+    short_description 'Log entries'
+    description <<-EOS
+      TBD
+    EOS
+  end
+
+  api :POST, '/log/entry', 'Submit a log message'
+  description <<-EOS
+    #{json_schema(Api::V1::LogEntryRepresenter, include: :writeable)}
+  EOS
+  def entry
+    entry_params = OpenStruct.new
+    consume!(entry_params, represent_with: Api::V1::LogEntryRepresenter)
+
+    errors = []
+
+    if entry_params.level.blank?
+      errors.push(:level_missing)
+    else
+      level = LOG_LEVELS[entry_params.level.try(:downcase)]
+      errors.push(:bad_level) if level.nil?
+    end
+
+    errors.push(:message_missing) if entry_params.message.blank?
+
+    if errors.any?
+      render_api_errors(errors)
+    else
+      message = entry_params.message[0..MAX_LOG_LENGTH]
+
+      Rails.logger.log(level, message)
+      head :created
+    end
+  end
+
+end

--- a/app/representers/api/v1/log_entry_representer.rb
+++ b/app/representers/api/v1/log_entry_representer.rb
@@ -1,0 +1,18 @@
+module Api::V1
+  class LogEntryRepresenter < Roar::Decorator
+
+    include Roar::JSON
+
+    property :level,
+             type: String,
+             readable: false,
+             writeable: true,
+             schema_info: { required: true }
+
+    property :message,
+             type: String,
+             readable: false,
+             writeable: true,
+             schema_info: { required: true }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,17 @@ module Tutor
       g.assets false
       g.view_specs false
     end
+
+    # rack-attack for throttling
+    Rack::Attack.cache.store = ActiveSupport::Cache::RedisStore.new(
+      url: redis_secrets['url'],
+      expires_in: 2.days
+    )
+
+    config.middleware.use Rack::Attack
+
+    config.after_initialize do
+      require 'rack-attack-settings'
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,11 @@ Rails.application.routes.draw do
     resources :enrollment_changes, only: :create do
       put 'approve', on: :member
     end
+
+    namespace 'log' do
+      post :entry
+    end
+
   end
 
   namespace 'admin' do

--- a/lib/rack-attack-settings.rb
+++ b/lib/rack-attack-settings.rb
@@ -1,0 +1,55 @@
+# Set up rack-attack settings
+
+class Rack::Attack
+
+  def self.routes
+    if @routes.nil?
+      Rails.application.reload_routes!
+      @routes = UrlGenerator.new
+    end
+    @routes
+  end
+
+  throttle(routes.api_log_entry_path, limit: 50, period: 1.day) do |req|
+    req.ip if req.path.starts_with?(routes.api_log_entry_path) && req.post?
+  end
+
+end
+
+# Monkey-patch the rack-attack Request object (this is where the author says to do this)
+
+class Rack::Attack::Request
+
+  def throttled?
+    env['rack.attack.match_type'] == :throttle
+  end
+
+  def is_first_one_throttled?
+    throttled? && match_data[:count] == match_data[:limit] + 1
+  end
+
+  def matched_path
+    env['rack.attack.matched']
+  end
+
+  def period
+    match_data[:period]
+  end
+
+  def log_throttled!
+    Rails.logger.info "Throttled #{ip} on #{matched_path}. Throttling continues (without further " \
+                      "logging) until the next #{period} second interval."
+  end
+
+  protected
+
+  def match_data
+    @match_data ||= env['rack.attack.match_data']
+  end
+end
+
+# Log events
+
+ActiveSupport::Notifications.subscribe("rack.attack") do |name, start, finish, request_id, req|
+  req.log_throttled! if req.is_first_one_throttled?
+end

--- a/spec/controllers/api/v1/log_controller_spec.rb
+++ b/spec/controllers/api/v1/log_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Api::V1::LogController, type: :controller, api: true, version: :v1 do
+
+  describe "#entry" do
+
+    it 'requires a level' do
+      expect(Rails.logger).not_to receive(:log)
+      log(message: 'hi')
+      expect(response.body_as_hash).to eq({status: 422, errors: [code: "level_missing"]})
+    end
+
+    it 'requires a valid level' do
+      expect(Rails.logger).not_to receive(:log)
+      log(level: 'blah', message: 'hi')
+      expect(response.body_as_hash).to eq({status: 422, errors: [code: "bad_level"]})
+    end
+
+
+    it 'requires a message' do
+      expect(Rails.logger).not_to receive(:log)
+      log(level: 'info', message: '')
+      expect(response.body_as_hash).to eq({status: 422, errors: [code: "message_missing"]})
+    end
+
+    described_class::LOG_LEVELS.each do |string, enum|
+      it "logs #{string}" do
+        expect(Rails.logger).to receive(:log).with(enum, 'hi')
+        log(level: string, message: 'hi')
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    it 'does not care about level case' do
+      expect(Rails.logger).to receive(:log).with(Logger::INFO, 'hi')
+      log(level: 'InFO', message: 'hi')
+      expect(response).to have_http_status(:created)
+    end
+
+  end
+
+  def log(options)
+    api_post :entry, nil, raw_post_data: options.to_json
+  end
+
+end

--- a/spec/controllers/api/v1/log_controller_spec.rb
+++ b/spec/controllers/api/v1/log_controller_spec.rb
@@ -25,14 +25,14 @@ describe Api::V1::LogController, type: :controller, api: true, version: :v1 do
 
     described_class::LOG_LEVELS.each do |string, enum|
       it "logs #{string}" do
-        expect(Rails.logger).to receive(:log).with(enum, 'hi')
+        expect(Rails.logger).to receive(:log).with(enum, '(ext) hi')
         log(level: string, message: 'hi')
         expect(response).to have_http_status(:created)
       end
     end
 
     it 'does not care about level case' do
-      expect(Rails.logger).to receive(:log).with(Logger::INFO, 'hi')
+      expect(Rails.logger).to receive(:log).with(Logger::INFO, '(ext) hi')
       log(level: 'InFO', message: 'hi')
       expect(response).to have_http_status(:created)
     end

--- a/spec/requests/throttling_spec.rb
+++ b/spec/requests/throttling_spec.rb
@@ -10,23 +10,23 @@ describe "Throttles", type: :request, version: :v1 do
 
       # Allowed
       limit.times do
-        api_post '/api/log/entry', nil, "REMOTE_ADDR" => "1.2.3.4"
+        api_post '/api/log/entry', nil
         expect(response).to_not have_http_status(429)
       end
 
       # First to pass the limit
       expect_any_instance_of(Rack::Attack::Request).to receive(:log_throttled!).once
-      api_post '/api/log/entry', nil, "REMOTE_ADDR" => "1.2.3.4"
+      api_post '/api/log/entry', nil
       expect(response).to have_http_status(429)
 
       # Second to pass the limit
-      api_post '/api/log/entry', nil, "REMOTE_ADDR" => "1.2.3.4"
+      api_post '/api/log/entry', nil
       expect(response).to have_http_status(429)
 
       allow_any_instance_of(Rack::Attack::Request).to receive(:ip).and_return("4.3.2.1")
 
       # Different IP OK
-      api_post '/api/log/entry', nil, "REMOTE_ADDR" => "4.3.2.1"
+      api_post '/api/log/entry', nil
       expect(response).to_not have_http_status(429)
     end
   end

--- a/spec/requests/throttling_spec.rb
+++ b/spec/requests/throttling_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "Throttles", type: :request, version: :v1 do
+
+  describe '/api/log/entry' do
+    let!(:limit) { 50 }
+
+    it 'allows requests under the limit, throttles at limit, and logs only once, all based on IP' do
+      allow_any_instance_of(Rack::Attack::Request).to receive(:ip).and_return("1.2.3.4")
+
+      # Allowed
+      limit.times do
+        api_post '/api/log/entry', nil, "REMOTE_ADDR" => "1.2.3.4"
+        expect(response).to_not have_http_status(429)
+      end
+
+      # First to pass the limit
+      expect_any_instance_of(Rack::Attack::Request).to receive(:log_throttled!).once
+      api_post '/api/log/entry', nil, "REMOTE_ADDR" => "1.2.3.4"
+      expect(response).to have_http_status(429)
+
+      # Second to pass the limit
+      api_post '/api/log/entry', nil, "REMOTE_ADDR" => "1.2.3.4"
+      expect(response).to have_http_status(429)
+
+      allow_any_instance_of(Rack::Attack::Request).to receive(:ip).and_return("4.3.2.1")
+
+      # Different IP OK
+      api_post '/api/log/entry', nil, "REMOTE_ADDR" => "4.3.2.1"
+      expect(response).to_not have_http_status(429)
+    end
+  end
+
+end


### PR DESCRIPTION
Adds an endpoint that the FE can use to submit log messages to the server. 

```
POST /api/log/entry

{
  level: "info",
  message: "tutor-js wishes tutor-server a Merry Christmas"
}
```

Both `level` and `message` are required.  

`level` can be one of `"unknown"`,  `"fatal"`, `"error"`, `"warn"`, `"info"`, or `"debug"` -- these match the default Rails logging levels.  By default, `"debug"` is not logged in production environments.  The `level` field is case insensitive.

`message` is restricted to 1000 characters; messages beyond that length are truncated.

This endpoint is throttled to 50 requests per day per IP.

cc @nathanstitt since we were recently talking about a situation where FE logging to the server would have been handy and since we also talked about another potential use for throttling.