### PR TITLE
Create performance report export with valid worksheet names

### DIFF
--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -32,9 +32,16 @@ module Tasks
         end
       end
 
+      def worksheet_name(name)
+        # worksheet names cannot be longer than 31 characters
+        name = name[0..30]
+        # worksheet names cannot contain characters :\/?*[]
+        name.gsub(/[:\\\/\[\]*?]/, '-')
+      end
+
       def create_data_worksheets(performance_report, package)
         performance_report.each do |report|
-          package.workbook.add_worksheet(name: report[:period][:name]) do |sheet|
+          package.workbook.add_worksheet(name: worksheet_name(report[:period][:name])) do |sheet|
             bold = sheet.styles.add_style b: true
             italic = sheet.styles.add_style i: true
             pct = sheet.styles.add_style num_fmt: Axlsx::NUM_FMT_PERCENT

--- a/spec/controllers/api/v1/performance_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/performance_reports_controller_spec.rb
@@ -479,6 +479,18 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
         api_post :export, teacher_token, parameters: { id: course.id }
         expect(response.body_as_hash[:job]).to match(%r{/jobs/[a-f0-9-]+})
       end
+
+      it 'does not blow up when the period name is more than 31 characters' do
+        period.to_model.update_attributes(name: 'a' * 50)
+        api_post :export, teacher_token, parameters: { id: course.id }
+        expect(response.status).to eq(202)
+      end
+
+      it 'does not blow up when the period name has invalid worksheet characters' do
+        period.to_model.update_attributes(name: '[p: 1 \/ 2? *]')
+        api_post :export, teacher_token, parameters: { id: course.id }
+        expect(response.status).to eq(202)
+      end
     end
 
     context 'failure' do


### PR DESCRIPTION
Valid characters for Excel sheet names:

 - does not exceed 31 characters
 - does not contain : \ / ? * [ ]