### PR TITLE
Make sure the cnx base url ends with a slash

### DIFF
--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -22,6 +22,7 @@ module OpenStax::Cnx::V1
   # tho may be SSL. An explicit SSL URL can be passed in `ssl`, or
   # by default the SSL URL will be guessed from the URL.
   def self.set_archive_url_base(url: nil, ssl: nil)
+    url = url.ends_with?('/') ? url : "#{url}/" unless url.nil?
     uri = Addressable::URI.parse(url || ssl)
     uri.scheme = 'http'
     @archive_url_base = uri.to_s

--- a/spec/lib/openstax/cnx/v1_spec.rb
+++ b/spec/lib/openstax/cnx/v1_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe OpenStax::Cnx::V1, :type => :external, :vcr => VCR_OPTS do
 
     expect(OpenStax::Cnx::V1.url_for('/resources/image.jpg')).to(
       eq('https://archive-staging-tutor.cnx.org/resources/image.jpg'))
+
+    OpenStax::Cnx::V1.with_archive_url(url: 'https://archive.cnx.org/contents') do
+      expect(OpenStax::Cnx::V1.url_for('module_id@version')).to(
+        eq('https://archive.cnx.org/contents/module_id@version'))
+    end
+
+    OpenStax::Cnx::V1.with_archive_url(url: 'https://archive.cnx.org/contents/') do
+      expect(OpenStax::Cnx::V1.url_for('module_id@version')).to(
+        eq('https://archive.cnx.org/contents/module_id@version'))
+    end
   end
 
   it "can fetch collections and modules from CNX" do


### PR DESCRIPTION
If the base url doesn't end with a slash,
`Addressable::URI.join('http://cnx.org/contents', 'id@version')` returns
`'http://cnx.org/id@version'`.