### PR TITLE
[bugfix] Don't extract url if it's a fragment identifier 

### DIFF
--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -36,7 +36,7 @@ module OpenStax::Cnx::V1::Fragment
 
       # No source attribute found, so try href
       original_url = url_node.try(:[], 'href')
-      return nil if original_url.nil?
+      return nil if original_url.nil? || original_url =~ /^#/
 
       # This is an anchor, which Page does not convert to https, so redo the conversion here
       uri = Addressable::URI.parse(original_url)


### PR DESCRIPTION
Fixes bug when links in content were only a fragment identifier

   `Absolute URI missing hierarchical segment: 'https:#Figure_19_02_Const_volt'`