### PR TITLE
Removed the http status code based on job status from `api/jobs#show`

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -28,21 +28,6 @@ class Api::V1::JobsController < Api::V1::ApiController
   def show
     job = Lev::BackgroundJob.find(params[:id])
     OSU::AccessPolicy.require_action_allowed!(:read, current_api_user, job)
-    code = http_status_code(job.status)
-    respond_with job, represent_with: Api::V1::JobRepresenter, status: code
-  end
-
-  private
-  def http_status_code(status)
-    case status
-    when Lev::BackgroundJob::STATE_SUCCEEDED
-      200
-    when Lev::BackgroundJob::STATE_FAILED
-      500
-    when Lev::BackgroundJob::STATE_KILLED || Lev::BackgroundJob::STATE_UNKNOWN
-      404
-    else
-      202
-    end
+    respond_with job, represent_with: Api::V1::JobRepresenter
   end
 end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
 
     it 'returns the status of queued jobs' do
       api_get :show, user_token, parameters: { id: job_id }
-      expect(response).to have_http_status(202)
+      expect(response).to have_http_status :success
       expect(response.body_as_hash).to include({ status: 'queued' })
     end
 
@@ -67,7 +67,7 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
       it 'returns the status of succeeded jobs' do
         api_get :show, user_token, parameters: { id: job_id }
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status :success
         expect(response.body_as_hash).to include({ status: 'succeeded' })
       end
 


### PR DESCRIPTION
This fixes the chain 500 errors in the teacher dashboard.