### PR TITLE
Change research export excel file dates to strings in iso8601 format

### DIFF
--- a/lib/export_data.rb
+++ b/lib/export_data.rb
@@ -106,10 +106,10 @@ class ExportData
           step.number,
           type,
           step.group_name,
-          [step.first_completed_at, style: date],
-          [step.last_completed_at, style: date],
-          [step.task.opens_at, style: date],
-          [step.task.due_at, style: date],
+          [step.first_completed_at.try(:iso8601)],
+          [step.last_completed_at.try(:iso8601)],
+          [step.task.opens_at.try(:iso8601)],
+          [step.task.due_at.try(:iso8601)],
           url
         ]
 

--- a/spec/lib/export_data_spec.rb
+++ b/spec/lib/export_data_spec.rb
@@ -77,14 +77,10 @@ RSpec.describe ExportData do
       expect(data['Step ID']).to eq(step.id)
       expect(data['Step Type']).to eq('Reading')
       expect(data['Group']).to eq(step.group_name)
-      expect(data['First Completed At'].beginning_of_minute).to eq(
-        step.first_completed_at.beginning_of_minute)
-      expect(data['Last Completed At'].beginning_of_minute).to eq(
-        step.last_completed_at.beginning_of_minute)
-      expect(data['Opens At'].beginning_of_minute).to eq(
-        step.task.opens_at.beginning_of_minute)
-      expect(data['Due At'].beginning_of_minute).to eq(
-        step.task.due_at.beginning_of_minute)
+      expect(data['First Completed At']).to eq(step.first_completed_at.iso8601)
+      expect(data['Last Completed At']).to eq(step.last_completed_at.iso8601)
+      expect(data['Opens At']).to eq(step.task.opens_at.iso8601)
+      expect(data['Due At']).to eq(step.task.due_at.iso8601)
       expect(data['URL']).to eq(step.tasked.url)
       expect(data['Correct Answer ID']).to eq(nil)
       expect(data['Answer ID']).to eq(nil)


### PR DESCRIPTION
The dates now look like this: "2016-01-22T20:03:34Z".

The failed test:

```
$ TZ=America/Chicago rspec spec/lib/export_data_spec.rb
100 / 108
F

Failures:

  1) ExportData with book exports data as a xlsx file
     Failure/Error: expect(data['First Completed At'].beginning_of_minute).to eq(

       expected: 2016-01-22 17:23:00.000000000 +0000
            got: 2016-01-22 11:23:00.000000000 +0000

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -Fri, 22 Jan 2016 17:23:00 UTC +00:00
       +2016-01-22 11:23:00 UTC

     # ./spec/lib/export_data_spec.rb:80:in `block (3 levels) in <top (required)>'

Finished in 31.97 seconds (files took 5.9 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/export_data_spec.rb:62 # ExportData with book exports data as a xlsx file

Coverage report generated for RSpec to /home/karen/tutor-server/coverage. 3318 / 4371 LOC (75.91%) covered.
[Coveralls] Outside the CI environment, not sending data.
```

The reason for this is that the time is converted to the local / system
timezone in excel, but when it was read back out, the timezone was set to UTC.

This commit changes the date exported to a string so excel doesn't parse
it.