### PR TITLE
Add route to change the student_identifier

### DIFF
--- a/app/representers/api/v1/student_self_update_representer.rb
+++ b/app/representers/api/v1/student_self_update_representer.rb
@@ -1,0 +1,16 @@
+module Api::V1
+  class StudentSelfUpdateRepresenter < Roar::Decorator
+
+    include Roar::JSON
+    include Representable::Coercion
+
+    property :student_identifier,
+             type: String,
+             writeable: true,
+             readable: true,
+             schema_info: {
+               required: true
+             }
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
 
 
     get 'user/courses', to: 'courses#index', as: :courses
+    patch 'user/courses/:course_id/student', to: 'students#update_self'
 
     resources :guides, path: 'courses', only: [] do
       member do

--- a/spec/representers/api/v1/student_self_update_representer_spec.rb
+++ b/spec/representers/api/v1/student_self_update_representer_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::StudentSelfUpdateRepresenter, type: :representer do
+  let!(:student) {
+    instance_spy(CourseMembership::Models::Student).tap do |dbl|
+      ## bug work-around, see:
+      ##   https://github.com/rspec/rspec-rails/issues/1309#issuecomment-118971828
+      allow(dbl).to receive(:as_json).and_return(dbl)
+    end
+  }
+
+  let(:representation) { ## NOTE: This is lazily-evaluated on purpose!
+    described_class.new(student).as_json
+  }
+
+  context "student_identifier" do
+    it "can be read" do
+      allow(student).to receive(:student_identifier).and_return("Student ID")
+      expect(representation).to include("student_identifier" => "Student ID")
+    end
+
+    it "can be written" do
+      described_class.new(student).from_json({"student_identifier" => "New Student ID"}.to_json)
+      expect(student).to have_received(:student_identifier=).with("New Student ID")
+    end
+  end
+end

--- a/spec/routing/api/v1/students_controller_routing_spec.rb
+++ b/spec/routing/api/v1/students_controller_routing_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe Api::V1::StudentsController, type: :routing, api: true, version: :v1 do
+
+  describe 'PATCH /api/user/courses/:course_id/student' do
+    it 'routes to #update_self' do
+      expect(patch '/api/user/courses/42/student').to route_to('api/v1/students#update_self',
+                                                               format: 'json', course_id: '42')
+    end
+  end
+
+  describe 'PATCH /api/students/:student_id' do
+    it 'routes to #update' do
+      expect(patch '/api/students/42').to route_to('api/v1/students#update',
+                                                   format: 'json', id: '42')
+    end
+  end
+
+  describe 'DELETE /api/students/:student_id' do
+    it 'routes to #destroy' do
+      expect(delete '/api/students/42').to route_to('api/v1/students#destroy',
+                                                    format: 'json', id: '42')
+    end
+  end
+
+  describe 'PUT /api/students/:student_id/undrop' do
+    it 'routes to #undrop' do
+      expect(put '/api/students/42/undrop').to route_to('api/v1/students#undrop',
+                                                        format: 'json', id: '42')
+    end
+  end
+
+end


### PR DESCRIPTION
- Added `PATCH /api/user/courses/:course_id/student` route - expects a JSON body with:
```json
{
  "student_identifier": "new identifier"
}
```
- Specs