### PR TITLE
Update Mathjax to version 2.6

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -4,7 +4,7 @@
   <title>OpenStax Tutor</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel='stylesheet' href='<%= Rails.application.secrets[:css_url] %>' />
-  <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
+  <script src="//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='<%= Rails.application.secrets[:js_url] %>' async></script>
   <%= csrf_meta_tags %>
   <%= render 'webview/google_analytics' %>


### PR DESCRIPTION
Version 2.5 has a bug with the latest Chrome.  It leaves a slim grey line at the end of each rendered block.

### With version 2.5:
![screen shot 2016-02-15 at 11 23 59 am](https://cloud.githubusercontent.com/assets/79566/13055772/dfe7ee94-d3d6-11e5-86bb-a2e6639adea0.png)

### After update to 2.6:
![screen shot 2016-02-15 at 11 25 34 am](https://cloud.githubusercontent.com/assets/79566/13055789/ef8c8896-d3d6-11e5-81af-f5eb384d8543.png)
