### PR TITLE
Include all tags with exercises

### DIFF
--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -32,6 +32,7 @@ module Api::V1
                readable: true,
                writeable: false,
                decorator: TagRepresenter,
+               getter: ->(*) { (tags + tags.flat_map(&:teks_tags)).uniq },
                schema_info: { required: true,
                               description: 'Tags for this exercise' }
 

--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -31,9 +31,6 @@ module Api::V1
     collection :tags,
                readable: true,
                writeable: false,
-               getter: ->(*) {
-                 (tags + tags.flat_map(&:teks_tags)).select{ |tag| tag.visible? }.uniq
-               },
                decorator: TagRepresenter,
                schema_info: { required: true,
                               description: 'Tags for this exercise' }

--- a/app/representers/api/v1/tag_representer.rb
+++ b/app/representers/api/v1/tag_representer.rb
@@ -36,6 +36,12 @@ module Api::V1
                description: 'The chapter and section in the book, e.g. [5, 2]'
              }
 
+    property :is_visible,
+             type: 'boolean',
+             getter: ->(*){ visible? },
+             readable: true,
+             writeable: false
+
     property :data,
              type: String,
              readable: true,

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -44,12 +44,19 @@ RSpec.describe Api::V1::ExerciseRepresenter, type: :representer do
           'type' => 'lo',
           'description' => 'Describe Newton\'s first law and friction',
           'chapter_section' => [4,2],
-        },
-        {
+          'is_visible' => true
+        }, {
+          "id"=>"ost-tag-lo-k12phys-ch04-s02-lo02",
+          "type"=>"lo",
+          "name"=>"Learning Objective 2",
+          "chapter_section"=>[4, 2],
+          "is_visible"=>false
+        }, {
           'id' => 'ost-tag-teks-112-39-c-4d',
           'type' => 'teks',
           'name' => '(D)',
           'description' => 'calculate the effect of forces on objects',
+          'is_visible' => true,
           'data' => '4d'
         }
       )

--- a/spec/representers/api/v1/tag_representer_spec.rb
+++ b/spec/representers/api/v1/tag_representer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Api::V1::TagRepresenter, type: :representer do
     expect(representation).to eq(
       'id' => 'k12phys-ch04-s02-lo02',
       'description' => 'Discuss the relationship between mass and inertia',
+      'is_visible' => true,
       'type' => 'lo',
       'chapter_section' => [4,2]
     )
@@ -43,6 +44,7 @@ RSpec.describe Api::V1::TagRepresenter, type: :representer do
       'id' => 'ost-tag-teks-112-39-c-4d',
       'name' => '(D)',
       'description' => 'calculate the effect of forces on objects',
+      'is_visible' => true,
       'type' => 'teks',
       'data' => '4d'
     )
@@ -54,14 +56,16 @@ RSpec.describe Api::V1::TagRepresenter, type: :representer do
       'id' => generic_tag.value,
       'name' => generic_tag.name,
       'description' => generic_tag.description,
-      'type' => 'generic',
+      'is_visible' => false,
+      'type' => 'generic'
     )
   end
 
   it 'shows the default name for dok tags' do
     representation = Api::V1::TagRepresenter.new(dok_tag).as_json
     expect(representation).to include(
-      'name' => 'DOK: 1'
+      'name' => 'DOK: 1',
+      'is_visible' => true
     )
   end
 


### PR DESCRIPTION
Indicate which ones should be normally displayed via a new 'is_visible' property

Needs to be merged & deployed along with FE PR https://github.com/openstax/tutor-js/pull/990, otherwise teachers will see all tags on the HW builder.