### PR TITLE
Background job changes

### DIFF
--- a/app/controllers/manager/job_actions.rb
+++ b/app/controllers/manager/job_actions.rb
@@ -13,7 +13,7 @@ module Manager::JobActions
 
   def show
     @job = Jobba.find(params[:id])
-    @custom_fields = @job.data
+    @custom_fields = @job.data || {}
     render 'manager/jobs/show'
   end
 end

--- a/app/views/manager/jobs/index.html.erb
+++ b/app/views/manager/jobs/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_header = "Queued jobs" %>
+<% @page_header = "Jobs" %>
 
 <div class='row'>
   <div class='col-xs-7'>

--- a/app/views/manager/jobs/show.html.erb
+++ b/app/views/manager/jobs/show.html.erb
@@ -3,14 +3,27 @@
 <table class="table table-striped">
   <thead>
     <tr>
+      <th>Name</th>
+      <th>Args</th>
       <th>Progress</th>
       <th>Errors</th>
+      <% if @job.attempt > 0 %>
+        <th>Prior Attempts</th>
+      <% end %>
       <th>Custom</th>
     </tr>
   </thead>
 
   <tbody>
     <tr>
+     <td class='job_name'>
+       <%= @job.job_name %>
+     </td>
+
+      <td class='job_args'>
+        <%= @job.job_args %>
+      </td>
+
       <td class='job_progress'>
         <%= number_to_percentage(@job.progress * 100, precision: 0) %>
       </td>
@@ -21,6 +34,14 @@
         <% end %>
       </td>
 
+      <% if @job.attempt > 0 %>
+        <td class='job_attempts'>
+          <% @job.prior_attempts.each do |job| %>
+            <p>Attempt <%= job.attempt + 1 %> - <%= job.state.name %></p>
+          <% end %>
+        </td>
+      <% end %>
+
       <td class='job_custom'>
         <% @custom_fields.each do |key, value| %>
           <p class='job_<%= key %>'>
@@ -29,6 +50,34 @@
           </p>
         <% end %>
       </td>
+    </tr>
+  </tbody>
+</table>
+
+<br />
+<br />
+<br />
+<br />
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Recorded At</th>
+      <th>Queued At</th>
+      <th>Started At</th>
+      <th>Succeeded At</th>
+      <th>Failed At</th>
+      <th>Killed At</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><%= @job.recorded_at %></td>
+      <td><%= @job.queued_at %></td>
+      <td><%= @job.started_at %></td>
+      <td><%= @job.succeeded_at %></td>
+      <td><%= @job.failed_at %></td>
+      <td><%= @job.killed_at %></td>
     </tr>
   </tbody>
 </table>

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Administration of queued jobs', :js do
   let(:user) { FactoryGirl.create(:user) }
   let(:role) { AddUserAsCourseTeacher[course: course, user: user] }
 
-  let(:status) { Jobba.all.to_a.last }
+  let(:status) { Jobba.find(@job_id) }
 
   before(:all) do
     Jobba.all.to_a.each { |status| status.delete! }
@@ -21,7 +21,7 @@ RSpec.feature 'Administration of queued jobs', :js do
 
   before(:each) do
     stub_current_user(admin)
-    Tasks::ExportPerformanceReport.perform_later(course: course, role: role)
+    @job_id = Tasks::ExportPerformanceReport.perform_later(course: course, role: role)
   end
 
   after(:each) do

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -48,8 +48,11 @@ RSpec.feature 'Administration of queued jobs', :js do
 
     # set the job as completed and refresh the page
     status.succeeded!
+    status.set_job_name('Export performance report')
     visit admin_job_path(status.id)
 
+    expect(page).to have_css('.job_name', text: 'Export performance report')
+    expect(page).to have_css('.job_args', text: '{}')
     expect(page).to have_css('.job_progress', text: '100%')
     expect(page).to have_css('.job_errors', text: '')
     expect(page).to have_css('.job_custom', text: '')

--- a/spec/features/admin/queued_jobs_spec.rb
+++ b/spec/features/admin/queued_jobs_spec.rb
@@ -41,6 +41,20 @@ RSpec.feature 'Administration of queued jobs', :js do
     expect(page).to have_css('.job_progress', text: '50%')
   end
 
+  scenario 'Viewing a job without any custom data' do
+    visit admin_jobs_path
+    click_link status.id
+    expect(current_path).to eq(admin_job_path(status.id))
+
+    # set the job as completed and refresh the page
+    status.succeeded!
+    visit admin_job_path(status.id)
+
+    expect(page).to have_css('.job_progress', text: '100%')
+    expect(page).to have_css('.job_errors', text: '')
+    expect(page).to have_css('.job_custom', text: '')
+  end
+
   scenario 'Getting more details about a job' do
     error = Lev::Error.new(code: 'bad', message: 'awful')
     status.add_error(error)


### PR DESCRIPTION
- Fix 500 error when viewing background job without custom data

  The error was:

  ```
Failure/Error: Unable to find matching line from backtrace
NoMethodError:
  undefined method `each' for nil:NilClass
  # ./app/views/manager/jobs/show.html.erb:25:in `_app_views_manager_jobs_show_html_erb__1808779094055715127_97159720'
  ```

- Rename jobs index page from "Queued jobs" to "Jobs"

    It is confusing because "queued" is a state that not all of the jobs are
    in.

- Change admin jobs feature specs to look up jobs by id …

  `Jobba.all.to_a.last` was not always returning the job we expected (the
  job that was most recently created).

- Show more information on admin background jobs page