### PR TITLE
More improvements for old jobs

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -27,6 +27,7 @@ class Api::V1::JobsController < Api::V1::ApiController
   EOS
   def show
     job = Jobba.find(params[:id])
+    return render_api_errors(:job_not_found, :not_found) if job.nil?
     OSU::AccessPolicy.require_action_allowed!(:read, current_api_user, job)
     respond_with job, represent_with: Api::V1::JobRepresenter
   end

--- a/app/controllers/manager/job_actions.rb
+++ b/app/controllers/manager/job_actions.rb
@@ -13,6 +13,7 @@ module Manager::JobActions
 
   def show
     @job = Jobba.find(params[:id])
+    raise ActionController::RoutingError.new('Not Found') if @job.nil?
     @custom_fields = @job.data || {}
     render 'manager/jobs/show'
   end

--- a/app/representers/api/v1/courses/cc/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/cc/dashboard_representer.rb
@@ -4,7 +4,7 @@ module Api::V1::Courses::Cc
 
     include ::Roar::JSON
 
-    class Base < Roar::Decorator
+    class TaskBase < ::Roar::Decorator
       include Roar::JSON
       include Representable::Coercion
 
@@ -17,9 +17,7 @@ module Api::V1::Courses::Cc
                type: String,
                readable: true,
                writeable: false
-    end
 
-    class TaskBase < Base
       property :opens_at,
                type: String,
                readable: true,

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -146,7 +146,7 @@ module Api::V1::Courses
     collection :plans,
                readable: true,
                writeable: false,
-               decorator: TaskPlanRepresenter
+               decorator: ::Api::V1::TaskPlanRepresenter
 
     collection :tasks,
                readable: true,

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -4,7 +4,7 @@ module Api::V1::Courses
 
     include ::Roar::JSON
 
-    class Base < Roar::Decorator
+    class TaskBase < Roar::Decorator
       include Roar::JSON
       include Representable::Coercion
 
@@ -17,49 +17,7 @@ module Api::V1::Courses
                type: String,
                readable: true,
                writeable: false
-    end
 
-    class Plan < Base
-
-      property :is_trouble,
-               readable: true,
-               writeable: false,
-               schema_info: { type: 'boolean' }
-
-      property :type,
-               type: String,
-               readable: true,
-               writeable: false
-
-      property :is_publish_requested,
-               readable: true,
-               writeable: true,
-               schema_info: { type: 'boolean' }
-
-      property :published_at,
-               type: String,
-               readable: true,
-               writeable: false,
-               getter: ->(*) { DateTimeUtilities.to_api_s(published_at) }
-
-      property :publish_last_requested_at,
-               type: String,
-               readable: true,
-               writeable: false,
-               getter: ->(*) { DateTimeUtilities.to_api_s(publish_last_requested_at) }
-
-      property :publish_job_uuid,
-               type: String,
-               readable: true,
-               writeable: false
-
-      collection :tasking_plans,
-                 readable: true,
-                 writeable: false,
-                 decorator: Api::V1::TaskingPlanRepresenter
-    end
-
-    class TaskBase < Base
       property :opens_at,
                type: String,
                readable: true,
@@ -188,7 +146,7 @@ module Api::V1::Courses
     collection :plans,
                readable: true,
                writeable: false,
-               decorator: Plan
+               decorator: TaskPlanRepresenter
 
     collection :tasks,
                readable: true,

--- a/app/representers/api/v1/task_plan_representer.rb
+++ b/app/representers/api/v1/task_plan_representer.rb
@@ -9,6 +9,12 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :is_trouble,
+             readable: true,
+             writeable: false,
+             schema_info: { type: 'boolean' },
+             if: ->(*) { respond_to? :is_trouble }
+
     property :content_ecosystem_id,
              as: :ecosystem_id,
              type: String,
@@ -36,24 +42,25 @@ module Api::V1
              getter: ->(*) { is_publish_requested? },
              schema_info: { type: 'boolean' }
 
-
     property :publish_last_requested_at,
              type: String,
              readable: true,
              writeable: false,
              getter: ->(*) { DateTimeUtilities.to_api_s(publish_last_requested_at) }
 
-    property :publish_job_uuid,
-             type: String,
+    property :publish_job,
+             decorator: JobRepresenter,
              readable: true,
-             writeable: false
+             writeable: false,
+             getter: ->(*) { Jobba.find(publish_job_uuid) },
+             if: ->(*) { !publish_job_uuid.blank? }
 
     property :publish_job_url,
              type: String,
              readable: true,
              writeable: false,
              getter: ->(*) { "/api/jobs/#{publish_job_uuid}" },
-             if: ->(*) { !publish_job_uuid.nil? }
+             if: ->(*) { !publish_job_uuid.blank? }
 
     property :published_at,
              type: String,

--- a/spec/controllers/admin/jobs_controller_spec.rb
+++ b/spec/controllers/admin/jobs_controller_spec.rb
@@ -16,11 +16,17 @@ RSpec.describe Admin::JobsController, type: :controller do
   context "GET #show" do
     let!(:job) { Jobba.create! }
 
-    it "returns http success" do
+    it "returns http success if the job exists" do
       controller.sign_in(admin)
 
       get :show, id: job.id
       expect(response).to have_http_status(:success)
+    end
+
+    it "raises ActionController::RoutingError if the job does not exist" do
+      controller.sign_in(admin)
+
+      expect{ get :show, id: 42 }.to raise_error(ActionController::RoutingError)
     end
   end
 

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
       expect(response.body_as_hash).to include({ status: 'queued' })
     end
 
+    it 'returns 404 Not Found if the job does not exist' do
+      api_get :show, user_token, parameters: { id: 42 }
+      expect(response).to have_http_status :not_found
+      expect(response.body_as_hash).to include({ errors: [{code: 'job_not_found'}], status: 404 })
+    end
+
     context 'with inline jobs' do
       before(:each) do
         ActiveJob::Base.queue_adapter = :inline

--- a/spec/controllers/content_analyst/jobs_controller_spec.rb
+++ b/spec/controllers/content_analyst/jobs_controller_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe ContentAnalyst::JobsController, type: :controller do
       get :show, id: job.id
       expect(response).to have_http_status(:success)
     end
+
+    it "raises ActionController::RoutingError if the job does not exist" do
+      controller.sign_in(content_analyst)
+
+      expect{ get :show, id: 42 }.to raise_error(ActionController::RoutingError)
+    end
   end
 
 end

--- a/spec/controllers/customer_service/jobs_controller_spec.rb
+++ b/spec/controllers/customer_service/jobs_controller_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe CustomerService::JobsController, type: :controller do
       get :show, id: job.id
       expect(response).to have_http_status(:success)
     end
+
+    it "raises ActionController::RoutingError if the job does not exist" do
+      controller.sign_in(customer_service)
+
+      expect{ get :show, id: 42 }.to raise_error(ActionController::RoutingError)
+    end
   end
 
 end


### PR DESCRIPTION
- Changed jobs controllers to return 404's on #show when the jobs don't exist
- Return publish information directly on TaskPlans so FE doesn't have to make extra requests for the jobs.