### PR TITLE
WIP Course-specific excluded exercises

### DIFF
--- a/app/subsystems/course_content/models/excluded_exercise.rb
+++ b/app/subsystems/course_content/models/excluded_exercise.rb
@@ -1,0 +1,6 @@
+class CourseContent::Models::ExcludedExercise < ActiveRecord::Base
+  belongs_to :course, subsystem: :entity
+
+  validates :course, presence: true
+  validates :number, presence: true, uniqueness: { scope: :entity_course_id }
+end

--- a/db/migrate/20160229221635_create_course_content_excluded_exercises.rb
+++ b/db/migrate/20160229221635_create_course_content_excluded_exercises.rb
@@ -1,0 +1,10 @@
+class CreateCourseContentExcludedExercises < ActiveRecord::Migration
+  def change
+    create_table :course_content_excluded_exercises do |t|
+      t.references :entity_course, null: false
+      t.integer    :number,        null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160225204521) do
+ActiveRecord::Schema.define(version: 20160229221635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -178,6 +178,13 @@ ActiveRecord::Schema.define(version: 20160225204521) do
 
   add_index "course_content_course_ecosystems", ["content_ecosystem_id", "entity_course_id"], name: "course_ecosystems_on_ecosystem_id_course_id", using: :btree
   add_index "course_content_course_ecosystems", ["entity_course_id", "created_at"], name: "course_ecosystems_on_course_id_created_at", using: :btree
+
+  create_table "course_content_excluded_exercises", force: :cascade do |t|
+    t.integer  "entity_course_id", null: false
+    t.integer  "number",           null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
 
   create_table "course_membership_enrollment_changes", force: :cascade do |t|
     t.integer  "user_profile_id",                                null: false

--- a/spec/factories/course_content/excluded_exercises.rb
+++ b/spec/factories/course_content/excluded_exercises.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :excluded_exercise do
+    association :course, factory: :entity_course
+    number { SecureRandom.hex(4).to_i(16)/2 }
+  end
+end

--- a/spec/subsystems/course_content/models/excluded_exercise_spec.rb
+++ b/spec/subsystems/course_content/models/excluded_exercise_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe CourseContent::Models::ExcludedExercise, type: :model do
+  it { is_expected.to belong_to(:course) }
+
+  it { is_expected.to validate_presence_of(:course) }
+  it { is_expected.to validate_presence_of(:number) }
+
+  it { is_expected.to validate_uniqueness_of(:number).scoped_to(:entity_course_id) }
+end


### PR DESCRIPTION
- Added CourseContent::ExcludedExercise model to keep track of course-specific excluded exercises

# TODO

- New or adapted API route to send questions to FE with exclusion info
- New API route so FE can exclude questions
- Update spaced practice/personalized algorithms to not pick excluded exercises
- Update personalized/spaced practice algorithms to skip steps without errors if no questions available (might need FE update?)