### PR TITLE
Simple System Notifications

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -7,7 +7,7 @@
 @import "admin_navbar";
 @import "manager";
 
- .offering-row {
+ .underlined-spaced-row {
    border-bottom: 1px solid gray;
    padding-bottom: 20px;
    margin-bottom: 20px

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -1,0 +1,16 @@
+class Admin::NotificationsController < Admin::BaseController
+
+  def index
+  end
+
+  def create
+    Settings::Notifications.add( params['new_message'] )
+    redirect_to :admin_notifications
+  end
+
+  def destroy
+    Settings::Notifications.remove( params['id'] )
+    redirect_to :admin_notifications
+  end
+
+end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -6,7 +6,8 @@ class Api::V1::NotificationsController < Api::V1::ApiController
   EOS
 
   def index
-    # NO SECURITY!  Should it at least check if the user is logged in?
+    # Note: this endpoint is unsecured by design.
+    # Notifications are intended to be viewable by anyone
     render json: Settings::Notifications.raw
   end
 

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::NotificationsController < Api::V1::ApiController
+
+  api :GET, '/notifications', 'Request current system notifications'
+  description <<-EOS
+    #{json_schema(Api::V1::NotificationRepresenter, include: :readable)}
+  EOS
+
+  def index
+    # NO SECURITY!  Should it at least check if the user is logged in?
+    render json: Settings::Notifications.raw
+  end
+
+end

--- a/app/representers/api/v1/notification_representer.rb
+++ b/app/representers/api/v1/notification_representer.rb
@@ -1,0 +1,16 @@
+module Api::V1
+  class NotificationRepresenter < Roar::Decorator
+
+    include Roar::JSON
+
+    property :id,
+             type: String,
+             readable: true,
+             writeable: false
+
+    property :message,
+             type: String,
+             readable: true,
+             writeable: false
+  end
+end

--- a/app/views/admin/catalog_offerings/_display_row.html.erb
+++ b/app/views/admin/catalog_offerings/_display_row.html.erb
@@ -1,4 +1,4 @@
-<div class='offering-row'>
+<div class='underlined-spaced-row'>
   <b>Book name:</b> <%= offering.salesforce_book_name %>
   <span style='float: right'>
     <%= link_to 'Edit', edit_admin_catalog_offering_url(offering.id) %>

--- a/app/views/admin/catalog_offerings/_edit_row.html.erb
+++ b/app/views/admin/catalog_offerings/_edit_row.html.erb
@@ -6,7 +6,7 @@
 </style>
 
 
-<div class='offering-row'>
+<div class='underlined-spaced-row'>
   <div class="form-group">
     <%= form.label :salesforce_book_name %>
     <%= form.text_field :salesforce_book_name,  {class: 'form-control'} %>

--- a/app/views/admin/notifications/index.html
+++ b/app/views/admin/notifications/index.html
@@ -1,0 +1,30 @@
+<% @page_header = "Active Notifications" %>
+
+<div>
+<% Settings::Notifications.each do | notice | -%>
+  <div class='col-xs-12'>
+
+    <%= link_to 'Remove', {action: :destroy, id: notice['id']},
+        data: {:confirm => 'Are you sure?  Notifications can not be re-created once removed'},
+        method: :delete, class: 'btn btn-warning' %>
+
+    <%= notice['message'] %>
+  </div>
+  <% end -%>
+
+<%= form_tag admin_notifications_path do  %>
+<div class='row'>
+  <div class='col-xs-11'>
+    <%= label_tag :new_message, 'New Notification' %>
+  </div>
+  <div class='col-xs-11'>
+    <div class='form-group'>
+      <%= text_field_tag :new_message, '', class: 'form-control' %>
+    </div>
+  </div>
+  <div class='col-xs-1'>
+    <input class='btn btn-default' type='submit' value='Add'>
+  </div>
+</div>
+<% end %>
+</div>

--- a/app/views/admin/notifications/index.html
+++ b/app/views/admin/notifications/index.html
@@ -2,6 +2,7 @@
 
 <div>
 <% Settings::Notifications.each do | notice | -%>
+<div class='row underlined-spaced-row'>
   <div class='col-xs-12'>
 
     <%= link_to 'Remove', {action: :destroy, id: notice['id']},
@@ -10,7 +11,8 @@
 
     <%= notice['message'] %>
   </div>
-  <% end -%>
+</div>
+<% end -%>
 
 <%= form_tag admin_notifications_path do  %>
 <div class='row'>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -77,12 +77,16 @@
             <li><%= link_to 'Research Data', admin_research_data_path %></li>
 
             <li><%= link_to 'Salesforce', admin_salesforce_path %></li>
-
-            <li><%= link_to 'Settings', admin_rails_settings_ui_path %></li>
-
-            <% if Timecop.enabled? %>
-              <li><%= link_to 'Time Travel', admin_timecop_path %></li>
-            <% end %>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">System Setting<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><%= link_to 'Settings', admin_rails_settings_ui_path %></li>
+                <li><%= link_to 'Notifications', admin_notifications_path %></li>
+                <% if Timecop.enabled? %>
+                  <li><%= link_to 'Time Travel', admin_timecop_path %></li>
+                <% end %>
+              </ul>
+            </li>
 
           </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Rails.application.routes.draw do
       post :entry
     end
 
+    resources :notifications, only: [:index]
   end
 
   namespace 'admin' do
@@ -176,6 +177,7 @@ Rails.application.routes.draw do
     end
 
     resources :tags, only: [:index, :edit, :update, :show]
+    resources :notifications,  only: [:index, :create, :destroy]
 
     get :timecop, controller: :timecop, action: :index
     put :reset_time, controller: :timecop

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -1,11 +1,16 @@
 module Settings
   mattr_accessor :store
+  class << self
 
-  def self.timecop_offset
-    store.get('timecop:offset')
-  end
+    def timecop_offset
+      store.get('timecop:offset')
+    end
 
-  def self.timecop_offset=(value)
-    store.set('timecop:offset', value)
+    def timecop_offset=(value)
+      store.set('timecop:offset', value)
+    end
+
   end
 end
+
+require_relative 'settings/notifications'

--- a/lib/settings/notifications.rb
+++ b/lib/settings/notifications.rb
@@ -1,0 +1,43 @@
+module Settings
+  module Notifications
+    KEY = 'system:notifications'
+    class << self
+      include Enumerable
+
+      # Returns a string that contains unparsed JSON which is
+      # intended to be sent directly to the user without parsing.
+      def raw
+        Settings.store.get(KEY) || '[]'
+      end
+
+      # Parsed JSON content of messages.
+      # yields objects with 'id' and 'message' keys
+      def each
+        messages.each{|notice| yield notice }
+      end
+
+      def add(message)
+        message = {'id' => SecureRandom.uuid, 'message' => message}
+        update!( messages.push(message) )
+        message
+      end
+
+      def remove(message_id)
+        update!(
+          messages.reject{|message| message['id'] == message_id }
+        )
+      end
+
+      private
+
+      def messages
+        ActiveSupport::JSON.decode(raw)
+      end
+
+      def update!(json)
+        Settings.store.set(KEY, ActiveSupport::JSON.encode(json))
+      end
+
+    end
+  end
+end

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Api::V1::NotificationsController, type: :controller, api: true, version: :v1 do
+
+  describe "#index" do
+    after(:each) do
+      Settings.store.del(Settings::Notifications::KEY)
+    end
+
+    it 'returns the contents of Settings::Notifications' do
+      1.upto(3){ | num | Settings::Notifications.add("message #{num}") }
+      api_get :index, nil
+      expect(response.body).to eq(Settings::Notifications.raw)
+    end
+
+  end
+
+end

--- a/spec/lib/settings/notifications_spec.rb
+++ b/spec/lib/settings/notifications_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Settings::Notifications, type: :lib do
+
+  after(:each) do
+    Settings.store.del(Settings::Notifications::KEY)
+  end
+
+  it 'can store a message' do
+    expect {
+      Settings::Notifications.add('a test message')
+    }.to_not raise_error
+  end
+
+  it 'reads raw json' do
+    Settings::Notifications.add('a stored message')
+    expect(Settings::Notifications.raw).to include('"message":"a stored message"')
+  end
+
+  it 'removes a single message' do
+    Settings::Notifications.add('message one')
+    two = Settings::Notifications.add('message two')
+    Settings::Notifications.add('message three')
+    expect(Settings::Notifications.count).to eq(3)
+    Settings::Notifications.remove(two['id'])
+    expect(Settings::Notifications.map{|n|n['message']}).to eq(
+      ["message one", "message three"]
+    )
+  end
+
+  it 'can iterate through messages' do
+    1.upto(3){ | num | Settings::Notifications.add("message #{num}") }
+    i = 0
+    Settings::Notifications.each do | notice |
+      expect(notice['message']).to eq("message #{i+=1}")
+    end
+  end
+
+end


### PR DESCRIPTION
Sets up an admin screen for storing system notifications messages to the redis store.  Notices are stored as a JSON encoded string and then served from the `/api/notifications` endpoint.