### PR TITLE
Hides exercise attachments in JSON

### DIFF
--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -25,7 +25,7 @@ module Api::V1
     property :content,
              readable: true,
              writeable: false,
-             getter: ->(*) { ::JSON.parse(content) },
+             getter: ->(*) { ::JSON.parse(content).except('attachments') },
              schema_info: { required: true }
 
     collection :tags,

--- a/lib/openstax/exercises/v1/fake_client.rb
+++ b/lib/openstax/exercises/v1/fake_client.rb
@@ -61,6 +61,12 @@ class OpenStax::Exercises::V1::FakeClient
       uid: options[:uid] || "#{options[:number].to_s}@#{options[:version].to_s}",
       tags: options[:tags] || [],
       stimulus_html: "This is fake exercise #{options[:number]}. <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span>",
+      attachments: [
+        {
+          id: "#{next_uid}",
+          asset: "https://somewhere.com/something.png"
+        }
+      ],
       questions: [
         {
           id: "#{next_uid}",

--- a/spec/lib/openstax/exercises/v1/fake_client_spec.rb
+++ b/spec/lib/openstax/exercises/v1/fake_client_spec.rb
@@ -20,14 +20,17 @@ RSpec.describe OpenStax::Exercises::V1::FakeClient, type: :external do
           uid: "42@1",
           tags: [],
           stimulus_html: "This is fake exercise 42. <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span>",
+          attachments: [
+            {id: "-1", asset: "https://somewhere.com/something.png"}
+          ],
           questions: [
             {
-              id: "-1",
+              id: "-2",
               formats: ["multiple-choice", "free-response"],
               stem_html: "Select 10 N.",
               answers: [
-                { id: "-2", content_html: "10 N", correctness: 1.0, feedback_html: 'Right!' },
-                { id: "-3", content_html: "1 N", correctness: 0.0, feedback_html: 'Wrong!' }
+                { id: "-3", content_html: "10 N", correctness: 1.0, feedback_html: 'Right!' },
+                { id: "-4", content_html: "1 N", correctness: 0.0, feedback_html: 'Wrong!' }
               ],
               solutions: [
                 content_html: 'The first one.'
@@ -58,15 +61,18 @@ RSpec.describe OpenStax::Exercises::V1::FakeClient, type: :external do
           uid: "-2@1",
           tags: ["franky"],
           stimulus_html: "This is fake exercise -2. <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span>",
+          attachments: [
+            {id: "-5", asset: "https://somewhere.com/something.png"}
+          ],
           questions: [
             {
-              id: "-4",
+              id: "-6",
               formats: ["multiple-choice", "free-response"],
               stem_html: "Select 10 N.",
               answers:[
-                { id: "-5", content_html: "10 N",
+                { id: "-7", content_html: "10 N",
                   correctness: 1.0, feedback_html: 'Right!' },
-                { id: "-6", content_html: "1 N",
+                { id: "-8", content_html: "1 N",
                   correctness: 0.0, feedback_html: 'Wrong!' }
               ],
               solutions: [

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::ExerciseRepresenter, type: :representer do
     expect(representation).to include(
       'id' => exercise.id.to_s,
       'url' => exercise.url,
-      'content' => JSON.parse(exercise.content),
+      'content' => JSON.parse(exercise.content).except('attachments'),
       'tags' => a_collection_containing_exactly(
         {
           'id' => 'ost-tag-lo-k12phys-ch04-s02-lo01',


### PR DESCRIPTION
Exercise attachments may contain images used in collaborator solutions, so we hide them in the JSON interface in tutor so that students don't find them.