### PR TITLE
Add the excluded_pools argument to the Biglearn RealClient

### DIFF
--- a/lib/openstax/biglearn/v1/real_client.rb
+++ b/lib/openstax/biglearn/v1/real_client.rb
@@ -73,7 +73,8 @@ class OpenStax::Biglearn::V1::RealClient
     uuids.first
   end
 
-  def get_projection_exercises(role:, pools:, count:, difficulty:, allow_repetitions:)
+  def get_projection_exercises(role:, pools:, count:, difficulty:, allow_repetitions:,
+                               excluded_pools: [])
     query = {
       learner_id: get_exchange_read_identifiers_for_roles(roles: role).first,
       number_of_questions: count,


### PR DESCRIPTION
Does nothing. Just so it doesn't blow up when called by OpenStax::Biglearn::V1