### PR TITLE
undefined local variable or method `error' for MapUsersAccounts

### DIFF
--- a/lib/map_users_accounts.rb
+++ b/lib/map_users_accounts.rb
@@ -23,7 +23,9 @@ module MapUsersAccounts
     def create_user
       result = User::CreateUser.call(account_id: @account.id)
 
-      raise error.message if error = result.errors.first
+      if (error = result.errors.first)
+        raise error.message
+      end
 
       result.outputs.user
     end

--- a/spec/routines/map_users_accounts_spec.rb
+++ b/spec/routines/map_users_accounts_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe MapUsersAccounts, type: :routine do
         OpenStax::Accounts::FindOrCreateAccount.call(username: 'account').outputs.account
       end
 
+      it 'raises errors during create_user' do
+        error = OpenStruct.new(message: 'hi') # error.message works
+        allow(User::CreateUser).to receive(:call).and_return(OpenStruct.new(errors: [error]))
+        expect{ MapUsersAccounts.send(:create_user) }.to raise_error('hi')
+      end
+
       it 'returns the created user for the account' do
         expect(user).to be_a(User::User)
         expect(user.account).to eq(account)


### PR DESCRIPTION
fixed create_user error and added spec

regarding: #1008 