### PR TITLE
tasks with immediate feedback

### DIFF
--- a/app/representers/api/v1/task_plan_representer.rb
+++ b/app/representers/api/v1/task_plan_representer.rb
@@ -45,7 +45,6 @@ module Api::V1
     property :is_feedback_immediate,
              readable: true,
              writeable: true,
-             getter: ->(*) { is_feedback_immediate? },
              schema_info: { type: 'boolean' }
 
     property :publish_last_requested_at,

--- a/app/representers/api/v1/task_plan_representer.rb
+++ b/app/representers/api/v1/task_plan_representer.rb
@@ -42,6 +42,12 @@ module Api::V1
              getter: ->(*) { is_publish_requested? },
              schema_info: { type: 'boolean' }
 
+    property :is_feedback_immediate,
+             readable: true,
+             writeable: true,
+             getter: ->(*) { is_feedback_immediate? },
+             schema_info: { type: 'boolean' }
+
     property :publish_last_requested_at,
              type: String,
              readable: true,

--- a/app/representers/api/v1/task_representer.rb
+++ b/app/representers/api/v1/task_representer.rb
@@ -74,7 +74,6 @@ module Api::V1
              as: :is_feedback_available,
              writeable: false,
              readable: true,
-             getter: ->(*) { feedback_available? },
              schema_info: { type: 'boolean', description: "If the feedback should be shown for the task" }
 
     property :spy,

--- a/app/representers/api/v1/task_representer.rb
+++ b/app/representers/api/v1/task_representer.rb
@@ -70,6 +70,13 @@ module Api::V1
                  description: "The steps which this Task is composed of"
                }
 
+    property :feedback_available?,
+             as: :is_feedback_available,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { feedback_available? },
+             schema_info: { type: 'boolean', description: "If the feedback should be shown for the task" }
+
     property :spy,
              type: Object,
              readable: true,

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -65,9 +65,10 @@ class DistributeTasks
       entity_task.taskings << tasking
 
       task = entity_task.task
+
       task.opens_at = opens_ats[ii]
       task.due_at = due_ats[ii] || (task.opens_at + 1.week)
-      task.feedback_at ||= task.due_at
+      task.feedback_at = task_plan.is_feedback_immediate? ? task.opens_at : task.feedback_at
     end
 
     save(entity_tasks)

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -68,7 +68,7 @@ class DistributeTasks
 
       task.opens_at = opens_ats[ii]
       task.due_at = due_ats[ii] || (task.opens_at + 1.week)
-      task.feedback_at = task_plan.is_feedback_immediate? ? task.opens_at : task.feedback_at
+      task.feedback_at ||= task_plan.is_feedback_immediate? ? task.opens_at : task.feedback_at
     end
 
     save(entity_tasks)

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -68,7 +68,7 @@ class DistributeTasks
 
       task.opens_at = opens_ats[ii]
       task.due_at = due_ats[ii] || (task.opens_at + 1.week)
-      task.feedback_at ||= task_plan.is_feedback_immediate? ? task.opens_at : task.feedback_at
+      task.feedback_at ||= task_plan.is_feedback_immediate? ? task.opens_at : task.due_at
     end
 
     save(entity_tasks)

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -8,14 +8,12 @@ class PropagateTaskPlanUpdates
 
     # For now we only handle tasking_plans that point to periods
     task_plan.tasking_plans.each do |tasking_plan|
-
       period = tasking_plan.target
       raise 'Cannot propagate plan changes for plan not assigned to a period' \
         unless period.is_a?(CourseMembership::Models::Period)
 
-          task_plan.assistant.update_tasks_for_plan(tasking_plan: tasking_plan, where: {
-                                                    taskings: { course_membership_period_id: period.id }
-                                                  })
+      task_plan.tasks.joins(:taskings).where(taskings: { course_membership_period_id: period.id })
+                     .update_all( task_plan.assistant.updated_attributes_for(tasking_plan:tasking_plan) )
     end
 
     task_plan.tasks.reset

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -13,6 +13,11 @@ class PropagateTaskPlanUpdates
       raise 'Cannot propagate plan changes for plan not assigned to a period' \
         unless period.is_a?(CourseMembership::Models::Period)
 
+
+      task_plan.assistant.update_tasks(task_plan: task_plan)
+
+
+
       feedback_at = if task_plan.type == 'homework'
                       task_plan.is_feedback_immediate? ? tasking_plan.opens_at : tasking_plan.due_at
                     else

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -13,8 +13,11 @@ class PropagateTaskPlanUpdates
       raise 'Cannot propagate plan changes for plan not assigned to a period' \
         unless period.is_a?(CourseMembership::Models::Period)
 
-      feedback_at = task_plan.type == 'homework' ? tasking_plan.due_at : Time.now
-
+      feedback_at = if task_plan.type == 'homework'
+                      task_plan.is_feedback_immediate? ? tasking_plan.opens_at : tasking_plan.due_at
+                    else
+                      Time.now
+                    end
       task_plan.tasks.joins(:taskings).where(taskings: { course_membership_period_id: period.id })
                      .update_all(opens_at: tasking_plan.opens_at,
                                  due_at: tasking_plan.due_at,

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -5,28 +5,17 @@ class PropagateTaskPlanUpdates
   protected
 
   def exec(task_plan:)
-    task_plan.tasks.update_all(title: task_plan.title, description: task_plan.description)
 
     # For now we only handle tasking_plans that point to periods
     task_plan.tasking_plans.each do |tasking_plan|
+
       period = tasking_plan.target
       raise 'Cannot propagate plan changes for plan not assigned to a period' \
         unless period.is_a?(CourseMembership::Models::Period)
 
-
-      task_plan.assistant.update_tasks(task_plan: task_plan)
-
-
-
-      feedback_at = if task_plan.type == 'homework'
-                      task_plan.is_feedback_immediate? ? tasking_plan.opens_at : tasking_plan.due_at
-                    else
-                      Time.now
-                    end
-      task_plan.tasks.joins(:taskings).where(taskings: { course_membership_period_id: period.id })
-                     .update_all(opens_at: tasking_plan.opens_at,
-                                 due_at: tasking_plan.due_at,
-                                 feedback_at: feedback_at)
+          task_plan.assistant.update_tasks_for_plan(tasking_plan: tasking_plan, where: {
+                                                    taskings: { course_membership_period_id: period.id }
+                                                  })
     end
 
     task_plan.tasks.reset

--- a/app/subsystems/tasks/assistants/event_assistant.rb
+++ b/app/subsystems/tasks/assistants/event_assistant.rb
@@ -1,6 +1,6 @@
 module Tasks
   module Assistants
-    class EventAssistant
+    class EventAssistant < Tasks::Assistants::GenericAssistant
       def self.schema
         '{
           "type": "object",
@@ -8,11 +8,6 @@ module Tasks
           "properties": {},
           "additionalProperties": false
         }'
-      end
-
-      def initialize(task_plan:, taskees:)
-        @task_plan = task_plan
-        @taskees = taskees
       end
 
       def build_tasks

--- a/app/subsystems/tasks/assistants/external_assignment_assistant.rb
+++ b/app/subsystems/tasks/assistants/external_assignment_assistant.rb
@@ -1,4 +1,4 @@
-class Tasks::Assistants::ExternalAssignmentAssistant
+class Tasks::Assistants::ExternalAssignmentAssistant < Tasks::Assistants::GenericAssistant
 
   def self.schema
     '{
@@ -13,11 +13,6 @@ class Tasks::Assistants::ExternalAssignmentAssistant
       },
       "additionalProperties": false
     }'
-  end
-
-  def initialize(task_plan:, taskees:)
-    @task_plan = task_plan
-    @taskees = taskees
   end
 
   def build_tasks

--- a/app/subsystems/tasks/assistants/extra_assignment_assistant.rb
+++ b/app/subsystems/tasks/assistants/extra_assignment_assistant.rb
@@ -1,4 +1,4 @@
-class Tasks::Assistants::ExtraAssignmentAssistant
+class Tasks::Assistants::ExtraAssignmentAssistant < Tasks::Assistants::GenericAssistant
 
   def self.schema
     '{
@@ -19,8 +19,8 @@ class Tasks::Assistants::ExtraAssignmentAssistant
   end
 
   def initialize(task_plan:, taskees:)
-    @task_plan = task_plan
-    @taskees = taskees
+    super
+
     outputs = collect_snap_labs
     @pages = outputs[:pages]
     @page_id_to_snap_lab_id = outputs[:page_id_to_snap_lab_id]

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -8,18 +8,15 @@ class Tasks::Assistants::GenericAssistant
     @taskees = taskees
   end
 
-  def update_tasks_for_plan(tasking_plan:, where:, attributes:{})
-
-    task_plan.tasks.update_all(title: task_plan.title, description: task_plan.description)
-
-    task_plan.tasks.joins(:taskings)
-      .where(where)
-      .update_all(attributes.reverse_merge({
-                   opens_at: tasking_plan.opens_at,
-                   due_at: tasking_plan.due_at,
-                   feedback_at: Time.now
-                 }))
-
+  def updated_attributes_for(tasking_plan:)
+    task_plan = tasking_plan.task_plan
+    {
+      title: task_plan.title,
+      description: task_plan.description,
+      opens_at: tasking_plan.opens_at,
+      due_at: tasking_plan.due_at,
+      feedback_at: Time.now
+    }
   end
 
 end

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -1,0 +1,11 @@
+# The generic assistant is a base class for other assistants to inherit from
+# It's not intended for direct use since it does not implement the all-important `build_tasks` method
+class Tasks::Assistants::GenericAssistant
+  attr_reader :task_plan, :taskees
+
+  def initialize(task_plan:, taskees:)
+    @task_plan = task_plan
+    @taskees = taskees
+  end
+
+end

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -8,4 +8,18 @@ class Tasks::Assistants::GenericAssistant
     @taskees = taskees
   end
 
+  def update_tasks_for_plan(tasking_plan:, where:, attributes:{})
+
+    task_plan.tasks.update_all(title: task_plan.title, description: task_plan.description)
+
+    task_plan.tasks.joins(:taskings)
+      .where(where)
+      .update_all(attributes.reverse_merge({
+                   opens_at: tasking_plan.opens_at,
+                   due_at: tasking_plan.due_at,
+                   feedback_at: Time.now
+                 }))
+
+  end
+
 end

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -48,10 +48,9 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
     end
   end
 
-  def update_tasks_for_plan(tasking_plan:, where:)
-    feedback_at = task_plan.is_feedback_immediate? ? tasking_plan.opens_at : tasking_plan.due_at
-
-    super(tasking_plan: tasking_plan, where: where, attributes: {feedback_at: feedback_at})
+  def updated_attributes_for(tasking_plan:)
+    attributes = super
+    attributes.merge({feedback_at: tasking_plan.task_plan.is_feedback_immediate? ? tasking_plan.opens_at : tasking_plan.due_at})
   end
 
   protected

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -1,4 +1,4 @@
-class Tasks::Assistants::HomeworkAssistant
+class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
 
   def self.schema
     '{
@@ -32,10 +32,7 @@ class Tasks::Assistants::HomeworkAssistant
     }'
   end
 
-  def initialize(task_plan:, taskees:)
-    @task_plan = task_plan
-    @taskees = taskees
-
+  def build_tasks
     collect_exercises
 
     @tag_exercise = {}
@@ -43,15 +40,18 @@ class Tasks::Assistants::HomeworkAssistant
     @page_pools = {}
     @pool_exercises = {}
     @ecosystems_map = {}
-  end
-
-  def build_tasks
     @taskees.collect do |taskee|
       build_homework_task(
         taskee:       taskee,
         exercises:    @exercises
       ).entity_task
     end
+  end
+
+  def update_tasks_for_plan(tasking_plan:, where:)
+    feedback_at = task_plan.is_feedback_immediate? ? tasking_plan.opens_at : tasking_plan.due_at
+
+    super(tasking_plan: tasking_plan, where: where, attributes: {feedback_at: feedback_at})
   end
 
   protected

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -1,4 +1,4 @@
-class Tasks::Assistants::IReadingAssistant
+class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::GenericAssistant
 
   def self.schema
     '{
@@ -20,10 +20,7 @@ class Tasks::Assistants::IReadingAssistant
     }'
   end
 
-  def initialize(task_plan:, taskees:)
-    @task_plan = task_plan
-    @taskees = taskees
-
+  def build_tasks
     collect_pages
 
     @tag_exercise = {}
@@ -31,9 +28,7 @@ class Tasks::Assistants::IReadingAssistant
     @page_pools = {}
     @pool_exercises = {}
     @ecosystems_map = {}
-  end
 
-  def build_tasks
     @taskees.collect do |taskee|
       build_ireading_task(
         taskee: taskee,

--- a/app/subsystems/tasks/models/assistant.rb
+++ b/app/subsystems/tasks/models/assistant.rb
@@ -15,8 +15,9 @@ class Tasks::Models::Assistant < Tutor::SubSystems::BaseModel
     code_class.new(task_plan: task_plan, taskees: taskees).build_tasks
   end
 
-  def update_tasks(task_plan:, taskees:)
-    code_class.new(task_plan: task_plan, taskees: taskees).update_tasks
+  def update_tasks_for_plan(tasking_plan:, where:)
+    code_class.new(task_plan: tasking_plan.task_plan, taskees: [])
+      .update_tasks_for_plan(tasking_plan: tasking_plan, where: where)
   end
 
   protected

--- a/app/subsystems/tasks/models/assistant.rb
+++ b/app/subsystems/tasks/models/assistant.rb
@@ -15,9 +15,9 @@ class Tasks::Models::Assistant < Tutor::SubSystems::BaseModel
     code_class.new(task_plan: task_plan, taskees: taskees).build_tasks
   end
 
-  def update_tasks_for_plan(tasking_plan:, where:)
+  def updated_attributes_for(tasking_plan:)
     code_class.new(task_plan: tasking_plan.task_plan, taskees: [])
-      .update_tasks_for_plan(tasking_plan: tasking_plan, where: where)
+      .updated_attributes_for(tasking_plan: tasking_plan)
   end
 
   protected

--- a/app/subsystems/tasks/models/assistant.rb
+++ b/app/subsystems/tasks/models/assistant.rb
@@ -15,6 +15,10 @@ class Tasks::Models::Assistant < Tutor::SubSystems::BaseModel
     code_class.new(task_plan: task_plan, taskees: taskees).build_tasks
   end
 
+  def update_tasks(task_plan:, taskees:)
+    code_class.new(task_plan: task_plan, taskees: taskees).update_tasks
+  end
+
   protected
 
   def code_class_existence

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -2,7 +2,7 @@ require 'json-schema'
 
 class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
 
-  UPDATABLE_ATTRIBUTES = ['title', 'description', 'published_at']
+  UPDATABLE_ATTRIBUTES = ['title', 'description', 'published_at', 'is_feedback_immediate']
 
   attr_writer :is_publish_requested
 

--- a/db/migrate/20160317184322_add_task_plan_feedback.rb
+++ b/db/migrate/20160317184322_add_task_plan_feedback.rb
@@ -1,0 +1,5 @@
+class AddTaskPlanFeedback < ActiveRecord::Migration
+  def change
+    add_column :tasks_task_plans, :is_feedback_immediate, :bool
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160225204521) do
+ActiveRecord::Schema.define(version: 20160317184322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,6 +179,16 @@ ActiveRecord::Schema.define(version: 20160225204521) do
   add_index "course_content_course_ecosystems", ["content_ecosystem_id", "entity_course_id"], name: "course_ecosystems_on_ecosystem_id_course_id", using: :btree
   add_index "course_content_course_ecosystems", ["entity_course_id", "created_at"], name: "course_ecosystems_on_course_id_created_at", using: :btree
 
+  create_table "course_content_excluded_exercises", force: :cascade do |t|
+    t.integer  "entity_course_id", null: false
+    t.integer  "exercise_number",  null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  add_index "course_content_excluded_exercises", ["entity_course_id"], name: "index_course_content_excluded_exercises_on_entity_course_id", using: :btree
+  add_index "course_content_excluded_exercises", ["exercise_number", "entity_course_id"], name: "index_excluded_exercises_on_number_and_course_id", unique: true, using: :btree
+
   create_table "course_membership_enrollment_changes", force: :cascade do |t|
     t.integer  "user_profile_id",                                null: false
     t.integer  "course_membership_enrollment_id"
@@ -245,15 +255,16 @@ ActiveRecord::Schema.define(version: 20160225204521) do
 
   create_table "course_profile_profiles", force: :cascade do |t|
     t.integer  "school_district_school_id"
-    t.integer  "entity_course_id",                                                 null: false
-    t.string   "name",                                                             null: false
-    t.string   "timezone",                  default: "Central Time (US & Canada)", null: false
-    t.datetime "created_at",                                                       null: false
-    t.datetime "updated_at",                                                       null: false
-    t.boolean  "is_concept_coach",                                                 null: false
-    t.string   "teacher_join_token",                                               null: false
+    t.integer  "entity_course_id",                                                   null: false
+    t.string   "name",                                                               null: false
+    t.string   "timezone",                    default: "Central Time (US & Canada)", null: false
+    t.datetime "created_at",                                                         null: false
+    t.datetime "updated_at",                                                         null: false
+    t.boolean  "is_concept_coach",                                                   null: false
+    t.string   "teacher_join_token",                                                 null: false
     t.integer  "catalog_offering_id"
     t.string   "appearance_code"
+    t.string   "biglearn_excluded_pool_uuid"
   end
 
   add_index "course_profile_profiles", ["catalog_offering_id"], name: "index_course_profile_profiles_on_catalog_offering_id", using: :btree
@@ -555,6 +566,7 @@ ActiveRecord::Schema.define(version: 20160225204521) do
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
     t.integer  "content_ecosystem_id",      null: false
+    t.boolean  "is_feedback_immediate"
   end
 
   add_index "tasks_task_plans", ["content_ecosystem_id"], name: "index_tasks_task_plans_on_content_ecosystem_id", using: :btree

--- a/spec/mocks/assistants/dummy_assistant.rb
+++ b/spec/mocks/assistants/dummy_assistant.rb
@@ -1,11 +1,6 @@
-class DummyAssistant
+class DummyAssistant < Tasks::Assistants::GenericAssistant
   def self.schema
     "{}"
-  end
-
-  def initialize(task_plan:, taskees:)
-    @task_plan = task_plan
-    @taskees = taskees
   end
 
   def build_tasks
@@ -16,4 +11,6 @@ class DummyAssistant
                        task_type: :external].entity_task
     end
   end
+
+
 end

--- a/spec/representers/api/v1/task_representer_spec.rb
+++ b/spec/representers/api/v1/task_representer_spec.rb
@@ -22,7 +22,13 @@ RSpec.describe Api::V1::TaskRepresenter, type: :representer do
     # the factory uses lipsum for title so just check for words
     expect(represented['spy']).to eq({ecosystem_id: ecosystem.id,
                                       ecosystem_title: ecosystem.title})
+  end
 
+  it 'includes feedback availability' do
+    task.feedback_at = nil
+    expect(described_class.new(task).to_hash).to include('is_feedback_available' => false)
+    task.feedback_at = Time.now - 1.second
+    expect(described_class.new(task).to_hash).to include('is_feedback_available' => true)
   end
 
 end

--- a/spec/representers/api/v1/task_search_representer_spec.rb
+++ b/spec/representers/api/v1/task_search_representer_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Api::V1::TaskSearchRepresenter, type: :representer do
             json['is_shared'] = task.is_shared?
             json['steps']     = task.task_steps.as_json
             json['spy']       = {'ecosystem_id' => ecosystem.id, 'ecosystem_title' => ecosystem.title}
+            json['is_feedback_available'] = task.feedback_available?
             json
           }
         )

--- a/spec/routines/propagate_task_plan_updates_spec.rb
+++ b/spec/routines/propagate_task_plan_updates_spec.rb
@@ -86,6 +86,15 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
           expect(task.feedback_at).to eq task.due_at
         end
       end
+
+      it 'sets feedback_at to opens_at when feedback is immediate' do
+        task_plan.update_attributes(type: 'homework', is_feedback_immediate: true)
+        PropagateTaskPlanUpdates.call(task_plan: task_plan)
+        task_plan.tasks.each do |task|
+          expect(task.feedback_at).to eq task.opens_at
+        end
+      end
+
     end
 
     context 'reading' do

--- a/spec/routines/propagate_task_plan_updates_spec.rb
+++ b/spec/routines/propagate_task_plan_updates_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
           expect(task.opens_at).to    be_within(1.second).of(old_opens_at)
           expect(task.due_at).to      be_within(1.second).of(old_due_at)
         end
+        allow(task_plan.assistant).to receive(:code_class).and_return(Tasks::Assistants::HomeworkAssistant)
 
         expect {
           PropagateTaskPlanUpdates.call(task_plan: task_plan)
@@ -88,6 +89,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
       end
 
       it 'sets feedback_at to opens_at when feedback is immediate' do
+        allow(task_plan.assistant).to receive(:code_class).and_return(Tasks::Assistants::HomeworkAssistant)
         task_plan.update_attributes(type: 'homework', is_feedback_immediate: true)
         PropagateTaskPlanUpdates.call(task_plan: task_plan)
         task_plan.tasks.each do |task|

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       assistant: assistant,
       content_ecosystem_id: ecosystem.id,
       description: "Hello!",
+      is_feedback_immediate: true,
       settings: {
         exercise_ids: teacher_selected_exercise_ids,
         exercises_count_dynamic: tutor_selected_exercise_count
@@ -126,7 +127,8 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       task = entity_task.task
       expect(task.description).to eq("Hello!")
       expect(task.homework?).to be_truthy
-      expect(task.feedback_at).to eq(task.due_at)
+      # feedback_at == opens_at because the task plan was set to immediate_feedback
+      expect(task.feedback_at).to eq(task.opens_at)
     end
 
     ## it "creates one task per taskee"


### PR DESCRIPTION
Is safe to be merged before FE code, just won't do anything until that's completed

This adds a `is_feedback_immediate` field on `task_plans`.  The distribute tasks routine then checks that and sets the `feedback_at` on `tasks`  to equal either the `opens_at` or `due_at` 

