### PR TITLE
maintenance HTML page

### DIFF
--- a/app/assets/html/maintenance.html.erb
+++ b/app/assets/html/maintenance.html.erb
@@ -1,0 +1,6 @@
+<%=
+  require 'error_page_builder'
+  ErrorPageBuilder.build(view: self,
+                         code: 503,
+                         heading: "We're offline for a brief upgrade!")
+%>


### PR DESCRIPTION
Adds a "We're in maintenace" page to tutor-server.  When assets are precompiled during a normal deploy, this page will be autogenerated in the /public directory.  After this is done once, for future deploys, ansible can copy this file plus all of /public/assets into some place where nginx can serve this file during downtime.  Need the assets folder to get the CSS and logo file.