### PR TITLE
copied new meta desc to the real meta tag

### DIFF
--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -12,6 +12,6 @@
   <meta property="og:type" content="website"/>
 <% end %>
 
-<meta name="Description" content="<%= @page_description ? @page_description : 'Personalized learning from a tutor that adapts to you.' %>">
+<meta name="Description" content="<%= @page_description ? @page_description : "If you're piloting Tutor in your class or interested in trying it, visit us here. Our adaptive courseware creates personalized learning paths for every student." %>">
 
 <link rel="shortcut icon" href="/favicon.ico" type="image/ico"/>


### PR DESCRIPTION
Previously I just had this in the Facebook OpenGraph description, should have been in the main `meta` tag.