### PR TITLE
Fix some odd spec failures that happen on ubuntu with Postgres 9.5

### DIFF
--- a/spec/routines/update_clues_spec.rb
+++ b/spec/routines/update_clues_spec.rb
@@ -198,16 +198,17 @@ RSpec.describe UpdateClues, type: :routine, vcr: VCR_OPTS do
     end
 
     context 'with some recent work' do
-      before(:all) { Timecop.freeze(Time.now + 5.minutes) }
-      after(:all)  { Timecop.return }
+      before(:all) do
+        Timecop.freeze(Time.now + 5.minutes)
 
-      before(:each) do
         @role.taskings.each do |tasking|
-          tasking.task.task.task_steps.select{ |ts| ts.completed? }.each do |ts|
+          tasking.task.task.task_steps.select(&:completed?).each do |ts|
             MarkTaskStepCompleted[task_step: ts]
           end
         end
       end
+
+      after(:all)  { Timecop.return }
 
       it 'causes requests to biglearn only for the recent work' do
         expect(@real_client).to receive(:request_clues).twice.and_call_original
@@ -244,7 +245,7 @@ RSpec.describe UpdateClues, type: :routine, vcr: VCR_OPTS do
     end
 
     context 'without recent work' do
-      before(:all) { Timecop.freeze(Time.now + 5.minutes) }
+      before(:all) { Timecop.freeze(Time.now + 10.minutes) }
       after(:all)  { Timecop.return }
 
       it 'does not cause requests to biglearn' do


### PR DESCRIPTION
The transaction rollback at the end of some specs was causing SELECT and SELECT FOR UPDATE to return different results...