### PR TITLE
Disallow repeats in practice when drawing locally

### DIFF
--- a/app/routines/reset_practice_widget.rb
+++ b/app/routines/reset_practice_widget.rb
@@ -118,6 +118,7 @@ class ResetPracticeWidget
 
     history = run(:get_history, role: role, type: :all).outputs
     chosen_exercises = run(:choose, exercises: filtered_exercises, count: count, history: history,
+                                    allow_repeats: false,
                                     randomize_exercises: randomize,
                                     randomize_order: randomize).outputs.exercises
     chosen_exercises


### PR DESCRIPTION
When BigLearn doesn't supply enough exercises, the practice widget should no longer be filled with repeats of locally-drawn exercises.