### PR TITLE
Reduce massive CC course export time by 98%

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -22,6 +22,7 @@ require 'logout_redirect_chooser'
 require 'openstax_rescue_from_this'
 require 'active_job/base_with_retry_conditions'
 require 'xlsx_helper'
+require 'axlsx_modifications'
 
 %w(
   biglearn

--- a/lib/axlsx_modifications.rb
+++ b/lib/axlsx_modifications.rb
@@ -1,0 +1,13 @@
+module Axlsx
+  class Comments < SimpleTypedList
+    def authors
+      [""]
+    end
+  end
+
+  class Comment
+    def author_index
+      0
+    end
+  end
+end


### PR DESCRIPTION
Turns out that the vast majority of the time spent exporting a spreadsheet was in the method in our Excel library that saves the file.  In there there is some very inefficient code having to do with recording the authors of comments.  Since our spreadsheets have lots of comments, this was killing our performance.  

This monkey patch of that code takes the time it takes to export the massive tutor-staging CC course from 317 seconds to 5 seconds. 

:-)