### PR TITLE
Get rid of N+1 queries on CC performance report

### DIFF
--- a/app/subsystems/tasks/get_cc_performance_report.rb
+++ b/app/subsystems/tasks/get_cc_performance_report.rb
@@ -50,7 +50,7 @@ module Tasks
 
     def get_cc_taskings(course)
       # Return cc tasks for a student, ignoring not_started tasks
-      course.taskings.preload(task: {concept_coach_task: :page},
+      course.taskings.preload(task: [:task, {concept_coach_task: :page}],
                               role: [{student: {enrollments: :period}},
                                      {profile: :account}])
                      .joins(task: [:task, :concept_coach_task])


### PR DESCRIPTION
Saves 5-10 seconds loading the scores page and the export for large courses.
Tested in the console on staging.