### PR TITLE
Changes to scores report and fixes for default count values

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -205,7 +205,7 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
   end
 
   def teacher_chosen_score
-    teacher_chosen_correct_exercise_count / actual_and_placeholder_exercise_count.to_f
+    teacher_chosen_correct_exercise_count / actual_and_placeholder_exercise_count.to_f rescue nil
   end
 
   protected

--- a/app/subsystems/tasks/performance_report_methods.rb
+++ b/app/subsystems/tasks/performance_report_methods.rb
@@ -3,9 +3,12 @@ module Tasks
     protected
 
     def included_in_averages?(task)
-      (task.task_type == 'homework' || task.task_type == 'concept_coach') &&
       task.exercise_count > 0 &&
-      (task.completed? || task.past_due?)
+      (
+        ( task.task_type == 'concept_coach' && task.completed?) ||
+        ( task.task_type == 'homework' && task.past_due? )
+      )
+
     end
 
     def average_scores(tasks)

--- a/db/migrate/20160505221319_add_defaults_for_null_counts.rb
+++ b/db/migrate/20160505221319_add_defaults_for_null_counts.rb
@@ -1,0 +1,17 @@
+class AddDefaultsForNullCounts < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        Tasks::Models::Task.preload(task_steps: :tasked).find_each(&:update_step_counts!)
+      end
+    end
+
+    change_column_null :tasks_tasks, :correct_on_time_exercise_steps_count, false
+    change_column_null :tasks_tasks, :completed_on_time_exercise_steps_count, false
+    change_column_null :tasks_tasks, :completed_on_time_steps_count, false
+
+    change_column_default :tasks_tasks, :correct_on_time_exercise_steps_count, 0
+    change_column_default :tasks_tasks, :completed_on_time_exercise_steps_count, 0
+    change_column_default :tasks_tasks, :completed_on_time_steps_count, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -706,9 +706,9 @@ ActiveRecord::Schema.define(version: 20160506181201) do
     t.datetime "updated_at",                                             null: false
     t.hstore   "spy"
     t.boolean  "is_late_work_accepted",                  default: false
-    t.integer  "correct_on_time_exercise_steps_count"
-    t.integer  "completed_on_time_exercise_steps_count"
-    t.integer  "completed_on_time_steps_count"
+    t.integer  "correct_on_time_exercise_steps_count",   default: 0,     null: false
+    t.integer  "completed_on_time_exercise_steps_count", default: 0,     null: false
+    t.integer  "completed_on_time_steps_count",          default: 0,     null: false
   end
 
   add_index "tasks_tasks", ["due_at", "opens_at"], name: "index_tasks_tasks_on_due_at_and_opens_at", using: :btree

--- a/spec/controllers/api/v1/performance_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/performance_reports_controller_spec.rb
@@ -61,20 +61,21 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
       end
 
       it 'should work on the happy path' do
-        api_get :index, teacher_token, parameters: { id: course.id }
+        Timecop.freeze(Time.now + 1.1.days) do
+          api_get :index, teacher_token, parameters: { id: course.id }
+        end
 
         expect(response).to have_http_status :success
         resp = response.body_as_hash
 
         expect(resp).to include({
           period_id: course.periods.first.id.to_s,
-          overall_average_score: 0.875,
+          overall_average_score: 0.6666666666666666,
           data_headings: [
             { title: 'Homework 2 task plan',
               plan_id: resp[0][:data_headings][0][:plan_id],
               type: 'homework',
-              due_at: resp[0][:data_headings][0][:due_at],
-              average_score: 0.75 },
+              due_at: resp[0][:data_headings][0][:due_at] },
             { title: 'Reading task plan',
               plan_id: resp[0][:data_headings][1][:plan_id],
               type: 'reading',
@@ -83,7 +84,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
               plan_id: resp[0][:data_headings][2][:plan_id],
               type: 'homework',
               due_at: resp[0][:data_headings][2][:due_at],
-              average_score: 1.0 }
+              average_score: 0.6666666666666666 }
           ],
           students: [{
             name: 'Student One',
@@ -91,7 +92,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             last_name: 'One',
             role: resp[0][:students][0][:role],
             student_identifier: 'S1',
-            average_score: 0.875,
+            average_score: 1.0,
             data: [
               {
                 type: 'homework',
@@ -110,7 +111,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 due_at: resp[0][:students][0][:data][0][:due_at],
                 last_worked_at: resp[0][:students][0][:data][0][:last_worked_at],
                 is_late_work_accepted: false,
-                is_included_in_averages: true
+                is_included_in_averages: false
               },
               {
                 type: 'reading',
@@ -157,6 +158,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             last_name: 'Two',
             role: resp[0][:students][1][:role],
             student_identifier: 'S2',
+            average_score: 0.3333333333333333,
             data: [
               {
                 type: 'homework',
@@ -213,13 +215,13 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 due_at: resp[0][:students][1][:data][2][:due_at],
                 last_worked_at: resp[0][:students][1][:data][2][:last_worked_at],
                 is_late_work_accepted: false,
-                is_included_in_averages: false
+                is_included_in_averages: true
               }
             ]
           }]
         }, {
           period_id: course.periods.order(:id).last.id.to_s,
-          overall_average_score: 1.0,
+          overall_average_score: 0.5,
           data_headings: [
             { title: 'Homework 2 task plan',
               plan_id: resp[1][:data_headings][0][:plan_id],
@@ -235,7 +237,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
               plan_id: resp[1][:data_headings][2][:plan_id],
               type: 'homework',
               due_at: resp[1][:data_headings][2][:due_at],
-              average_score: 1.0
+              average_score: 0.5
             }
           ],
           students: [{
@@ -244,6 +246,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             last_name: 'Four',
             role: resp[1][:students][0][:role],
             student_identifier: 'S4',
+            average_score: 0.0,
             data: [
               {
                 type: 'homework',
@@ -297,7 +300,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
                 recovered_exercise_count: 0,
                 due_at: resp[1][:students][0][:data][2][:due_at],
                 is_late_work_accepted: false,
-                is_included_in_averages: false
+                is_included_in_averages: true
               }
             ]
           },
@@ -375,7 +378,9 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
         student = CourseMembership::Models::Student.find_by(role: role)
         MoveStudent.call(period: period_2, student: student)
 
-        api_get :index, teacher_token, parameters: { id: course.id }
+        Timecop.freeze(Time.now + 1.1.days) do
+          api_get :index, teacher_token, parameters: { id: course.id }
+        end
 
         expect(response).to have_http_status :success
         resp = response.body_as_hash
@@ -387,8 +392,8 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
         # moved to period 2; on the other hand, period 2 now has average scores where
         # it didn't before
         expect(resp[0][:data_headings][0]).not_to have_key(:average_score)
-        expect(resp[1][:data_headings][0][:average_score]).to eq 0.75
-        expect(resp[1][:data_headings][2][:average_score]).to eq 1.0
+        expect(resp[1][:overall_average_score]).to eq (1+0.0+1)/3  # added in a 1.0
+        expect(resp[1][:data_headings][2][:average_score]).to eq (1.0+0+1)/3
 
         # There should now be 3 students in period 2 whereas before there were 2
         expect(resp[1][:students].length).to eq 3

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -100,7 +100,7 @@ class SetupPerformanceReportData
     future_homework_taskplan.tasking_plans << Tasks::Models::TaskingPlan.new(
       target: course,
       task_plan: future_homework_taskplan,
-      opens_at: Time.now + 1.day,
+      opens_at: Time.now + 1.5.day,
       due_at: Time.now + 2.days
     )
 


### PR DESCRIPTION
* Adds `null: false` constraints to `on_time` counts in the DB
* Changes what is includes in scores report averages.