### PR TITLE
Editing assignments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'openstax_exchange', '~> 0.2.1'
 gem 'chronic'
 
 # API versioning and documentation
-gem 'openstax_api', '~> 7.0.1'
+gem 'openstax_api', '~> 7.1.0'
 
 gem 'apipie-rails'
 gem 'maruku'
@@ -158,7 +158,7 @@ gem 'rails-settings-ui'
 
 # Nicely-styled static error pages
 gem 'error_page_assets'
-gem 'render_anywhere', :require => false
+gem 'render_anywhere', require: false
 
 # Add P3P headers for IE
 gem 'p3p'
@@ -262,7 +262,7 @@ group :production do
   gem 'unicorn-worker-killer'
 
   # AWS SES
-  gem 'aws-ses', '~> 0.6.0', :require => 'aws/ses'
+  gem 'aws-ses', '~> 0.6.0', require: 'aws/ses'
 
   # Fog
   gem 'fog', require: 'fog/aws'

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'openstax_exchange', '~> 0.2.1'
 gem 'chronic'
 
 # API versioning and documentation
-gem 'openstax_api', '~> 6.1.4'
+gem 'openstax_api', '~> 7.0.1'
 
 gem 'apipie-rails'
 gem 'maruku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,7 +613,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    sortability (0.0.3)
+    sortability (0.1.0)
       rails
       squeel
     sprockets (2.12.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_api (6.1.4)
+    openstax_api (7.0.1)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
       lev (>= 1.0.0)
@@ -752,7 +752,7 @@ DEPENDENCIES
   omniauth-oauth2 (~> 1.3.1)
   omniauth-salesforce
   openstax_accounts (~> 6.3.2)
-  openstax_api (~> 6.1.4)
+  openstax_api (~> 7.0.1)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.6.0)
   openstax_utilities (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,11 +371,11 @@ GEM
       mime-types (>= 1.16, < 4)
     maruku (0.7.2)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_magick (4.2.0)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
-    multi_json (1.11.3)
+    minitest (5.9.0)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -426,7 +426,7 @@ GEM
       representable (>= 2.0)
       roar (>= 1.0)
       squeel (>= 0.5.0)
-    openstax_api (7.0.1)
+    openstax_api (7.1.0)
       doorkeeper (>= 2.0)
       exception_notification (>= 4.0)
       lev (>= 1.0.0)
@@ -752,7 +752,7 @@ DEPENDENCIES
   omniauth-oauth2 (~> 1.3.1)
   omniauth-salesforce
   openstax_accounts (~> 6.3.2)
-  openstax_api (~> 7.0.1)
+  openstax_api (~> 7.1.0)
   openstax_exchange (~> 0.2.1)
   openstax_rescue_from (~> 1.6.0)
   openstax_utilities (~> 4.2.0)
@@ -801,4 +801,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/app/access_policies/task_access_policy.rb
+++ b/app/access_policies/task_access_policy.rb
@@ -5,7 +5,7 @@ class TaskAccessPolicy
       requestor.is_human? &&
       ((user_is_tasked?(requestor, task) && task.past_open?) || user_is_teacher?(requestor, task))
     when :change_is_late_work_accepted
-      requestor.is_human? && user_is_teacher?(requestor, task)
+      requestor.is_human? && !task.deleted? && user_is_teacher?(requestor, task)
     when :hide
       requestor.is_human? && task.deleted? && user_is_tasked?(requestor, task)
     else

--- a/app/access_policies/task_access_policy.rb
+++ b/app/access_policies/task_access_policy.rb
@@ -2,16 +2,12 @@ class TaskAccessPolicy
   def self.action_allowed?(action, requestor, task)
     case action
     when :read
-      requestor.is_human? && (
-        (
-          DoesTaskingExist[task_component: task, user: requestor] &&
-          task.past_open?
-        ) || (
-          user_is_teacher?(requestor, task)
-        )
-      )
+      requestor.is_human? &&
+      ((user_is_tasked?(requestor, task) && task.past_open?) || user_is_teacher?(requestor, task))
     when :change_is_late_work_accepted
       requestor.is_human? && user_is_teacher?(requestor, task)
+    when :hide
+      requestor.is_human? && task.deleted? && user_is_tasked?(requestor, task)
     else
       false
     end
@@ -22,6 +18,10 @@ class TaskAccessPolicy
              task.concept_coach_task.try(:task).try(:taskings).try(:first)
                                     .try(:period).try(:course) # cc course
     course.is_a?(Entity::Course) ? course : nil
+  end
+
+  def self.user_is_tasked?(user, task)
+    DoesTaskingExist[user: user, task_component: task]
   end
 
   def self.user_is_teacher?(user, task)

--- a/app/access_policies/task_plan_access_policy.rb
+++ b/app/access_policies/task_plan_access_policy.rb
@@ -1,7 +1,7 @@
 class TaskPlanAccessPolicy
   def self.action_allowed?(action, requestor, task_plan)
     case action
-    when :read, :create, :update, :destroy
+    when :read, :create, :update, :destroy, :restore
       if task_plan.owner.is_a?(Entity::Course)
         UserIsCourseTeacher[user: requestor, course: task_plan.owner] rescue false
       elsif requestor.is_human?

--- a/app/access_policies/tasked_access_policy.rb
+++ b/app/access_policies/tasked_access_policy.rb
@@ -11,7 +11,7 @@ class TaskedAccessPolicy
     when :update, :mark_completed, :related_exercise
       requestor.is_human? &&
       DoesTaskingExist[task_component: tasked, user: requestor] &&
-      tasked.task_step.task.past_open?
+      tasked.task_step.task.past_open? && !tasked.task_step.task.deleted?
     else
       false
     end

--- a/app/controllers/api/v1/course_exercises_controller.rb
+++ b/app/controllers/api/v1/course_exercises_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::CourseExercisesController < Api::V1::ApiController
     ]
 
     respond_with exercise_representations, represent_with: Api::V1::ExercisesRepresenter,
-                                           responder: ResponderWithPutContent
+                                           responder: ResponderWithPutPatchDeleteContent
   end
 
   protected

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
                                       with: [:roles, :periods, :ecosystem, :students]].first
       respond_with course_info, represent_with: Api::V1::CourseRepresenter,
                                 location: nil,
-                                responder: ResponderWithPutContent
+                                responder: ResponderWithPutPatchDeleteContent
     end
   end
 

--- a/app/controllers/api/v1/enrollment_changes_controller.rb
+++ b/app/controllers/api/v1/enrollment_changes_controller.rb
@@ -123,7 +123,7 @@ class Api::V1::EnrollmentChangesController < Api::V1::ApiController
       if result.errors.empty?
         respond_with result.outputs.enrollment_change,
                      represent_with: Api::V1::EnrollmentChangeRepresenter,
-                     responder: ResponderWithPutContent
+                     responder: ResponderWithPutPatchDeleteContent
       else
         render_api_errors(result.errors.first.code)
         raise ActiveRecord::Rollback

--- a/app/controllers/api/v1/periods_controller.rb
+++ b/app/controllers/api/v1/periods_controller.rb
@@ -44,13 +44,16 @@ class Api::V1::PeriodsController < Api::V1::ApiController
       respond_with result.outputs.period,
                    represent_with: Api::V1::PeriodRepresenter,
                    location: nil,
-                   responder: ResponderWithPutContent
+                   responder: ResponderWithPutPatchDeleteContent
     end
   end
 
   api :DELETE, '/periods/:id', 'Deletes a period for authorized teachers'
+  description <<-EOS
+    #{json_schema(Api::V1::PeriodRepresenter, include: :readable)}
+  EOS
   def destroy
-    standard_destroy(@period.to_model)
+    standard_destroy(@period.to_model, Api::V1::PeriodRepresenter)
   end
 
   private

--- a/app/controllers/api/v1/practices_controller.rb
+++ b/app/controllers/api/v1/practices_controller.rb
@@ -17,7 +17,7 @@ module Api
         if result.errors.any?
           render_api_errors(result.errors)
         else
-          respond_with result.outputs[:entity_task].task,
+          respond_with result.outputs[:task],
                        represent_with: Api::V1::TaskRepresenter,
                        location: nil
         end
@@ -29,7 +29,7 @@ module Api
         task = GetPracticeWidget[role: get_practice_role]
 
         task.nil? ? head(:not_found) :
-                    respond_with(task.task, represent_with: Api::V1::TaskRepresenter)
+                    respond_with(task, represent_with: Api::V1::TaskRepresenter)
       end
 
       private

--- a/app/controllers/api/v1/students_controller.rb
+++ b/app/controllers/api/v1/students_controller.rb
@@ -55,7 +55,7 @@ class Api::V1::StudentsController < Api::V1::ApiController
 
     if @student.save
       # http://stackoverflow.com/a/27413178
-      respond_with @student, responder: ResponderWithPutContent,
+      respond_with @student, responder: ResponderWithPutPatchDeleteContent,
                              represent_with: Api::V1::StudentSelfUpdateRepresenter
     else
       render_api_errors(@student.errors)
@@ -82,7 +82,7 @@ class Api::V1::StudentsController < Api::V1::ApiController
     else
       respond_with @result.outputs.student,
                    represent_with: Api::V1::StudentRepresenter,
-                   responder: ResponderWithPutContent
+                   responder: ResponderWithPutPatchDeleteContent
     end
   end
 
@@ -91,6 +91,8 @@ class Api::V1::StudentsController < Api::V1::ApiController
     Drops a student from their course.
 
     Possible error code: already_inactive
+
+    #{json_schema(Api::V1::StudentRepresenter, include: :readable)}
   EOS
   def destroy
     OSU::AccessPolicy.require_action_allowed!(:destroy, current_api_user, @student)
@@ -99,7 +101,9 @@ class Api::V1::StudentsController < Api::V1::ApiController
     if result.errors.any?
       render_api_errors(result.errors)
     else
-      head :no_content
+      respond_with result.outputs.student,
+                   represent_with: Api::V1::StudentRepresenter,
+                   responder: ResponderWithPutPatchDeleteContent
     end
   end
 
@@ -118,7 +122,7 @@ class Api::V1::StudentsController < Api::V1::ApiController
     else
       respond_with result.outputs.student,
                    represent_with: Api::V1::StudentRepresenter,
-                   responder: ResponderWithPutContent
+                   responder: ResponderWithPutPatchDeleteContent
     end
   end
 

--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -43,7 +43,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
       render_api_errors(result.errors)
     else
       respond_with @task_step.reload,
-                   responder: ResponderWithPutContent,
+                   responder: ResponderWithPutPatchDeleteContent,
                    represent_with: Api::V1::TaskStepRepresenter
     end
   end
@@ -63,7 +63,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
       render_api_errors(result.errors)
     else
       respond_with result.outputs.related_exercise_step,
-                   responder: ResponderWithPutContent,
+                   responder: ResponderWithPutPatchDeleteContent,
                    represent_with: Api::V1::TaskStepRepresenter
     end
   end

--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
   protected
 
   def get_task_step
-    @task_step = ::Tasks::Models::TaskStep.find(params[:id])
+    @task_step = ::Tasks::Models::TaskStep.with_deleted.find(params[:id])
     @tasked = @task_step.tasked
   end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -61,7 +61,7 @@ class Api::V1::TasksController < Api::V1::ApiController
   protected
 
   def get_task
-    @task = Tasks::Models::Task.find(params[:id])
+    @task = Tasks::Models::Task.with_deleted.find(params[:id])
   end
 
   def change_is_late_work_accepted(task, is_accepted)

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::TasksController < Api::V1::ApiController
 
+  before_action :get_task
+
   resource_description do
     api_versions "v1"
     short_description 'Represents a task assigned to a user or role'
@@ -19,11 +21,11 @@ class Api::V1::TasksController < Api::V1::ApiController
   ###############################################################
 
   api :GET, '/tasks/:id', 'Gets the specified Task'
-  # description <<-EOS
-  #   #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
-  # EOS
+  description <<-EOS
+    #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
+  EOS
   def show
-    standard_read(::Tasks::Models::Task.find(params[:id]), Api::V1::TaskRepresenter, true)
+    standard_read(@task, Api::V1::TaskRepresenter, true)
   end
 
   api :PUT, '/tasks/:id/accept_late_work', 'Accept late work in the task score'
@@ -32,7 +34,7 @@ class Api::V1::TasksController < Api::V1::ApiController
     the `score` that it computes.  Does not change the underlying counts in any way.
   EOS
   def accept_late_work
-    change_is_late_work_accepted(true)
+    change_is_late_work_accepted(@task, true)
   end
 
 
@@ -42,13 +44,27 @@ class Api::V1::TasksController < Api::V1::ApiController
     the `score` that it computes.  Does not change the underlying counts in any way.
   EOS
   def reject_late_work
-    change_is_late_work_accepted(false)
+    change_is_late_work_accepted(@task, false)
+  end
+
+  api :DELETE, '/tasks/:id', 'Hide the task from the student\'s dashboard'
+  description <<-EOS
+    Hides the Task from the student's dashboard
+  EOS
+  def destroy
+    OSU::AccessPolicy.require_action_allowed!(:hide, current_api_user, @task)
+    @task.hide.save!
+    respond_with @task, represent_with: Api::V1::TaskRepresenter,
+                        responder: ResponderWithPutPatchDeleteContent
   end
 
   protected
 
-  def change_is_late_work_accepted(is_accepted)
-    task = Tasks::Models::Task.find(params[:id])
+  def get_task
+    @task = Tasks::Models::Task.find(params[:id])
+  end
+
+  def change_is_late_work_accepted(task, is_accepted)
     OSU::AccessPolicy.require_action_allowed!(:change_is_late_work_accepted, current_api_user, task)
     task.is_late_work_accepted = is_accepted
     task.save! # would be Exceptional if this failed

--- a/app/controllers/api/v1/teachers_controller.rb
+++ b/app/controllers/api/v1/teachers_controller.rb
@@ -12,10 +12,12 @@ class Api::V1::TeachersController < Api::V1::ApiController
   api :DELETE, '/teachers/:teacher_id', 'Removes a teacher from the course'
   description <<-EOS
     Removes a teacher from the course.
+
+    #{json_schema(Api::V1::TeacherRepresenter, include: :readable)}
   EOS
   def destroy
     OSU::AccessPolicy.require_action_allowed!(:destroy, current_api_user, @teacher)
-    standard_destroy(@teacher)
+    standard_destroy(@teacher, Api::V1::TeacherRepresenter)
   end
 
   protected

--- a/app/controllers/manager/stats_actions.rb
+++ b/app/controllers/manager/stats_actions.rb
@@ -14,7 +14,7 @@ module Manager::StatsActions
 
   def concept_coach
     cc_tasks = Tasks::Models::ConceptCoachTask.preload([
-      {page: {chapter: {book: {chapters: :pages}}}}, {task: [:task, {taskings: {role: :profile}}]}
+      {page: {chapter: {book: {chapters: :pages}}}}, {task: {taskings: {role: :profile}}}
     ]).to_a
 
     @cc_stats = {
@@ -54,11 +54,11 @@ module Manager::StatsActions
   protected
 
   def get_task_stats(cc_tasks)
-    tasks = cc_tasks.map{ |cc| cc.task.task }
+    tasks = cc_tasks.map(&:task)
     total = tasks.length
-    students = tasks.flat_map{ |tt| tt.taskings.map{ |tg| tg.role.profile } }.uniq.length
-    in_progress = tasks.select{ |tt| tt.in_progress? }.length
-    completed = tasks.select{ |tt| tt.completed? }.length
+    students = tasks.flat_map{ |task| task.taskings.map{ |tg| tg.role.profile } }.uniq.length
+    in_progress = tasks.select(&:in_progress?).length
+    completed = tasks.select(&:completed?).length
     not_started = total - (in_progress + completed)
     exercises = tasks.map(&:exercise_steps_count).reduce(:+)
     completed_exercises = tasks.map(&:completed_exercise_steps_count).reduce(:+)

--- a/app/models/entity/task.rb
+++ b/app/models/entity/task.rb
@@ -1,5 +1,0 @@
-class Entity::Task < Tutor::SubSystems::BaseModel
-  has_many :taskings, subsystem: :tasks, dependent: :destroy, autosave: true, inverse_of: :task
-  has_one :task, subsystem: :tasks, dependent: :destroy, autosave: true, inverse_of: :entity_task
-  has_one :concept_coach_task, subsystem: :tasks, dependent: :destroy, inverse_of: :task
-end

--- a/app/models/entity/task_plan.rb
+++ b/app/models/entity/task_plan.rb
@@ -1,2 +1,0 @@
-class Entity::TaskPlan < Tutor::SubSystems::BaseModel
-end

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -54,6 +54,7 @@ module Api::V1::Courses
                schema_info: { type: 'boolean' }
 
       property :deleted?,
+               as: :is_deleted,
                readable: true,
                writeable: false,
                schema_info: {

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -52,6 +52,14 @@ module Api::V1::Courses
                readable: true,
                writeable: false,
                schema_info: { type: 'boolean' }
+
+      property :deleted?,
+               readable: true,
+               writeable: false,
+               schema_info: {
+                 type: 'boolean',
+                 description: "Whether or not this task has been withdrawn by the teacher"
+               }
     end
 
     class ReadingTask < TaskBase

--- a/app/representers/api/v1/task_representer.rb
+++ b/app/representers/api/v1/task_representer.rb
@@ -81,5 +81,6 @@ module Api::V1
              type: Object,
              readable: true,
              writeable: false
+
   end
 end

--- a/app/representers/api/v1/teacher_representer.rb
+++ b/app/representers/api/v1/teacher_representer.rb
@@ -1,0 +1,49 @@
+module Api::V1
+  class TeacherRepresenter < Roar::Decorator
+
+    include Roar::JSON
+    include Representable::Coercion
+
+    property :id,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true
+             }
+
+    property :entity_course_id,
+             as: :course_id,
+             type: String,
+             writeable: true,
+             readable: true,
+             schema_info: {
+               required: true
+             }
+
+    property :entity_role_id,
+             as: :role_id,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true
+             }
+
+    property :first_name,
+             type: String,
+             writeable: false,
+             readable: true
+
+    property :last_name,
+             type: String,
+             writeable: false,
+             readable: true
+
+    property :name,
+             type: String,
+             writeable: false,
+             readable: true
+
+  end
+end

--- a/app/routines/add_user_as_course_teacher.rb
+++ b/app/routines/add_user_as_course_teacher.rb
@@ -2,8 +2,8 @@ class AddUserAsCourseTeacher
   lev_routine express_output: :role
 
   uses_routine UserIsCourseTeacher, as: :is_teacher
-  uses_routine Role::CreateUserRole, translations: {outputs: {type: :verbatim}}
-  uses_routine CourseMembership::AddTeacher
+  uses_routine Role::CreateUserRole, translations: { outputs: { type: :verbatim } }
+  uses_routine CourseMembership::AddTeacher, translations: { outputs: { type: :verbatim } }
 
   protected
 

--- a/app/routines/add_user_as_period_student.rb
+++ b/app/routines/add_user_as_period_student.rb
@@ -3,10 +3,8 @@ class AddUserAsPeriodStudent
 
   uses_routine UserIsCourseTeacher
   uses_routine UserIsCourseStudent
-  uses_routine Role::CreateUserRole,
-    translations: { outputs: { type: :verbatim } }
-  uses_routine CourseMembership::AddStudent,
-    translations: { outputs: { type: :verbatim } }
+  uses_routine Role::CreateUserRole, translations: { outputs: { type: :verbatim } }
+  uses_routine CourseMembership::AddStudent, translations: { outputs: { type: :verbatim } }
 
   protected
 

--- a/app/routines/calculate_task_stats.rb
+++ b/app/routines/calculate_task_stats.rb
@@ -141,8 +141,8 @@ class CalculateTaskStats
 
   def generate_period_stat_data
     tasks = @tasks.preload([:task_steps, {taskings: :period}]).to_a
-    grouped_tasks = tasks.group_by do |tt|
-      tt.taskings.first.try(:period) || no_period
+    grouped_tasks = tasks.group_by do |task|
+      task.taskings.first.try(:period) || no_period
     end
     grouped_tasks.map do |period, period_tasks|
       current_page_stats = generate_page_stats_for_task_steps(

--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -36,8 +36,8 @@ module DashboardRoutineMethods
   end
 
   def load_tasks(role, role_type)
-    tasks = run(:get_tasks, roles: role).outputs.tasks
-    tasks = tasks.select{ |task| task.past_open? } if :student == role_type
+    tasks = run(:get_tasks, roles: role).outputs.tasks.reject(&:hidden?)
+    tasks = tasks.select(&:past_open?) if :student == role_type
     outputs[:tasks] = tasks
   end
 end

--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -36,12 +36,8 @@ module DashboardRoutineMethods
   end
 
   def load_tasks(role, role_type)
-    entity_tasks = run(:get_tasks, roles: role).outputs.tasks
-    entity_tasks = entity_tasks.joins(:task).preload(:task)
-    entity_tasks = entity_tasks.select do |entity_task|
-      entity_task.task.past_open?
-    end if :student == role_type
-    tasks = entity_tasks.map(&:task)
+    tasks = run(:get_tasks, roles: role).outputs.tasks
+    tasks = tasks.select{ |task| task.past_open? } if :student == role_type
     outputs[:tasks] = tasks
   end
 end

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -30,8 +30,9 @@ class DistributeTasks
 
     # Delete pre-existing assignments only if
     # no assignments are open and protect_unopened_tasks is false
-    tasks.each(&:destroy) if !protect_unopened_tasks &&
-                             tasks.none?{ |task| task.past_open?(current_time: publish_time) }
+    tasks.each(&:really_destroy!) \
+      if !protect_unopened_tasks &&
+         tasks.none?{ |task| task.past_open?(current_time: publish_time) }
 
     tasked_taskees = tasks.reject(&:destroyed?)
                           .flat_map{ |task| task.taskings.map(&:role) }

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -6,9 +6,9 @@ class DistributeTasks
 
   protected
 
-  def save(entity_tasks)
-    entity_tasks.each do |entity_task|
-      entity_task.task.task_steps.each_with_index do |task_step, index|
+  def save(tasks)
+    tasks.each do |task|
+      task.task_steps.each_with_index do |task_step, index|
         tasked = task_step.tasked
         tasked.task_step = nil
         tasked.save!
@@ -16,25 +16,25 @@ class DistributeTasks
         task_step.number = index + 1
       end
 
-      entity_task.task.update_step_counts
+      task.update_step_counts
     end
 
-    Entity::Task.import! entity_tasks, recursive: true
-    entity_tasks.each(&:clear_association_cache)
+    Tasks::Models::Task.import! tasks, recursive: true
+    tasks.each(&:clear_association_cache)
   end
 
   def exec(task_plan, publish_time = Time.current, protect_unopened_tasks = false)
     task_plan.lock!
 
-    tasks = task_plan.tasks.preload(:entity_task, { taskings: :role })
+    tasks = task_plan.tasks.preload(taskings: :role)
 
     # Delete pre-existing assignments only if
     # no assignments are open and protect_unopened_tasks is false
-    tasks.each{ |tt| tt.entity_task.destroy } \
-      if !protect_unopened_tasks && tasks.none?{ |tt| tt.past_open?(current_time: publish_time) }
+    tasks.each(&:destroy) if !protect_unopened_tasks &&
+                             tasks.none?{ |task| task.past_open?(current_time: publish_time) }
 
-    tasked_taskees = tasks.select{ |tt| !tt.destroyed? }
-                          .flat_map{ |tt| tt.taskings.map(&:role) }
+    tasked_taskees = tasks.reject(&:destroyed?)
+                          .flat_map{ |task| task.taskings.map(&:role) }
 
     tasking_plans = run(:get_tasking_plans, task_plan).outputs.tasking_plans
 
@@ -49,37 +49,32 @@ class DistributeTasks
     assistant = task_plan.assistant
 
     # Call the assistant code to create Tasks, then distribute them
-    entity_tasks = assistant.build_tasks(task_plan: task_plan, taskees: untasked_taskees)
+    tasks = assistant.build_tasks(task_plan: task_plan, taskees: untasked_taskees)
     fatal_error(code: :empty_tasks,
                 message: 'Tasks could not be published because some tasks were empty') \
-      if entity_tasks.any? do |entity_task|
-        !entity_task.task.stepless? && entity_task.task.task_steps.empty?
-      end
-    entity_tasks.each_with_index do |entity_task, ii|
+      if tasks.any?{ |task| !task.stepless? && task.task_steps.empty? }
+    tasks.each_with_index do |task, ii|
       role = untasked_taskees[ii]
       tasking = Tasks::Models::Tasking.new(
-        task: entity_task,
+        task: task,
         role: role,
         period: role.student.try(:period)
       )
-      entity_task.taskings << tasking
-
-      task = entity_task.task
-
+      task.taskings << tasking
       task.time_zone = time_zones[ii]
       task.opens_at = opens_ats[ii]
       task.due_at = due_ats[ii]
       task.feedback_at = task_plan.is_feedback_immediate ? nil : task.due_at
     end
 
-    save(entity_tasks)
+    save(tasks)
 
     if task_plan.persisted?
       task_plan.published_at.nil? ? task_plan.update_attribute(:published_at, publish_time) : \
                                     task_plan.touch # Touch is necessary to avoid double updates
     end
 
-    outputs[:entity_tasks] = entity_tasks
+    outputs[:tasks] = tasks
   end
 
 end

--- a/app/routines/get_concept_coach.rb
+++ b/app/routines/get_concept_coach.rb
@@ -1,6 +1,6 @@
 class GetConceptCoach
 
-  lev_routine express_output: :entity_task, transaction: :serializable
+  lev_routine express_output: :task, transaction: :serializable
 
   uses_routine Tasks::GetConceptCoachTask, as: :get_cc_task
 
@@ -25,10 +25,9 @@ class GetConceptCoach
 
     ecosystem, pool = get_ecosystem_and_pool(page)
     history = run(:get_history, role: role, type: :concept_coach).outputs
-    existing_cc_task = run(:get_cc_task, role: role, page: page).outputs.entity_task
+    existing_cc_task = run(:get_cc_task, role: role, page: page).outputs.task
     unless existing_cc_task.nil?
-      outputs.entity_task = existing_cc_task
-      outputs.task = existing_cc_task.task
+      outputs.task = existing_cc_task
       run(:add_spy_info, to: outputs.task, from: [ecosystem, {history: history.tasks}])
       return
     end
@@ -122,8 +121,6 @@ class GetConceptCoach
     run(:add_spy_info, to: outputs.task,
                        from: [ecosystem, { history: history.tasks,
                                            spaced_practice: spaced_practice_status }])
-
-    outputs.entity_task = outputs.task.entity_task
   end
 
   def get_role_and_page(user:, cnx_book_id:, cnx_page_id:)

--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -19,8 +19,8 @@ class GetStudentGuide
   def completed_exercise_task_steps_for_role(role)
     get_completed_exercise_task_steps(
       role.taskings
-        .preload(task: {task: :task_steps})
-        .flat_map{ |tasking| tasking.task.task.task_steps }
+        .preload(task: :task_steps)
+        .flat_map{ |tg| tg.task.task_steps }
     )
   end
 

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -6,10 +6,12 @@ class PropagateTaskPlanUpdates
 
   def updated_attributes_for(tasking_plan:)
     task_plan = tasking_plan.task_plan
+
+    # This routine is only called after tasks are open and
+    # we do not allow changing the open date after open
     {
       title: task_plan.title,
       description: task_plan.description,
-      opens_at_ntz: tasking_plan.opens_at_ntz,
       due_at_ntz: tasking_plan.due_at_ntz,
       feedback_at_ntz: task_plan.is_feedback_immediate ? nil : tasking_plan.due_at_ntz
     }

--- a/app/routines/reset_practice_widget.rb
+++ b/app/routines/reset_practice_widget.rb
@@ -22,10 +22,11 @@ class ResetPracticeWidget
   protected
 
   def exec(role:, exercise_source:, page_ids: nil, chapter_ids: nil, randomize: true)
-    # Get the existing practice widget and remove incomplete exercises from it
-    # so they can be used in later practice
+    # Get the existing practice widget and hard-delete
+    # incomplete exercises from it so they can be used in later practice
     existing_practice_task = run(:get_practice_widget, role: role).outputs.task
-    existing_practice_task.task_steps.incomplete.destroy_all unless existing_practice_task.nil?
+    existing_practice_task.task_steps.incomplete.each(&:really_destroy!) \
+      unless existing_practice_task.nil?
 
     # Gather 5 exercises
     count = 5

--- a/app/routines/reset_practice_widget.rb
+++ b/app/routines/reset_practice_widget.rb
@@ -1,5 +1,5 @@
 class ResetPracticeWidget
-  lev_routine express_output: :entity_task
+  lev_routine express_output: :task
 
   uses_routine GetPracticeWidget, as: :get_practice_widget
 
@@ -24,7 +24,7 @@ class ResetPracticeWidget
   def exec(role:, exercise_source:, page_ids: nil, chapter_ids: nil, randomize: true)
     # Get the existing practice widget and remove incomplete exercises from it
     # so they can be used in later practice
-    existing_practice_task = run(:get_practice_widget, role: role).outputs.task.try(:task)
+    existing_practice_task = run(:get_practice_widget, role: role).outputs.task
     existing_practice_task.task_steps.incomplete.destroy_all unless existing_practice_task.nil?
 
     # Gather 5 exercises
@@ -80,9 +80,7 @@ class ResetPracticeWidget
                                       related_content_array: related_content_array)
     run(:add_spy_info, to: outputs.task, from: ecosystem)
 
-    run(:create_tasking, role: role, task: outputs.task.entity_task)
-
-    outputs.entity_task = outputs.task.entity_task
+    run(:create_tasking, role: role, task: outputs.task)
   end
 
   def get_fake_exercises(count)
@@ -106,8 +104,6 @@ class ResetPracticeWidget
 
   def get_local_exercises(ecosystem:, count:, role:, pools:, randomize:,
                           additional_excluded_numbers: [])
-    entity_tasks = role.taskings.preload(task: {task: {task_steps: :tasked}}).map(&:task)
-
     pool_exercises = pools.flat_map(&:exercises)
 
     course = role.student.try(:course)

--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -4,7 +4,7 @@ module CourseMembership
 
     def exec(student:)
       fatal_error(code: :already_active) unless student.deleted?
-      student.restore
+      student.restore(rescursive: true)
       student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)
       outputs[:student] = student

--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -5,6 +5,7 @@ module CourseMembership
     def exec(student:)
       fatal_error(code: :already_active) unless student.deleted?
       student.restore
+      student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)
       outputs[:student] = student
     end

--- a/app/subsystems/course_membership/add_enrollment.rb
+++ b/app/subsystems/course_membership/add_enrollment.rb
@@ -14,6 +14,7 @@ class CourseMembership::AddEnrollment
     student.enrollments << outputs[:enrollment]
     student.restore if student.deleted?
     outputs[:student] = student
+    transfer_errors_from(outputs[:student], {type: :verbatim}, true)
 
     ReassignPublishedPeriodTaskPlans.perform_later(period: period.to_model) \
       if assign_published_period_tasks

--- a/app/subsystems/course_membership/add_teacher.rb
+++ b/app/subsystems/course_membership/add_teacher.rb
@@ -4,7 +4,8 @@ class CourseMembership::AddTeacher
   protected
 
   def exec(course:, role:)
-    ss_map = CourseMembership::Models::Teacher.create(entity_course_id: course.id, entity_role_id: role.id)
-    transfer_errors_from(ss_map, {type: :verbatim}, true)
+    outputs.teacher = CourseMembership::Models::Teacher.create(entity_course_id: course.id,
+                                                               entity_role_id: role.id)
+    transfer_errors_from(outputs.teacher, {type: :verbatim}, true)
   end
 end

--- a/app/subsystems/course_membership/inactivate_student.rb
+++ b/app/subsystems/course_membership/inactivate_student.rb
@@ -5,6 +5,7 @@ module CourseMembership
     def exec(student:)
       fatal_error(code: :already_inactive) if student.deleted?
       student.destroy
+      student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)
       outputs[:student] = student
     end

--- a/app/subsystems/course_membership/models/enrollment.rb
+++ b/app/subsystems/course_membership/models/enrollment.rb
@@ -10,7 +10,7 @@ class CourseMembership::Models::Enrollment < Tutor::SubSystems::BaseModel
   validates :student, presence: true
   validate :same_course
 
-  default_scope -> { order(created_at: :asc) }
+  default_scope -> { order(:created_at) }
 
   scope :latest, -> {
     joins{CourseMembership::Models::Enrollment.unscoped.as(:newer_enrollment).on{

--- a/app/subsystems/course_membership/models/teacher.rb
+++ b/app/subsystems/course_membership/models/teacher.rb
@@ -4,4 +4,6 @@ class CourseMembership::Models::Teacher < Tutor::SubSystems::BaseModel
 
   validates :role,   presence: true, uniqueness: true
   validates :course, presence: true
+
+  delegate :username, :first_name, :last_name, :full_name, :name, to: :role
 end

--- a/app/subsystems/tasks/add_related_exercise_after_step.rb
+++ b/app/subsystems/tasks/add_related_exercise_after_step.rb
@@ -49,7 +49,7 @@ class Tasks::AddRelatedExerciseAfterStep
     related_exercises = ecosystem.exercises_by_ids(related_exercise_ids)
 
     # Assume only 1 taskee for now
-    role = task_step.task.entity_task.taskings.map(&:role).first
+    role = task_step.task.taskings.map(&:role).first
     course = role.student.try(:course)
 
     task_exercise_numbers = task_step.task.tasked_exercises.map{ |te| te.exercise.number }

--- a/app/subsystems/tasks/assistants/README.md
+++ b/app/subsystems/tasks/assistants/README.md
@@ -7,7 +7,8 @@ Assistant Classes must:
 
   2. Implement the `build_tasks` method which:
        - Builds Task objects for the TaskPlan given during initialization
-       - Returns an array containing the Entity::Tasks to be assigned to the taskees (in order)
+       - Returns an array containing the Tasks::Models::Task to be assigned to the taskees
+         (in order)
 
   3. Implement the `schema` singleton method which:
        - Receives no arguments

--- a/app/subsystems/tasks/assistants/event_assistant.rb
+++ b/app/subsystems/tasks/assistants/event_assistant.rb
@@ -16,7 +16,7 @@ module Tasks
                            task_type: :event,
                            title: task_plan.title,
                            description: task_plan.description]
-        end.map(&:entity_task)
+        end
       end
 
       private

--- a/app/subsystems/tasks/assistants/external_assignment_assistant.rb
+++ b/app/subsystems/tasks/assistants/external_assignment_assistant.rb
@@ -24,7 +24,7 @@ class Tasks::Assistants::ExternalAssignmentAssistant < Tasks::Assistants::Generi
     @taskees.map.with_index do |taskee, i|
       build_external_task(task_plan: @task_plan,
                           taskee: taskee,
-                          student: students[i]).entity_task
+                          student: students[i])
     end
   end
 

--- a/app/subsystems/tasks/assistants/extra_assignment_assistant.rb
+++ b/app/subsystems/tasks/assistants/extra_assignment_assistant.rb
@@ -30,7 +30,7 @@ class Tasks::Assistants::ExtraAssignmentAssistant < Tasks::Assistants::FragmentA
 
   def build_tasks
     taskees.map do |taskee|
-      build_extra_task(pages: @pages, page_id_to_snap_lab_id: @page_id_to_snap_lab_id).entity_task
+      build_extra_task(pages: @pages, page_id_to_snap_lab_id: @page_id_to_snap_lab_id)
     end
   end
 

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -40,12 +40,7 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
     @page_pools = {}
     @pool_exercises = {}
     @ecosystems_map = {}
-    @taskees.map do |taskee|
-      build_homework_task(
-        taskee:       taskee,
-        exercises:    @exercises
-      ).entity_task
-    end
+    @taskees.map{ |taskee| build_homework_task(taskee: taskee, exercises: @exercises) }
   end
 
   protected

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -28,7 +28,7 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
   end
 
   def build_tasks
-    taskees.map{ |taskee| build_reading_task(pages: @pages, taskee: taskee).entity_task }
+    taskees.map{ |taskee| build_reading_task(pages: @pages, taskee: taskee) }
   end
 
   protected

--- a/app/subsystems/tasks/build_task.rb
+++ b/app/subsystems/tasks/build_task.rb
@@ -4,9 +4,6 @@ class Tasks::BuildTask
   protected
 
   def exec(attributes)
-    attributes[:entity_task] ||= Entity::Task.new
-    task = Tasks::Models::Task.new(attributes)
-    task.entity_task.task = task
-    outputs[:task] = task
+    outputs[:task] = Tasks::Models::Task.new(attributes)
   end
 end

--- a/app/subsystems/tasks/create_concept_coach_task.rb
+++ b/app/subsystems/tasks/create_concept_coach_task.rb
@@ -29,12 +29,10 @@ module Tasks
 
       outputs.task.save!
 
-      entity_task = outputs.task.entity_task
-
-      run(:create_tasking, role: role, task: entity_task, period: period)
+      run(:create_tasking, role: role, task: outputs.task, period: period)
 
       outputs.concept_coach_task = Tasks::Models::ConceptCoachTask.create!(
-        content_page_id: page.id, entity_role_id: role.id, task: entity_task
+        content_page_id: page.id, entity_role_id: role.id, task: outputs.task
       )
     end
 

--- a/app/subsystems/tasks/create_tasking.rb
+++ b/app/subsystems/tasks/create_tasking.rb
@@ -4,9 +4,8 @@ class Tasks::CreateTasking
   protected
 
   def exec(role:, task:, period: nil)
-    entity_task = task.is_a?(Entity::Task) ? task : task.entity_task
     outputs[:tasking] = Tasks::Models::Tasking.create!(
-      role: role, task: entity_task, period: period
+      role: role, task: task, period: period
     )
   end
 end

--- a/app/subsystems/tasks/does_tasking_exist.rb
+++ b/app/subsystems/tasks/does_tasking_exist.rb
@@ -6,20 +6,16 @@ class Tasks::DoesTaskingExist
   def exec(task_component:, roles:)
 
     task = case task_component
-    when Entity::Task
-      task_component
     when Tasks::Models::Task
-      task_component.entity_task
+      task_component
     when Tasks::Models::TaskStep
-      task_component.task.entity_task
+      task_component.task
     else
-      task_component.task_step.task.entity_task
+      task_component.task_step.task
     end
 
     role_ids = roles.map(&:id)
 
-    outputs[:does_tasking_exist] =
-      Tasks::Models::Tasking.where{entity_task_id == my{task.id}}
-                            .where{entity_role_id.in role_ids}.any?
+    outputs[:does_tasking_exist] = task.taskings.any?{ |tg| roles.include?(tg.role) }
   end
 end

--- a/app/subsystems/tasks/get_cc_performance_report.rb
+++ b/app/subsystems/tasks/get_cc_performance_report.rb
@@ -50,11 +50,11 @@ module Tasks
 
     def get_cc_taskings(course)
       # Return cc tasks for a student, ignoring not_started tasks
-      course.taskings.preload(task: [:task, {concept_coach_task: :page}],
+      course.taskings.preload(task: {concept_coach_task: :page},
                               role: [{student: {enrollments: :period}},
                                      {profile: :account}])
-                     .joins(task: [:task, :concept_coach_task])
-                     .where{task.task.completed_steps_count > 0}
+                     .joins(task: :concept_coach_task)
+                     .where{task.completed_steps_count > 0}
                      .to_a
     end
 
@@ -85,7 +85,7 @@ module Tasks
     def get_cc_data_headings(period_cc_tasks_map_array, sorted_period_pages)
       sorted_period_pages.map do |page|
         page_tasks = period_cc_tasks_map_array.flat_map{ |hash| hash[page] }.compact
-                                              .map{ |cc_task| cc_task.task.task }
+                                              .map(&:task)
 
         {
           cnx_page_id: page.uuid,
@@ -103,8 +103,8 @@ module Tasks
         cc_tasks = page_cc_tasks_map_for_role[page]
         next if cc_tasks.nil?
 
-        # Here we assume only 1 CC task per student per page
-        cc_tasks.first.task.task
+        # Only 1 CC task per student per page
+        cc_tasks.first.task
       end
 
       get_student_data(tasks)

--- a/app/subsystems/tasks/get_concept_coach_task.rb
+++ b/app/subsystems/tasks/get_concept_coach_task.rb
@@ -1,10 +1,10 @@
 class Tasks::GetConceptCoachTask
-  lev_routine express_output: :entity_task
+  lev_routine express_output: :task
 
   protected
 
   def exec(role:, page:)
-    outputs[:entity_task] = Tasks::Models::ConceptCoachTask
+    outputs[:task] = Tasks::Models::ConceptCoachTask
       .joins(:page)
       .where(page: { uuid: page.uuid }, entity_role_id: role.id)
       .lock.take.try(:task)

--- a/app/subsystems/tasks/get_practice_task.rb
+++ b/app/subsystems/tasks/get_practice_task.rb
@@ -7,11 +7,10 @@ class Tasks::GetPracticeTask
     task_types = [Tasks::Models::Task.task_types[:chapter_practice],
                   Tasks::Models::Task.task_types[:page_practice],
                   Tasks::Models::Task.task_types[:mixed_practice]]
-    outputs[:task] = Tasks::Models::Task.joins{entity_task.taskings}
-                                        .where{entity_task.taskings.entity_role_id == role.id}
+    outputs[:task] = Tasks::Models::Task.joins{taskings}
+                                        .where{taskings.entity_role_id == role.id}
                                         .where{task_type.in my { task_types }}
                                         .order{created_at}
                                         .last
-                                        .try(:entity_task)
   end
 end

--- a/app/subsystems/tasks/get_redirect_url.rb
+++ b/app/subsystems/tasks/get_redirect_url.rb
@@ -22,8 +22,7 @@ class Tasks::GetRedirectUrl
   end
 
   def task_page(course:, role:, task_plan:)
-    task = Tasks::GetTasks[roles: [role]].joins(:task).where(
-      task: { tasks_task_plan_id: task_plan.id }).first
+    task = Tasks::GetTasks[roles: [role]].where(tasks_task_plan_id: task_plan.id).first
     "/courses/#{course.id}/tasks/#{task.id}"
   end
 

--- a/app/subsystems/tasks/get_tasks.rb
+++ b/app/subsystems/tasks/get_tasks.rb
@@ -8,7 +8,8 @@ class Tasks::GetTasks
   def exec(roles:)
     role_ids = verify_and_get_id_array(roles, Entity::Role)
 
-    outputs[:tasks] = Tasks::Models::Task.joins{taskings}
+    outputs[:tasks] = Tasks::Models::Task.with_deleted
+                                         .joins{taskings}
                                          .where{taskings.entity_role_id.in role_ids}
   end
 

--- a/app/subsystems/tasks/get_tasks.rb
+++ b/app/subsystems/tasks/get_tasks.rb
@@ -8,8 +8,8 @@ class Tasks::GetTasks
   def exec(roles:)
     role_ids = verify_and_get_id_array(roles, Entity::Role)
 
-    outputs[:tasks] = Entity::Task.joins{taskings}
-                                  .where{taskings.entity_role_id.in role_ids}
+    outputs[:tasks] = Tasks::Models::Task.joins{taskings}
+                                         .where{taskings.entity_role_id.in role_ids}
   end
 
 end

--- a/app/subsystems/tasks/models/concept_coach_task.rb
+++ b/app/subsystems/tasks/models/concept_coach_task.rb
@@ -6,7 +6,7 @@ module Tasks::Models
 
     belongs_to :page, subsystem: :content
     belongs_to :role, subsystem: :entity
-    belongs_to :task, subsystem: :entity
+    belongs_to :task, inverse_of: :concept_coach_task
 
     validates :page, presence: true
     validates :role, presence: true, uniqueness: { scope: :content_page_id }

--- a/app/subsystems/tasks/models/concept_coach_task.rb
+++ b/app/subsystems/tasks/models/concept_coach_task.rb
@@ -1,12 +1,14 @@
 module Tasks::Models
   class ConceptCoachTask < Tutor::SubSystems::BaseModel
 
+    acts_as_paranoid
+
     CORE_EXERCISES_COUNT = 3
     SPACED_EXERCISES_MAP = [[2, 1], [:random, 1]]
 
     belongs_to :page, subsystem: :content
     belongs_to :role, subsystem: :entity
-    belongs_to :task, inverse_of: :concept_coach_task
+    belongs_to :task, ->{ with_deleted }, inverse_of: :concept_coach_task
 
     validates :page, presence: true
     validates :role, presence: true, uniqueness: { scope: :content_page_id }

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -2,6 +2,9 @@ require_relative '../placeholder_strategies/homework_personalized'
 require_relative '../placeholder_strategies/i_reading_personalized'
 
 class Tasks::Models::Task < Tutor::SubSystems::BaseModel
+
+  acts_as_paranoid
+
   enum task_type: [:homework, :reading, :chapter_practice,
                    :page_practice, :mixed_practice, :external,
                    :event, :extra, :concept_coach]
@@ -10,15 +13,15 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
 
   belongs_to_time_zone :opens_at, :due_at, :feedback_at, suffix: :ntz
 
-  belongs_to :task_plan, inverse_of: :tasks
+  belongs_to :task_plan, -> { with_deleted }, inverse_of: :tasks
 
-  sortable_has_many :task_steps, on: :number, dependent: :destroy,
-                                 inverse_of: :task, autosave: true
-  has_many :tasked_exercises, through: :task_steps, source: :tasked,
-                                                    source_type: 'Tasks::Models::TaskedExercise'
+  sortable_has_many :task_steps, -> { with_deleted.order(:number) },
+                                 on: :number, dependent: :destroy, inverse_of: :task, autosave: true
+  has_many :tasked_exercises, -> { with_deleted }, through: :task_steps, source: :tasked,
+                                                  source_type: 'Tasks::Models::TaskedExercise'
 
-  has_many :taskings, dependent: :destroy, autosave: true, inverse_of: :task
-  has_one :concept_coach_task, dependent: :destroy, inverse_of: :task
+  has_many :taskings, -> { with_deleted }, dependent: :destroy, autosave: true, inverse_of: :task
+  has_one :concept_coach_task, -> { with_deleted }, dependent: :destroy, inverse_of: :task
 
   validates :title, presence: true
 

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -69,12 +69,21 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
     feedback_at.nil? || current_time >= feedback_at
   end
 
+  def hidden?
+    deleted? && hidden_at.present? && hidden_at >= deleted_at
+  end
+
   def completed?
     steps_count == completed_steps_count
   end
 
   def in_progress?
     completed_steps_count > 0 && !completed?
+  end
+
+  def hide(current_time: Time.current)
+    self.hidden_at = current_time
+    self
   end
 
   def set_last_worked_at(time:)

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -30,6 +30,8 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
 
   validate :valid_settings, :same_ecosystem, :changes_allowed, :not_past_due_when_publishing
 
+  scope :preloaded, -> { preload(:owner, :tasking_plans, tasks: [:taskings, task_steps: :tasked]) }
+
   def tasks_past_open?
     tasks.any?(&:past_open?)
   end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -1,6 +1,10 @@
 class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
-  sortable_belongs_to :task, on: :number, inverse_of: :task_steps, touch: true
-  belongs_to :tasked, polymorphic: true, dependent: :destroy, inverse_of: :task_step, touch: true
+
+  acts_as_paranoid
+
+  sortable_belongs_to :task, -> { with_deleted }, on: :number, inverse_of: :task_steps, touch: true
+  belongs_to :tasked, -> { with_deleted }, polymorphic: true, dependent: :destroy,
+                                          inverse_of: :task_step, touch: true
 
   enum group_type: [:default_group, :core_group, :spaced_practice_group,
                     :personalized_group, :recovery_group]

--- a/app/subsystems/tasks/models/tasking.rb
+++ b/app/subsystems/tasks/models/tasking.rb
@@ -1,9 +1,9 @@
 class Tasks::Models::Tasking < Tutor::SubSystems::BaseModel
-  belongs_to :task, subsystem: :entity, inverse_of: :taskings
+  belongs_to :task, inverse_of: :taskings
   belongs_to :role, subsystem: :entity
 
   belongs_to :period, -> { with_deleted }, subsystem: :course_membership
 
   validates :task, presence: true
-  validates :role, presence: true, uniqueness: { scope: :entity_task_id }
+  validates :role, presence: true, uniqueness: { scope: :tasks_task_id }
 end

--- a/app/subsystems/tasks/models/tasking.rb
+++ b/app/subsystems/tasks/models/tasking.rb
@@ -1,9 +1,13 @@
 class Tasks::Models::Tasking < Tutor::SubSystems::BaseModel
-  belongs_to :task, inverse_of: :taskings
+
+  acts_as_paranoid
+
+  belongs_to :task, -> { with_deleted }, inverse_of: :taskings
   belongs_to :role, subsystem: :entity
 
   belongs_to :period, -> { with_deleted }, subsystem: :course_membership
 
   validates :task, presence: true
   validates :role, presence: true, uniqueness: { scope: :tasks_task_id }
+
 end

--- a/app/subsystems/tasks/models/tasking_plan.rb
+++ b/app/subsystems/tasks/models/tasking_plan.rb
@@ -1,8 +1,10 @@
 class Tasks::Models::TaskingPlan < Tutor::SubSystems::BaseModel
 
+  acts_as_paranoid
+
   belongs_to_time_zone :opens_at, :due_at, suffix: :ntz
 
-  belongs_to :task_plan, inverse_of: :tasking_plans
+  belongs_to :task_plan, -> { with_deleted }, inverse_of: :tasking_plans
   belongs_to :target, -> { respond_to?(:with_deleted) ? with_deleted : all }, polymorphic: true
 
   validates :target, presence: true
@@ -44,4 +46,5 @@ class Tasks::Models::TaskingPlan < Tutor::SubSystems::BaseModel
     errors.add(:target, 'cannot be assigned to')
     false
   end
+
 end

--- a/app/subsystems/tasks/models/tasking_plan.rb
+++ b/app/subsystems/tasks/models/tasking_plan.rb
@@ -1,7 +1,5 @@
 class Tasks::Models::TaskingPlan < Tutor::SubSystems::BaseModel
 
-  UPDATABLE_ATTRIBUTES_AFTER_OPEN = ['due_at_ntz']
-
   belongs_to_time_zone :opens_at, :due_at, suffix: :ntz
 
   belongs_to :task_plan, inverse_of: :tasking_plans
@@ -13,7 +11,7 @@ class Tasks::Models::TaskingPlan < Tutor::SubSystems::BaseModel
   validates :opens_at_ntz, :due_at_ntz, presence: true, timeliness: { type: :date }
   validates :time_zone, presence: true
 
-  validate :changes_allowed, :due_at_in_the_future, :due_at_on_or_after_opens_at
+  validate :due_at_in_the_future, :due_at_on_or_after_opens_at
 
   validate :owner_can_task_target
 
@@ -25,26 +23,11 @@ class Tasks::Models::TaskingPlan < Tutor::SubSystems::BaseModel
     !due_at.nil? && current_time > due_at
   end
 
-  def tasks_past_open?
-    task_plan.try(:published_at).present? && past_open?
-  end
-
   protected
 
-  def changes_allowed
-    return unless tasks_past_open?
-    forbidden_attributes = changes.except(*UPDATABLE_ATTRIBUTES_AFTER_OPEN)
-    return if forbidden_attributes.empty?
-
-    forbidden_attributes.each do |key, value|
-      errors.add(key.to_sym, "cannot be updated after the open date")
-    end
-
-    false
-  end
-
   def due_at_in_the_future
-    return if !due_at_ntz_changed? || due_at.nil? || due_at > Time.current
+    return if !task_plan.try(:is_publish_requested?) ||
+              !due_at_ntz_changed? || due_at.nil? || due_at > Time.current
     errors.add(:due_at, 'cannot be set into the past')
     false
   end

--- a/app/subsystems/tasks/placeholder_strategies/homework_personalized.rb
+++ b/app/subsystems/tasks/placeholder_strategies/homework_personalized.rb
@@ -27,9 +27,11 @@ class Tasks::PlaceholderStrategies::HomeworkPersonalized
 
     task_step_chosen_exercise_pairs = personalized_placeholder_task_steps.zip(chosen_exercises)
     task_step_chosen_exercise_pairs.each do |step, exercise|
-      step.tasked.destroy!
-      # If no exercise available, remove the placeholder completely
-      next step.destroy! if exercise.nil?
+      # If no exercise available, hard-delete the TaskStep and the TaskedPlaceholder
+      next step.really_destroy! if exercise.nil?
+
+      # Otherwise, hard-delete just the TaskedPlaceholder
+      step.tasked.really_destroy!
 
       TaskExercise[task_step: step, exercise: exercise]
       # inject_debug_content!(step.tasked, "This exercise is part of the #{step.group_type}")

--- a/app/subsystems/tasks/placeholder_strategies/i_reading_personalized.rb
+++ b/app/subsystems/tasks/placeholder_strategies/i_reading_personalized.rb
@@ -26,9 +26,11 @@ class Tasks::PlaceholderStrategies::IReadingPersonalized
 
     task_step_chosen_exercise_pairs = personalized_placeholder_task_steps.zip(chosen_exercises)
     task_step_chosen_exercise_pairs.each do |step, exercise|
-      step.tasked.destroy!
-      # If no exercise available, remove the placeholder completely
-      next step.destroy! if exercise.nil?
+      # If no exercise available, hard-delete the TaskStep and the TaskedPlaceholder
+      next step.really_destroy! if exercise.nil?
+
+      # Otherwise, hard-delete just the TaskedPlaceholder
+      step.tasked.really_destroy!
 
       TaskExercise[task_step: step, exercise: exercise]
       # inject_debug_content!(step.tasked, "This exercise is part of the #{step.group_type}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
       get 'tasks', on: :collection
     end
 
-    resources :tasks, only: [:show] do
+    resources :tasks, only: [:show, :destroy] do
       member do
         put 'accept_late_work'
         put 'reject_late_work'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
         member do
           get 'stats'
           get 'review'
+          put 'restore'
         end
       end
 

--- a/db/migrate/20151029184944_add_correct_answer_id_to_tasks_tasked_exercises.rb
+++ b/db/migrate/20151029184944_add_correct_answer_id_to_tasks_tasked_exercises.rb
@@ -2,7 +2,7 @@ class AddCorrectAnswerIdToTasksTaskedExercises < ActiveRecord::Migration
   def change
     add_column :tasks_tasked_exercises, :correct_answer_id, :string
 
-    Tasks::Models::TaskedExercise.lock.find_each do |te|
+    Tasks::Models::TaskedExercise.unscoped.lock.find_each do |te|
       te.update_column(:correct_answer_id, te.correct_question_answer_ids[0].first)
     end
 

--- a/db/migrate/20160114232922_change_default_group_task_steps_to_recovery_group.rb
+++ b/db/migrate/20160114232922_change_default_group_task_steps_to_recovery_group.rb
@@ -1,12 +1,14 @@
 class ChangeDefaultGroupTaskStepsToRecoveryGroup < ActiveRecord::Migration
   def up
     Tasks::Models::TaskStep
+      .unscoped
       .where(group_type: Tasks::Models::TaskStep.group_types[:default_group])
       .update_all(group_type: Tasks::Models::TaskStep.group_types[:recovery_group])
   end
 
   def down
     Tasks::Models::TaskStep
+      .unscoped
       .where(group_type: Tasks::Models::TaskStep.group_types[:recovery_group])
       .update_all(group_type: Tasks::Models::TaskStep.group_types[:default_group])
   end

--- a/db/migrate/20160225204521_fix_tasked_exercise_answer_orders.rb
+++ b/db/migrate/20160225204521_fix_tasked_exercise_answer_orders.rb
@@ -1,6 +1,10 @@
 class FixTaskedExerciseAnswerOrders < ActiveRecord::Migration
   def up
-    Tasks::Models::TaskedExercise.update_all('content = content_exercises.content FROM content_exercises WHERE tasks_tasked_exercises.content_exercise_id = content_exercises.id')
+    Tasks::Models::TaskedExercise.unscoped.update_all(
+      'content = content_exercises.content
+       FROM content_exercises
+       WHERE tasks_tasked_exercises.content_exercise_id = content_exercises.id'
+    )
   end
 
   def down

--- a/db/migrate/20160411214041_change_can_be_recovered_to_related_exercise_ids.rb
+++ b/db/migrate/20160411214041_change_can_be_recovered_to_related_exercise_ids.rb
@@ -25,7 +25,8 @@ class ChangeCanBeRecoveredToRelatedExerciseIds < ActiveRecord::Migration
             # For the original Try Another,
             # we allow only exercises that share at least one LO or APLO with the original exercise
             related_exercise_ids = pool_exercises.select do |ex|
-              ex.los.any?{ |tt| los.include?(tt) } || ex.aplos.any?{ |tt| aplos.include?(tt) }
+              ex.los.any?{ |task| los.include?(task) } ||
+              ex.aplos.any?{ |task| aplos.include?(task) }
             end.map(&:id)
 
             related_exercise_ids_map[exercise.id] = related_exercise_ids

--- a/db/migrate/20160411214041_change_can_be_recovered_to_related_exercise_ids.rb
+++ b/db/migrate/20160411214041_change_can_be_recovered_to_related_exercise_ids.rb
@@ -7,7 +7,7 @@ class ChangeCanBeRecoveredToRelatedExerciseIds < ActiveRecord::Migration
       dir.up do
         related_exercise_ids_map = {}
 
-        Tasks::Models::TaskedExercise.preload(
+        Tasks::Models::TaskedExercise.unscoped.preload(
           [:task_step, {exercise: {page: :reading_context_pool}}]
         ).where(can_be_recovered: true).find_each do |te|
           next if te.task_step.nil?
@@ -37,7 +37,7 @@ class ChangeCanBeRecoveredToRelatedExerciseIds < ActiveRecord::Migration
       end
 
       dir.down do
-        Tasks::Models::TaskedExercise.preload(:task_step).select do |te|
+        Tasks::Models::TaskedExercise.unscoped.preload(:task_step).select do |te|
           te.task_step.related_exercise_ids.any?
         end.each do |te|
           te.update_attribute :can_be_recovered, true

--- a/db/migrate/20160416010537_add_multipart_fields_to_tasks_tasked_exercise.rb
+++ b/db/migrate/20160416010537_add_multipart_fields_to_tasks_tasked_exercise.rb
@@ -5,7 +5,7 @@ class AddMultipartFieldsToTasksTaskedExercise < ActiveRecord::Migration
 
     reversible do |dir|
       dir.up do
-        Tasks::Models::TaskedExercise.update_all(
+        Tasks::Models::TaskedExercise.unscoped.update_all(
           "question_id = substring(content from '\"questions\":\\[\\{\"id\":(\\d+),')"
         )
       end

--- a/db/migrate/20160421021631_add_late_work_fields_to_tasks_tasks.rb
+++ b/db/migrate/20160421021631_add_late_work_fields_to_tasks_tasks.rb
@@ -7,7 +7,7 @@ class AddLateWorkFieldsToTasksTasks < ActiveRecord::Migration
 
     reversible do |dir|
       dir.up do
-        Tasks::Models::Task.preload(task_steps: :tasked).find_each(&:update_step_counts!)
+        Tasks::Models::Task.unscoped.preload(task_steps: :tasked).find_each(&:update_step_counts!)
       end
     end
   end

--- a/db/migrate/20160505221319_add_defaults_for_null_counts.rb
+++ b/db/migrate/20160505221319_add_defaults_for_null_counts.rb
@@ -1,6 +1,6 @@
 class AddDefaultsForNullCounts < ActiveRecord::Migration
   def up
-    Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+    Tasks::Models::Task.unscoped.preload(task_steps: :tasked).find_each do |task|
       task.update_step_counts.save!(validate: false)
     end
 

--- a/db/migrate/20160506181201_truncate_free_responses.rb
+++ b/db/migrate/20160506181201_truncate_free_responses.rb
@@ -1,6 +1,6 @@
 class TruncateFreeResponses < ActiveRecord::Migration
   def up
-    Tasks::Models::TaskedExercise.update_all('free_response = left(free_response, 10000)')
+    Tasks::Models::TaskedExercise.unscoped.update_all('free_response = left(free_response, 10000)')
   end
 
   def down

--- a/db/migrate/20160517202901_change_is_feedback_immediate_null_and_default.rb
+++ b/db/migrate/20160517202901_change_is_feedback_immediate_null_and_default.rb
@@ -1,9 +1,11 @@
 class ChangeIsFeedbackImmediateNullAndDefault < ActiveRecord::Migration
   def up
-    Tasks::Models::TaskPlan.where(type: 'homework', is_feedback_immediate: nil)
+    Tasks::Models::TaskPlan.unscoped
+                           .where(type: 'homework', is_feedback_immediate: nil)
                            .update_all(is_feedback_immediate: false)
 
-    Tasks::Models::TaskPlan.where(is_feedback_immediate: nil)
+    Tasks::Models::TaskPlan.unscoped
+                           .where(is_feedback_immediate: nil)
                            .update_all(is_feedback_immediate: true)
 
     change_column_default :tasks_task_plans, :is_feedback_immediate, true

--- a/db/migrate/20160524141809_add_deleted_at_to_task_models.rb
+++ b/db/migrate/20160524141809_add_deleted_at_to_task_models.rb
@@ -9,7 +9,9 @@ class AddDeletedAtToTaskModels < ActiveRecord::Migration
     add_column :tasks_tasked_exercises, :deleted_at, :datetime
     add_column :tasks_tasked_videos, :deleted_at, :datetime
     add_column :tasks_tasked_interactives, :deleted_at, :datetime
+    add_column :tasks_tasked_external_urls, :deleted_at, :datetime
     add_column :tasks_tasked_placeholders, :deleted_at, :datetime
+    add_column :tasks_concept_coach_tasks, :deleted_at, :datetime
 
     add_index :tasks_task_plans, :deleted_at
     add_index :tasks_tasking_plans, :deleted_at
@@ -20,6 +22,8 @@ class AddDeletedAtToTaskModels < ActiveRecord::Migration
     add_index :tasks_tasked_exercises, :deleted_at
     add_index :tasks_tasked_videos, :deleted_at
     add_index :tasks_tasked_interactives, :deleted_at
+    add_index :tasks_tasked_external_urls, :deleted_at
     add_index :tasks_tasked_placeholders, :deleted_at
+    add_index :tasks_concept_coach_tasks, :deleted_at
   end
 end

--- a/db/migrate/20160524141809_add_deleted_at_to_task_models.rb
+++ b/db/migrate/20160524141809_add_deleted_at_to_task_models.rb
@@ -1,0 +1,25 @@
+class AddDeletedAtToTaskModels < ActiveRecord::Migration
+  def change
+    add_column :tasks_task_plans, :deleted_at, :datetime
+    add_column :tasks_tasking_plans, :deleted_at, :datetime
+    add_column :tasks_tasks, :deleted_at, :datetime
+    add_column :tasks_taskings, :deleted_at, :datetime
+    add_column :tasks_task_steps, :deleted_at, :datetime
+    add_column :tasks_tasked_readings, :deleted_at, :datetime
+    add_column :tasks_tasked_exercises, :deleted_at, :datetime
+    add_column :tasks_tasked_videos, :deleted_at, :datetime
+    add_column :tasks_tasked_interactives, :deleted_at, :datetime
+    add_column :tasks_tasked_placeholders, :deleted_at, :datetime
+
+    add_index :tasks_task_plans, :deleted_at
+    add_index :tasks_tasking_plans, :deleted_at
+    add_index :tasks_tasks, :deleted_at
+    add_index :tasks_taskings, :deleted_at
+    add_index :tasks_task_steps, :deleted_at
+    add_index :tasks_tasked_readings, :deleted_at
+    add_index :tasks_tasked_exercises, :deleted_at
+    add_index :tasks_tasked_videos, :deleted_at
+    add_index :tasks_tasked_interactives, :deleted_at
+    add_index :tasks_tasked_placeholders, :deleted_at
+  end
+end

--- a/db/migrate/20160524142958_improve_deleted_at_indices.rb
+++ b/db/migrate/20160524142958_improve_deleted_at_indices.rb
@@ -1,0 +1,27 @@
+class ImproveDeletedAtIndices < ActiveRecord::Migration
+  def change
+    add_index :course_membership_enrollment_changes, :deleted_at
+
+    add_index :course_membership_enrollments, :deleted_at
+
+    remove_index :course_membership_periods,
+                 column: [:entity_course_id, :name],
+                 unique: true,
+                 where: "(deleted_at IS NULL)"
+    add_index :course_membership_periods, [:name, :entity_course_id],
+              unique: true, where: "(deleted_at IS NULL)"
+    add_index :course_membership_periods, :entity_course_id
+    add_index :course_membership_periods, :deleted_at
+
+    remove_index :course_membership_students,
+                 column: [:entity_course_id, :deleted_at],
+                 name: 'course_membership_students_course_inactive'
+    remove_index :course_membership_students,
+                 column: [:student_identifier, :entity_course_id],
+                 name: 'index_course_membership_students_on_s_identifier_and_e_c_id',
+                 unique: true
+    add_index :course_membership_students, [:entity_course_id, :student_identifier],
+              name: 'index_course_membership_students_on_e_c_id_and_s_identifier', unique: true
+    add_index :course_membership_students, :deleted_at
+  end
+end

--- a/db/migrate/20160524152139_remove_entity_tasks.rb
+++ b/db/migrate/20160524152139_remove_entity_tasks.rb
@@ -3,13 +3,13 @@ class RemoveEntityTasks < ActiveRecord::Migration
     add_column :tasks_taskings, :tasks_task_id, :integer
     add_column :tasks_concept_coach_tasks, :tasks_task_id, :integer
 
-    Tasks::Models::Tasking.update_all(
+    Tasks::Models::Tasking.unscoped.update_all(
       'tasks_task_id = tasks_tasks.id
        FROM tasks_tasks
        WHERE tasks_tasks.entity_task_id = tasks_taskings.entity_task_id'
     )
 
-    Tasks::Models::ConceptCoachTask.update_all(
+    Tasks::Models::ConceptCoachTask.unscoped.update_all(
       'tasks_task_id = tasks_tasks.id
        FROM tasks_tasks
        WHERE tasks_tasks.entity_task_id = tasks_concept_coach_tasks.entity_task_id'

--- a/db/migrate/20160524152139_remove_entity_tasks.rb
+++ b/db/migrate/20160524152139_remove_entity_tasks.rb
@@ -1,0 +1,38 @@
+class RemoveEntityTasks < ActiveRecord::Migration
+  def up
+    add_column :tasks_taskings, :tasks_task_id, :integer
+    add_column :tasks_concept_coach_tasks, :tasks_task_id, :integer
+
+    Tasks::Models::Tasking.update_all(
+      'tasks_task_id = tasks_tasks.id
+       FROM tasks_tasks
+       WHERE tasks_tasks.entity_task_id = tasks_taskings.entity_task_id'
+    )
+
+    Tasks::Models::ConceptCoachTask.update_all(
+      'tasks_task_id = tasks_tasks.id
+       FROM tasks_tasks
+       WHERE tasks_tasks.entity_task_id = tasks_concept_coach_tasks.entity_task_id'
+    )
+
+    change_column_null :tasks_taskings, :tasks_task_id, false
+    change_column_null :tasks_concept_coach_tasks, :tasks_task_id, false
+
+    add_index :tasks_taskings, [:tasks_task_id, :entity_role_id], unique: true
+    add_index :tasks_taskings, :entity_role_id
+    add_index :tasks_concept_coach_tasks, :tasks_task_id, unique: true
+
+    add_foreign_key :tasks_taskings, :tasks_tasks
+    add_foreign_key :tasks_concept_coach_tasks, :tasks_tasks
+
+    remove_column :tasks_taskings, :entity_task_id
+    remove_column :tasks_concept_coach_tasks, :entity_task_id
+    remove_column :tasks_tasks, :entity_task_id
+
+    drop_table :entity_tasks
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20160526202800_add_hidden_at_to_tasks_tasks.rb
+++ b/db/migrate/20160526202800_add_hidden_at_to_tasks_tasks.rb
@@ -1,0 +1,7 @@
+class AddHiddenAtToTasksTasks < ActiveRecord::Migration
+  def change
+    add_column :tasks_tasks, :hidden_at, :datetime
+
+    add_index :tasks_tasks, :hidden_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160520002440) do
+ActiveRecord::Schema.define(version: 20160524142958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(version: 20160520002440) do
 
   add_index "course_membership_enrollment_changes", ["course_membership_enrollment_id"], name: "index_course_membership_enrollments_on_enrollment_id", using: :btree
   add_index "course_membership_enrollment_changes", ["course_membership_period_id"], name: "index_course_membership_enrollment_changes_on_period_id", using: :btree
+  add_index "course_membership_enrollment_changes", ["deleted_at"], name: "index_course_membership_enrollment_changes_on_deleted_at", using: :btree
   add_index "course_membership_enrollment_changes", ["user_profile_id"], name: "index_course_membership_enrollment_changes_on_user_profile_id", using: :btree
 
   create_table "course_membership_enrollments", force: :cascade do |t|
@@ -217,6 +218,7 @@ ActiveRecord::Schema.define(version: 20160520002440) do
 
   add_index "course_membership_enrollments", ["course_membership_period_id", "course_membership_student_id"], name: "course_membership_enrollments_period_student", using: :btree
   add_index "course_membership_enrollments", ["course_membership_student_id", "created_at"], name: "course_membership_enrollments_student_created_at_uniq", unique: true, using: :btree
+  add_index "course_membership_enrollments", ["deleted_at"], name: "index_course_membership_enrollments_on_deleted_at", using: :btree
 
   create_table "course_membership_periods", force: :cascade do |t|
     t.integer  "entity_course_id",  null: false
@@ -229,8 +231,10 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.string   "default_due_time"
   end
 
+  add_index "course_membership_periods", ["deleted_at"], name: "index_course_membership_periods_on_deleted_at", using: :btree
   add_index "course_membership_periods", ["enrollment_code"], name: "index_course_membership_periods_on_enrollment_code", unique: true, using: :btree
-  add_index "course_membership_periods", ["entity_course_id", "name"], name: "index_course_membership_periods_on_entity_course_id_and_name", unique: true, where: "(deleted_at IS NULL)", using: :btree
+  add_index "course_membership_periods", ["entity_course_id"], name: "index_course_membership_periods_on_entity_course_id", using: :btree
+  add_index "course_membership_periods", ["name", "entity_course_id"], name: "index_course_membership_periods_on_name_and_entity_course_id", unique: true, where: "(deleted_at IS NULL)", using: :btree
 
   create_table "course_membership_students", force: :cascade do |t|
     t.integer  "entity_course_id",   null: false
@@ -243,9 +247,9 @@ ActiveRecord::Schema.define(version: 20160520002440) do
   end
 
   add_index "course_membership_students", ["deidentifier"], name: "index_course_membership_students_on_deidentifier", unique: true, using: :btree
-  add_index "course_membership_students", ["entity_course_id", "deleted_at"], name: "course_membership_students_course_inactive", using: :btree
+  add_index "course_membership_students", ["deleted_at"], name: "index_course_membership_students_on_deleted_at", using: :btree
+  add_index "course_membership_students", ["entity_course_id", "student_identifier"], name: "index_course_membership_students_on_e_c_id_and_s_identifier", unique: true, using: :btree
   add_index "course_membership_students", ["entity_role_id"], name: "index_course_membership_students_on_entity_role_id", unique: true, using: :btree
-  add_index "course_membership_students", ["student_identifier", "entity_course_id"], name: "index_course_membership_students_on_s_identifier_and_e_c_id", unique: true, using: :btree
 
   create_table "course_membership_teachers", force: :cascade do |t|
     t.integer  "entity_course_id", null: false
@@ -581,9 +585,11 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.datetime "updated_at",                               null: false
     t.integer  "content_ecosystem_id",                     null: false
     t.boolean  "is_feedback_immediate",     default: true, null: false
+    t.datetime "deleted_at"
   end
 
   add_index "tasks_task_plans", ["content_ecosystem_id"], name: "index_tasks_task_plans_on_content_ecosystem_id", using: :btree
+  add_index "tasks_task_plans", ["deleted_at"], name: "index_tasks_task_plans_on_deleted_at", using: :btree
   add_index "tasks_task_plans", ["owner_id", "owner_type"], name: "index_tasks_task_plans_on_owner_id_and_owner_type", using: :btree
   add_index "tasks_task_plans", ["tasks_assistant_id"], name: "index_tasks_task_plans_on_tasks_assistant_id", using: :btree
 
@@ -600,8 +606,10 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
     t.integer  "related_exercise_ids", default: [], null: false, array: true
+    t.datetime "deleted_at"
   end
 
+  add_index "tasks_task_steps", ["deleted_at"], name: "index_tasks_task_steps_on_deleted_at", using: :btree
   add_index "tasks_task_steps", ["tasked_id", "tasked_type"], name: "index_tasks_task_steps_on_tasked_id_and_tasked_type", unique: true, using: :btree
   add_index "tasks_task_steps", ["tasks_task_id", "number"], name: "index_tasks_task_steps_on_tasks_task_id_and_number", unique: true, using: :btree
 
@@ -617,9 +625,11 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.string   "correct_answer_id",                   null: false
     t.boolean  "is_in_multipart",     default: false, null: false
     t.string   "question_id",                         null: false
+    t.datetime "deleted_at"
   end
 
   add_index "tasks_tasked_exercises", ["content_exercise_id"], name: "index_tasks_tasked_exercises_on_content_exercise_id", using: :btree
+  add_index "tasks_tasked_exercises", ["deleted_at"], name: "index_tasks_tasked_exercises_on_deleted_at", using: :btree
   add_index "tasks_tasked_exercises", ["question_id"], name: "index_tasks_tasked_exercises_on_question_id", using: :btree
 
   create_table "tasks_tasked_external_urls", force: :cascade do |t|
@@ -635,11 +645,17 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
   end
 
+  add_index "tasks_tasked_interactives", ["deleted_at"], name: "index_tasks_tasked_interactives_on_deleted_at", using: :btree
+
   create_table "tasks_tasked_placeholders", force: :cascade do |t|
-    t.integer "placeholder_type", default: 0, null: false
+    t.integer  "placeholder_type", default: 0, null: false
+    t.datetime "deleted_at"
   end
+
+  add_index "tasks_tasked_placeholders", ["deleted_at"], name: "index_tasks_tasked_placeholders_on_deleted_at", using: :btree
 
   create_table "tasks_tasked_readings", force: :cascade do |t|
     t.string   "url",           null: false
@@ -648,7 +664,10 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.text     "book_location"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.datetime "deleted_at"
   end
+
+  add_index "tasks_tasked_readings", ["deleted_at"], name: "index_tasks_tasked_readings_on_deleted_at", using: :btree
 
   create_table "tasks_tasked_videos", force: :cascade do |t|
     t.string   "url",        null: false
@@ -656,7 +675,10 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
   end
+
+  add_index "tasks_tasked_videos", ["deleted_at"], name: "index_tasks_tasked_videos_on_deleted_at", using: :btree
 
   create_table "tasks_tasking_plans", force: :cascade do |t|
     t.integer  "target_id",          null: false
@@ -667,8 +689,10 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
     t.integer  "time_zone_id",       null: false
+    t.datetime "deleted_at"
   end
 
+  add_index "tasks_tasking_plans", ["deleted_at"], name: "index_tasks_tasking_plans_on_deleted_at", using: :btree
   add_index "tasks_tasking_plans", ["due_at_ntz", "opens_at_ntz"], name: "index_tasks_tasking_plans_on_due_at_ntz_and_opens_at_ntz", using: :btree
   add_index "tasks_tasking_plans", ["target_id", "target_type", "tasks_task_plan_id"], name: "index_tasking_plans_on_t_id_and_t_type_and_t_p_id", unique: true, using: :btree
   add_index "tasks_tasking_plans", ["tasks_task_plan_id"], name: "index_tasks_tasking_plans_on_tasks_task_plan_id", using: :btree
@@ -680,9 +704,11 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.integer  "course_membership_period_id"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
+    t.datetime "deleted_at"
   end
 
   add_index "tasks_taskings", ["course_membership_period_id"], name: "index_tasks_taskings_on_course_membership_period_id", using: :btree
+  add_index "tasks_taskings", ["deleted_at"], name: "index_tasks_taskings_on_deleted_at", using: :btree
   add_index "tasks_taskings", ["entity_role_id", "entity_task_id"], name: "tasks_taskings_role_id_on_task_id_unique", unique: true, using: :btree
   add_index "tasks_taskings", ["entity_task_id"], name: "index_tasks_taskings_on_entity_task_id", using: :btree
 
@@ -716,8 +742,10 @@ ActiveRecord::Schema.define(version: 20160520002440) do
     t.integer  "completed_on_time_exercise_steps_count", default: 0,     null: false
     t.integer  "completed_on_time_steps_count",          default: 0,     null: false
     t.integer  "time_zone_id"
+    t.datetime "deleted_at"
   end
 
+  add_index "tasks_tasks", ["deleted_at"], name: "index_tasks_tasks_on_deleted_at", using: :btree
   add_index "tasks_tasks", ["due_at_ntz", "opens_at_ntz"], name: "index_tasks_tasks_on_due_at_ntz_and_opens_at_ntz", using: :btree
   add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id", unique: true, using: :btree
   add_index "tasks_tasks", ["last_worked_at"], name: "index_tasks_tasks_on_last_worked_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524142958) do
+ActiveRecord::Schema.define(version: 20160524152139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -313,11 +313,6 @@ ActiveRecord::Schema.define(version: 20160524142958) do
 
   add_index "entity_roles", ["role_type"], name: "index_entity_roles_on_role_type", using: :btree
 
-  create_table "entity_tasks", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "fine_print_contracts", force: :cascade do |t|
     t.string   "name",       null: false
     t.integer  "version"
@@ -535,16 +530,16 @@ ActiveRecord::Schema.define(version: 20160524142958) do
   add_index "tasks_assistants", ["name"], name: "index_tasks_assistants_on_name", unique: true, using: :btree
 
   create_table "tasks_concept_coach_tasks", force: :cascade do |t|
-    t.integer  "entity_task_id",  null: false
     t.integer  "content_page_id", null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.integer  "entity_role_id",  null: false
+    t.integer  "tasks_task_id",   null: false
   end
 
   add_index "tasks_concept_coach_tasks", ["content_page_id"], name: "index_tasks_concept_coach_tasks_on_content_page_id", using: :btree
   add_index "tasks_concept_coach_tasks", ["entity_role_id", "content_page_id"], name: "index_tasks_concept_coach_tasks_on_e_r_id_and_c_p_id", unique: true, using: :btree
-  add_index "tasks_concept_coach_tasks", ["entity_task_id"], name: "index_tasks_concept_coach_tasks_on_entity_task_id", unique: true, using: :btree
+  add_index "tasks_concept_coach_tasks", ["tasks_task_id"], name: "index_tasks_concept_coach_tasks_on_tasks_task_id", unique: true, using: :btree
 
   create_table "tasks_course_assistants", force: :cascade do |t|
     t.integer  "entity_course_id",     null: false
@@ -700,21 +695,20 @@ ActiveRecord::Schema.define(version: 20160524142958) do
 
   create_table "tasks_taskings", force: :cascade do |t|
     t.integer  "entity_role_id",              null: false
-    t.integer  "entity_task_id",              null: false
     t.integer  "course_membership_period_id"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.datetime "deleted_at"
+    t.integer  "tasks_task_id",               null: false
   end
 
   add_index "tasks_taskings", ["course_membership_period_id"], name: "index_tasks_taskings_on_course_membership_period_id", using: :btree
   add_index "tasks_taskings", ["deleted_at"], name: "index_tasks_taskings_on_deleted_at", using: :btree
-  add_index "tasks_taskings", ["entity_role_id", "entity_task_id"], name: "tasks_taskings_role_id_on_task_id_unique", unique: true, using: :btree
-  add_index "tasks_taskings", ["entity_task_id"], name: "index_tasks_taskings_on_entity_task_id", using: :btree
+  add_index "tasks_taskings", ["entity_role_id"], name: "index_tasks_taskings_on_entity_role_id", using: :btree
+  add_index "tasks_taskings", ["tasks_task_id", "entity_role_id"], name: "index_tasks_taskings_on_tasks_task_id_and_entity_role_id", unique: true, using: :btree
 
   create_table "tasks_tasks", force: :cascade do |t|
     t.integer  "tasks_task_plan_id"
-    t.integer  "entity_task_id",                                         null: false
     t.integer  "task_type",                                              null: false
     t.string   "title",                                                  null: false
     t.text     "description"
@@ -747,7 +741,6 @@ ActiveRecord::Schema.define(version: 20160524142958) do
 
   add_index "tasks_tasks", ["deleted_at"], name: "index_tasks_tasks_on_deleted_at", using: :btree
   add_index "tasks_tasks", ["due_at_ntz", "opens_at_ntz"], name: "index_tasks_tasks_on_due_at_ntz_and_opens_at_ntz", using: :btree
-  add_index "tasks_tasks", ["entity_task_id"], name: "index_tasks_tasks_on_entity_task_id", unique: true, using: :btree
   add_index "tasks_tasks", ["last_worked_at"], name: "index_tasks_tasks_on_last_worked_at", using: :btree
   add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type", using: :btree
   add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id", using: :btree
@@ -840,7 +833,7 @@ ActiveRecord::Schema.define(version: 20160524142958) do
   add_foreign_key "school_district_schools", "school_district_districts", on_update: :cascade, on_delete: :nullify
   add_foreign_key "tasks_concept_coach_tasks", "content_pages", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_concept_coach_tasks", "entity_roles", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_concept_coach_tasks", "entity_tasks", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_concept_coach_tasks", "tasks_tasks"
   add_foreign_key "tasks_course_assistants", "entity_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_course_assistants", "tasks_assistants", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_performance_report_exports", "entity_courses", on_update: :cascade, on_delete: :cascade
@@ -853,8 +846,7 @@ ActiveRecord::Schema.define(version: 20160524142958) do
   add_foreign_key "tasks_tasking_plans", "time_zones", on_update: :cascade, on_delete: :nullify
   add_foreign_key "tasks_taskings", "course_membership_periods", on_update: :cascade, on_delete: :nullify
   add_foreign_key "tasks_taskings", "entity_roles", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_taskings", "entity_tasks", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_tasks", "entity_tasks", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_taskings", "tasks_tasks"
   add_foreign_key "tasks_tasks", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_tasks", "time_zones", on_update: :cascade, on_delete: :nullify
   add_foreign_key "user_administrators", "user_profiles", on_update: :cascade, on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524152139) do
+ActiveRecord::Schema.define(version: 20160526202800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -742,10 +742,12 @@ ActiveRecord::Schema.define(version: 20160524152139) do
     t.integer  "completed_on_time_steps_count",          default: 0,     null: false
     t.integer  "time_zone_id"
     t.datetime "deleted_at"
+    t.datetime "hidden_at"
   end
 
   add_index "tasks_tasks", ["deleted_at"], name: "index_tasks_tasks_on_deleted_at", using: :btree
   add_index "tasks_tasks", ["due_at_ntz", "opens_at_ntz"], name: "index_tasks_tasks_on_due_at_ntz_and_opens_at_ntz", using: :btree
+  add_index "tasks_tasks", ["hidden_at"], name: "index_tasks_tasks_on_hidden_at", using: :btree
   add_index "tasks_tasks", ["last_worked_at"], name: "index_tasks_tasks_on_last_worked_at", using: :btree
   add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type", using: :btree
   add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -534,10 +534,12 @@ ActiveRecord::Schema.define(version: 20160524152139) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.integer  "entity_role_id",  null: false
+    t.datetime "deleted_at"
     t.integer  "tasks_task_id",   null: false
   end
 
   add_index "tasks_concept_coach_tasks", ["content_page_id"], name: "index_tasks_concept_coach_tasks_on_content_page_id", using: :btree
+  add_index "tasks_concept_coach_tasks", ["deleted_at"], name: "index_tasks_concept_coach_tasks_on_deleted_at", using: :btree
   add_index "tasks_concept_coach_tasks", ["entity_role_id", "content_page_id"], name: "index_tasks_concept_coach_tasks_on_e_r_id_and_c_p_id", unique: true, using: :btree
   add_index "tasks_concept_coach_tasks", ["tasks_task_id"], name: "index_tasks_concept_coach_tasks_on_tasks_task_id", unique: true, using: :btree
 
@@ -632,7 +634,10 @@ ActiveRecord::Schema.define(version: 20160524152139) do
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
   end
+
+  add_index "tasks_tasked_external_urls", ["deleted_at"], name: "index_tasks_tasked_external_urls_on_deleted_at", using: :btree
 
   create_table "tasks_tasked_interactives", force: :cascade do |t|
     t.string   "url",        null: false

--- a/lib/acts_as_tasked.rb
+++ b/lib/acts_as_tasked.rb
@@ -6,8 +6,10 @@ module ActsAsTasked
 
   module ClassMethods
     def acts_as_tasked
-      class_eval do
-        has_one :task_step, as: :tasked, inverse_of: :tasked
+      class_exec do
+        acts_as_paranoid
+
+        has_one :task_step, -> { with_deleted }, as: :tasked, inverse_of: :tasked
 
         after_update { task_step.try(:touch) if task_step.try(:persisted?) }
 

--- a/lib/tasks/demo/demo_base.rb
+++ b/lib/tasks/demo/demo_base.rb
@@ -340,11 +340,11 @@ class DemoBase
 
   # def make_and_work_practice_widget(role:, num_correct:, book_part_ids: [],
   #                                                        page_ids: [])
-  #   # entity_task = ResetPracticeWidget[book_part_ids: book_part_ids,
-  #   #                                   page_ids: page_ids,
-  #   #                                   role: role, exercise_source: :biglearn]
+  #   # task = ResetPracticeWidget[book_part_ids: book_part_ids,
+  #   #                            page_ids: page_ids,
+  #   #                            role: role, exercise_source: :biglearn]
 
-  #   # entity_task.task.task_steps.first(num_correct).each do |task_step|
+  #   # task.task_steps.first(num_correct).each do |task_step|
   #   #   Hacks::AnswerExercise[task_step: task_step, is_correct: true]
   #   # end
   # end
@@ -433,13 +433,12 @@ class DemoBase
   end
 
   def distribute_tasks(task_plan:)
-    entity_tasks = run(DistributeTasks, task_plan).outputs.entity_tasks
+    tasks = run(DistributeTasks, task_plan).outputs.tasks
 
-    log("Assigned #{task_plan.type} #{entity_tasks.count} times")
-    log("One task looks like: " + print_entity_task(entity_task: entity_tasks.first)) \
-      if entity_tasks.any?
+    log("Assigned #{task_plan.type} #{tasks.count} times")
+    log("One task looks like: " + print_task(task: tasks.first)) if tasks.any?
 
-    entity_tasks
+    tasks
   end
 
   # `responses` is an array of 1 (or true), 0 (or false), or nil; nil means
@@ -552,10 +551,6 @@ class DemoBase
     end
     codes = task.task_steps.map{ |step| step_code(step) }
     "Task #{task.id} / #{task.task_type}\n#{codes.join(', ')}\n#{types.join(' ')}"
-  end
-
-  def print_entity_task(entity_task:)
-    print_task(task: entity_task.task)
   end
 
   def randomizer

--- a/lib/tasks/demo/work.rb
+++ b/lib/tasks/demo/work.rb
@@ -77,8 +77,8 @@ class DemoWork < DemoBase
   def work_cc_assignments(student)
     user = User::User.new(strategy: student.role.profile.wrap)
     log("Working concept coach assignments for: #{user.name}")
-    student.role.taskings.preload(task: { task: { task_steps: :tasked } }).each do |tasking|
-      task = tasking.task.task
+    student.role.taskings.preload(task: { task_steps: :tasked }).each do |tasking|
+      task = tasking.task
       next unless task.concept_coach?
 
       task.task_steps.each do |task_step|

--- a/lib/tutor/subsystems/association_extensions.rb
+++ b/lib/tutor/subsystems/association_extensions.rb
@@ -22,7 +22,7 @@ module Tutor::SubSystems
 
       def set_subsystem_options(association_name, scope, options, is_belongs_to=false)
         # While rarely used, assocations can be created with a
-        # scope to limit the record, `belongs_to :user, ->{ where(id: 2) }, class_name: "MyUser"`
+        # scope to limit the record, `belongs_to :user, -> { where(id: 2) }, class_name: "MyUser"`
         # To cope with having either two or three arguments, Rails inspects the scope arguemnt.
         # If it's a Hash, then It's considered the options and the options argument is ignored.
         options = scope if scope.is_a?(Hash)

--- a/spec/access_policies/task_access_policy_spec.rb
+++ b/spec/access_policies/task_access_policy_spec.rb
@@ -67,16 +67,28 @@ RSpec.describe TaskAccessPolicy, type: :access_policy do
     context 'and the requestor is human' do
       # already true for User
 
-      context 'and the requestor is a course teacher' do
-        before { allow(UserIsCourseTeacher).to receive(:[]) { true } }
-
-        it { should eq true }
-      end
-
-      context 'and the requestor is not a course teacher' do
-        before { allow(DoesTaskingExist).to receive(:[]) { true } }
+      context 'and the task is deleted' do
+        before do
+          task.destroy!
+          allow(DoesTaskingExist).to receive(:[]) { true }
+          allow(UserIsCourseTeacher).to receive(:[]) { true }
+        end
 
         it { should eq false }
+      end
+
+      context 'and the task is not deleted' do
+        context 'and the requestor is a course teacher' do
+          before { allow(UserIsCourseTeacher).to receive(:[]) { true } }
+
+          it { should eq true }
+        end
+
+        context 'and the requestor is not a course teacher' do
+          before { allow(DoesTaskingExist).to receive(:[]) { true } }
+
+          it { should eq false }
+        end
       end
     end
 

--- a/spec/access_policies/task_access_policy_spec.rb
+++ b/spec/access_policies/task_access_policy_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe TaskAccessPolicy, type: :access_policy do
-  let!(:requestor) { FactoryGirl.create(:user) }
-  let!(:task)      { FactoryGirl.create(:tasks_task) }
+  let!(:requestor)         { FactoryGirl.create(:user) }
+  let!(:task)              { FactoryGirl.create(:tasks_task) }
 
-  subject(:action_allowed) do
-    TaskAccessPolicy.action_allowed?(action, requestor, task)
-  end
+  subject(:action_allowed) { TaskAccessPolicy.action_allowed?(action, requestor, task) }
 
   context 'when the action is :read' do
     let(:action) { :read }
@@ -20,13 +18,13 @@ RSpec.describe TaskAccessPolicy, type: :access_policy do
         context "and the task's open date has passed" do
           before { allow(task).to receive(:past_open?) { true } }
 
-          it { should be true }
+          it { should eq true }
         end
 
         context "and the task's open date has not passed" do
           before { allow(task).to receive(:past_open?) { false } }
 
-          it { should be false }
+          it { should eq false }
         end
       end
 
@@ -34,7 +32,7 @@ RSpec.describe TaskAccessPolicy, type: :access_policy do
         before { allow(DoesTaskingExist).to receive(:[]) { false } }
 
         context 'and the task has a course' do
-          it { should be false }
+          it { should eq false }
         end
 
         context 'and the task has no course' do
@@ -45,22 +43,86 @@ RSpec.describe TaskAccessPolicy, type: :access_policy do
 
           after { task.update_attribute :task_plan, @task_plan }
 
-          it { should be false }
+          it { should eq false }
         end
       end
 
       context 'and the requestor is a course teacher' do
-        before { allow(DoesTaskingExist).to receive(:[]) { false }
-                 allow(UserIsCourseTeacher).to receive(:[]) { true } }
+        before { allow(UserIsCourseTeacher).to receive(:[]) { true } }
 
-        it { should be true }
+        it { should eq true }
       end
     end
 
     context 'and the requestor is not human' do
       before { allow(requestor).to receive(:is_human?) { false } }
 
-      it { should be false }
+      it { should eq false }
+    end
+  end
+
+  context 'when the action is :change_is_late_work_accepted' do
+    let(:action) { :change_is_late_work_accepted }
+
+    context 'and the requestor is human' do
+      # already true for User
+
+      context 'and the requestor is a course teacher' do
+        before { allow(UserIsCourseTeacher).to receive(:[]) { true } }
+
+        it { should eq true }
+      end
+
+      context 'and the requestor is not a course teacher' do
+        before { allow(DoesTaskingExist).to receive(:[]) { true } }
+
+        it { should eq false }
+      end
+    end
+
+    context 'and the requestor is not human' do
+      before { allow(requestor).to receive(:is_human?) { false } }
+
+      it { should eq false }
+    end
+  end
+
+  context 'when the action is :hide' do
+    let(:action) { :hide }
+
+    context 'and the requestor is human' do
+      # already true for User
+
+      context 'and the task is deleted' do
+        before { task.destroy! }
+
+        context 'and the requestor has taskings in the task' do
+          before { allow(DoesTaskingExist).to receive(:[]) { true } }
+
+          it { should eq true }
+        end
+
+        context 'and the requestor has no taskings in the task' do
+          before { allow(UserIsCourseTeacher).to receive(:[]) { true } }
+
+          it { should eq false }
+        end
+      end
+
+      context 'and the task is not deleted' do
+        before do
+          allow(DoesTaskingExist).to receive(:[]) { true }
+          allow(UserIsCourseTeacher).to receive(:[]) { true }
+        end
+
+        it { should eq false }
+      end
+    end
+
+    context 'and the requestor is not human' do
+      before { allow(requestor).to receive(:is_human?) { false } }
+
+      it { should eq false }
     end
   end
 
@@ -68,7 +130,7 @@ RSpec.describe TaskAccessPolicy, type: :access_policy do
     context "when the action is :#{disallowed_action}" do
       let(:action) { disallowed_action }
 
-      it { should be false }
+      it { should eq false }
     end
   end
 end

--- a/spec/access_policies/task_plan_access_policy_spec.rb
+++ b/spec/access_policies/task_plan_access_policy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TaskPlanAccessPolicy, type: :access_policy do
       task_plan.save!
     end
 
-    [:read, :create, :update, :destroy].each do |test_action|
+    [:read, :create, :update, :destroy, :restore].each do |test_action|
       context "#{test_action}" do
         let(:action) { test_action }
         it { should be true }
@@ -51,7 +51,7 @@ RSpec.describe TaskPlanAccessPolicy, type: :access_policy do
       task_plan.save!
     end
 
-    [:read, :create, :update, :destroy].each do |test_action|
+    [:read, :create, :update, :destroy, :restore].each do |test_action|
       context "#{test_action}" do
         let(:action) { test_action }
         it { should be false }
@@ -67,7 +67,7 @@ RSpec.describe TaskPlanAccessPolicy, type: :access_policy do
       task_plan.save!
     end
 
-    [:read, :create, :update, :destroy].each do |test_action|
+    [:read, :create, :update, :destroy, :restore].each do |test_action|
       context "#{test_action}" do
         let(:action) { test_action }
         it { should be true }
@@ -78,7 +78,7 @@ RSpec.describe TaskPlanAccessPolicy, type: :access_policy do
   context 'non-owners' do
     let(:requestor) { non_owner }
 
-    [:read, :create, :update, :destroy].each do |test_action|
+    [:read, :create, :update, :destroy, :restore].each do |test_action|
       context "#{test_action}" do
         let(:action) { test_action }
         it { should be false }

--- a/spec/access_policies/tasked_access_policy_spec.rb
+++ b/spec/access_policies/tasked_access_policy_spec.rb
@@ -21,37 +21,46 @@ RSpec.describe TaskedAccessPolicy, type: :access_policy do
         context 'and the tasked is part of a task for the requestor' do
           before { allow(DoesTaskingExist).to receive(:[]) { true } }
 
+          context "and the task is deleted" do
+            before do
+              allow(tasked.task_step.task).to receive(:deleted?) { true }
+              allow(tasked.task_step.task).to receive(:past_open?) { true }
+            end
+
+            it { should eq action == :read }
+          end
+
           context "and the task's open date has passed" do
             before { allow(tasked.task_step.task).to receive(:past_open?) { true } }
 
-            it { should be true }
+            it { should eq true }
           end
 
           context "and the task's open date has not passed" do
             before { allow(tasked.task_step.task).to receive(:past_open?) { false } }
 
-            it { should be false }
+            it { should eq false }
           end
         end
 
         context 'and the tasked is not part of a task for the requestor' do
           before { allow(DoesTaskingExist).to receive(:[]) { false } }
 
-          it { should be false }
+          it { should eq false }
         end
 
         context 'and the requestor is a course teacher' do
           before { allow(DoesTaskingExist).to receive(:[]) { false }
                    allow(UserIsCourseTeacher).to receive(:[]) { true } }
 
-          it { should be action == :read }
+          it { should eq action == :read }
         end
       end
 
       context 'and the requestor is not human' do
         before { allow(requestor).to receive(:is_human?) { false } }
 
-        it { should be false }
+        it { should eq false }
       end
     end
   end
@@ -59,7 +68,7 @@ RSpec.describe TaskedAccessPolicy, type: :access_policy do
   context 'when the action is unknown' do
     let(:action) { :unknown_fooey }
 
-    it { should be false }
+    it { should eq false }
   end
 
   context 'when the tasking is in the tasks subsystem' do

--- a/spec/controllers/admin/stats_controller_spec.rb
+++ b/spec/controllers/admin/stats_controller_spec.rb
@@ -29,14 +29,8 @@ RSpec.describe Admin::StatsController, type: :controller do
   end
 
   context "GET #concept_coach" do
-    let!(:tasks)         do
-      3.times.map { FactoryGirl.create :tasks_task, task_type: :concept_coach }
-    end
-    let!(:cc_tasks)       do
-      tasks.map do |task|
-        FactoryGirl.create :tasks_concept_coach_task, task: task.entity_task
-      end
-    end
+    let!(:tasks)    { 3.times.map { FactoryGirl.create :tasks_task, task_type: :concept_coach } }
+    let!(:cc_tasks) { tasks.map{ |task| FactoryGirl.create :tasks_concept_coach_task, task: task } }
 
     it "returns http success" do
       controller.sign_in admin

--- a/spec/controllers/api/v1/cc/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/cc/tasks_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::Cc::TasksController, type: :controller, api: true, versi
     context 'existing task' do
       let!(:cc_task) { GetConceptCoach[user: @user_1,
                                        cnx_book_id: @book.uuid,
-                                       cnx_page_id: @page.uuid].task }
+                                       cnx_page_id: @page.uuid] }
 
       it 'should not create a new task for the same user' do
         expect{ show_api_call(@user_1_token) }.not_to change{ Tasks::Models::Task.count }

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -695,31 +695,31 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
 
       @task_1 = GetConceptCoach[
         user: student_user, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task
+      ]
       @task_1.task_steps.each do |ts|
         Hacks::AnswerExercise[task_step: ts, is_correct: true]
       end
       @task_2 = GetConceptCoach[
         user: student_user, cnx_book_id: @book.uuid, cnx_page_id: @page_2.uuid
-      ].task
+      ]
       @task_2.task_steps.each do |ts|
         Hacks::AnswerExercise[task_step: ts, is_correct: false]
       end
       @task_3 = GetConceptCoach[
         user: student_user, cnx_book_id: @book.uuid, cnx_page_id: @page_3.uuid
-      ].task
+      ]
       @task_3.task_steps.each do |ts|
         Hacks::AnswerExercise[task_step: ts, is_correct: ts.core_group?]
       end
       @task_4 = GetConceptCoach[
         user: student_user_2, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task
+      ]
       @task_4.task_steps.select(&:core_group?).first(2).each_with_index do |ts, ii|
         Hacks::AnswerExercise[task_step: ts, is_correct: ii == 0]
       end
       @task_5 = GetConceptCoach[
         user: student_user_2, cnx_book_id: @book.uuid, cnx_page_id: @page_2.uuid
-      ].task
+      ]
     end
 
     after(:all) do

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -9,21 +9,17 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
   let(:user_token) { FactoryGirl.create(:doorkeeper_access_token, resource_owner_id: user.id) }
   let(:admin_token) { FactoryGirl.create(:doorkeeper_access_token, resource_owner_id: admin.id) }
 
-  before(:all) do
-    Jobba.all.to_a.each { |status| status.delete! }
-  end
+  before(:all) { Jobba.all.to_a.each(&:delete!) }
 
-  after(:all) do
-    Jobba.all.to_a.each { |status| status.delete! }
-  end
+  after(:all)  { Jobba.all.to_a.each(&:delete!) }
 
   before do
     stub_const 'TestRoutine', Class.new
-    TestRoutine.class_eval {
+    TestRoutine.class_exec do
       lev_routine
       protected
       def exec; end
-    }
+    end
   end
 
   describe 'GET #index' do
@@ -59,7 +55,8 @@ RSpec.describe Api::V1::JobsController, type: :controller, api: true, version: :
     it 'returns 404 Not Found if the job does not exist' do
       api_get :show, user_token, parameters: { id: 42 }
       expect(response).to have_http_status :not_found
-      expect(response.body_as_hash).to include({ errors: [{code: 'job_not_found'}], status: 404 })
+      expect(response.body_as_hash).to include(errors: [{code: 'job_not_found',
+                                                         message: 'Job not found'}], status: 404)
     end
 
     context 'with inline jobs' do

--- a/spec/controllers/api/v1/log_controller_spec.rb
+++ b/spec/controllers/api/v1/log_controller_spec.rb
@@ -7,20 +7,23 @@ describe Api::V1::LogController, type: :controller, api: true, version: :v1 do
     it 'requires a level' do
       expect(Rails.logger).not_to receive(:log)
       log(message: 'hi')
-      expect(response.body_as_hash).to eq({status: 422, errors: [code: "level_missing"]})
+      expect(response.body_as_hash).to eq({status: 422, errors: [{code: "level_missing",
+                                                                  message: "Level missing"}]})
     end
 
     it 'requires a valid level' do
       expect(Rails.logger).not_to receive(:log)
       log(level: 'blah', message: 'hi')
-      expect(response.body_as_hash).to eq({status: 422, errors: [code: "bad_level"]})
+      expect(response.body_as_hash).to eq({status: 422, errors: [{code: "bad_level",
+                                                                  message: "Bad level"}]})
     end
 
 
     it 'requires a message' do
       expect(Rails.logger).not_to receive(:log)
       log(level: 'info', message: '')
-      expect(response.body_as_hash).to eq({status: 422, errors: [code: "message_missing"]})
+      expect(response.body_as_hash).to eq({status: 422, errors: [{code: "message_missing",
+                                                                  message: "Message missing"}]})
     end
 
     described_class::LOG_LEVELS.each do |string, enum|

--- a/spec/controllers/api/v1/periods_controller_spec.rb
+++ b/spec/controllers/api/v1/periods_controller_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe Api::V1::PeriodsController, type: :controller, api: true, version
 
       api_delete :destroy, teacher_token, parameters: { id: period.id }
 
-      expect(response).to have_http_status(204)
-      expect(response.body).to be_empty
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq Api::V1::PeriodRepresenter.new(period).to_json
       expect(CourseMembership::Models::Period.all).to be_empty
     end
 

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -203,7 +203,8 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
         context 'caller is a course teacher' do
           it 'removes the student from the course' do
             api_delete :destroy, teacher_token, parameters: valid_params
-            expect(response).to have_http_status(:no_content)
+            expect(response).to have_http_status(:ok)
+            expect(response.body_as_hash[:is_active]).to eq false
 
             student.reload
             expect(student.persisted?).to eq true
@@ -266,7 +267,7 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
           it 'undrops the student from the course' do
             api_put :undrop, teacher_token, parameters: valid_params
             expect(response).to have_http_status(:ok)
-            expect(response.body_as_hash[:is_active]).to be true
+            expect(response.body_as_hash[:is_active]).to eq true
 
             student.reload
             expect(student.persisted?).to eq true

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -17,15 +17,16 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
   let!(:published_task_plan) { FactoryGirl.create(:tasked_task_plan,
                                                   number_of_students: 0,
                                                   owner: course,
-                                                  assistant: get_assistant(course: course,
-                                                                           task_plan_type: 'reading'),
+                                                  assistant: get_assistant(
+                                                    course: course, task_plan_type: 'reading'),
                                                   published_at: Time.current) }
   let!(:ecosystem) { published_task_plan.ecosystem }
   let!(:page)      { ecosystem.pages.first }
   let!(:task_plan) { FactoryGirl.build(:tasks_task_plan,
                                        owner: course,
-                                       assistant: get_assistant(course: course,
-                                                                task_plan_type: 'reading'),
+                                       assistant: get_assistant(
+                                         course: course, task_plan_type: 'reading'
+                                       ),
                                        content_ecosystem_id: ecosystem.id,
                                        settings: { page_ids: [page.id.to_s] },
                                        type: 'reading',
@@ -39,7 +40,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
     AddUserAsPeriodStudent.call(period: period, user: student)
   end
 
-  context 'show' do
+  context '#show' do
     before(:each) do
       task_plan.save!
     end
@@ -89,7 +90,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
     end
   end
 
-  context 'create' do
+  context '#create' do
     it 'allows a teacher to create a task_plan for their course' do
       controller.sign_in teacher
       expect { api_post :create,
@@ -189,7 +190,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
     end
   end
 
-  context 'update' do
+  context '#update' do
     before(:each) do
       task_plan.save!
     end
@@ -359,7 +360,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
     end
   end
 
-  context 'destroy' do
+  context '#destroy' do
     before(:each) { task_plan.save! }
 
     it 'allows a teacher to destroy a task_plan for their course' do
@@ -391,7 +392,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
     end
   end
 
-  context 'restore' do
+  context '#restore' do
     before(:each) do
       task_plan.save!
       task_plan.destroy!

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -382,20 +382,6 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
       expect { api_delete :destroy, nil, parameters: { course_id: course.id, id: task_plan.id } }
         .to raise_error(SecurityTransgression)
     end
-
-    it 'does not leave orphaned entity_tasks behind' do
-      # Change the opens_at dates for the tasks so we can delete them
-      published_task_plan.tasks.each do |task|
-        task.opens_at = Time.current.tomorrow
-        task.save!
-      end
-
-      controller.sign_in teacher
-      expect{ api_delete :destroy, nil, parameters: { course_id: course.id,
-                                                      id: published_task_plan.id } }
-        .to change{ ::Entity::Task.count }.by(-1)
-      ::Entity::Task.all.each{ |entity_task| expect(entity_task.task).not_to be_nil }
-    end
   end
 
   context 'stats' do

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -406,7 +406,7 @@ describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v
     end
 
     it 'does not allow a teacher to restore a task_plan that is not destroyed' do
-      task_plan.restore
+      task_plan.restore!(recursive: true)
       controller.sign_in teacher
       expect{ api_put :restore, nil, parameters: { course_id: course.id, id: task_plan.id } }
         .not_to change{ Tasks::Models::TaskPlan.count }

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -24,8 +24,7 @@ describe Api::V1::TaskStepsController, type: :controller, api: true, version: :v
 
   let!(:task)               { task_step.task.reload }
 
-  let!(:tasking)            { FactoryGirl.create :tasks_tasking, role: user_1_role,
-                                                                 task: task.entity_task }
+  let!(:tasking)            { FactoryGirl.create :tasks_tasking, role: user_1_role, task: task }
 
   let!(:tasked_exercise)    {
     te = FactoryGirl.build :tasks_tasked_exercise
@@ -248,7 +247,7 @@ describe Api::V1::TaskStepsController, type: :controller, api: true, version: :v
       AddUserAsPeriodStudent[period: period, user: user_1]
       task = ResetPracticeWidget[role: Entity::Role.last, exercise_source: :fake]
 
-      step = task.task.task_steps.first
+      step = task.task_steps.first
 
       api_put :update, user_1_token, parameters: { id: step.id },
               raw_post_data: { free_response: "Ipsum lorem" }
@@ -263,8 +262,7 @@ describe Api::V1::TaskStepsController, type: :controller, api: true, version: :v
     # Make sure the type has the tasks_ prefix
     type = type.to_s.starts_with?("tasks_") ? type : "tasks_#{type}".to_sym
     tasked = FactoryGirl.create(type)
-    tasking = FactoryGirl.create(:tasks_tasking, role: owner,
-                                 task: tasked.task_step.task.entity_task)
+    tasking = FactoryGirl.create(:tasks_tasking, role: owner, task: tasked.task_step.task)
     tasked
   end
 

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -20,8 +20,7 @@ describe Api::V1::TasksController, type: :controller, api: true, version: :v1 do
   let!(:task_1)          { FactoryGirl.create :tasks_task, title: 'A Task Title',
                                               step_types: [:tasks_tasked_reading,
                                                            :tasks_tasked_exercise] }
-  let!(:tasking_1)       { FactoryGirl.create :tasks_tasking, role: user_1_role,
-                                                              task: task_1.entity_task }
+  let!(:tasking_1)       { FactoryGirl.create :tasks_tasking, role: user_1_role, task: task_1 }
 
   let!(:teacher_user)       { FactoryGirl.create(:user) }
   let!(:teacher_role)  { AddUserAsCourseTeacher[course: task_1.task_plan.owner, user: teacher_user] }

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -2,33 +2,35 @@ require "rails_helper"
 
 describe Api::V1::TasksController, type: :controller, api: true, version: :v1 do
 
-  let!(:application)     { FactoryGirl.create :doorkeeper_application }
-  let!(:user_1)          { FactoryGirl.create(:user) }
-  let!(:user_1_token)    { FactoryGirl.create :doorkeeper_access_token,
-                                              application: application,
-                                              resource_owner_id: user_1.id }
+  let!(:application)        { FactoryGirl.create :doorkeeper_application }
+  let!(:user_1)             { FactoryGirl.create(:user) }
+  let!(:user_1_token)       { FactoryGirl.create :doorkeeper_access_token,
+                                                 application: application,
+                                                 resource_owner_id: user_1.id }
 
-  let!(:user_1_role)     { Role::GetDefaultUserRole[user_1] }
+  let!(:user_1_role)        { Role::GetDefaultUserRole[user_1] }
 
-  let!(:user_2)          { FactoryGirl.create(:user) }
-  let!(:user_2_token)    { FactoryGirl.create :doorkeeper_access_token,
-                                              application: application,
-                                              resource_owner_id: user_2.id }
+  let!(:user_2)             { FactoryGirl.create(:user) }
+  let!(:user_2_token)       { FactoryGirl.create :doorkeeper_access_token,
+                                                 application: application,
+                                                 resource_owner_id: user_2.id }
 
-  let!(:userless_token)  { FactoryGirl.create :doorkeeper_access_token, application: application }
+  let!(:userless_token)     { FactoryGirl.create :doorkeeper_access_token,
+                                                 application: application }
 
-  let!(:task_1)          { FactoryGirl.create :tasks_task, title: 'A Task Title',
-                                              step_types: [:tasks_tasked_reading,
-                                                           :tasks_tasked_exercise] }
-  let!(:tasking_1)       { FactoryGirl.create :tasks_tasking, role: user_1_role, task: task_1 }
+  let!(:task_1)             { FactoryGirl.create :tasks_task, title: 'A Task Title',
+                                                 step_types: [:tasks_tasked_reading,
+                                                              :tasks_tasked_exercise] }
+  let!(:tasking_1)          { FactoryGirl.create :tasks_tasking, role: user_1_role, task: task_1 }
 
   let!(:teacher_user)       { FactoryGirl.create(:user) }
-  let!(:teacher_role)  { AddUserAsCourseTeacher[course: task_1.task_plan.owner, user: teacher_user] }
+  let!(:teacher_role)       { AddUserAsCourseTeacher[course: task_1.task_plan.owner,
+                                                     user: teacher_user] }
   let!(:teacher_user_token) { FactoryGirl.create :doorkeeper_access_token,
                                                  application: application,
                                                  resource_owner_id: teacher_user.id }
 
-  describe "#show" do
+  context "#show" do
     it "should work on the happy path" do
       api_get :show, user_1_token, parameters: {id: task_1.id}
       expect(response.code).to eq '200'
@@ -50,28 +52,104 @@ describe Api::V1::TasksController, type: :controller, api: true, version: :v1 do
     end
   end
 
-  describe "changing is_late_work_accepted" do
-    it "should be able to change it to true" do
-      expect(task_1.is_late_work_accepted).to be_falsy
-      api_put :accept_late_work, teacher_user_token, parameters: {id: task_1.id}
-      expect(response).to have_http_status(:no_content)
-      expect(task_1.reload.is_late_work_accepted).to be_truthy
+  context "#accept_late_work" do
+    context 'deleted task' do
+      before{ task_1.destroy! }
+
+      it 'does not change is_late_work_accepted to true' do
+        expect {
+          api_put :accept_late_work, teacher_user_token, parameters: {id: task_1.id}
+        }.to raise_error(SecurityTransgression)
+
+        expect(task_1.is_late_work_accepted).to eq false
+      end
     end
 
-    it "should be able to change it to false" do
-      task_1.update_attribute(:is_late_work_accepted, true)
-      expect(task_1.is_late_work_accepted).to be_truthy
-      api_put :reject_late_work, teacher_user_token, parameters: {id: task_1.id}
-      expect(response).to have_http_status(:no_content)
-      expect(task_1.reload.is_late_work_accepted).to be_falsy
+    context 'non-deleted task' do
+      it "changes is_late_work_accepted to true" do
+        expect(task_1.is_late_work_accepted).to be_falsy
+        api_put :accept_late_work, teacher_user_token, parameters: {id: task_1.id}
+        expect(response).to have_http_status(:no_content)
+        expect(task_1.reload.is_late_work_accepted).to be_truthy
+      end
+
+      it "can only be used by teachers" do
+        expect {
+          api_put :accept_late_work, user_1_token, parameters: {id: task_1.id}
+        }.to raise_error(SecurityTransgression)
+      end
+    end
+  end
+
+  context "#reject_late_work" do
+    before { task_1.update_attribute :is_late_work_accepted, true }
+
+    context 'deleted task' do
+      before{ task_1.destroy! }
+
+      it 'does not change is_late_work_accepted to false' do
+        expect {
+          api_put :reject_late_work, teacher_user_token, parameters: {id: task_1.id}
+        }.to raise_error(SecurityTransgression)
+
+        expect(task_1.is_late_work_accepted).to eq true
+      end
     end
 
-    it "shouldn't be changeable by non-teacher" do
-      expect{
-        api_put :accept_late_work, user_1_token, parameters: {id: task_1.id}
-      }.to raise_error(SecurityTransgression)
+    context 'non-deleted task' do
+      it "changes is_late_work_accepted to false" do
+        expect(task_1.is_late_work_accepted).to be_truthy
+        api_put :reject_late_work, teacher_user_token, parameters: {id: task_1.id}
+        expect(response).to have_http_status(:no_content)
+        expect(task_1.reload.is_late_work_accepted).to be_falsy
+      end
+
+      it "can only be used by teachers" do
+        expect {
+          api_put :reject_late_work, user_1_token, parameters: {id: task_1.id}
+        }.to raise_error(SecurityTransgression)
+      end
+    end
+  end
+
+  context "#destroy" do
+    context 'student' do
+      let!(:token) { user_1_token }
+
+      context 'deleted task' do
+        before { task_1.destroy! }
+
+        it 'hides the task' do
+          api_delete :destroy, token, parameters: {id: task_1.id}
+
+          expect(task_1.reload).to be_hidden
+        end
+      end
+
+      context 'non-deleted task' do
+        it 'does not hide the task' do
+          expect {
+            api_delete :destroy, token, parameters: {id: task_1.id}
+          }.to raise_error(SecurityTransgression)
+
+          expect(task_1.reload).not_to be_hidden
+        end
+      end
     end
 
+    context 'non-student' do
+      let!(:token) { teacher_user_token }
+
+      before{ task_1.destroy! }
+
+      it 'does not hide the task' do
+        expect {
+          api_delete :destroy, token, parameters: {id: task_1.id}
+        }.to raise_error(SecurityTransgression)
+
+        expect(task_1.reload).not_to be_hidden
+      end
+    end
   end
 
 end

--- a/spec/controllers/customer_service/stats_controller_spec.rb
+++ b/spec/controllers/customer_service/stats_controller_spec.rb
@@ -29,14 +29,8 @@ RSpec.describe CustomerService::StatsController, type: :controller do
   end
 
   context "GET #concept_coach" do
-    let!(:tasks)         do
-      3.times.map { FactoryGirl.create :tasks_task, task_type: :concept_coach }
-    end
-    let!(:cc_tasks)       do
-      tasks.map do |task|
-        FactoryGirl.create :tasks_concept_coach_task, task: task.entity_task
-      end
-    end
+    let!(:tasks)    { 3.times.map { FactoryGirl.create :tasks_task, task_type: :concept_coach } }
+    let!(:cc_tasks) { tasks.map{ |task| FactoryGirl.create :tasks_concept_coach_task, task: task } }
 
     it "returns http success" do
       controller.sign_in customer_service

--- a/spec/controllers/short_codes_controller_spec.rb
+++ b/spec/controllers/short_codes_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ShortCodesController, type: :controller do
   let(:student) { FactoryGirl.create(:user) }
   let(:student_role) { AddUserAsPeriodStudent[period: period, user: student] }
 
-  let(:tasking) { FactoryGirl.create(:tasks_tasking, role: student_role, task: task.entity_task) }
+  let(:tasking) { FactoryGirl.create(:tasks_tasking, role: student_role, task: task) }
   let(:tasking_gid) { tasking.to_global_id.to_s }
 
   let(:task_plan_code) { FactoryGirl.create(:short_code_short_code,

--- a/spec/factories/entity/tasks.rb
+++ b/spec/factories/entity/tasks.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :entity_task, class: '::Entity::Task' do
-  end
-end

--- a/spec/factories/tasks/concept_coach_tasks.rb
+++ b/spec/factories/tasks/concept_coach_tasks.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :tasks_concept_coach_task, class: '::Tasks::Models::ConceptCoachTask' do
     association :page, factory: :content_page
     association :role, factory: :entity_role
-    association :task, factory: :entity_task
+    association :task, factory: :tasks_task
 
     after(:build) do |cc_task, evaluator|
       cc_task.task.taskings << Tasks::Models::Tasking.new(role: cc_task.role, task: cc_task.task)

--- a/spec/factories/tasks/task_plans.rb
+++ b/spec/factories/tasks/task_plans.rb
@@ -17,17 +17,14 @@ FactoryGirl.define do
     is_feedback_immediate { type != 'homework' }
 
     after(:build) do |task_plan, evaluator|
-      code_class_name_hash = {
-        code_class_name: evaluator.assistant_code_class_name
-      }
-
+      code_class_name_hash = { code_class_name: evaluator.assistant_code_class_name }
       task_plan.assistant ||= Tasks::Models::Assistant.find_by(code_class_name_hash) || \
                               build(:tasks_assistant, code_class_name_hash)
 
       task_plan.content_ecosystem_id ||= task_plan.owner.ecosystems.first
       task_plan.ecosystem ||= build(:content_ecosystem)
 
-      evaluator.num_tasking_plans.times do
+      task_plan.tasking_plans = evaluator.num_tasking_plans.times.map do
         build(:tasks_tasking_plan,
               task_plan: task_plan,
               opens_at: evaluator.opens_at,

--- a/spec/factories/tasks/tasked_exercises.rb
+++ b/spec/factories/tasks/tasked_exercises.rb
@@ -29,8 +29,7 @@ FactoryGirl.define do
 
     trait :with_tasking do
       after(:build) do |tasked, evaluator|
-        create(:tasks_tasking, role: evaluator.tasked_to,
-                               task: tasked.task_step.task.entity_task)
+        create(:tasks_tasking, role: evaluator.tasked_to, task: tasked.task_step.task)
       end
     end
 

--- a/spec/factories/tasks/taskings.rb
+++ b/spec/factories/tasks/taskings.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :tasks_tasking, class: '::Tasks::Models::Tasking' do
-    role   { Entity::Role.create! }
-    task   { Entity::Task.create! }
+    association :role, factory: :entity_role
+    association :task, factory: :tasks_task
+
     period { role.student.try(:period) }
   end
 end

--- a/spec/factories/tasks/tasks.rb
+++ b/spec/factories/tasks/tasks.rb
@@ -9,7 +9,6 @@ FactoryGirl.define do
     end
 
     association :task_plan, factory: :tasks_task_plan
-    association :entity_task, factory: :entity_task
 
     task_type :reading
     title       { task_plan.title }
@@ -27,12 +26,11 @@ FactoryGirl.define do
       end
 
       evaluator.num_random_taskings.times do
-        task.entity_task.taskings << FactoryGirl.build(:tasks_tasking, task: task.entity_task)
+        task.taskings << FactoryGirl.build(:tasks_tasking, task: task)
       end
 
       [evaluator.tasked_to].flatten.each do |role|
-        task.entity_task.taskings << FactoryGirl.build(:tasks_tasking, task: task.entity_task,
-                                                                       role: role)
+        task.taskings << FactoryGirl.build(:tasks_tasking, task: task, role: role)
       end
     end
   end

--- a/spec/mocks/assistants/dummy_assistant.rb
+++ b/spec/mocks/assistants/dummy_assistant.rb
@@ -8,7 +8,7 @@ class DummyAssistant < Tasks::Assistants::GenericAssistant
       Tasks::BuildTask[task_plan: @task_plan,
                        title: @task_plan.title,
                        description: @task_plan.description,
-                       task_type: :external].entity_task
+                       task_type: :external]
     end
   end
 

--- a/spec/representers/api/v1/courses/dashboard_representer_spec.rb
+++ b/spec/representers/api/v1/courses/dashboard_representer_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           past_due?: false,
           actual_and_placeholder_exercise_count: 5,
           completed_exercise_count: 4,
-          correct_exercise_count: 3
+          correct_exercise_count: 3,
+          deleted?: true
         }),
         Hashie::Mash.new({
           id: 37,
@@ -84,6 +85,7 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           completed?: false,
           actual_and_placeholder_exercise_count: 7,
           completed_exercise_count: 6,
+          deleted?: false
         }),
         Hashie::Mash.new({
           id: 89,
@@ -96,7 +98,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           past_due?: true,
           actual_and_placeholder_exercise_count: 8,
           completed_exercise_count: 8,
-          correct_exercise_count: 3
+          correct_exercise_count: 3,
+          deleted?: false
         }),
         Hashie::Mash.new({
           id: 99,
@@ -106,7 +109,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           last_worked_at: last_worked_at,
           task_type: :external,
           completed?: true,
-          past_due?: true
+          past_due?: true,
+          deleted?: false
         }),
       ]
       mash.course = {
@@ -170,7 +174,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           "type" => "homework",
           "complete" => false,
           "exercise_count" => 5,
-          "complete_exercise_count" => 4
+          "complete_exercise_count" => 4,
+          "is_deleted" => true
         ),
         a_hash_including(
           "id" => '37',
@@ -180,7 +185,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           "type" => "reading",
           "complete" => false,
           "exercise_count" => 7,
-          "complete_exercise_count" => 6
+          "complete_exercise_count" => 6,
+          "is_deleted" => false
         ),
         a_hash_including(
           "id" => '89',
@@ -192,7 +198,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           "complete" => true,
           "exercise_count" => 8,
           "complete_exercise_count" => 8,
-          "correct_exercise_count" => 3
+          "correct_exercise_count" => 3,
+          "is_deleted" => false
         ),
         a_hash_including(
           "id" => '99',
@@ -201,7 +208,8 @@ RSpec.describe Api::V1::Courses::DashboardRepresenter, type: :representer do
           "due_at" => api_due_at,
           "last_worked_at" => api_last_worked_at,
           "type" => "external",
-          "complete" => true
+          "complete" => true,
+          "is_deleted" => false
         ),
       ),
       "role" => {

--- a/spec/representers/api/v1/student_representer_spec.rb
+++ b/spec/representers/api/v1/student_representer_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::StudentRepresenter, type: :representer do
-  let!(:user) { FactoryGirl.create(:user) }
-  let!(:period) { FactoryGirl.create(:course_membership_period) }
-  let!(:student) {
-    AddUserAsPeriodStudent.call(period: period, user: user).outputs.student
-  }
+  let!(:user)    { FactoryGirl.create(:user) }
+  let!(:period)  { FactoryGirl.create(:course_membership_period) }
+  let!(:student) { AddUserAsPeriodStudent.call(period: period, user: user).outputs.student }
 
   it 'represents a student' do
     representation = Api::V1::StudentRepresenter.new(student).as_json

--- a/spec/representers/api/v1/task_search_representer_spec.rb
+++ b/spec/representers/api/v1/task_search_representer_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe Api::V1::TaskSearchRepresenter, type: :representer do
     let!(:default_task)   { FactoryGirl.create(:tasks_task) }
     let!(:task_count)     { rand(5..10) }
     let!(:ecosystem)      { FactoryGirl.build(:content_ecosystem) }
-    let!(:tasks)          { task_count.times.map {
-                              FactoryGirl.create(:tasks_task, ecosystem: ecosystem)
-                           } }
+    let!(:tasks)          do
+      task_count.times.map{ FactoryGirl.create(:tasks_task, ecosystem: ecosystem) }
+    end
 
-    let!(:taskings)       { tasks.map { |t| FactoryGirl.create(
-      :tasks_tasking, task: t.entity_task, role: role
-    ) } }
+    let!(:taskings)       do
+      tasks.map{ |task| FactoryGirl.create(:tasks_tasking, task: task, role: role) }
+    end
 
     let!(:output)         { Hashie::Mash.new(
-      'items' => GetCourseUserTasks[course: course, user: user].map(&:task)
+      'items' => GetCourseUserTasks[course: course, user: user]
     ) }
     let!(:representation) { Api::V1::TaskSearchRepresenter.new(output).as_json }
 

--- a/spec/representers/api/v1/teacher_representer_spec.rb
+++ b/spec/representers/api/v1/teacher_representer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TeacherRepresenter, type: :representer do
+  let!(:user)    { FactoryGirl.create(:user) }
+  let!(:course)  { FactoryGirl.create(:entity_course) }
+  let!(:teacher) { AddUserAsCourseTeacher.call(course: course, user: user).outputs.teacher }
+
+  it 'represents a teacher' do
+    representation = Api::V1::TeacherRepresenter.new(teacher.reload).as_json
+
+    expect(representation).to eq(
+      'id' => teacher.id.to_s,
+      'course_id' => course.id.to_s,
+      'role_id' => teacher.role.id.to_s,
+      'first_name' => teacher.first_name,
+      'last_name' => teacher.last_name,
+      'name' => teacher.name
+    )
+  end
+end

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -71,7 +71,7 @@ describe "Get authentication status", type: :request, version: :v1 do
         {'HTTP_ORIGIN' => origin, 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'}
       expect(response.headers['Access-Control-Allow-Origin']).to eq(origin)
       expect(response.headers['Access-Control-Allow-Methods']).to eq(
-        'GET, OPTIONS'
+        'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
       )
     end
 

--- a/spec/routines/add_spy_info_spec.rb
+++ b/spec/routines/add_spy_info_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe AddSpyInfo, type: :routine do
   end
 
   it 'sets spy info from an array of models' do
-    task = FactoryGirl.create(:entity_task)
+    task = FactoryGirl.create(:tasks_task)
     dest = AddSpyInfo[to: {}, from: [task, ecosystem]]
     expect(dest.spy).to eq({'task_id' => task.id,
+                            'task_title' => 'A task',
                             'ecosystem_id' => ecosystem.id,
                             'ecosystem_title' => ecosystem.title})
   end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DistributeTasks, type: :routine do
     before(:each) do
       DistributeTasks.call(task_plan)
       new_user.to_model.roles.each do |role|
-        role.taskings.each{ |tasking| tasking.task.destroy }
+        role.taskings.each{ |tasking| tasking.task.really_destroy! }
       end
       task_plan.reload
     end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe DistributeTasks, type: :routine do
     it 'fails to publish the task_plan if one or more non-stepless tasks would be empty' do
       original_build_tasks = DummyAssistant.instance_method(:build_tasks)
       allow_any_instance_of(DummyAssistant).to receive(:build_tasks) do |receiver|
-        entity_tasks = original_build_tasks.bind(receiver).call
-        entity_tasks.each{ |et| et.task.task_type = :reading }
+        tasks = original_build_tasks.bind(receiver).call
+        tasks.each{ |task| task.task_type = :reading }
       end
 
       expect(task_plan.tasks).to be_empty
@@ -62,7 +62,7 @@ RSpec.describe DistributeTasks, type: :routine do
       before(:each) do
         opens_at = Time.current.tomorrow
         task_plan.tasking_plans.each{ |tp| tp.update_attribute(:opens_at, opens_at) }
-        task_plan.tasks.each{ |tt| tt.update_attribute(:opens_at, opens_at) }
+        task_plan.tasks.each{ |task| task.update_attribute(:opens_at, opens_at) }
       end
 
       it 'rebuilds the tasks for the task_plan' do
@@ -88,7 +88,7 @@ RSpec.describe DistributeTasks, type: :routine do
       before(:each) do
         opens_at = Time.current.yesterday
         task_plan.tasking_plans.each{ |tp| tp.update_attribute(:opens_at, opens_at) }
-        task_plan.tasks.each{ |tt| tt.update_attribute(:opens_at, opens_at) }
+        task_plan.tasks.each{ |task| task.update_attribute(:opens_at, opens_at) }
       end
 
       it 'does not rebuild existing tasks for the task_plan' do

--- a/spec/routines/does_tasking_exist_spec.rb
+++ b/spec/routines/does_tasking_exist_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DoesTaskingExist, type: :routine do
   let(:tasked)    { FactoryGirl.create(:tasks_tasked_exercise) }
   let!(:tasking)  { FactoryGirl.create(:tasks_tasking,
                                        role: Role::GetDefaultUserRole[taskee],
-                                       task: tasked.task_step.task.entity_task) }
+                                       task: tasked.task_step.task) }
 
   it "returns true for a tasked and the taskee" do
     expect(DoesTaskingExist[task_component: tasked, user: taskee]).to be_truthy

--- a/spec/routines/get_cc_dashboard_spec.rb
+++ b/spec/routines/get_cc_dashboard_spec.rb
@@ -105,31 +105,31 @@ describe GetCcDashboard, type: :routine do
     before(:each) do
       @task_1 = GetConceptCoach[
         user: @student_user, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task
+      ]
       @task_1.task_steps.each do |ts|
         Hacks::AnswerExercise[task_step: ts, is_correct: true]
       end
       @task_2 = GetConceptCoach[
         user: @student_user, cnx_book_id: @book.uuid, cnx_page_id: @page_2.uuid
-      ].task
+      ]
       @task_2.task_steps.each do |ts|
         Hacks::AnswerExercise[task_step: ts, is_correct: false]
       end
       @task_3 = GetConceptCoach[
         user: @student_user, cnx_book_id: @book.uuid, cnx_page_id: @page_3.uuid
-      ].task
+      ]
       @task_3.task_steps.each do |ts|
         Hacks::AnswerExercise[task_step: ts, is_correct: ts.core_group?]
       end
       @task_4 = GetConceptCoach[
         user: @student_user_2, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task
+      ]
       @task_4.task_steps.select(&:core_group?).first(2).each_with_index do |ts, ii|
         Hacks::AnswerExercise[task_step: ts, is_correct: ii == 0]
       end
       @task_5 = GetConceptCoach[
         user: @student_user_2, cnx_book_id: @book.uuid, cnx_page_id: @page_2.uuid
-      ].task
+      ]
     end
 
     it "works for a student" do
@@ -466,7 +466,7 @@ describe GetCcDashboard, type: :routine do
       expect(@counts).to eq 8
 
       # Answering an exercise invalidates the period cache
-      @period.to_model.taskings.first.task.task.tasked_exercises.first.task_step
+      @period.to_model.taskings.first.task.tasked_exercises.first.task_step
              .update_attribute(:last_completed_at, Time.current)
 
       # Miss (4 times = 4 counts per period * 1 period)

--- a/spec/routines/get_concept_coach_spec.rb
+++ b/spec/routines/get_concept_coach_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe GetConceptCoach, type: :routine, speed: :medium do
       task = nil
       expect{ task = described_class[
         user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task }.to change{ Tasks::Models::Task.count }.by(1)
+      ] }.to change{ Tasks::Models::Task.count }.by(1)
       expect(task.task_steps.size).to eq exercises_count(0)
       task.task_steps.each do |task_step|
         expect(task_step.tasked.exercise.page.id).to eq @page_1.id
@@ -74,9 +74,9 @@ RSpec.describe GetConceptCoach, type: :routine, speed: :medium do
       task = nil
       expect{ task = described_class[
         user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task }.to change{ Tasks::Models::ConceptCoachTask.count }.by(1)
+      ] }.to change{ Tasks::Models::ConceptCoachTask.count }.by(1)
       cc_task = Tasks::Models::ConceptCoachTask.order(:created_at).last
-      expect(cc_task.task).to eq task.entity_task
+      expect(cc_task.task).to eq task
     end
 
     it 'returns an error if the book is invalid' do
@@ -111,13 +111,13 @@ RSpec.describe GetConceptCoach, type: :routine, speed: :medium do
   context 'existing task' do
     let!(:existing_task) { described_class[user: @user_1,
                                            cnx_book_id: @book.uuid,
-                                           cnx_page_id: @page_1.uuid].task }
+                                           cnx_page_id: @page_1.uuid] }
 
     it 'should not create a new task for the same user and page' do
       task = nil
       expect{ task = described_class[
         user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task }.not_to change{ Tasks::Models::ConceptCoachTask.count }
+      ] }.not_to change{ Tasks::Models::ConceptCoachTask.count }
       expect(task).to eq existing_task
     end
 
@@ -125,7 +125,7 @@ RSpec.describe GetConceptCoach, type: :routine, speed: :medium do
       task = nil
       expect{ task = described_class[
         user: @user_2, cnx_book_id: @book.uuid, cnx_page_id: @page_1.uuid
-      ].task }.to change{ Tasks::Models::ConceptCoachTask.count }.by(1)
+      ] }.to change{ Tasks::Models::ConceptCoachTask.count }.by(1)
       expect(task).not_to eq existing_task
       expect(task.task_steps.size).to eq exercises_count(0)
       task.task_steps.each do |task_step|
@@ -137,7 +137,7 @@ it 'should create a new task for a different page and properly assign spaced pra
       task = nil
       expect{ task = described_class[
         user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: @page_2.uuid
-      ].task }.to change{ Tasks::Models::ConceptCoachTask.count }.by(1)
+      ] }.to change{ Tasks::Models::ConceptCoachTask.count }.by(1)
       expect(task).not_to eq existing_task
       expect(task.task_steps.size).to eq exercises_count(1)
       task.task_steps.first(CORE_EXERCISES_COUNT).each do |task_step|
@@ -153,7 +153,7 @@ it 'should create a new task for a different page and properly assign spaced pra
       tasks = task_pages.map do |page|
         described_class[
           user: @user_1, cnx_book_id: @book.uuid, cnx_page_id: page.uuid
-        ].task
+        ]
       end
 
       tasks.each_with_index do |task, ii|

--- a/spec/routines/propagate_task_plan_updates_spec.rb
+++ b/spec/routines/propagate_task_plan_updates_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
     end
 
     context 'homework' do
-      it 'propagates task_plan changes to all of its tasks' do
+      it 'propagates task_plan changes (except opens_at) to all of its tasks' do
         task_plan.type = 'homework'
         task_plan.is_feedback_immediate = false
         task_plan.save!(validate: false)
@@ -76,7 +76,9 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
           expect(task.opens_at).to    be_within(1.second).of(old_opens_at)
           expect(task.due_at).to      be_within(1.second).of(old_due_at)
         end
-        allow(task_plan.assistant).to receive(:code_class).and_return(Tasks::Assistants::HomeworkAssistant)
+        allow(task_plan.assistant).to(
+          receive(:code_class).and_return(Tasks::Assistants::HomeworkAssistant)
+        )
 
         expect {
           PropagateTaskPlanUpdates.call(task_plan: task_plan)
@@ -86,14 +88,16 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
         task_plan.tasks.each do |task|
           expect(task.title).to       eq new_title
           expect(task.description).to eq new_description
-          expect(task.opens_at).to    be_within(1.second).of(new_opens_at)
+          expect(task.opens_at).to    be_within(1.second).of(old_opens_at)
           expect(task.due_at).to      be_within(1.second).of(new_due_at)
           expect(task.feedback_at).to eq task.due_at
         end
       end
 
       it 'sets feedback_at to nil when feedback is immediate' do
-        allow(task_plan.assistant).to receive(:code_class).and_return(Tasks::Assistants::HomeworkAssistant)
+        allow(task_plan.assistant).to(
+          receive(:code_class).and_return(Tasks::Assistants::HomeworkAssistant)
+        )
         task_plan.update_attributes(type: 'homework', is_feedback_immediate: true)
         PropagateTaskPlanUpdates.call(task_plan: task_plan)
         task_plan.tasks.each do |task|
@@ -104,7 +108,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
     end
 
     context 'reading' do
-      it 'propagates task_plan changes to all of its tasks' do
+      it 'propagates task_plan changes (except opens_at) to all of its tasks' do
         task_plan.update_attribute(:type, 'reading')
         expect(task_plan.tasks).not_to be_empty
         task_plan.tasks.each do |task|
@@ -122,7 +126,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
         task_plan.tasks.each do |task|
           expect(task.title).to       eq new_title
           expect(task.description).to eq new_description
-          expect(task.opens_at).to    be_within(1.second).of(new_opens_at)
+          expect(task.opens_at).to    be_within(1.second).of(old_opens_at)
           expect(task.due_at).to      be_within(1.second).of(new_due_at)
           expect(task.feedback_available?).to be_truthy
         end

--- a/spec/routines/reassign_published_period_task_plans_spec.rb
+++ b/spec/routines/reassign_published_period_task_plans_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe ReassignPublishedPeriodTaskPlans, type: :routine do
 
   before(:each) {
     DistributeTasks.call(task_plan_1)
-    new_user.to_model.roles.each{ |role|
-      role.taskings.each{ |tasking| tasking.task.destroy }
-    }
+    # We are pretending this user is new to the period, so hard-delete their tasks
+    new_user.to_model.roles.each do |role|
+      role.taskings.each{ |tasking| tasking.task.really_destroy! }
+    end
   }
 
   context 'unpublished task_plan' do

--- a/spec/routines/reassign_published_period_task_plans_spec.rb
+++ b/spec/routines/reassign_published_period_task_plans_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ReassignPublishedPeriodTaskPlans, type: :routine do
       expect(result.errors).to be_empty
       expect(task_plan_1.tasks.size).to eq 2
       expect(task_plan_1.tasks).to include old_task
-      new_task = task_plan_1.tasks.reject{ |tt| tt == old_task }.first
+      new_task = task_plan_1.tasks.reject{ |task| task == old_task }.first
       expect(new_task.taskings.first.role.profile).to eq new_user.to_model
     end
   end

--- a/spec/routines/reset_practice_widget_spec.rb
+++ b/spec/routines/reset_practice_widget_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe ResetPracticeWidget, type: :routine do
 
   it 'creates tasks with 5 exercise steps and feedback immediately available' do
     expect(practice_task).to be_persisted
-    expect(practice_task.task.task_steps.reload.size).to eq 5
-    practice_task.task.task_steps.each{ |task_step| expect(task_step.exercise?).to eq true }
-    expect(practice_task.task.feedback_available?).to be_truthy
+    expect(practice_task.task_steps.reload.size).to eq 5
+    practice_task.task_steps.each{ |task_step| expect(task_step.exercise?).to eq true }
+    expect(practice_task.feedback_available?).to be_truthy
   end
 
   it 'clears incomplete steps from previous practice widgets' do
-    Hacks::AnswerExercise[task_step: practice_task.task.task_steps.first, is_correct: false]
+    Hacks::AnswerExercise[task_step: practice_task.task_steps.first, is_correct: false]
     practice_task_2 = ResetPracticeWidget[role: role, exercise_source: :fake, page_ids: []]
     expect(practice_task_2).to be_persisted
-    expect(practice_task.task.task_steps.reload.size).to eq 1
+    expect(practice_task.task_steps.reload.size).to eq 1
   end
 
   it 'errors when biglearn does not return enough' do

--- a/spec/routines/update_clues_spec.rb
+++ b/spec/routines/update_clues_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe UpdateClues, type: :routine, vcr: VCR_OPTS do
         Timecop.freeze(Time.current + 5.minutes)
 
         @role.taskings.each do |tasking|
-          tasking.task.task.task_steps.select(&:completed?).each do |ts|
+          tasking.task.task_steps.select(&:completed?).each do |ts|
             MarkTaskStepCompleted[task_step: ts]
           end
         end

--- a/spec/routing/api/v1/task_plans_controller_routing_spec.rb
+++ b/spec/routing/api/v1/task_plans_controller_routing_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe Api::V1::TaskPlansController, type: :routing, api: true, version: :v1 do
+
+  context 'DELETE /api/task_plans/:id' do
+    it "routes to #destroy" do
+      expect(delete '/api/plans/42').to(
+        route_to('api/v1/task_plans#destroy', format: 'json', id: '42')
+      )
+    end
+  end
+
+  context 'PUT /api/task_plans/:id/restore' do
+    it "routes to #restore" do
+      expect(put '/api/plans/42/restore').to(
+        route_to('api/v1/task_plans#restore', format: 'json', id: '42')
+      )
+    end
+  end
+
+end

--- a/spec/routing/api/v1/tasks_controller_routing_spec.rb
+++ b/spec/routing/api/v1/tasks_controller_routing_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe Api::V1::TasksController, type: :routing, api: true, version: :v1 do
+
+  context 'DELETE /api/tasks/:id' do
+    it "routes to #destroy" do
+      expect(delete '/api/tasks/42').to route_to('api/v1/tasks#destroy', format: 'json', id: '42')
+    end
+  end
+
+end

--- a/spec/subsystems/tasks/add_related_exercise_after_step_spec.rb
+++ b/spec/subsystems/tasks/add_related_exercise_after_step_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Tasks::AddRelatedExerciseAfterStep, type: :routine do
 
   let!(:task)            { tasked_reading.task_step.task }
 
-  let!(:tasking)         { FactoryGirl.create :tasks_tasking, task: task.entity_task }
+  let!(:tasking)         { FactoryGirl.create :tasks_tasking, task: task }
 
   let!(:tasked_exercise) {
     te = FactoryGirl.build(:tasks_tasked_exercise)

--- a/spec/subsystems/tasks/assistants/event_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/event_assistant_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Tasks::Assistants::EventAssistant, type: :assistant do
                                   description: 'No class today, kiddos',
                                   owner: course)
 
-    tasks = DistributeTasks.call(task_plan).outputs.entity_tasks.flat_map(&:task)
+    tasks = DistributeTasks.call(task_plan).outputs.tasks
 
     expect(tasks.length).to eq 3
     expect(tasks.flat_map(&:task_type).uniq).to eq(['event'])

--- a/spec/subsystems/tasks/assistants/external_assignment_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/external_assignment_assistant_spec.rb
@@ -37,19 +37,15 @@ RSpec.describe Tasks::Assistants::ExternalAssignmentAssistant, type: :assistant 
   }
 
   let!(:tasking_plans_1) {
-    FactoryGirl.build(:tasks_tasking_plan,
-                      task_plan: task_plan_1,
-                      target: course)
+    FactoryGirl.build(:tasks_tasking_plan, task_plan: task_plan_1, target: course)
   }
 
   let!(:tasking_plans_2) {
-    FactoryGirl.create(:tasks_tasking_plan,
-                       task_plan: task_plan_2,
-                       target: course)
+    FactoryGirl.create(:tasks_tasking_plan, task_plan: task_plan_2, target: course)
   }
 
   it 'assigns tasked external urls to students' do
-    tasks = DistributeTasks.call(task_plan_1).outputs.entity_tasks.map(&:task)
+    tasks = DistributeTasks.call(task_plan_1).outputs.tasks
     expect(tasks.length).to eq num_taskees
 
     tasks.each do |task|
@@ -60,7 +56,7 @@ RSpec.describe Tasks::Assistants::ExternalAssignmentAssistant, type: :assistant 
   end
 
   it 'assigns tasked external urls with templatized urls to students' do
-    tasks = DistributeTasks.call(task_plan_2).outputs.entity_tasks.map(&:task)
+    tasks = DistributeTasks.call(task_plan_2).outputs.tasks
     expect(tasks.length).to eq num_taskees
 
     tasks.each do |task|

--- a/spec/subsystems/tasks/assistants/extra_assignment_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/extra_assignment_assistant_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Tasks::Assistants::ExtraAssignmentAssistant, type: :assistant, vc
   }
 
   it 'assigns tasked readings and exercises to students' do
-    tasks = DistributeTasks.call(task_plan).outputs.entity_tasks.map(&:task)
+    tasks = DistributeTasks.call(task_plan).outputs.tasks
     expect(tasks.length).to eq(num_taskees)
     tasks.each do |task|
       # We added 2 snap lab notes:

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -151,12 +151,11 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       allow(Tasks::Assistants::HomeworkAssistant).
         to receive(:num_personalized_exercises) { personalized_exercise_count }
 
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
 
       ## it "sets description, task type, and feedback_at"
-      entity_tasks.each do |entity_task|
-        entity_task.reload.reload
-        task = entity_task.task
+      tasks.each do |task|
+        task.reload.reload
         expect(task.description).to eq("Hello!")
         expect(task.homework?).to be_truthy
         # feedback_at == nil because the task plan was set to immediate_feedback
@@ -164,23 +163,23 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       end
 
       ## it "creates one task per taskee"
-      expect(entity_tasks.count).to eq(taskee_users.count)
+      expect(tasks.count).to eq(taskee_users.count)
 
       ## it "assigns each task to one role"
-      entity_tasks.each do |entity_task|
-        expect(entity_task.taskings.count).to eq(1)
+      tasks.each do |task|
+        expect(task.taskings.count).to eq(1)
       end
       expected_roles = taskee_users.map{ |taskee| Role::GetDefaultUserRole[taskee] }
-      expect(entity_tasks.map{|t| t.taskings.first.role}).to match_array expected_roles
+      expect(tasks.map{|t| t.taskings.first.role}).to match_array expected_roles
 
       ## it "assigns the correct number of exercises"
-      entity_tasks.each do |entity_task|
-        expect(entity_task.task.task_steps.count).to eq(assignment_exercise_count)
+      tasks.each do |task|
+        expect(task.task_steps.count).to eq(assignment_exercise_count)
       end
 
       ## it "assigns the teacher-selected exercises as the task's core exercises"
-      entity_tasks.each do |entity_task|
-        core_task_steps = entity_task.task.core_task_steps
+      tasks.each do |task|
+        core_task_steps = task.core_task_steps
         expect(core_task_steps.count).to eq(teacher_selected_exercises.count)
 
         core_task_steps.each_with_index do |task_step, ii|
@@ -196,8 +195,8 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       end
 
       ## it "assigns the tutor-selected spaced practice exercises"
-      entity_tasks.each do |entity_task|
-        spaced_practice_task_steps = entity_task.task.spaced_practice_task_steps
+      tasks.each do |task|
+        spaced_practice_task_steps = task.spaced_practice_task_steps
         expect(spaced_practice_task_steps.count).to eq(tutor_selected_exercise_count)
 
         spaced_practice_task_steps.each do |task_step|
@@ -207,8 +206,8 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
       end
 
       ## it "assigns personalized exercise placeholders"
-      entity_tasks.each do |entity_task|
-        personalized_task_steps = entity_task.task.personalized_task_steps
+      tasks.each do |task|
+        personalized_task_steps = task.personalized_task_steps
         expect(personalized_task_steps.count).to eq(personalized_exercise_count)
 
         personalized_task_steps.each do |task_step|
@@ -231,10 +230,10 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
                                                         exercise_number: exercise.number)
       end
 
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
 
-      entity_tasks.each do |entity_task|
-        core_task_steps = entity_task.task.core_task_steps
+      tasks.each do |task|
+        core_task_steps = task.core_task_steps
         expect(core_task_steps.count).to eq(teacher_selected_exercises.count)
 
         core_task_steps.each_with_index do |task_step, ii|
@@ -248,10 +247,10 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
           expect(tasked_exercise.content).to eq(exercise.content)
         end
 
-        spaced_practice_task_steps = entity_task.task.spaced_practice_task_steps
+        spaced_practice_task_steps = task.spaced_practice_task_steps
         expect(spaced_practice_task_steps.count).to eq 0
 
-        personalized_task_steps = entity_task.task.personalized_task_steps
+        personalized_task_steps = task.personalized_task_steps
         expect(personalized_task_steps.count).to eq(personalized_exercise_count)
 
         personalized_task_steps.each do |task_step|

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -121,14 +121,13 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
     it 'splits a CNX module into many different steps and assigns them with immediate feedback' do
       allow(Tasks::Assistants::IReadingAssistant).to receive(:k_ago_map) { [[0, 2]]}
 
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
-      expect(entity_tasks.length).to eq num_taskees
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      expect(tasks.length).to eq num_taskees
 
-      entity_tasks.each do |entity_task|
-        entity_task.reload.reload
-        expect(entity_task.taskings.length).to eq 1
+      tasks.each do |task|
+        task.reload.reload
+        expect(task.taskings.length).to eq 1
 
-        task = entity_task.task
         expect(task.feedback_at).to be_nil
 
         task_steps = task.task_steps
@@ -174,21 +173,20 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       end
 
       expected_roles = taskee_users.map{ |tu| Role::GetDefaultUserRole[tu] }
-      expect(entity_tasks.map{|et| et.taskings.first.role}).to eq expected_roles
+      expect(tasks.map{|task| task.taskings.first.role}).to eq expected_roles
     end
 
     it 'does not assign dynamic exercises if the dynamic exercises pool is empty' do
       allow(Tasks::Assistants::IReadingAssistant).to receive(:k_ago_map) { [[0, 2]] }
 
       task_plan.update_attribute(:settings, { 'page_ids' => [@content_pages.first.id.to_s] })
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
-      expect(entity_tasks.length).to eq num_taskees
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      expect(tasks.length).to eq num_taskees
 
-      entity_tasks.each do |entity_task|
-        entity_task.reload.reload
-        expect(entity_task.taskings.length).to eq 1
+      tasks.each do |task|
+        task.reload.reload
+        expect(task.taskings.length).to eq 1
 
-        task = entity_task.task
         expect(task.feedback_at).to be_nil
 
         task_steps = task.task_steps
@@ -209,7 +207,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       end
 
       expected_roles = taskee_users.map{ |tu| Role::GetDefaultUserRole[tu] }
-      expect(entity_tasks.map{|et| et.taskings.first.role}).to eq expected_roles
+      expect(tasks.map{|task| task.taskings.first.role}).to eq expected_roles
     end
 
     it 'does not assign excluded dynamic exercises' do
@@ -223,11 +221,11 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         end
       end
 
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
-      expect(entity_tasks.length).to eq num_taskees
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      expect(tasks.length).to eq num_taskees
 
-      entity_tasks.each do |entity_task|
-        task = entity_task.reload.reload.task
+      tasks.each do |task|
+        task = task.reload.reload
         task_steps = task.task_steps
 
         expect(task_steps.count).to eq(@core_step_gold_data.count + 1)
@@ -248,7 +246,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       end
 
       expected_roles = taskee_users.map{ |tu| Role::GetDefaultUserRole[tu] }
-      expect(entity_tasks.map{|et| et.taskings.first.role}).to eq expected_roles
+      expect(tasks.map{|task| task.taskings.first.role}).to eq expected_roles
     end
   end
 
@@ -351,13 +349,13 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       allow(Tasks::Assistants::IReadingAssistant).to receive(:k_ago_map) { [[0, 2]] }
       allow(Tasks::Assistants::IReadingAssistant).to receive(:num_personalized_exercises) { 0 }
 
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
-      entity_tasks.each do |entity_task|
-        entity_task.reload.reload
-        expect(entity_task.taskings.length).to eq 1
-        expect(entity_task.task.feedback_at).to be_nil
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks.each do |task|
+        task.reload.reload
+        expect(task.taskings.length).to eq 1
+        expect(task.feedback_at).to be_nil
 
-        task_steps = entity_task.task.task_steps
+        task_steps = task.task_steps
 
         expect(task_steps.count).to eq task_step_gold_data.count
         task_steps.each_with_index do |task_step, ii|
@@ -478,13 +476,13 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       allow(Tasks::Assistants::IReadingAssistant).to receive(:k_ago_map) { [[0, 2]] }
       allow(Tasks::Assistants::IReadingAssistant).to receive(:num_personalized_exercises) { 0 }
 
-      entity_tasks = DistributeTasks.call(task_plan).outputs.entity_tasks
-      entity_tasks.each do |entity_task|
-        entity_task.reload.reload
-        expect(entity_task.taskings.length).to eq 1
-        expect(entity_task.task.feedback_at).to be_nil
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks.each do |task|
+        task.reload.reload
+        expect(task.taskings.length).to eq 1
+        expect(task.feedback_at).to be_nil
 
-        task_steps = entity_task.task.task_steps
+        task_steps = task.task_steps
 
         expect(task_steps.count).to eq task_step_gold_data.count
         task_steps.each_with_index do |task_step, ii|

--- a/spec/subsystems/tasks/create_concept_coach_task_spec.rb
+++ b/spec/subsystems/tasks/create_concept_coach_task_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Tasks::CreateConceptCoachTask, type: :routine do
     cc_task = Tasks::Models::ConceptCoachTask.order(:created_at).last
     expect(cc_task.page).to eq page_model
     expect(cc_task.role).to eq role
-    expect(cc_task.task).to eq task.entity_task
+    expect(cc_task.task).to eq task
     expect(task.taskings.first.role).to eq role
   end
 end

--- a/spec/subsystems/tasks/get_cc_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_cc_performance_report_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Tasks::GetCcPerformanceReport, type: :routine, speed: :slow do
     # Transform the course into a CC course
     @course.profile.update_attribute(:is_concept_coach, true)
     @course.students.each do |student|
-      Tasks::Models::Task.joins(entity_task: :taskings)
-                         .where(entity_task: {taskings: {entity_role_id: student.entity_role_id}},
+      Tasks::Models::Task.joins(:taskings)
+                         .where(taskings: {entity_role_id: student.entity_role_id},
                                 task_type: 'homework').to_a.each_with_index do |task, index|
         task.task_type = 'concept_coach'
         task.task_plan = nil
@@ -30,7 +30,7 @@ RSpec.describe Tasks::GetCcPerformanceReport, type: :routine, speed: :slow do
         Tasks::Models::ConceptCoachTask.create!(
           content_page_id: @ecosystem.books.first.chapters.third.pages[index].id,
           role: task.taskings.first.role,
-          task: task.entity_task
+          task: task
         )
       end
     end

--- a/spec/subsystems/tasks/get_redirect_url_spec.rb
+++ b/spec/subsystems/tasks/get_redirect_url_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Tasks::GetRedirectUrl, type: :routine do
 
   let!(:user) { FactoryGirl.create(:user) }
 
-  let!(:tasking) { FactoryGirl.create(:tasks_tasking, role: student_role, task: task.entity_task) }
+  let!(:tasking) { FactoryGirl.create(:tasks_tasking, role: student_role, task: task) }
 
   it 'returns the edit task plan page for teachers' do
     result = described_class.call(gid: task_plan_gid, user: teacher)
@@ -28,7 +28,7 @@ RSpec.describe Tasks::GetRedirectUrl, type: :routine do
   it 'returns the task page for students' do
     result = described_class.call(gid: task_plan_gid, user: student)
     expect(result.errors).to be_empty
-    expect(result.outputs.uri).to eq("/courses/#{course.id}/tasks/#{task.entity_task.id}")
+    expect(result.outputs.uri).to eq("/courses/#{course.id}/tasks/#{task.id}")
   end
 
   it 'raises SecurityTransgression for users not in the course' do

--- a/spec/subsystems/tasks/get_task_plans_spec.rb
+++ b/spec/subsystems/tasks/get_task_plans_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Tasks::GetTaskPlans, type: :routine do
 
     # Remove placeholder steps since they can sometimes be deleted, messing up our counting
     tasks.each do |task|
-      task.task_steps.select(&:placeholder?).each(&:destroy!)
+      task.task_steps.select(&:placeholder?).each(&:really_destroy!)
       task.reload.update_step_counts!
     end
 

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -82,14 +82,12 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).not_to be_valid
   end
 
-  context 'publishing' do
-    it 'requires all tasking_plan due_ats to be in the future' do
-      task_plan.is_publish_requested = true
-      expect(task_plan).to be_valid
+  it 'requires all tasking_plan due_ats to be in the future when publishing' do
+    task_plan.is_publish_requested = true
+    expect(task_plan).to be_valid
 
-      task_plan.tasking_plans.first.due_at = Time.current.yesterday
-      expect(task_plan).to_not be_valid
-    end
+    task_plan.tasking_plans.first.due_at = Time.current.yesterday
+    expect(task_plan).to_not be_valid
   end
 
 end

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -68,10 +68,11 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).to be_valid
   end
 
-  it 'allows name and description to be updated after a task is open' do
+  it 'allows name, description and is_feedback_immediate to be updated after a task is open' do
     task_plan.tasks << new_task
     task_plan.title = 'New Title'
     task_plan.description = 'New description!'
+    task_plan.is_feedback_immediate = false
     expect(task_plan).to be_valid
   end
 
@@ -81,25 +82,14 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).not_to be_valid
   end
 
-  it 'requires due_at to be in the future when publishing' do
-    task_plan.is_publish_requested = true
-    expect(task_plan).to be_valid
+  context 'publishing' do
+    it 'requires all tasking_plan due_ats to be in the future' do
+      task_plan.is_publish_requested = true
+      expect(task_plan).to be_valid
 
-    task_plan.tasking_plans.first.due_at = Time.current.yesterday
-    expect(task_plan).to_not be_valid
+      task_plan.tasking_plans.first.due_at = Time.current.yesterday
+      expect(task_plan).to_not be_valid
+    end
   end
 
-  it 'cannot be deleted if it has open tasks' do
-    expect(task_plan.destroy).to eq task_plan
-    expect(task_plan.destroyed?).to eq true
-
-    new_task.save!
-    new_task.reload
-    expect(new_task.task_plan.destroy).to eq false
-    expect(new_task.task_plan.destroyed?).to eq false
-    expect(new_task.task_plan.errors).to include(:base)
-    expect(new_task.task_plan.errors.messages).to(
-      include(:base => ["cannot be deleted after it is open"])
-    )
-  end
 end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -453,5 +453,25 @@ RSpec.describe Tasks::Models::Task, type: :model do
       expect(task.correct_on_time_exercise_steps_count).to eq 1
     end
 
+    it 'is hidden only if it has been hidden after being deleted for the last time' do
+      task = FactoryGirl.create :tasks_task
+      expect(task.reload).not_to be_hidden
+
+      task.task_plan.destroy!
+      expect(task.reload).not_to be_hidden
+
+      task.hide.save!
+      expect(task).to be_hidden
+
+      task.task_plan.reload.restore!(recursive: true)
+      expect(task.reload).not_to be_hidden
+
+      task.task_plan.destroy!
+      expect(task.reload).not_to be_hidden
+
+      task.hide.save!
+      expect(task).to be_hidden
+    end
+
   end
 end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -62,10 +62,10 @@ RSpec.describe Tasks::Models::Task, type: :model do
 
   it "reports is_shared? correctly" do
     task1 = FactoryGirl.create(:tasks_task)
-    FactoryGirl.create(:tasks_tasking, task: task1.entity_task)
+    FactoryGirl.create(:tasks_tasking, task: task1)
     expect(task1.is_shared?).to be_falsy
 
-    FactoryGirl.create(:tasks_tasking, task: task1.entity_task)
+    FactoryGirl.create(:tasks_tasking, task: task1)
     expect(task1.is_shared?).to be_truthy
   end
 

--- a/spec/subsystems/tasks/models/tasking_plan_spec.rb
+++ b/spec/subsystems/tasks/models/tasking_plan_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Tasks::Models::TaskingPlan, type: :model do
   it { is_expected.to validate_presence_of(:due_at_ntz) }
   it { is_expected.to validate_presence_of(:time_zone) }
 
-  it "requires due_at to be in the future when changed" do
+  it "requires due_at to be in the future when changed after the task_plan is published" do
+    task_plan.published_at = Time.current
     expect(tasking_plan).to be_valid
     tasking_plan.due_at = tasking_plan.time_zone.to_tz.now
     expect(tasking_plan).not_to be_valid

--- a/spec/subsystems/tasks/models/tasking_plan_spec.rb
+++ b/spec/subsystems/tasks/models/tasking_plan_spec.rb
@@ -19,9 +19,16 @@ RSpec.describe Tasks::Models::TaskingPlan, type: :model do
   it { is_expected.to validate_presence_of(:due_at_ntz) }
   it { is_expected.to validate_presence_of(:time_zone) }
 
+  it "requires due_at to be in the future when changed" do
+    expect(tasking_plan).to be_valid
+    tasking_plan.due_at = tasking_plan.time_zone.to_tz.now
+    expect(tasking_plan).not_to be_valid
+  end
+
   it "requires due_at to be after opens_at" do
-    task = FactoryGirl.build(:tasks_task, opens_at: Time.current, due_at: Time.current - 1.hour)
-    expect(task).to_not be_valid
+    expect(tasking_plan).to be_valid
+    tasking_plan.opens_at = tasking_plan.due_at
+    expect(tasking_plan).not_to be_valid
   end
 
   it "requires target to be unique for the task_plan" do

--- a/spec/subsystems/tasks/models/tasking_spec.rb
+++ b/spec/subsystems/tasks/models/tasking_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Tasks::Models::Tasking, type: :model do
   it { is_expected.to validate_presence_of(:task) }
   it { is_expected.to validate_presence_of(:role) }
 
-  it { is_expected.to validate_uniqueness_of(:role).scoped_to(:entity_task_id) }
+  it { is_expected.to validate_uniqueness_of(:role).scoped_to(:tasks_task_id) }
 
   it "requires role to be unique for the task" do
     expect(tasking).to be_valid
@@ -20,4 +20,3 @@ RSpec.describe Tasks::Models::Tasking, type: :model do
                              role: tasking.role)).to_not be_valid
   end
 end
-

--- a/spec/subsystems/user/models/profile_spec.rb
+++ b/spec/subsystems/user/models/profile_spec.rb
@@ -24,29 +24,4 @@ RSpec.describe User::Models::Profile, type: :model do
   [:first_name=, :last_name=, :full_name=, :title=].each do |method|
     it { is_expected.to delegate_method(method).to(:account).with_arguments('foo') }
   end
-
-  it 'still exists after delete' do
-    profile1 = FactoryGirl.create(:user_profile)
-    id = profile1.id
-    profile1.delete
-    expect(described_class.with_deleted.where(id: id).one?).to be_truthy
-    expect(profile1.deleted_at).to be_present
-  end
-
-  it 'still exists after destroy' do
-    profile1 = FactoryGirl.create(:user_profile)
-    id = profile1.id
-    profile1.destroy
-    expect(described_class.with_deleted.where(id: id).one?).to be_truthy
-    expect(profile1.deleted_at).to be_present
-  end
-
-  it 'can be undeleted' do
-    profile1 = FactoryGirl.create(:user_profile)
-    id = profile1.id
-    profile1.destroy
-    expect(profile1.deleted_at).to be_present
-    profile1.restore
-    expect(profile1.deleted_at).to be_nil
-  end
 end

--- a/spec/support/create_student_history.rb
+++ b/spec/support/create_student_history.rb
@@ -61,9 +61,9 @@ class CreateStudentHistory
     run(:distribute_tasks, create_ireading_task_plan(ecosystem, course, periods))
 
     task_plan = create_homework_task_plan(ecosystem, course, periods)
-    entity_tasks = run(:distribute_tasks, task_plan).outputs.entity_tasks
-    entity_tasks.each do |entity_task|
-      task = entity_task.task.reload
+    tasks = run(:distribute_tasks, task_plan).outputs.tasks
+    tasks.each do |task|
+      task = task.reload
       answer_correctly(task.task_steps(true), 2)
     end
   end
@@ -72,7 +72,7 @@ class CreateStudentHistory
     ResetPracticeWidget[role: role,
                         chapter_ids: ids[:chapters],
                         page_ids: ids[:pages],
-                        exercise_source: :local].task.task_steps
+                        exercise_source: :local].task_steps
   end
 
   def answer_correctly(steps, num)


### PR DESCRIPTION
IRREVERSIBLE MIGRATION

BACKUP YOUR DB IF INTEND TO USE IT TO TEST OLD CODE IN THE FUTURE

- Changed task_plan and tasking_plan allowed edits to match latest decisions
- Removed Entity::Task
- Added acts_as_paranoid to task_plan, tasking_plan, tasks, taskings, task_steps and taskeds.
- Added delete/undelete assignment API for teachers
- Add hide API for students
- Specs