### PR TITLE
Fix another broken migration

### DIFF
--- a/db/migrate/20160505221319_add_defaults_for_null_counts.rb
+++ b/db/migrate/20160505221319_add_defaults_for_null_counts.rb
@@ -1,6 +1,8 @@
 class AddDefaultsForNullCounts < ActiveRecord::Migration
   def up
-    Tasks::Models::Task.preload(task_steps: :tasked).find_each(&:update_step_counts!)
+    Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+      task.update_step_counts.save!(validate: false)
+    end
 
     change_column_default :tasks_tasks, :correct_on_time_exercise_steps_count, 0
     change_column_default :tasks_tasks, :completed_on_time_exercise_steps_count, 0


### PR DESCRIPTION
This migration was failing because the tasks were trying to validate the opens_at_ntz column which doesn't exist yet at this point (it's in a later migration).