### PR TITLE
capture shortId in imports, more data in Toc representer

### DIFF
--- a/app/representers/api/v1/book_toc_representer.rb
+++ b/app/representers/api/v1/book_toc_representer.rb
@@ -10,6 +10,24 @@ module Api::V1
              readable: true,
              schema_info: { required: true }
 
+    property :uuid,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: 'The uuid of the book, e.g. "95e61258-2faf-41d4-af92-f62e1414175a"'
+             }
+
+    property :short_id,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: 'The `shortId` of the book, e.g. "meEn-Pci"'
+             }
+
     property :cnx_id,
              type: String,
              writeable: false,
@@ -17,6 +35,24 @@ module Api::V1
              schema_info: {
                required: false,
                description: 'The cnx id of the book, e.g. "95e61258-2faf-41d4-af92-f62e1414175a@3"'
+             }
+
+    property :archive_url,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The base of the archive URL, e.g. 'https://archive.cnx.org'"
+             }
+
+    property :webview_url,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The base of the webview URL, e.g. 'https://cnx.org'"
              }
 
     property :title,

--- a/app/representers/api/v1/page_toc_representer.rb
+++ b/app/representers/api/v1/page_toc_representer.rb
@@ -10,6 +10,24 @@ module Api::V1
              readable: true,
              schema_info: { required: true }
 
+    property :uuid,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: 'The uuid of the page, e.g. "95e61258-2faf-41d4-af92-f62e1414175a"'
+             }
+
+    property :short_id,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: 'The `shortId` of the page, e.g. "raNQgZ7E"'
+             }
+
     property :cnx_id,
              type: String,
              writeable: false,

--- a/app/subsystems/content/book.rb
+++ b/app/subsystems/content/book.rb
@@ -15,8 +15,16 @@ module Content
       verify_and_return @strategy.archive_url, klass: String, error: StrategyError
     end
 
+    def webview_url
+      verify_and_return @strategy.webview_url, klass: String, error: StrategyError
+    end
+
     def uuid
       verify_and_return @strategy.uuid, klass: String, error: StrategyError
+    end
+
+    def short_id
+      verify_and_return @strategy.short_id, klass: String, error: StrategyError, allow_nil: true
     end
 
     def version

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -19,6 +19,7 @@ class Content::ImportBook
     book = Content::Models::Book.new(
         url: cnx_book.canonical_url,
         uuid: cnx_book.uuid,
+        short_id: cnx_book.short_id,
         version: cnx_book.version,
         title: cnx_book.title,
         content: cnx_book.root_book_part.contents,

--- a/app/subsystems/content/models/book.rb
+++ b/app/subsystems/content/models/book.rb
@@ -19,6 +19,10 @@ class Content::Models::Book < Tutor::SubSystems::BaseModel
     Addressable::URI.parse(url).site
   end
 
+  def webview_url
+    archive_url.gsub('archive.','')
+  end
+
   def cnx_id
     "#{uuid}@#{version}"
   end

--- a/app/subsystems/content/page.rb
+++ b/app/subsystems/content/page.rb
@@ -15,6 +15,10 @@ module Content
       verify_and_return @strategy.uuid, klass: ::Content::Uuid, error: StrategyError
     end
 
+    def short_id
+      verify_and_return @strategy.short_id, klass: String, error: StrategyError, allow_nil: true
+    end
+
     def version
       verify_and_return @strategy.version, klass: String, error: StrategyError
     end

--- a/app/subsystems/content/routines/import_page.rb
+++ b/app/subsystems/content/routines/import_page.rb
@@ -29,7 +29,8 @@ class Content::Routines::ImportPage
                                                number: number,
                                                book_location: book_location,
                                                uuid: cnx_page.uuid,
-                                               version: cnx_page.version)
+                                               version: cnx_page.version,
+                                               short_id: cnx_page.short_id)
     outputs[:page].save if save
     transfer_errors_from(outputs[:page], {type: :verbatim}, true)
     chapter.pages << outputs[:page] unless chapter.nil?

--- a/app/subsystems/content/strategies/direct/book.rb
+++ b/app/subsystems/content/strategies/direct/book.rb
@@ -6,7 +6,7 @@ module Content
         wraps ::Content::Models::Book
 
         exposes :ecosystem, :chapters, :pages, :exercises, :url, :archive_url,
-                :uuid, :version, :cnx_id, :title
+                :webview_url, :uuid, :short_id, :version, :cnx_id, :title
 
         alias_method :entity_ecosystem, :ecosystem
         def ecosystem

--- a/app/subsystems/content/strategies/direct/page.rb
+++ b/app/subsystems/content/strategies/direct/page.rb
@@ -8,7 +8,8 @@ module Content
         exposes :chapter, :reading_dynamic_pool, :reading_context_pool, :homework_core_pool,
                 :homework_dynamic_pool, :practice_widget_pool, :concept_coach_pool,
                 :all_exercises_pool, :exercises, :tags, :los, :aplos, :url, :uuid, :version,
-                :cnx_id, :title, :content, :book_location, :is_intro?, :fragments, :snap_labs
+                :cnx_id, :title, :content, :book_location, :is_intro?, :fragments, :snap_labs,
+                :short_id
 
         alias_method :entity_chapter, :chapter
         def chapter

--- a/db/migrate/20160601225450_add_short_id_to_book_and_page.rb
+++ b/db/migrate/20160601225450_add_short_id_to_book_and_page.rb
@@ -1,0 +1,6 @@
+class AddShortIdToBookAndPage < ActiveRecord::Migration
+  def change
+    add_column :content_books, :short_id, :string
+    add_column :content_pages, :short_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160531190234) do
+ActiveRecord::Schema.define(version: 20160601225450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20160531190234) do
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
     t.jsonb    "reading_processing_instructions", default: [], null: false
+    t.string   "short_id"
   end
 
   add_index "content_books", ["content_ecosystem_id"], name: "index_content_books_on_content_ecosystem_id", using: :btree
@@ -140,6 +141,7 @@ ActiveRecord::Schema.define(version: 20160531190234) do
     t.datetime "updated_at",                       null: false
     t.integer  "content_all_exercises_pool_id"
     t.integer  "content_concept_coach_pool_id"
+    t.string   "short_id"
   end
 
   add_index "content_pages", ["content_chapter_id", "number"], name: "index_content_pages_on_content_chapter_id_and_number", unique: true, using: :btree

--- a/lib/openstax/cnx/v1/book.rb
+++ b/lib/openstax/cnx/v1/book.rb
@@ -26,6 +26,10 @@ module OpenStax::Cnx::V1
       }
     end
 
+    def short_id
+      @short_id ||= hash.fetch('shortId', nil)
+    end
+
     def version
       @version ||= hash.fetch('version') { |key|
         raise "Book id=#{id} is missing #{key}"

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -66,6 +66,10 @@ module OpenStax::Cnx::V1
       }
     end
 
+    def short_id
+      @short_id ||= full_hash.fetch('shortId', nil)
+    end
+
     def version
       @version ||= full_hash.fetch('version') { |key|
         raise "Book id=#{id} is missing #{key}"

--- a/spec/controllers/api/v1/ecosystems_controller_spec.rb
+++ b/spec/controllers/api/v1/ecosystems_controller_spec.rb
@@ -83,7 +83,10 @@ RSpec.describe Api::V1::EcosystemsController, type: :controller, api: true,
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to eq([{
           id: ecosystem.books.first.id.to_s,
+          uuid: ecosystem.books.first.uuid,
           cnx_id: ecosystem.books.first.cnx_id,
+          archive_url: "https://archive.cnx.org",
+          webview_url: "https://cnx.org",
           title: 'book title',
           type: 'part',
           chapter_section: [],
@@ -96,6 +99,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :controller, api: true,
               children: [
                 {
                   id: ecosystem.books.first.chapters.first.pages.first.id.to_s,
+                  uuid: ecosystem.books.first.chapters.first.pages.first.uuid,
                   cnx_id: ecosystem.books.first.chapters.first.pages.first.cnx_id,
                   title: 'first page',
                   chapter_section: [1, 1],
@@ -103,6 +107,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :controller, api: true,
                 },
                 {
                   id: ecosystem.books.first.chapters.first.pages.second.id.to_s,
+                  uuid: ecosystem.books.first.chapters.first.pages.second.uuid,
                   cnx_id: ecosystem.books.first.chapters.first.pages.second.cnx_id,
                   title: 'second page',
                   chapter_section: [1, 2],
@@ -118,6 +123,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :controller, api: true,
               children: [
                 {
                   id: ecosystem.books.first.chapters.second.pages.first.id.to_s,
+                  uuid: ecosystem.books.first.chapters.second.pages.first.uuid,
                   cnx_id: ecosystem.books.first.chapters.second.pages.first.cnx_id,
                   title: 'third page',
                   chapter_section: [2, 1],

--- a/spec/factories/content/books.rb
+++ b/spec/factories/content/books.rb
@@ -4,11 +4,11 @@ FactoryGirl.define do
       contents {{}}
     end
 
-    url { Faker::Internet.url }
     title { contents[:title] || Faker::Lorem.words(3) }
     content { contents.to_json }
     uuid { SecureRandom.uuid }
     version { Random.rand(1..10) }
+    url { "https://archive.cnx.org/contents/#{uuid}@#{version}" }
     reading_processing_instructions {
       [
         { css: '.ost-reading-discard, .os-teacher, [data-type="glossary"]',

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -195,7 +195,6 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
   context 'with The Scientific Method' do
     before(:all) do
       DatabaseCleaner.start
-
       page_info = { id: '9545b9a2-c371-4a31-abb9-3a4a1fff497b@8', title: 'The Scientific Method' }
       @page = VCR.use_cassette('OpenStax_Cnx_V1_Page/with_The_Scientific_Method', VCR_OPTS) do
         page_for(page_info).tap{ |page| page.full_hash }

--- a/spec/representers/api/v1/book_toc_representer_spec.rb
+++ b/spec/representers/api/v1/book_toc_representer_spec.rb
@@ -3,13 +3,22 @@ require 'rails_helper'
 RSpec.describe Api::V1::BookTocRepresenter, type: :representer do
   let(:book) { { id: 1,
                  cnx_id: '123abc',
+                 short_id: 'shorty',
+                 uuid: 'uuid',
                  title: 'Good book',
                  type: 'foo',
+                 archive_url: 'archive',
+                 webview_url: 'webview',
                  chapter_section: [4, 1] } }
 
   subject(:represented) { described_class.new(Hashie::Mash.new(book)).to_hash }
 
-  it 'sets the type to part' do
+  it 'works on the happy path' do
     expect(represented['type']).to eq('part')
+    expect(represented['short_id']).to eq 'shorty'
+    expect(represented['uuid']).to eq 'uuid'
+    expect(represented['archive_url']).to eq 'archive'
+    expect(represented['webview_url']).to eq 'webview'
   end
+
 end

--- a/spec/representers/api/v1/page_toc_representer_spec.rb
+++ b/spec/representers/api/v1/page_toc_representer_spec.rb
@@ -3,17 +3,21 @@ require 'rails_helper'
 RSpec.describe Api::V1::PageTocRepresenter, type: :representer do
   let(:page) { { id: 1,
                  cnx_id: '321cba',
+                 short_id: 'shorty',
+                 uuid: 'uuid',
                  title: 'Neat page',
                  type: 'baz',
                  book_location: [4, 3] } }
 
   subject(:represented) { described_class.new(Hashie::Mash.new(page)).to_hash }
 
-  it 'sets the type to page' do
-    expect(represented['type']).to eq('page')
-  end
-
   it 'renames book_location to chapter_section' do
     expect(represented['chapter_section']).to eq([4, 3])
+  end
+
+  it 'works on the happy path' do
+    expect(represented['type']).to eq('page')
+    expect(represented['short_id']).to eq 'shorty'
+    expect(represented['uuid']).to eq 'uuid'
   end
 end

--- a/spec/subsystems/content/import_book_spec.rb
+++ b/spec/subsystems/content/import_book_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe Content::ImportBook, type: :routine, speed: :slow, vcr: VCR_OPTS 
     end
     book = ecosystem.books.first
 
+    # shortId pulled in, webview_url good
+
+    expect(book.short_id).to eq "8QUzyvgD"
+    expect(book.archive_url).to eq "https://archive.cnx.org"
+    expect(book.webview_url).to eq "https://cnx.org"
+    expect(book.chapters.first.pages.first.short_id).to eq "rZudN6XP"
+
     # Units are ignored
 
     part = book.chapters.first


### PR DESCRIPTION
Makes it so that https://github.com/openstax/tutor-js/pull/1078 can show CNX URLs with short IDs instead of long UUIDs.  Also lets that PR have non-hard-coded CNX webview URLs.