### PR TITLE
Remove duplicate (less good) resorting of students in CC export

### DIFF
--- a/app/subsystems/tasks/performance_report/export_cc_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_cc_xlsx.rb
@@ -300,8 +300,6 @@ module Tasks
 
         first_student_row = sheet.rows.count + 1
 
-        students = report[:students].sort_by{|student| student[:last_name] || ""}
-
         first_data_column = 4 + counts_extra_cols + 1
         cols_per_task = format == :counts ? 4 : 3
         last_data_column = first_data_column+num_tasks*cols_per_task-1
@@ -312,7 +310,7 @@ module Tasks
         out_of_enable_range =
           XlsxHelper.range([first_data_column, out_of_enable_row, last_data_column, out_of_enable_row])
 
-        students.each_with_index do |student, ss|
+        report[:students].each_with_index do |student, ss|
           student_columns = [
             student[:first_name],
             student[:last_name],

--- a/spec/subsystems/tasks/performance_report/export_cc_xlsx_spec.rb
+++ b/spec/subsystems/tasks/performance_report/export_cc_xlsx_spec.rb
@@ -100,39 +100,6 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
         ],
         students: [
           {
-            name: "Zeter Zymphony",
-            first_name: "Zeter",
-            last_name: "Zymphony",
-            student_identifier: "SID1",
-            role: nil,
-            data: [
-              {
-                late: false,
-                status: 'completed',
-                type: 'concept_coach',
-                id: 43,
-                due_at: Chronic.parse("2/29/2016 1PM"),
-                last_worked_at: Chronic.parse("2/29/2016 11AM"),
-                actual_and_placeholder_exercise_count: 11,
-                completed_exercise_count: 11,
-                correct_exercise_count: 9,
-                recovered_exercise_count: 0
-              },
-              {
-                late: true,
-                status: 'in_progress',
-                type: 'concept_coach',
-                id: 44,
-                due_at: Chronic.parse("3/15/2016 1PM"),
-                last_worked_at: Chronic.parse("3/17/2016 5PM"),
-                actual_and_placeholder_exercise_count: 9,
-                completed_exercise_count: 5,
-                correct_exercise_count: 2,
-                recovered_exercise_count: 0
-              }
-            ]
-          },
-          {
             name: "Abby Gail",
             first_name: "Abby",
             last_name: "Gail",
@@ -171,6 +138,39 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
                 last_worked_at: Chronic.parse("3/2/2016 4PM"),
                 actual_and_placeholder_exercise_count: 9,
                 completed_exercise_count: 4,
+                correct_exercise_count: 2,
+                recovered_exercise_count: 0
+              }
+            ]
+          },
+          {
+            name: "Zeter Zymphony",
+            first_name: "Zeter",
+            last_name: "Zymphony",
+            student_identifier: "SID1",
+            role: nil,
+            data: [
+              {
+                late: false,
+                status: 'completed',
+                type: 'concept_coach',
+                id: 43,
+                due_at: Chronic.parse("2/29/2016 1PM"),
+                last_worked_at: Chronic.parse("2/29/2016 11AM"),
+                actual_and_placeholder_exercise_count: 11,
+                completed_exercise_count: 11,
+                correct_exercise_count: 9,
+                recovered_exercise_count: 0
+              },
+              {
+                late: true,
+                status: 'in_progress',
+                type: 'concept_coach',
+                id: 44,
+                due_at: Chronic.parse("3/15/2016 1PM"),
+                last_worked_at: Chronic.parse("3/17/2016 5PM"),
+                actual_and_placeholder_exercise_count: 9,
+                completed_exercise_count: 5,
                 correct_exercise_count: 2,
                 recovered_exercise_count: 0
               }


### PR DESCRIPTION
... already sorted when the performance data is generated using a more thorough sort.

