### PR TITLE
Combine exercises that require context with the step before when possible

### DIFF
--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -39,6 +39,15 @@ module Api::V1::Tasks
                description: "The ID of the part, present even if there is only one part."
              }
 
+    property :context,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The Exercise's context (only present if required by the Exercise)"
+             }
+
     property :content_hash_for_students,
              as: :content,
              type: String,

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -20,7 +20,11 @@ class DistributeTasks
     end
 
     Tasks::Models::Task.import! tasks, recursive: true
-    tasks.each(&:clear_association_cache)
+    tasks.each do |task|
+      task.task_steps.reset
+      task.tasked_exercises.reset
+      task.taskings.reset
+    end
   end
 
   def exec(task_plan, publish_time = Time.current, protect_unopened_tasks = false)

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -20,6 +20,7 @@ class DistributeTasks
     end
 
     Tasks::Models::Task.import! tasks, recursive: true
+
     tasks.each do |task|
       task.task_steps.reset
       task.tasked_exercises.reset

--- a/app/routines/task_exercise.rb
+++ b/app/routines/task_exercise.rb
@@ -28,6 +28,7 @@ class TaskExercise
         content_exercise_id: exercise.id,
         url: exercise.url,
         title: title || exercise.title,
+        context: exercise.context,
         content: question[:content],
         question_id: question[:id],
         is_in_multipart: questions.size > 1

--- a/app/subsystems/content/models/tag.rb
+++ b/app/subsystems/content/models/tag.rb
@@ -16,8 +16,8 @@ class Content::Models::Tag < Tutor::SubSystems::BaseModel
   has_many :same_value_tags, class_name: 'Tag', primary_key: 'value', foreign_key: 'value'
 
   # List the different types of tags
-  enum tag_type: [ :generic, :lo, :aplo, :teks, :dok, :blooms,
-                   :length, :cnxmod, :id, :requires_context ]
+  enum tag_type: [ :generic, :lo, :aplo, :teks, :dok, :blooms, :length,
+                   :cnxmod, :id, :requires_context, :cnxfeature ]
 
   validates :value, presence: true
   validates :tag_type, presence: true

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -65,7 +65,7 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
       node_id = exercise_fragment.node_id
       return if node_id.blank?
 
-      feature_tag = "context-cnxfeature:#{page.uuid}:#{node_id}"
+      feature_tag = "context-cnxfeature:#{page.uuid}##{node_id}"
       exercise = get_random_unused_exercise_with_tags([feature_tag])
 
       return if exercise.nil?
@@ -99,8 +99,8 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
       # Retrieve an exercise related to the previous step by LO
       exercise = tasked.exercise
 
-      los = Set.new(exercise.los.map(&:id))
-      aplos = Set.new(exercise.aplos.map(&:id))
+      los = Set.new exercise.los.map(&:id)
+      aplos = Set.new exercise.aplos.map(&:id)
 
       pool_exercises.select do |ex|
         ex.los.any?{ |tag| los.include?(tag.id) } || ex.aplos.any?{ |tag| aplos.include?(tag.id) }
@@ -110,7 +110,7 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
       node_id = exercise_fragment.node_id
       return if node_id.blank?
 
-      feature_tag = "context-cnxfeature:#{page.uuid}:#{node_id}"
+      feature_tag = "context-cnxfeature:#{page.uuid}##{node_id}"
       pool_exercises.select{ |ex| ex.tags.any?{ |tag| tag == feature_tag } }
     end
 

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -17,7 +17,7 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   validates :tasked_id, uniqueness: { scope: :tasked_type }
   validates :group_type, presence: true
 
-  delegate :can_be_answered?, :has_correctness?, to: :tasked
+  delegate :can_be_answered?, :has_correctness?, :has_content?, to: :tasked
 
   scope :complete,   -> { where{first_completed_at != nil} }
   scope :incomplete, -> { where{first_completed_at == nil} }

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -26,6 +26,10 @@ class Tasks::Models::TaskedExercise < Tutor::SubSystems::BaseModel
     true
   end
 
+  def has_content?
+    true
+  end
+
   def is_correct?
     correct_answer_id == answer_id
   end

--- a/app/subsystems/tasks/models/tasked_interactive.rb
+++ b/app/subsystems/tasks/models/tasked_interactive.rb
@@ -3,4 +3,8 @@ class Tasks::Models::TaskedInteractive < Tutor::SubSystems::BaseModel
 
   validates :url, presence: true
   validates :content, presence: true
+
+  def has_content?
+    true
+  end
 end

--- a/app/subsystems/tasks/models/tasked_reading.rb
+++ b/app/subsystems/tasks/models/tasked_reading.rb
@@ -5,4 +5,8 @@ class Tasks::Models::TaskedReading < Tutor::SubSystems::BaseModel
 
   validates :url, presence: true
   validates :content, presence: true
+
+  def has_content?
+    true
+  end
 end

--- a/app/subsystems/tasks/models/tasked_video.rb
+++ b/app/subsystems/tasks/models/tasked_video.rb
@@ -3,4 +3,8 @@ class Tasks::Models::TaskedVideo < Tutor::SubSystems::BaseModel
 
   validates :url, presence: true
   validates :content, presence: true
+
+  def has_content?
+    true
+  end
 end

--- a/db/migrate/20160603151054_add_context_to_tasks_tasked_exercises.rb
+++ b/db/migrate/20160603151054_add_context_to_tasks_tasked_exercises.rb
@@ -1,0 +1,5 @@
+class AddContextToTasksTaskedExercises < ActiveRecord::Migration
+  def change
+    add_column :tasks_tasked_exercises, :context, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601225450) do
+ActiveRecord::Schema.define(version: 20160603151054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -629,6 +629,7 @@ ActiveRecord::Schema.define(version: 20160601225450) do
     t.boolean  "is_in_multipart",     default: false, null: false
     t.string   "question_id",                         null: false
     t.datetime "deleted_at"
+    t.text     "context"
   end
 
   add_index "tasks_tasked_exercises", ["content_exercise_id"], name: "index_tasks_tasked_exercises_on_content_exercise_id", using: :btree

--- a/lib/acts_as_tasked.rb
+++ b/lib/acts_as_tasked.rb
@@ -20,6 +20,10 @@ module ActsAsTasked
           false
         end
 
+        def has_content?
+          false
+        end
+
         def exercise?
           false
         end

--- a/lib/openstax/cnx/v1/fragment/exercise.rb
+++ b/lib/openstax/cnx/v1/fragment/exercise.rb
@@ -16,9 +16,9 @@ module OpenStax::Cnx::V1
     def self.absolutize_exercise_urls(node)
       node.css(EMBED_CODE_CSS).each do |anchor|
         href = anchor.attribute('href')
-        short_code = EMBED_TAG_REGEX.match(href.value).try(:[], 1)
+        embed_tag = EMBED_TAG_REGEX.match(href.value).try(:[], 1)
         uri = OpenStax::Exercises::V1.uri_for('/api/exercises')
-        uri.query_values = { q: "tag:\"#{short_code}\"" }
+        uri.query_values = { q: "tag:\"#{embed_tag}\"" }
         href.value = uri.to_s
       end
     end

--- a/lib/openstax/exercises/v1/exercise.rb
+++ b/lib/openstax/exercises/v1/exercise.rb
@@ -60,6 +60,10 @@ class OpenStax::Exercises::V1::Exercise
     @cnxmod_hashes ||= tag_hashes.select{ |hash| hash[:type] == :cnxmod }
   end
 
+  def cnxfeature_hashes
+    @cnxfeature_hashes ||= tag_hashes.select{ |hash| hash[:type] == :cnxfeature }
+  end
+
   def import_tag_hashes
     @import_tag_hashes ||= lo_hashes + aplo_hashes + cnxmod_hashes
   end
@@ -76,13 +80,17 @@ class OpenStax::Exercises::V1::Exercise
     @cnxmods ||= cnxmod_hashes.map{ |hash| hash[:value] }
   end
 
+  def cnxfeatures
+    @cnxfeatures ||= cnxfeature_hashes.map{ |hash| hash[:value] }
+  end
+
   def import_tags
     @import_tags ||= import_tag_hashes.map{ |hash| hash[:value] }
   end
 
   def feature_ids(page_uuid)
     feature_tag_start = "context-cnxfeature:#{page_uuid}#"
-    feature_tags = tags.select{ |tag| tag.start_with? feature_tag_start }
+    feature_tags = cnxfeatures.select{ |tag| tag.start_with? feature_tag_start }
     feature_tags.map{ |tag| tag.sub(feature_tag_start, '') }
   end
 

--- a/lib/tagger.rb
+++ b/lib/tagger.rb
@@ -17,7 +17,8 @@ module Tagger
     blooms: /\Ablooms[:-](\d+)\z/,
     length: /\Atime[:-](\w+)\z/,
     teks: /\A(?:teks:|ost-tag-teks-)[\w-]+-(\w+)\z/,
-    requires_context: /\Arequires-context:(?:y(?:es)?|t(?:rue)?)\z/
+    requires_context: /\Arequires-context:(?:y(?:es)?|t(?:rue)?)\z/,
+    cnxfeature: /\A(?:context-)?cnxfeature:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}#([\w-]+)\z/
   })
 
   # The capture from the regex above is substituted into the template to form the tag name

--- a/spec/lib/tagger_spec.rb
+++ b/spec/lib/tagger_spec.rb
@@ -65,17 +65,19 @@ RSpec.describe Tagger, type: :lib do
         { value: 'requires-context:yes', name: nil, type: :requires_context },
         { value: 'requires-context:t', name: nil, type: :requires_context },
         { value: 'requires-context:true', name: nil, type: :requires_context },
+        { value: 'context-cnxfeature:6a0568d8-23d7-439b-9a01-16e4e73886b3#fs-featureid',
+          name: nil, type: :cnxfeature },
         { value: 'dont-care', name: nil, type: :generic }
       ]
     end
 
     let(:correct_data) do
       [ nil, nil, '7', '8', 'short', '9a', '6a0568d8-23d7-439b-9a01-16e4e73886b3',
-        '101', nil, nil, nil, nil, nil ]
+        '101', nil, nil, nil, nil, 'fs-featureid', nil ]
     end
 
     let(:correct_book_locations) do
-      [ [1, 2], [4, 5], [], [], [], [], [], [], [], [], [], [], [] ]
+      [ [1, 2], [4, 5], [], [], [], [], [], [], [], [], [], [], [], [] ]
     end
 
     it 'generates correct tag types' do

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
     ## TaskedExercise-specific properties
     allow(exercise).to receive(:url).and_return('Some url')
     allow(exercise).to receive(:title).and_return('Some title')
+    allow(exercise).to receive(:context).and_return('Some context')
     allow(exercise).to receive(:content_hash_for_students).and_return('Some content')
     allow(exercise).to receive(:solution).and_return('Some solution')
     allow(exercise).to receive(:feedback).and_return('Some feedback')
@@ -63,6 +64,10 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
 
     it "has the correct 'title'" do
       expect(representation).to include("title" => 'Some title')
+    end
+
+    it "has the correct 'context'" do
+      expect(representation).to include("context" => 'Some context')
     end
 
     it "has the correct 'content'" do

--- a/spec/routines/task_exercise_spec.rb
+++ b/spec/routines/task_exercise_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TaskExercise, type: :routine do
   end
 
   let!(:multipart_exercise)  do
-    content_exercise = FactoryGirl.create(:content_exercise, num_parts: 2)
+    content_exercise = FactoryGirl.create(:content_exercise, num_parts: 2, context: 'Some context')
     strategy = Content::Strategies::Direct::Exercise.new(content_exercise)
     Content::Exercise.new(strategy: strategy)
   end
@@ -36,11 +36,13 @@ RSpec.describe TaskExercise, type: :routine do
     expect(task.task_steps.length).to eq 2
     expect(task.task_steps.first).to eq task_step
 
-    expect(task.task_steps[0].tasked.is_in_multipart).to be_truthy
-    expect(task.task_steps[1].tasked.is_in_multipart).to be_truthy
+    expected_content = ["(0)", "(1)"]
 
-    expect(task.task_steps[0].tasked.content).to match("(0)")
-    expect(task.task_steps[1].tasked.content).to match("(1)")
+    task.tasked_exercises.each_with_index do |tasked_exercise, index|
+      expect(tasked_exercise.is_in_multipart).to eq true
+      expect(tasked_exercise.context).to eq 'Some context'
+      expect(tasked_exercise.content).to include expected_content[index]
+    end
   end
 
   it 'can insert multiple exercise steps in order for a single placeholder step' do

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -155,7 +155,6 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
 
       ## it "sets description, task type, and feedback_at"
       tasks.each do |task|
-        task.reload.reload
         expect(task.description).to eq("Hello!")
         expect(task.homework?).to be_truthy
         # feedback_at == nil because the task plan was set to immediate_feedback

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -389,7 +389,8 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
     let!(:pools) { Content::Routines::PopulateExercisePools[book: page.book] }
 
     let!(:task_plan) {
-      FactoryGirl.build(:tasks_task_plan,
+      FactoryGirl.build(
+        :tasks_task_plan,
         assistant: @assistant,
         content_ecosystem_id: ecosystem.id,
         settings: { 'page_ids' => [page.id.to_s] },
@@ -485,6 +486,153 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
             eq Set.new(task_step_gold_data[ii][:related_exercise_ids])
           )
         end
+      end
+    end
+
+  end
+
+  context "for a fake cnx page" do
+    let(:reading_content)     do
+      "Read about Newton's Flaming Laser Sword on
+       <a href=\"https://en.wikipedia.org/wiki/Mike_Alder#Newton.27s_flaming_laser_sword\">
+         Wikipedia
+       </a>"
+    end
+    let(:video_content)       do
+      '<div id="fs-video">
+         <iframe src="https://www.youtube.com/embed/C00l_Vid/"></iframe>
+       </div>'
+    end
+    let(:interactive_content) do
+      '<div id="fs-interactive">
+         <iframe src="https://connexions.github.io/simulations/nfls/"></iframe>
+       </div>'
+    end
+
+    let!(:page)            do
+      FactoryGirl.create :content_page, title: "Newton's Flaming Laser Sword"
+    end
+    let!(:book)            { page.book }
+    let!(:ecosystem_model) { book.ecosystem }
+    let!(:ecosystem)       { Content::Ecosystem.new(strategy: ecosystem_model.wrap) }
+
+    let!(:cnxmod_tag)                  do
+      FactoryGirl.create(:content_tag, value: "context-cnxmod:#{page.uuid}",
+                                       tag_type: :cnxmod,
+                                       ecosystem: ecosystem_model).tap do |tag|
+        page.tags << tag
+      end
+    end
+    let!(:video_exercise_id_tag)       do
+      FactoryGirl.create :content_tag, value: 'k12phys-ch99-ex01',
+                                       tag_type: :id,
+                                       ecosystem: ecosystem_model
+    end
+    let!(:interactive_cnxfeature_tag) do
+      FactoryGirl.create :content_tag, value: "context-cnxfeature:#{page.uuid}#fs-interactive",
+                                       tag_type: :cnxfeature,
+                                       ecosystem: ecosystem_model
+    end
+
+    let!(:video_exercise) do
+      FactoryGirl.create(:content_exercise, page: page, context: video_content).tap do |exercise|
+        exercise.tags << cnxmod_tag
+        exercise.tags << video_exercise_id_tag
+      end
+    end
+    let!(:interactive_exercise) do
+      FactoryGirl.create(:content_exercise, page: page,
+                                            context: interactive_content).tap do |exercise|
+        exercise.tags << cnxmod_tag
+        exercise.tags << interactive_cnxfeature_tag
+      end
+    end
+
+    let!(:task_plan) {
+      FactoryGirl.build(
+        :tasks_task_plan,
+        assistant: @assistant,
+        content_ecosystem_id: ecosystem.id,
+        settings: { 'page_ids' => [page.id.to_s] },
+        num_tasking_plans: 0
+      )
+    }
+
+    let!(:course) do
+      task_plan.owner.tap{ |course| AddEcosystemToCourse[course: course, ecosystem: ecosystem] }
+    end
+
+    let!(:period) { CreatePeriod[course: course] }
+
+    let!(:taskee_user) do
+      FactoryGirl.create(:user_profile).tap do |profile|
+        strategy = User::Strategies::Direct::User.new(profile)
+        user = User::User.new(strategy: strategy)
+        AddUserAsPeriodStudent.call(user: user, period: period)
+        user
+      end
+    end
+
+    let!(:tasking_plan) do
+      tasking_plan = FactoryGirl.build(
+        :tasks_tasking_plan, task_plan: task_plan, target: taskee_user
+      )
+
+      task_plan.tasking_plans << tasking_plan
+      task_plan.save!
+
+      tasking_plan
+    end
+
+    let!(:task_step_gold_data) do
+      [
+        { klass: Tasks::Models::TaskedReading,  title: "Newton's Flaming Laser Sword" },
+        { klass: Tasks::Models::TaskedExercise, title: nil },
+        { klass: Tasks::Models::TaskedExercise, title: nil }
+      ]
+    end
+
+    it 'combines exercises with context with the previous step when possible' do
+      allow(Tasks::Assistants::IReadingAssistant).to receive(:k_ago_map) { [] }
+      allow(Tasks::Assistants::IReadingAssistant).to receive(:num_personalized_exercises) { 0 }
+
+      allow_any_instance_of(Content::Models::Page).to receive(:fragments) do
+        [
+          OpenStax::Cnx::V1::Fragment::Reading.new(
+            node: Nokogiri::HTML.fragment(reading_content).first_element_child,
+            title: "Doesn't matter, the first fragment's title comes from the page"
+          ),
+          OpenStax::Cnx::V1::Fragment::Video.new(
+            node: Nokogiri::HTML.fragment(video_content).first_element_child,
+            title: "Watch Newton use the Force against Robert Hooke"
+          ),
+          OpenStax::Cnx::V1::Fragment::Exercise.new(
+            node: Nokogiri::HTML.fragment(
+              "<div class=\"exercise\">
+                 <a href=#ost/api/ex/#{video_exercise_id_tag.value}>[Link]</a>
+               </div>"
+            ).first_element_child,
+            title: nil
+          ),
+          OpenStax::Cnx::V1::Fragment::Interactive.new(
+            node: Nokogiri::HTML.fragment(interactive_content).first_element_child,
+            title: "Now try it yourself"
+          ),
+          OpenStax::Cnx::V1::Fragment::Exercise.new(
+            node: Nokogiri::HTML.fragment(interactive_content).first_element_child,
+            title: nil
+          )
+        ]
+      end
+
+      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      expect(tasks.size).to eq 1
+      task_steps = tasks.first.task_steps
+
+      expect(task_steps.count).to eq task_step_gold_data.count
+      task_steps.each_with_index do |task_step, ii|
+        expect(task_step.tasked.class).to eq(task_step_gold_data[ii][:klass])
+        expect(task_step.tasked.title).to eq(task_step_gold_data[ii][:title])
       end
     end
 

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -52,9 +52,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       @task_step_gold_data = \
         @core_step_gold_data + @spaced_practice_step_gold_data + @personalized_step_gold_data
 
-      cnx_pages = cnx_page_hashes.map do |hash|
-        OpenStax::Cnx::V1::Page.new(hash: hash)
-      end
+      cnx_pages = cnx_page_hashes.map{ |hash| OpenStax::Cnx::V1::Page.new(hash: hash) }
 
       chapter = FactoryGirl.create :content_chapter, title: "Forces and Newton's Laws of Motion"
 
@@ -125,7 +123,6 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
-        task.reload.reload
         expect(task.taskings.length).to eq 1
 
         expect(task.feedback_at).to be_nil
@@ -184,7 +181,6 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
-        task.reload.reload
         expect(task.taskings.length).to eq 1
 
         expect(task.feedback_at).to be_nil
@@ -225,7 +221,6 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
-        task = task.reload.reload
         task_steps = task.task_steps
 
         expect(task_steps.count).to eq(@core_step_gold_data.count + 1)
@@ -351,7 +346,6 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
 
       tasks = DistributeTasks.call(task_plan).outputs.tasks
       tasks.each do |task|
-        task.reload.reload
         expect(task.taskings.length).to eq 1
         expect(task.feedback_at).to be_nil
 
@@ -478,7 +472,6 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
 
       tasks = DistributeTasks.call(task_plan).outputs.tasks
       tasks.each do |task|
-        task.reload.reload
         expect(task.taskings.length).to eq 1
         expect(task.feedback_at).to be_nil
 


### PR DESCRIPTION
- Actually send the exercise context to FE when students are working tasks
- Combine exercise context with the previous step when possible
- cnxfeature is now a new tag type
- Fixes a bug that prevented readings from picking up exercises by the cnxfeature tags