### PR TITLE
Fixes for UpdateSalesforceStats and admin course stats views

### DIFF
--- a/app/controllers/manager/stats_actions.rb
+++ b/app/controllers/manager/stats_actions.rb
@@ -5,7 +5,7 @@ module Manager::StatsActions
 
   def courses
     @courses = Entity::Course.joins(:profile).preload(
-      [:profile, :teachers, {periods: :active_enrollments}]
+      [:profile, :teachers, {periods: :latest_enrollments}]
     ).order{ profile.name }.to_a
     @course_url_proc = course_url_proc
 

--- a/app/routines/update_salesforce_stats.rb
+++ b/app/routines/update_salesforce_stats.rb
@@ -19,7 +19,7 @@ class UpdateSalesforceStats
         course_ids = attached_records.map{ |ar| ar.tutor_gid.try(:model_id) }.compact
         course_id_to_preloaded_course_map = \
           Entity::Course.where(id: course_ids)
-                        .preload([:teachers, {periods: :active_enrollments}])
+                        .preload([:teachers, {periods: :latest_enrollments}])
                         .index_by(&:id)
 
         attached_records.each do |attached_record|
@@ -59,7 +59,7 @@ class UpdateSalesforceStats
 
   def update_class_size_stats(class_size, course)
     class_size.num_teachers = course.teachers.length
-    class_size.num_students = course.periods.flat_map(&:active_enrollments).length
+    class_size.num_students = course.periods.flat_map(&:latest_enrollments).length
     class_size.num_sections = course.periods.length
   end
 

--- a/app/views/manager/stats/courses.html.erb
+++ b/app/views/manager/stats/courses.html.erb
@@ -21,7 +21,7 @@
         <%= course.teachers.map{ |teacher| teacher.role.role_user.profile.name }.join(', ') %>
       </td>
       <td><%= course.periods.length %></td>
-      <td><%= course.periods.flat_map(&:active_enrollments).length %></td>
+      <td><%= course.periods.flat_map(&:latest_enrollments).length %></td>
     </tr>
   <% end %>
   </tbody>


### PR DESCRIPTION
- Replace all instances of active_enrollments with latest_enrollments (active_enrollments was removed in the paranoia PR)