### PR TITLE
Improve non CC scores performance by removing an N+1 query on time_zones

### DIFF
--- a/app/subsystems/tasks/get_cc_performance_report.rb
+++ b/app/subsystems/tasks/get_cc_performance_report.rb
@@ -85,8 +85,7 @@ module Tasks
 
     def get_cc_data_headings(period_cc_tasks_map_array, sorted_period_pages)
       sorted_period_pages.map do |page|
-        page_tasks = period_cc_tasks_map_array.flat_map{ |hash| hash[page] }.compact
-                                              .map(&:task)
+        page_tasks = period_cc_tasks_map_array.flat_map{ |hash| hash[page] }.compact.map(&:task)
 
         {
           cnx_page_id: page.uuid,

--- a/app/subsystems/tasks/get_tp_performance_report.rb
+++ b/app/subsystems/tasks/get_tp_performance_report.rb
@@ -79,12 +79,12 @@ module Tasks
       # Return reading, homework and external tasks for a student
       # .reorder(nil) removes the ordering from the period default scope so .uniq won't blow up
       # .uniq is necessary for the preloading to work...
-      course.taskings.joins(task: { task_plan: :tasking_plans })
-                     .where(task: {task_type: task_types})
-                     .preload(task: {task_plan: {tasking_plans: :target}},
-                              role: [{student: {enrollments: :period}}, {profile: :account}])
-                     .reorder(nil).uniq.to_a
-                     .select{ |tasking| tasking.task.past_open? }
+      course.taskings
+            .joins(task: { task_plan: :tasking_plans })
+            .where(task: {task_type: task_types})
+            .preload(task: [{task_plan: {tasking_plans: [:target, :time_zone]}}, :time_zone],
+                     role: [{student: {enrollments: :period}}, {profile: :account}])
+            .reorder(nil).uniq.to_a.select{ |tasking| tasking.task.past_open? }
     end
 
     def get_data_headings(tasking_plans, task_plan_results)


### PR DESCRIPTION
Turns out CC tasks have nil open/due dates so they don't need this (I think).