### PR TITLE
Improve the biglearn clue cache

### DIFF
--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -27,7 +27,8 @@ class GetStudentGuide
       completed_tasked_exercises, course
     )
 
-    { period_id: period.id }
-      .merge compile_course_guide(course, completed_tasked_exercises, exercise_id_to_page_map)
+    { period_id: period.id }.merge(
+      compile_course_guide(course, completed_tasked_exercises, exercise_id_to_page_map)
+    )
   end
 end

--- a/app/routines/update_clues.rb
+++ b/app/routines/update_clues.rb
@@ -114,8 +114,8 @@ class UpdateClues
         next [] if period_worked_pools.empty?
 
         # Update CLUes for the entire period, plus CLUes for individual students that did work
-        [[period_roles, period_worked_pools, period]] + \
-        period_roles_to_worked_pools_map.map{ |role, pools| [[role], pools, role] }
+        [[period_roles, period_worked_pools]] + \
+        period_roles_to_worked_pools_map.map{ |role, pools| [[role], pools] }
       end
     end
 
@@ -134,7 +134,7 @@ class UpdateClues
 
       slice_size = [max_query_size/num_roles, 1].max
       pools.each_slice(slice_size).map do |sliced_pools|
-        [roles, sliced_pools, query.third]
+        [roles, sliced_pools]
       end
     end
 
@@ -145,9 +145,8 @@ class UpdateClues
 
       threads = split_clue_queries.each_slice(slice_size).map do |queries|
         Thread.new do
-          queries.map do |roles, pools, cache_for|
-            OpenStax::Biglearn::V1.get_clues(roles: roles, pools: pools,
-                                             cache_for: cache_for, force_cache_miss: true)
+          queries.map do |roles, pools|
+            OpenStax::Biglearn::V1.get_clues(roles: roles, pools: pools, force_cache_miss: true)
           end
         end
       end

--- a/lib/course_guide_methods.rb
+++ b/lib/course_guide_methods.rb
@@ -58,19 +58,7 @@ module CourseGuideMethods
       te.task_step.task.taskings.map(&:role)
     end.uniq
 
-    case type
-    when :student
-      # Student guide: query by role
-      Rails.logger.warn('student clues called for more than one role') if roles.size > 1
-      OpenStax::Biglearn::V1.get_clues(roles: roles.first, pools: pools, cache_for: roles.first)
-    when :teacher
-      # Teacher guide: query by period
-      periods = roles.map{ |role| role.student.period }.uniq
-      Rails.logger.warn('teacher clues called for more than one period') if periods.size > 1
-      OpenStax::Biglearn::V1.get_clues(roles: roles, pools: pools, cache_for: periods.first)
-    else
-      raise 'Course guide type must be either :student or :teacher'
-    end
+    OpenStax::Biglearn::V1.get_clues(roles: roles, pools: pools)
   end
 
   def compile_pages(sorted_page_groupings, clues_map)

--- a/lib/openstax/biglearn/v1.rb
+++ b/lib/openstax/biglearn/v1.rb
@@ -58,7 +58,7 @@ module OpenStax::Biglearn::V1
   # Each CLUe refers to one specific pool, but uses all roles given.
   # May return nil if no CLUe is available
   # (e.g. no exercises in the pools or confidence too low).
-  def self.get_clues(roles:, pools:, cache_for: nil, force_cache_miss: false)
+  def self.get_clues(roles:, pools:, force_cache_miss: false)
     roles = [roles].flatten.compact
     pools = [pools].flatten.compact
 
@@ -68,8 +68,7 @@ module OpenStax::Biglearn::V1
     # No roles given: map all pools to nil
     return pools.each_with_object({}) { |pool, hash| hash[pool.uuid] = nil } if roles.empty?
 
-    clue = client.get_clues(roles: roles, pools: pools,
-                            cache_for: cache_for, force_cache_miss: force_cache_miss)
+    clue = client.get_clues(roles: roles, pools: pools, force_cache_miss: force_cache_miss)
   end
 
   #

--- a/lib/openstax/biglearn/v1/fake_client.rb
+++ b/lib/openstax/biglearn/v1/fake_client.rb
@@ -100,7 +100,7 @@ class OpenStax::Biglearn::V1::FakeClient
     question_ids.first(count)
   end
 
-  def get_clues(roles:, pools:, cache_for: 'ignored', force_cache_miss: 'ignored')
+  def get_clues(roles:, pools:, force_cache_miss: 'ignored')
     # The fake client CLUe results are completely random
     pools.each_with_object({}) do |pool, hash|
       aggregate = rand(0.0..1.0)

--- a/spec/lib/openstax/biglearn/v1_spec.rb
+++ b/spec/lib/openstax/biglearn/v1_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe OpenStax::Biglearn::V1, type: :external do
     let!(:client_double) {
       double.tap do |dbl|
         allow(dbl).to receive(:get_clues)
-                  .with(roles: dummy_roles, pools: dummy_pools,
-                        cache_for: nil, force_cache_miss: false)
+                  .with(roles: dummy_roles, pools: dummy_pools, force_cache_miss: false)
                   .and_return('client get_clues response')
         allow(dbl).to receive(:add_exercises)
                   .with(exercises: dummy_exercises)


### PR DESCRIPTION
Instead of passing around the `cache_for` parameter, just XOR the learner identifiers and use that as part of the cache key. So if the period learners change, the period CLUe cache is immediately invalidated.