### PR TITLE
Require user sign-in to use short codes

### DIFF
--- a/app/controllers/short_codes_controller.rb
+++ b/app/controllers/short_codes_controller.rb
@@ -1,5 +1,4 @@
 class ShortCodesController < ApplicationController
-  skip_before_filter :authenticate_user!
 
   def redirect
     handle_with(

--- a/app/controllers/short_codes_controller.rb
+++ b/app/controllers/short_codes_controller.rb
@@ -1,5 +1,10 @@
 class ShortCodesController < ApplicationController
 
+  # ShortCodes currently require an authenticated user in order to detect the appropriate role for a course
+  # In the future, this requirement could be removed by adding a `requires_authentication` flag to the short_codes table
+  # If and when that occurs, authentication could be skipped by doing something like:
+  # skip_before_filter :authenticate_user!, if: ->(*) { current_short_code.requires_authentication? }
+
   def redirect
     handle_with(
       ShortCode::ShortCodeRedirect,

--- a/app/controllers/short_codes_controller.rb
+++ b/app/controllers/short_codes_controller.rb
@@ -1,10 +1,5 @@
 class ShortCodesController < ApplicationController
 
-  # ShortCodes currently require an authenticated user in order to detect the appropriate role for a course
-  # In the future, this requirement could be removed by adding a `requires_authentication` flag to the short_codes table
-  # If and when that occurs, authentication could be skipped by doing something like:
-  # skip_before_filter :authenticate_user!, if: ->(*) { current_short_code.requires_authentication? }
-
   def redirect
     handle_with(
       ShortCode::ShortCodeRedirect,
@@ -29,6 +24,8 @@ class ShortCodesController < ApplicationController
                       )
           when :short_code_not_found
             raise ShortCodeNotFound
+          when :authentication_required
+            authenticate_user!
           when :invalid_user
             raise SecurityTransgression
           else

--- a/app/subsystems/tasks/get_redirect_url.rb
+++ b/app/subsystems/tasks/get_redirect_url.rb
@@ -9,6 +9,7 @@ class Tasks::GetRedirectUrl
     task_plan = GlobalID::Locator.locate(gid)
 
     fatal_error(code: :plan_not_found) if task_plan.nil?
+    fatal_error(code: :authentication_required) if user.is_anonymous?
 
     course = task_plan.owner
 

--- a/spec/controllers/short_codes_controller_spec.rb
+++ b/spec/controllers/short_codes_controller_spec.rb
@@ -31,12 +31,19 @@ RSpec.describe ShortCodesController, type: :controller do
   let(:tasking_code) { FactoryGirl.create(:short_code_short_code,
                                           uri: tasking_gid) }
 
+  it 'redirects users to sign in before access' do
+    get :redirect, short_code: absolute_url.code
+    expect(response).to redirect_to(%r{/accounts/login})
+  end
+
   it 'redirects users to absolute urls' do
+    controller.sign_in(teacher)
     get :redirect, short_code: absolute_url.code
     expect(response).to redirect_to('https://cnx.org')
   end
 
   it 'redirects users to relative urls' do
+    controller.sign_in(student)
     get :redirect, short_code: relative_url.code
     expect(response).to redirect_to('dashboard')
   end
@@ -57,6 +64,7 @@ RSpec.describe ShortCodesController, type: :controller do
   end
 
   it 'raises ShortCodeNotFound for short code not found' do
+    controller.sign_in(user)
     expect {
       get :redirect, short_code: 'somethingrandom'
     }.to raise_error(ShortCodeNotFound)

--- a/spec/subsystems/tasks/get_redirect_url_spec.rb
+++ b/spec/subsystems/tasks/get_redirect_url_spec.rb
@@ -31,15 +31,16 @@ RSpec.describe Tasks::GetRedirectUrl, type: :routine do
     expect(result.outputs.uri).to eq("/courses/#{course.id}/tasks/#{task.id}")
   end
 
+  it 'returns :authentication_required for anonomouse users' do
+    expect(
+      described_class.call(gid: task_plan_gid, user: User::User.anonymous)
+    ).to have_routine_error(:authentication_required)
+  end
+
   it 'returns :invalid_user for users not in the course' do
     expect(
       described_class.call(gid: task_plan_gid, user: user)
     ).to have_routine_error(:invalid_user)
   end
 
-  it 'returns :invalid_user for anonymous users' do
-    expect(
-      described_class.call(gid: task_plan_gid, user: User::User.anonymous)
-    ).to have_routine_error(:invalid_user)
-  end
 end


### PR DESCRIPTION
Currently when a non-logged in user attempts to use a short code for an assignment, a `SecurityTransgression` is raised.

This is because the short-code routines eventually call `Tasks::GetRedirectUrl`, which needs to know if the user is a teacher or student, it calls `ChooseCourseRole` which raises `invalid_role` because the anonymous user doesn't have any role.

It seems to me that the redirected url will require login anyway, so it's easiest just to require logging in before the redirect occurs.  However this isn't going to work if there are uses for short-codes that do not require logging in.  If there are, then we'll have to figure out a different solution.

I haven't fixed up the specs yet until we can discuss.