### PR TITLE
More assignment creation optimizations

### DIFF
--- a/app/routines/add_spy_info.rb
+++ b/app/routines/add_spy_info.rb
@@ -18,7 +18,7 @@ class AddSpyInfo
   def values_from(val)
     case val
     when Array
-      val.map{ |value| values_from(value) }.reduce(&:merge)
+      val.map{ |value| values_from(value) }.reduce(&:merge) || {}
     when Hash
       val.each_with_object({}) { |(key, value), hash| hash[key] = values_from(value) }
     else

--- a/app/routines/choose_exercises.rb
+++ b/app/routines/choose_exercises.rb
@@ -4,7 +4,7 @@ class ChooseExercises
 
   def exec(exercises:, count:, history:, allow_repeats: true,
            randomize_exercises: true, randomize_order: true)
-    worked_exercise_numbers_set = Set.new history.exercises.flatten.map(&:number)
+    worked_exercise_numbers_set = Set.new history.exercise_numbers.flatten
 
     exercises = exercises.uniq
     exercises = exercises.shuffle if randomize_exercises
@@ -16,7 +16,7 @@ class ChooseExercises
 
     new_exercises_count = [new_exercises.size, count].min
     repeated_exercises_count = allow_repeats ? \
-                                [repeated_exercises.size, count - new_exercises_count].min : 0
+                                 [repeated_exercises.size, count - new_exercises_count].min : 0
 
     chosen_exercises = new_exercises.first(new_exercises_count) + \
                        repeated_exercises.first(repeated_exercises_count)

--- a/app/routines/get_concept_coach.rb
+++ b/app/routines/get_concept_coach.rb
@@ -24,7 +24,7 @@ class GetConceptCoach
     role, page = get_role_and_page(user: user, cnx_book_id: cnx_book_id, cnx_page_id: cnx_page_id)
 
     ecosystem, pool = get_ecosystem_and_pool(page)
-    history = run(:get_history, role: role, type: :concept_coach).outputs
+    history = run(:get_history, roles: role, type: :concept_coach).outputs.history[role]
     existing_cc_task = run(:get_cc_task, role: role, page: page).outputs.task
     unless existing_cc_task.nil?
       outputs.task = existing_cc_task

--- a/app/routines/get_ecosystem_exercises_from_biglearn.rb
+++ b/app/routines/get_ecosystem_exercises_from_biglearn.rb
@@ -52,7 +52,7 @@ class GetEcosystemExercisesFromBiglearn
         pool_exercises = pools.flat_map(&:exercises)
         candidate_exercises = run(:filter, exercises: pool_exercises,
                                            course: course).outputs.exercises
-        history = run(:get_history, role: role, type: :all).outputs
+        history = run(:get_history, roles: role, type: :all).outputs.history[role]
         chosen_exercises = run(:choose, exercises: candidate_exercises, count: count,
                                         history: history, allow_repeats: false).outputs.exercises
         numbers = chosen_exercises.map(&:number).uniq

--- a/app/routines/get_ecosystem_pools_by_page_ids_and_pool_types.rb
+++ b/app/routines/get_ecosystem_pools_by_page_ids_and_pool_types.rb
@@ -7,13 +7,10 @@ class GetEcosystemPoolsByPageIdsAndPoolTypes
   def exec(ecosystem:, page_ids: nil, pool_types: nil)
     pages = page_ids.nil? ? ecosystem.pages : ecosystem.pages_by_ids(page_ids)
 
-    pool_types = [pool_types].flatten.compact
+    pool_types = [pool_types].flatten.compact.uniq
 
     # Default to all types
     pool_types = Content::Pool.pool_types if pool_types.empty?
-
-    # Convert to set
-    pool_types = Set.new pool_types
 
     # Build map of pool types to pools
     outputs[:pools_map] = pool_types.each_with_object({}) do |pool_type, result|

--- a/app/routines/get_exercises.rb
+++ b/app/routines/get_exercises.rb
@@ -22,7 +22,7 @@ class GetExercises
                                                        page_ids: page_ids,
                                                        pool_types: pool_types]
 
-    excluded_exercise_numbers = Set.new(course.excluded_exercises.pluck(:exercise_number)) \
+    excl_exercise_numbers_set = Set.new(course.excluded_exercises.pluck(:exercise_number)) \
       unless course.nil?
 
     all_exercises = []
@@ -36,7 +36,7 @@ class GetExercises
         hash[exercise.uid] ||= Api::V1::ExerciseRepresenter.new(exercise).to_hash
         hash[exercise.uid]['pool_types'] ||= []
         hash[exercise.uid]['pool_types'] << pool_type
-        hash[exercise.uid]['is_excluded'] = excluded_exercise_numbers.include?(exercise.number) \
+        hash[exercise.uid]['is_excluded'] = excl_exercise_numbers_set.include?(exercise.number) \
           unless course.nil?
       end
 

--- a/app/routines/get_history.rb
+++ b/app/routines/get_history.rb
@@ -82,7 +82,7 @@ class GetHistory
         when :concept_coach
           [task.concept_coach_task.content_page_id]
         else
-          []
+          task.tasked_exercises.map{ |te| te.exercise.content_page_id }.uniq
         end
       end
 

--- a/app/routines/get_history.rb
+++ b/app/routines/get_history.rb
@@ -1,97 +1,100 @@
 class GetHistory
+  MAX_ROLES_PER_QUERY = 10
+
   lev_routine express_output: :history
 
   protected
 
   def exec(roles:, type: :all)
-    roles = [roles].flatten.compact
-    roles_by_id = roles.index_by(&:id)
-    role_ids = roles_by_id.keys
-
-    all_tasks = Tasks::Models::Task
-      .joins{[task_plan.outer, taskings]}
-      .where(taskings: { entity_role_id: role_ids })
-      .preload([:task_plan, :concept_coach_task, {tasked_exercises: :exercise}])
-      .select([Tasks::Models::Task.arel_table[Arel.star],
-               Tasks::Models::Tasking.arel_table[:entity_role_id]])
-
-    all_tasks = all_tasks.where(task_type: Tasks::Models::Task.task_types[type]) unless type == :all
-
-    reading_tasks, other_tasks = all_tasks.partition(&:reading?)
-
-    # Find reading pages without dynamic exercises
-    grouped_reading_tasks = reading_tasks.group_by(&:task_plan).map do |task_plan, tasks|
-      [(task_plan.settings['page_ids'] || []).compact, tasks]
-    end
-    reading_page_ids = grouped_reading_tasks.map(&:first).flatten.uniq
-    reading_pages = Content::Models::Page.where(id: reading_page_ids).preload(:reading_dynamic_pool)
-    non_dynamic_reading_pages = reading_pages.to_a.select{ |page| page.reading_dynamic_pool.empty? }
-    non_dynamic_reading_page_ids_set = non_dynamic_reading_pages.map(&:id)
-
-    # Remove reading tasks without dynamic exercises from the history
-    filtered_grouped_reading_tasks = grouped_reading_tasks.reject do |page_ids, tasks|
-      reading_page_ids = page_ids.map(&:to_i)
-      reading_page_ids.all?{ |page_id| non_dynamic_reading_page_ids_set.include? page_id }
-    end
-    filtered_reading_tasks = filtered_grouped_reading_tasks.flat_map(&:second)
-
-    filtered_tasks = filtered_reading_tasks + other_tasks
-    grouped_tasks = filtered_tasks.group_by(&:entity_role_id)
-
-    # Add an empty array for roles with no tasks
-    taskless_role_ids = role_ids.reject{ |role_id| grouped_tasks.has_key? role_id }
-    taskless_role_ids.each{ |role_id| grouped_tasks[role_id] = [] }
-
-    # Since getting page_ids for homework tasks requires DB access, get them all at once
-    exercise_id_to_page_id_map = {}
-    homework_tasks = all_tasks.select(&:homework?)
-    all_hw_exercise_ids = homework_tasks.flat_map{ |task| task.task_plan.settings['exercise_ids'] }
-    all_hw_exercises = Content::Models::Exercise.where(id: all_hw_exercise_ids)
-                                                .select([:id, :content_page_id])
-    all_hw_exercises.each do |exercise|
-      exercise_id_to_page_id_map[exercise.id] = exercise.content_page_id
-    end
-
     all_history = Hashie::Mash.new
 
-    grouped_tasks.each do |entity_role_id, tasks|
-      history = Hashie::Mash.new
+    [roles].flatten.compact.each_slice(MAX_ROLES_PER_QUERY) do |roles_slice|
+      roles_by_id = roles_slice.index_by(&:id)
+      role_ids = roles_by_id.keys
 
-      role = roles_by_id[entity_role_id]
+      all_tasks = Tasks::Models::Task
+        .joins{[task_plan.outer, taskings]}
+        .where(taskings: { entity_role_id: role_ids })
+        .preload([:task_plan, :concept_coach_task, {tasked_exercises: :exercise}])
+        .select([Tasks::Models::Task.arel_table[Arel.star],
+                 Tasks::Models::Tasking.arel_table[:entity_role_id]])
 
-      sorted_tasks = tasks.sort_by do |task|
-        due_date = task.due_at_ntz.to_f
-        open_date = task.opens_at_ntz.to_f
-        tie_breaker = (task.task_plan || task).created_at.to_f
+      all_tasks = all_tasks.where(task_type: Tasks::Models::Task.task_types[type]) unless type == :all
 
-        [due_date, open_date, tie_breaker]
-      end.reverse!
+      reading_tasks, other_tasks = all_tasks.partition(&:reading?)
 
-      history.total_count = sorted_tasks.size
+      # Find reading pages without dynamic exercises
+      grouped_reading_tasks = reading_tasks.group_by(&:task_plan).map do |task_plan, tasks|
+        [(task_plan.settings['page_ids'] || []).compact, tasks]
+      end
+      reading_page_ids = grouped_reading_tasks.map(&:first).flatten.uniq
+      reading_pages = Content::Models::Page.where(id: reading_page_ids).preload(:reading_dynamic_pool)
+      non_dynamic_reading_pages = reading_pages.to_a.select{ |page| page.reading_dynamic_pool.empty? }
+      non_dynamic_reading_page_ids_set = non_dynamic_reading_pages.map(&:id)
 
-      history.ecosystem_ids = sorted_tasks.map{ |task| task.task_plan.try(:content_ecosystem_id) }
+      # Remove reading tasks without dynamic exercises from the history
+      filtered_grouped_reading_tasks = grouped_reading_tasks.reject do |page_ids, tasks|
+        reading_page_ids = page_ids.map(&:to_i)
+        reading_page_ids.all?{ |page_id| non_dynamic_reading_page_ids_set.include? page_id }
+      end
+      filtered_reading_tasks = filtered_grouped_reading_tasks.flat_map(&:second)
 
-      # The core page ids exclude spaced practice/personalized pages
-      history.core_page_ids = sorted_tasks.map do |task|
-        case task.task_type.to_sym
-        when :reading
-          task.task_plan.settings['page_ids'].compact.map(&:to_i)
-        when :homework
-          exercise_ids = task.task_plan.settings['exercise_ids'].compact.map(&:to_i)
-          exercise_ids.map{ |exercise_id| exercise_id_to_page_id_map[exercise_id] }.compact.uniq
-        when :concept_coach
-          [task.concept_coach_task.content_page_id]
-        else
-          task.tasked_exercises.map{ |te| te.exercise.content_page_id }.uniq
+      filtered_tasks = filtered_reading_tasks + other_tasks
+      grouped_tasks = filtered_tasks.group_by(&:entity_role_id)
+
+      # Add an empty array for roles with no tasks
+      taskless_role_ids = role_ids.reject{ |role_id| grouped_tasks.has_key? role_id }
+      taskless_role_ids.each{ |role_id| grouped_tasks[role_id] = [] }
+
+      # Since getting page_ids for homework tasks requires DB access, get them all at once
+      exercise_id_to_page_id_map = {}
+      homework_tasks = all_tasks.select(&:homework?)
+      all_hw_exercise_ids = homework_tasks.flat_map{ |task| task.task_plan.settings['exercise_ids'] }
+      all_hw_exercises = Content::Models::Exercise.where(id: all_hw_exercise_ids)
+                                                  .select([:id, :content_page_id])
+      all_hw_exercises.each do |exercise|
+        exercise_id_to_page_id_map[exercise.id] = exercise.content_page_id
+      end
+
+      grouped_tasks.each do |entity_role_id, tasks|
+        history = Hashie::Mash.new
+
+        role = roles_by_id[entity_role_id]
+
+        sorted_tasks = tasks.sort_by do |task|
+          due_date = task.due_at_ntz.to_f
+          open_date = task.opens_at_ntz.to_f
+          tie_breaker = (task.task_plan || task).created_at.to_f
+
+          [due_date, open_date, tie_breaker]
+        end.reverse!
+
+        history.total_count = sorted_tasks.size
+
+        history.ecosystem_ids = sorted_tasks.map{ |task| task.task_plan.try(:content_ecosystem_id) }
+
+        # The core page ids exclude spaced practice/personalized pages
+        history.core_page_ids = sorted_tasks.map do |task|
+          case task.task_type.to_sym
+          when :reading
+            task.task_plan.settings['page_ids'].compact.map(&:to_i)
+          when :homework
+            exercise_ids = task.task_plan.settings['exercise_ids'].compact.map(&:to_i)
+            exercise_ids.map{ |exercise_id| exercise_id_to_page_id_map[exercise_id] }.compact.uniq
+          when :concept_coach
+            [task.concept_coach_task.content_page_id]
+          else
+            task.tasked_exercises.map{ |te| te.exercise.content_page_id }.uniq
+          end
         end
-      end
 
-      # The exercise numbers include spaced practice/personalized exercises
-      history.exercise_numbers = sorted_tasks.map do |task|
-        task.tasked_exercises.map{ |te| te.exercise.number }
-      end
+        # The exercise numbers include spaced practice/personalized exercises
+        history.exercise_numbers = sorted_tasks.map do |task|
+          task.tasked_exercises.map{ |te| te.exercise.number }
+        end
 
-      all_history[role] = history
+        all_history[role] = history
+      end
     end
 
     outputs.history = all_history

--- a/app/routines/get_history.rb
+++ b/app/routines/get_history.rb
@@ -21,15 +21,15 @@ class GetHistory
                             .flat_map{ |task| task.task_plan.settings['page_ids'] }.compact.uniq
     reading_pages = Content::Models::Page.where(id: reading_page_ids).preload(:reading_dynamic_pool)
     non_dynamic_reading_pages = reading_pages.to_a.select{ |page| page.reading_dynamic_pool.empty? }
-    non_dynamic_reading_page_ids_set = Set.new non_dynamic_reading_pages.map(&:id)
+    non_dynamic_reading_page_ids = non_dynamic_reading_pages.map(&:id)
 
     # Remove the current task and reading tasks without dynamic exercises from the history
     tasks = tasks.to_a.reject do |task|
       next true if task.id == current_task_id
       next false unless task.task_type == 'reading'
 
-      reading_page_ids_set = Set.new (task.task_plan.settings['page_ids'] || []).compact.map(&:to_i)
-      reading_page_ids_set.subset? non_dynamic_reading_page_ids_set
+      reading_page_ids = (task.task_plan.settings['page_ids'] || []).compact.map(&:to_i)
+      reading_page_ids.all?{ |page_id| non_dynamic_reading_page_ids.include? page_id }
     end
 
     # Always put the current_task at the top of the list, if given

--- a/app/routines/reset_practice_widget.rb
+++ b/app/routines/reset_practice_widget.rb
@@ -113,7 +113,7 @@ class ResetPracticeWidget
                additional_excluded_numbers: additional_excluded_numbers
     ).outputs.exercises
 
-    history = run(:get_history, role: role, type: :all).outputs
+    history = run(:get_history, roles: role, type: :all).outputs.history[role]
     chosen_exercises = run(:choose, exercises: filtered_exercises, count: count, history: history,
                                     allow_repeats: false,
                                     randomize_exercises: randomize,

--- a/app/subsystems/content/routines/import_exercises.rb
+++ b/app/subsystems/content/routines/import_exercises.rb
@@ -12,7 +12,7 @@ class Content::Routines::ImportExercises
   # page can be a Content::Models::Page or a block
   # that takes an OpenStax::Exercises::V1::Exercise
   # and returns a Content::Models::Page for that exercise
-  def exec(ecosystem:, page:, query_hash:, excluded_exercise_numbers: Set.new)
+  def exec(ecosystem:, page:, query_hash:, excluded_exercise_numbers: [])
     outputs[:exercises] = []
 
     wrappers = OpenStax::Exercises::V1.exercises(query_hash)['items']

--- a/app/subsystems/content/routines/populate_exercise_pools.rb
+++ b/app/subsystems/content/routines/populate_exercise_pools.rb
@@ -38,7 +38,7 @@ class Content::Routines::PopulateExercisePools
                                                             pool_type: :all_exercises)
 
         page.exercises.each do |exercise|
-          tags = Set.new exercise.exercise_tags.map{ |et| et.tag.value }
+          tags = exercise.exercise_tags.map{ |et| et.tag.value }
 
           # Reading Dynamic (Concept Coach)
           page.reading_dynamic_pool.content_exercise_ids << exercise.id \

--- a/app/subsystems/tasks/add_related_exercise_after_step.rb
+++ b/app/subsystems/tasks/add_related_exercise_after_step.rb
@@ -58,7 +58,7 @@ class Tasks::AddRelatedExerciseAfterStep
                                        additional_excluded_numbers: task_exercise_numbers)
                             .outputs.exercises
 
-    history = run(:get_history, role: role, type: :all).outputs
+    history = run(:get_history, roles: role, type: :all).outputs.history[role]
 
     run(:choose, exercises: candidate_exercises, count: 1, history: history).outputs.exercises.first
   end

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -99,19 +99,20 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
       # Retrieve an exercise related to the previous step by LO
       exercise = tasked.exercise
 
-      los = Set.new exercise.los.map(&:id)
-      aplos = Set.new exercise.aplos.map(&:id)
+      lo_ids = exercise.los.map(&:id)
+      aplo_ids = exercise.aplos.map(&:id)
 
       pool_exercises.select do |ex|
-        ex.los.any?{ |tag| los.include?(tag.id) } || ex.aplos.any?{ |tag| aplos.include?(tag.id) }
+        ex.los.any?{ |lo| lo_ids.include?(lo.id) } ||
+        ex.aplos.any?{ |aplo| aplo_ids.include?(aplo.id) }
       end
     else # Try One (Exemplar)
       # Retrieve an exercise tagged with the context-cnxfeature tag
       node_id = exercise_fragment.node_id
       return if node_id.blank?
 
-      feature_tag = "context-cnxfeature:#{node_id}"
-      pool_exercises.select{ |ex| ex.tags.any?{ |tag| tag.value == feature_tag } }
+      feature_tag_value = "context-cnxfeature:#{node_id}"
+      pool_exercises.select{ |ex| ex.tags.any?{ |tag| tag.value == feature_tag_value } }
     end
 
     previous_step.related_exercise_ids = related_exercises.map(&:id) || []

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -91,31 +91,37 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
   end
 
   def store_related_exercises(exercise_fragment:, page:, previous_step:, title: nil)
-    pool_exercises = page.reading_context_pool.exercises(preload_tags: true)
-    tasked = previous_step.tasked
+    @related_exercise_ids ||= {}
 
-    related_exercises = \
-    if tasked.is_a?(Tasks::Models::TaskedExercise) # Try Another
-      # Retrieve an exercise related to the previous step by LO
-      exercise = tasked.exercise
+    unless @related_exercise_ids.has_key?(exercise_fragment)
+      pool_exercises = page.reading_context_pool.exercises(preload_tags: true)
+      tasked = previous_step.tasked
 
-      lo_ids = exercise.los.map(&:id)
-      aplo_ids = exercise.aplos.map(&:id)
+      related_exercises = \
+      if tasked.is_a?(Tasks::Models::TaskedExercise) # Try Another
+        # Retrieve an exercise related to the previous step by LO
+        exercise = tasked.exercise
 
-      pool_exercises.select do |ex|
-        ex.los.any?{ |lo| lo_ids.include?(lo.id) } ||
-        ex.aplos.any?{ |aplo| aplo_ids.include?(aplo.id) }
+        lo_ids = exercise.los.map(&:id)
+        aplo_ids = exercise.aplos.map(&:id)
+
+        pool_exercises.select do |ex|
+          ex.los.any?{ |lo| lo_ids.include?(lo.id) } ||
+          ex.aplos.any?{ |aplo| aplo_ids.include?(aplo.id) }
+        end
+      else # Try One (Exemplar)
+        # Retrieve an exercise tagged with the context-cnxfeature tag
+        node_id = exercise_fragment.node_id
+        return if node_id.blank?
+
+        feature_tag_value = "context-cnxfeature:#{node_id}"
+        pool_exercises.select{ |ex| ex.tags.any?{ |tag| tag.value == feature_tag_value } }
       end
-    else # Try One (Exemplar)
-      # Retrieve an exercise tagged with the context-cnxfeature tag
-      node_id = exercise_fragment.node_id
-      return if node_id.blank?
 
-      feature_tag_value = "context-cnxfeature:#{node_id}"
-      pool_exercises.select{ |ex| ex.tags.any?{ |tag| tag.value == feature_tag_value } }
+      @related_exercise_ids[exercise_fragment] = related_exercises.map(&:id) || []
     end
 
-    previous_step.related_exercise_ids = related_exercises.map(&:id) || []
+    previous_step.related_exercise_ids = @related_exercise_ids[exercise_fragment]
   end
 
   def task_video(video_fragment:, step:, title: nil)

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -29,7 +29,7 @@ class Tasks::Assistants::GenericAssistant
   end
 
   def reset_used_exercises
-    @used_exercise_numbers = Set.new
+    @used_exercise_numbers = []
   end
 
   def get_random_unused_page_exercise_with_tags(page, tags)

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -47,4 +47,17 @@ class Tasks::Assistants::GenericAssistant
     end
   end
 
+  def add_current_task_to_individual_history(task:, history:)
+    ecosystem = Content::Ecosystem.new(strategy: task_plan.ecosystem.wrap)
+    tasked_exercises = task.task_steps.select(&:exercise?).map(&:tasked)
+    exercises = tasked_exercises.map{ |te| Content::Exercise.new(strategy: te.exercise.wrap) }
+
+    history.tasks.unshift task
+    history.ecosystems.unshift ecosystem
+    history.tasked_exercises.unshift tasked_exercises
+    history.exercises.unshift exercises
+
+    history
+  end
+
 end

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -47,13 +47,10 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
   end
 
   def build_tasks
-    # Don't load too many histories at once so we don't risk running out of memory
-    taskees.each_slice(5).flat_map do |taskee_slice|
-      histories = GetHistory[roles: taskee_slice, type: :homework]
+    histories = GetHistory[roles: taskees, type: :homework]
 
-      taskee_slice.map do |taskee|
-        build_homework_task(taskee: taskee, exercises: @exercises, history: histories[taskee])
-      end
+    taskees.map do |taskee|
+      build_homework_task(taskee: taskee, exercises: @exercises, history: histories[taskee])
     end
   end
 

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -46,6 +46,16 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
 
   protected
 
+  def self.k_ago_map
+    ## Entries in the list have the form:
+    ##   [from-this-many-events-ago, choose-this-many-exercises]
+    [ [2,1], [4,1] ]
+  end
+
+  def self.num_personalized_exercises
+    1
+  end
+
   def collect_pages
     ecosystem.pages_by_ids(task_plan.settings['page_ids'])
   end
@@ -97,9 +107,11 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
   end
 
   def add_spaced_practice_exercise_steps!(task:, taskee:, history:)
-    history = add_current_task_to_individual_history(task: task, history: history)
+    history = add_current_task_to_individual_history(
+      task: task, core_page_ids: @pages.map(&:id), history: history
+    )
 
-    core_exercise_numbers = history.exercises.first.map(&:number)
+    core_exercise_numbers = history.exercise_numbers.first
 
     course = task_plan.owner
 
@@ -107,25 +119,21 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
 
     self.class.k_ago_map.each do |k_ago, num_requested|
       # Not enough history
-      if k_ago >= history.tasks.size
+      if k_ago >= history.total_count
         spaced_practice_status << "Not enough tasks in history to fill the #{k_ago}-ago slot"
         next
       end
 
-      spaced_ecosystem = history.ecosystems[k_ago]
+      spaced_ecosystem_id = history.ecosystem_ids[k_ago]
 
-      # Get pages from the TaskPlan settings
-      spaced_task = history.tasks[k_ago]
-      page_ids = spaced_task.task_plan.settings['page_ids']
-      spaced_pages = spaced_ecosystem.pages_by_ids(page_ids)
+      # Get core pages from the history
+      spaced_page_ids = history.core_page_ids[k_ago]
+      spaced_pages = get_pages(spaced_page_ids)
 
-      # Reuse Ecosystems map when possible
-      @ecosystems_map[spaced_ecosystem.id] ||= Content::Map.find_or_create_by(
-        from_ecosystems: [spaced_ecosystem, ecosystem].uniq, to_ecosystem: ecosystem
-      )
+      ecosystems_map = map_spaced_ecosystem_id_to_ecosystem(spaced_ecosystem_id)
 
       # Map the pages to exercises in the new ecosystem
-      spaced_exercises = @ecosystems_map[spaced_ecosystem.id].map_pages_to_exercises(
+      spaced_exercises = ecosystems_map.map_pages_to_exercises(
         pages: spaced_pages, pool_type: :reading_dynamic
       ).values.flatten.uniq
 
@@ -152,16 +160,6 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
     AddSpyInfo[to: task, from: { spaced_practice: spaced_practice_status }]
 
     task
-  end
-
-  def self.k_ago_map
-    ## Entries in the list have the form:
-    ##   [from-this-many-events-ago, choose-this-many-exercises]
-    [ [2,1], [4,1] ]
-  end
-
-  def self.num_personalized_exercises
-    1
   end
 
   def add_personalized_exercise_steps!(task:, taskee:)

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -33,14 +33,11 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
     reading_dynamic_pools = ecosystem.reading_dynamic_pools(pages: @pages)
     skip_dynamic = reading_dynamic_pools.all?(&:empty?)
 
-    # Don't load too many histories at once so we don't risk running out of memory
-    taskees.each_slice(5).flat_map do |taskee_slice|
-      histories = GetHistory[roles: taskee_slice, type: :reading]
+    histories = GetHistory[roles: taskees, type: :reading]
 
-      taskee_slice.map do |taskee|
-        build_reading_task(pages: @pages, taskee: taskee,
-                           history: histories[taskee], skip_dynamic: skip_dynamic)
-      end
+    taskees.map do |taskee|
+      build_reading_task(pages: @pages, taskee: taskee,
+                         history: histories[taskee], skip_dynamic: skip_dynamic)
     end
   end
 

--- a/db/migrate/20160411214041_change_can_be_recovered_to_related_exercise_ids.rb
+++ b/db/migrate/20160411214041_change_can_be_recovered_to_related_exercise_ids.rb
@@ -19,14 +19,13 @@ class ChangeCanBeRecoveredToRelatedExerciseIds < ActiveRecord::Migration
           if related_exercise_ids.nil?
             pool_exercises = exercise.page.reading_context_pool.exercises
 
-            los = Set.new(exercise.los)
-            aplos = Set.new(exercise.aplos)
+            los = exercise.los
+            aplos = exercise.aplos
 
             # For the original Try Another,
             # we allow only exercises that share at least one LO or APLO with the original exercise
             related_exercise_ids = pool_exercises.select do |ex|
-              ex.los.any?{ |task| los.include?(task) } ||
-              ex.aplos.any?{ |task| aplos.include?(task) }
+              ex.los.any?{ |lo| los.include?(lo) } || ex.aplos.any?{ |aplo| aplos.include?(aplo) }
             end.map(&:id)
 
             related_exercise_ids_map[exercise.id] = related_exercise_ids

--- a/lib/entity.rb
+++ b/lib/entity.rb
@@ -5,7 +5,7 @@ class Entity
   # Keep track of which AR classes are wrapped by which Entities and vice-versa
   cattr_reader :_wrap_class_procs, :_unwrapped_classes
   @@_wrap_class_procs = Hash.new
-  @@_unwrapped_classes = Hash.new { |hash, key| hash[key] = Set.new }
+  @@_unwrapped_classes = Hash.new { |hash, key| hash[key] = [] }
 
   class << self
     # Lists class and instance methods that are part of the API

--- a/spec/factories/tasks/tasked_task_plan.rb
+++ b/spec/factories/tasks/tasked_task_plan.rb
@@ -56,9 +56,6 @@ FactoryGirl.define do
       task_plan.tasking_plans = [build(:tasks_tasking_plan, task_plan: task_plan, target: period)]
     end
 
-    after(:create) do |task_plan, evaluator|
-      DistributeTasks.call(task_plan)
-      task_plan.reload
-    end
+    after(:create) { |task_plan, evaluator| DistributeTasks.call(task_plan) }
   end
 end

--- a/spec/factories/tasks/tasked_task_plan.rb
+++ b/spec/factories/tasks/tasked_task_plan.rb
@@ -16,14 +16,14 @@ FactoryGirl.define do
     end
 
     ecosystem do
+      require File.expand_path('../../../vcr_helper', __FILE__)
+
       cnx_page = OpenStax::Cnx::V1::Page.new(
         hash: { 'id' => '640e3e84-09a5-4033-b2a7-b7fe5ec29dc6',
                 'title' => 'Newton\'s First Law of Motion: Inertia' }
       )
 
       chapter = FactoryGirl.create :content_chapter
-
-      require File.expand_path('../../../vcr_helper', __FILE__)
 
       VCR.use_cassette("TaskedTaskPlan/with_inertia", VCR_OPTS) do
         @page = Content::Routines::ImportPage[cnx_page: cnx_page, chapter: chapter,

--- a/spec/routines/choose_exercises_spec.rb
+++ b/spec/routines/choose_exercises_spec.rb
@@ -7,7 +7,7 @@ describe ChooseExercises, type: :routine do
   let!(:unworked_exercises) { exercises - worked_exercises }
 
   let!(:count)    { 3 }
-  let!(:history)  { Hashie::Mash.new(exercises: [worked_exercises]) }
+  let!(:history)  { Hashie::Mash.new(exercise_numbers: [worked_exercises.map(&:number)]) }
 
   let(:args) { { exercises: exercises, count: count, history: history, allow_repeats: allow_repeats,
                  randomize_exercises: randomize_exercises, randomize_order: randomize_order } }

--- a/spec/routines/get_history_spec.rb
+++ b/spec/routines/get_history_spec.rb
@@ -89,13 +89,11 @@ describe GetHistory, type: :routine, speed: :slow do
   end
 
   context 'when creating a new reading task' do
-    let(:new_task) { FactoryGirl.build :tasks_task, tasked_to: @role  }
-
     context 'when all tasks have dynamic reading exercises' do
-      let(:correct_tasks) { [new_task, @reading_task_3, @reading_task_2, @reading_task_1] }
+      let(:correct_tasks) { [@reading_task_3, @reading_task_2, @reading_task_1] }
 
       it 'returns the correct history' do
-        history = described_class.call(role: @role, type: :reading, current_task: new_task).outputs
+        history = described_class.call(roles: @role, type: :reading).outputs.history[@role]
         expect(history.tasks).to eq correct_tasks
         expect(history.ecosystems).to eq correct_ecosystems
         history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
@@ -104,7 +102,7 @@ describe GetHistory, type: :routine, speed: :slow do
     end
 
     context 'when some tasks don\'t have dynamic reading exercises' do
-      let(:correct_tasks) { [new_task, @reading_task_2, @reading_task_1] }
+      let(:correct_tasks) { [@reading_task_2, @reading_task_1] }
 
       before(:each) do
         @reading_task_3.reload.tasked_exercises.map{ |te| te.exercise.page }.uniq.each do |page|
@@ -113,7 +111,7 @@ describe GetHistory, type: :routine, speed: :slow do
       end
 
       it 'does not return tasks with no dynamic reading exercises' do
-        history = described_class.call(role: @role, type: :reading, current_task: new_task).outputs
+        history = described_class.call(roles: @role, type: :reading).outputs.history[@role]
         expect(history.tasks).to eq correct_tasks
         expect(history.ecosystems).to eq correct_ecosystems
         history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
@@ -123,11 +121,10 @@ describe GetHistory, type: :routine, speed: :slow do
   end
 
   context 'when creating a new homework task' do
-    let(:new_task)      { FactoryGirl.build :tasks_task, tasked_to: @role, task_type: :homework }
-    let(:correct_tasks) { [new_task, @homework_task_3, @homework_task_2, @homework_task_1] }
+    let(:correct_tasks) { [@homework_task_3, @homework_task_2, @homework_task_1] }
 
     it 'returns the correct history' do
-      history = described_class.call(role: @role, type: :homework, current_task: new_task).outputs
+      history = described_class.call(roles: @role, type: :homework).outputs.history[@role]
       expect(history.tasks).to eq correct_tasks
       expect(history.ecosystems).to eq correct_ecosystems
       history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
@@ -136,48 +133,12 @@ describe GetHistory, type: :routine, speed: :slow do
   end
 
   context 'when creating a new practice task' do
-    let(:new_task) { FactoryGirl.build :tasks_task, tasked_to: @role, task_type: :mixed_practice  }
-
-    context 'when all reading tasks have dynamic reading exercises' do
-      let(:correct_tasks) { [new_task, @homework_task_3, @reading_task_3, @homework_task_2,
-                             @reading_task_2, @homework_task_1, @reading_task_1] }
-
-      it 'returns the correct history' do
-        history = described_class.call(role: @role, type: :all, current_task: new_task).outputs
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
-      end
-    end
-
-    context 'when some reading tasks don\'t have dynamic reading exercises' do
-      let(:correct_tasks) { [new_task, @homework_task_3, @homework_task_2,
-                             @reading_task_2, @homework_task_1, @reading_task_1] }
-
-      before(:each) do
-        @reading_task_3.reload.tasked_exercises.map{ |te| te.exercise.page }.uniq.each do |page|
-          page.reading_dynamic_pool.update_attribute(:content_exercise_ids, [])
-        end
-      end
-
-      it 'does not return tasks with no dynamic reading exercises' do
-        history = described_class.call(role: @role, type: :all, current_task: new_task).outputs
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
-      end
-    end
-  end
-
-  context 'when creating a "try another" step' do
     context 'when all reading tasks have dynamic reading exercises' do
       let(:correct_tasks) { [@homework_task_3, @reading_task_3, @homework_task_2,
                              @reading_task_2, @homework_task_1, @reading_task_1] }
 
       it 'returns the correct history' do
-        history = described_class.call(role: @role, type: :all).outputs
+        history = described_class.call(roles: @role, type: :all).outputs.history[@role]
         expect(history.tasks).to eq correct_tasks
         expect(history.ecosystems).to eq correct_ecosystems
         history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
@@ -196,7 +157,41 @@ describe GetHistory, type: :routine, speed: :slow do
       end
 
       it 'does not return tasks with no dynamic reading exercises' do
-        history = described_class.call(role: @role, type: :all).outputs
+        history = described_class.call(roles: @role, type: :all).outputs.history[@role]
+        expect(history.tasks).to eq correct_tasks
+        expect(history.ecosystems).to eq correct_ecosystems
+        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
+        expect(history_exercise_sets).to eq correct_exercise_sets
+      end
+    end
+  end
+
+  context 'when creating a "try another" step' do
+    context 'when all reading tasks have dynamic reading exercises' do
+      let(:correct_tasks) { [@homework_task_3, @reading_task_3, @homework_task_2,
+                             @reading_task_2, @homework_task_1, @reading_task_1] }
+
+      it 'returns the correct history' do
+        history = described_class.call(roles: @role, type: :all).outputs.history[@role]
+        expect(history.tasks).to eq correct_tasks
+        expect(history.ecosystems).to eq correct_ecosystems
+        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
+        expect(history_exercise_sets).to eq correct_exercise_sets
+      end
+    end
+
+    context 'when some reading tasks don\'t have dynamic reading exercises' do
+      let(:correct_tasks) { [@homework_task_3, @homework_task_2,
+                             @reading_task_2, @homework_task_1, @reading_task_1] }
+
+      before(:each) do
+        @reading_task_3.reload.tasked_exercises.map{ |te| te.exercise.page }.uniq.each do |page|
+          page.reading_dynamic_pool.update_attribute(:content_exercise_ids, [])
+        end
+      end
+
+      it 'does not return tasks with no dynamic reading exercises' do
+        history = described_class.call(roles: @role, type: :all).outputs.history[@role]
         expect(history.tasks).to eq correct_tasks
         expect(history.ecosystems).to eq correct_ecosystems
         history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }

--- a/spec/routines/get_history_spec.rb
+++ b/spec/routines/get_history_spec.rb
@@ -85,7 +85,7 @@ describe GetHistory, type: :routine, speed: :slow do
       when :concept_coach
         [task.concept_coach_task.content_page_id]
       else
-        []
+        task.tasked_exercises.map{ |te| te.exercise.content_page_id }.uniq
       end
     end
   end

--- a/spec/routines/get_history_spec.rb
+++ b/spec/routines/get_history_spec.rb
@@ -70,22 +70,28 @@ describe GetHistory, type: :routine, speed: :slow do
 
   after(:all) { DatabaseCleaner.clean }
 
-  let(:correct_ecosystems) do
+  let(:correct_total_count)   { correct_tasks.size }
+
+  let(:correct_ecosystem_ids) { correct_tasks.map{ |task| task.task_plan.content_ecosystem_id } }
+
+  let(:correct_core_page_ids) do
     correct_tasks.map do |task|
-      model = task.task_plan.ecosystem
-      strategy = Content::Strategies::Direct::Ecosystem.new(model)
-      Content::Ecosystem.new(strategy: strategy)
+      case task.task_type.to_sym
+      when :reading
+        task.task_plan.settings['page_ids'].compact.map(&:to_i)
+      when :homework
+        exercise_ids = task.task_plan.settings['exercise_ids'].compact.map(&:to_i)
+        Content::Models::Exercise.where(id: exercise_ids).map(&:content_page_id).uniq
+      when :concept_coach
+        [task.concept_coach_task.content_page_id]
+      else
+        []
+      end
     end
   end
 
-  let(:correct_exercise_sets)  do
-    correct_tasks.map do |task|
-      Set.new task.tasked_exercises.map do |te|
-        model = te.exercise
-        strategy = Content::Strategies::Direct::Exercise.new(model)
-        Content::Exercise.new(strategy: strategy)
-      end
-    end
+  let(:correct_exercise_number_sets)  do
+    correct_tasks.map{ |task| Set.new task.tasked_exercises.map{ |te| te.exercise.number } }
   end
 
   context 'when creating a new reading task' do
@@ -94,10 +100,11 @@ describe GetHistory, type: :routine, speed: :slow do
 
       it 'returns the correct history' do
         history = described_class.call(roles: @role, type: :reading).outputs.history[@role]
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
       end
     end
 
@@ -112,10 +119,11 @@ describe GetHistory, type: :routine, speed: :slow do
 
       it 'does not return tasks with no dynamic reading exercises' do
         history = described_class.call(roles: @role, type: :reading).outputs.history[@role]
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
       end
     end
   end
@@ -124,11 +132,12 @@ describe GetHistory, type: :routine, speed: :slow do
     let(:correct_tasks) { [@homework_task_3, @homework_task_2, @homework_task_1] }
 
     it 'returns the correct history' do
-      history = described_class.call(roles: @role, type: :homework).outputs.history[@role]
-      expect(history.tasks).to eq correct_tasks
-      expect(history.ecosystems).to eq correct_ecosystems
-      history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-      expect(history_exercise_sets).to eq correct_exercise_sets
+        history = described_class.call(roles: @role, type: :homework).outputs.history[@role]
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
     end
   end
 
@@ -139,10 +148,11 @@ describe GetHistory, type: :routine, speed: :slow do
 
       it 'returns the correct history' do
         history = described_class.call(roles: @role, type: :all).outputs.history[@role]
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
       end
     end
 
@@ -158,10 +168,11 @@ describe GetHistory, type: :routine, speed: :slow do
 
       it 'does not return tasks with no dynamic reading exercises' do
         history = described_class.call(roles: @role, type: :all).outputs.history[@role]
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
       end
     end
   end
@@ -173,10 +184,11 @@ describe GetHistory, type: :routine, speed: :slow do
 
       it 'returns the correct history' do
         history = described_class.call(roles: @role, type: :all).outputs.history[@role]
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
       end
     end
 
@@ -192,10 +204,11 @@ describe GetHistory, type: :routine, speed: :slow do
 
       it 'does not return tasks with no dynamic reading exercises' do
         history = described_class.call(roles: @role, type: :all).outputs.history[@role]
-        expect(history.tasks).to eq correct_tasks
-        expect(history.ecosystems).to eq correct_ecosystems
-        history_exercise_sets = history.exercises.map{ |exercises| Set.new exercises }
-        expect(history_exercise_sets).to eq correct_exercise_sets
+        expect(history.total_count).to eq correct_total_count
+        expect(history.ecosystem_ids).to eq correct_ecosystem_ids
+        expect(history.core_page_ids).to eq correct_core_page_ids
+        history_exercise_number_sets = history.exercise_numbers.map{ |numbers| Set.new numbers }
+        expect(history_exercise_number_sets).to eq correct_exercise_number_sets
       end
     end
   end


### PR DESCRIPTION
Turns out Ruby sets are only worth it when you have on the order of 100 `includes?` operations with on the order of 100 elements. So I removed `Set.new` from places where I expect less than 100 includes and elements.

- Removed some calls to `Set.new`
- Added some memoization to the fragment assistant.
- Allowed GetHistory to be batched for multiple roles.
- Check that a reading task should be excluded from history due to no dynamic exercises only once per task plan.