### PR TITLE
Fix double sims and add iframe interactive or video classes

### DIFF
--- a/app/subsystems/content/exercise.rb
+++ b/app/subsystems/content/exercise.rb
@@ -60,6 +60,10 @@ module Content
       verify_and_return @strategy.aplos, klass: ::Content::Tag, error: StrategyError
     end
 
+    def feature_ids
+      verify_and_return @strategy.feature_ids, klass: String, error: StrategyError
+    end
+
     def page
       verify_and_return @strategy.page, klass: ::Content::Page, error: StrategyError
     end

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -42,6 +42,10 @@ class Content::Models::Exercise < Tutor::SubSystems::BaseModel
     tags.to_a.select(&:cnxmod?)
   end
 
+  def cnxfeatures
+    tags.to_a.select(&:cnxfeature?)
+  end
+
   def content_hash
     ::JSON.parse(content)
   end
@@ -63,6 +67,10 @@ class Content::Models::Exercise < Tutor::SubSystems::BaseModel
 
   def is_multipart?
     content_hash['questions'].size > 1
+  end
+
+  def feature_ids
+    cnxfeatures.map(&:data)
   end
 
 end

--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -32,7 +32,7 @@ class Content::Models::Page < Tutor::SubSystems::BaseModel
 
   before_validation :cache_fragments_and_snap_labs
 
-  delegate :is_intro?, :feature_node, to: :parser
+  delegate :is_intro?, to: :parser
 
   def cnx_id
     "#{uuid}@#{version}"
@@ -73,10 +73,18 @@ class Content::Models::Page < Tutor::SubSystems::BaseModel
     snap_labs.map{ |snap_lab| snap_lab.merge(page_id: id) }
   end
 
+  def context_for_feature_ids(feature_ids)
+    parser_class.feature_node(parser.converted_root, feature_ids).try(:to_html)
+  end
+
   protected
 
+  def parser_class
+    OpenStax::Cnx::V1::Page
+  end
+
   def parser
-    @parser ||= OpenStax::Cnx::V1::Page.new(title: title, content: content)
+    @parser ||= parser_class.new(title: title, content: content)
   end
 
   def fragment_splitter

--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -74,7 +74,20 @@ class Content::Models::Page < Tutor::SubSystems::BaseModel
   end
 
   def context_for_feature_ids(feature_ids)
-    parser_class.feature_node(parser.converted_root, feature_ids).try(:to_html)
+    @context_for_feature_ids ||= {}
+    return @context_for_feature_ids[feature_ids] if @context_for_feature_ids.has_key?(feature_ids)
+
+    feature_node = nil
+    fragments.each do |fragment|
+      next unless fragment.respond_to?(:to_html)
+
+      fragment_node = Nokogiri::HTML.fragment(fragment.to_html)
+      feature_node = parser_class.feature_node(fragment_node, feature_ids)
+
+      break unless feature_node.nil?
+    end
+
+    @context_for_feature_ids[feature_ids] = feature_node.try(:to_html)
   end
 
   protected

--- a/app/subsystems/content/routines/import_exercises.rb
+++ b/app/subsystems/content/routines/import_exercises.rb
@@ -30,9 +30,7 @@ class Content::Routines::ImportExercises
 
       if wrapper.requires_context?
         feature_ids = wrapper.feature_ids(exercise_page.uuid)
-        wrapper.context = feature_ids.map do |feature_id|
-          exercise_page.feature_node(feature_id).try(:to_html)
-        end.compact.join("\n")
+        wrapper.context = exercise_page.context_for_feature_ids(feature_ids)
         Rails.logger.warn do
           "Exercise #{wrapper.uid} requires context, but feature ID(s) [#{
             feature_ids.join(', ')}] could not be found on #{exercise_page.url}"

--- a/app/subsystems/content/strategies/direct/exercise.rb
+++ b/app/subsystems/content/strategies/direct/exercise.rb
@@ -7,7 +7,7 @@ module Content
 
         exposes :page, :tags, :los, :aplos, :url, :title, :preview, :context, :content, :uid,
                 :number, :version, :content_hash, :pool_types, :is_excluded, :has_interactive,
-                :has_video, :content_as_independent_questions
+                :has_video, :content_as_independent_questions, :feature_ids
 
         def to_model
           repository

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -80,9 +80,6 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
       feature_node = OpenStax::Cnx::V1::Page.feature_node(node, exercise.feature_ids)
 
       unless feature_node.nil?
-        # Reassign context to exercise to pick up any modifications due to processing instructions
-        exercise.context = feature_node.to_html
-
         # Remove context from previous step
         feature_node.remove
         previous_step.tasked.content = node.to_html

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -11,18 +11,18 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
 
       title ||= fragment.title
 
-      step_modifier = ->(step) {
+      step_modifier = ->(step) do
         step.group_type = :core_group
         step.add_labels(fragment.labels)
         step.add_related_content(related_content)
-      }
+      end
 
-      step_builder = ->() {
+      step_builder = ->() do
         Tasks::Models::TaskStep.new(task: task).tap do |step|
           step_modifier.call(step)
           task.add_step(step)
         end
-      }
+      end
 
       # For Exercise and OptionalExercise (subclass of Exercise)
       previous_step = task.task_steps.last if fragment.is_a? OpenStax::Cnx::V1::Fragment::Exercise
@@ -73,13 +73,20 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
 
     # Removes the current exercise's context from the previous step
     # Removes the previous step completely if this modification makes its content blank
-    if previous_step.present? && exercise.context.present? &&
-       previous_step.has_content? && previous_step.tasked.content.include?(exercise.context)
-      previous_step.tasked.content = previous_step.tasked.content.sub(exercise.context, '')
+    if previous_step.present? && previous_step.has_content? && exercise.context.present?
+      node = Nokogiri::HTML.fragment(previous_step.tasked.content)
+
+      # Remove any feature_ids used as exercise context from the previous step
+      feature_ids = exercise.feature_ids
+      feature_ids.each{ |feature_id| node.at_css("##{feature_id}").try(:remove) }
+
+      previous_step.tasked.content = node.to_html
 
       if previous_step.tasked.content.blank?
+        # If the previous step is now blank, remove it from the task
         task.task_steps.delete(previous_step)
       else
+        # If the previous step is persisted, save it again
         previous_step.tasked.save! if previous_step.tasked.persisted?
       end
     end

--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -1,17 +1,16 @@
 require 'addressable/uri'
 require 'open-uri'
 
-require_relative './v1/fragment_splitter'
+require_relative './v1/custom_css'
 
 require_relative './v1/fragment'
 require_relative './v1/fragment/embedded'
-
-require_relative './v1/fragment/reading'
 require_relative './v1/fragment/video'
 require_relative './v1/fragment/interactive'
-
+require_relative './v1/fragment/reading'
 require_relative './v1/fragment/exercise'
 require_relative './v1/fragment/optional_exercise'
+require_relative './v1/fragment_splitter'
 
 require_relative './v1/book'
 require_relative './v1/book_part'

--- a/lib/openstax/cnx/v1/custom_css.rb
+++ b/lib/openstax/cnx/v1/custom_css.rb
@@ -1,0 +1,9 @@
+module OpenStax::Cnx::V1
+  class CustomCss
+    include Singleton
+
+    define_method(:'has-descendants') do |node_set, selector, number = 1|
+      node_set.select{ |node| node.css(selector).size >= number }
+    end
+  end
+end

--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -7,17 +7,46 @@ module OpenStax::Cnx::V1
     # Used to get the title if there are no title nodes
     LABEL_ATTRIBUTE = 'data-label'
 
-    class_attribute :default_width, :default_height
+    # CSS to find embedded element containers (will be replaced with iframe)
+    CONTAINER_CSS = '.os-interactive-link, .ost-embed-container'
 
-    # CSS to find the embedded element container (will be replaced with iframe)
-    CONTAINER_CSS = '.ost-embed-container'
-    MEDIA_CSS = '[data-type="media"]'
-
-    # CSS to find the embedded content url
+    # CSS to find embedded content urls
     TAGGED_URL_CSS = 'iframe.os-embed, a.os-embed, .os-embed iframe, .os-embed a'
     UNTAGGED_URL_CSS = 'iframe, a'
 
+    class_attribute :default_width, :default_height
+
     attr_reader :url, :width, :height, :to_html
+
+    # This code is run in page.rb during import
+    def self.replace_embed_links_with_iframes(node)
+      containers = node.css(CONTAINER_CSS)
+
+      containers.each do |container|
+        url_node = get_url_node(container)
+
+        case url_node.try(:name)
+        when 'iframe'
+          # Reuse url node's iframe
+          container.replace(url_node)
+        when 'a'
+          # Build iframe based on the link's URL
+          iframe = Nokogiri::XML::Node.new('iframe', node.document)
+          iframe['src'] = url
+          iframe['width'] = width
+          iframe['height'] = height
+
+          # Save the url node's parent
+          parent = url_node.parent
+          # Replace the url node with its text
+          url_node.replace(url_node.inner_html)
+          # Replace the container with the new iframe or append it to the parent node
+          container.replace(iframe)
+        end
+      end
+
+      node
+    end
 
     def initialize(node:, title: nil, labels: nil)
       super
@@ -28,51 +57,24 @@ module OpenStax::Cnx::V1
                              title_nodes.map{ |node| node.content.strip }.uniq.join('; ')
       end
 
-      container = node.at_css(CONTAINER_CSS) || node.at_css(MEDIA_CSS)
-      url_node = node.at_css(TAGGED_URL_CSS) || node.css(UNTAGGED_URL_CSS).last
+      url_node = get_url_node(node)
 
       @width = url_node.try(:[], 'width') || default_width
       @height = url_node.try(:[], 'height') || default_height
 
-      @url = url_node.try(:[], 'src')
-
-      if @url.nil?
-        # No source attribute found, so try href
-        original_url = url_node.try(:[], 'href')
-
-        # Node is considered blank if we cannot find the url
-        unless original_url.nil? || original_url =~ /\A#/
-          # This is an anchor, which Page does not convert to https, so redo the conversion here
-          uri = Addressable::URI.parse(original_url)
-          uri.scheme = 'https'
-          @url = uri.to_s
-        end
-      end
-
-      case url_node.try(:name)
-      when 'iframe'
-        # Reuse url node's iframe
-        container.replace(url_node) unless container.nil?
-      when 'a'
-        # Build iframe based on the link's URL
-        iframe = Nokogiri::XML::Node.new('iframe', node.document)
-        iframe['src'] = url
-        iframe['width'] = width
-        iframe['height'] = height
-
-        # Save the url node's parent
-        parent = url_node.parent
-        # Replace the url node with its text
-        url_node.replace(url_node.inner_html)
-        # Replace the container with the new iframe or append it to the parent node
-        container.nil? ? parent.add_next_sibling(iframe) : container.replace(iframe)
-      end
+      @url = url_node.try(:[], 'src') || url_node.try(:[], 'href')
 
       @to_html = node.to_html
     end
 
     def blank?
       url.blank?
+    end
+
+    protected
+
+    def get_url_node(node)
+      node.at_css(TAGGED_URL_CSS) || node.css(UNTAGGED_URL_CSS).last
     end
 
   end

--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -11,7 +11,9 @@ module OpenStax::Cnx::V1
     TAGGED_URL_CSS = 'iframe.os-embed, a.os-embed, .os-embed iframe, .os-embed a'
     UNTAGGED_URL_CSS = 'iframe, a'
 
-    class_attribute :default_width, :default_height
+    class_attribute :iframe_classes, :default_width, :default_height
+
+    self.iframe_classes = ['os-embed']
 
     attr_reader :url, :width, :height, :to_html
 
@@ -30,6 +32,13 @@ module OpenStax::Cnx::V1
       @height = url_node.try(:[], 'height') || default_height
 
       @url = url_node.try(:[], 'src') || url_node.try(:[], 'href')
+
+      if url_node.name == 'iframe'
+        node_classes = url_node['class'].to_s.split(' ') + iframe_classes
+        url_node['class'] = node_classes.uniq.join(' ')
+        url_node['width'] = default_width
+        url_node['height'] = default_height
+      end
 
       @to_html = node.to_html
     end

--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -36,8 +36,10 @@ module OpenStax::Cnx::V1
       if url_node.name == 'iframe'
         node_classes = url_node['class'].to_s.split(' ') + iframe_classes
         url_node['class'] = node_classes.uniq.join(' ')
-        url_node['width'] = default_width
-        url_node['height'] = default_height
+
+        # To always force the default iframe size, change ||= to =
+        url_node['width'] ||= default_width
+        url_node['height'] ||= default_height
       end
 
       @to_html = node.to_html

--- a/lib/openstax/cnx/v1/fragment/exercise.rb
+++ b/lib/openstax/cnx/v1/fragment/exercise.rb
@@ -15,7 +15,7 @@ module OpenStax::Cnx::V1
 
     attr_reader :embed_tags
 
-    # This code is run in page.rb during import
+    # This code is run from lib/openstax/cnx/v1/page.rb during import
     def self.absolutize_exercise_urls(node)
       node.css(EXERCISE_EMBED_CODE_CSS).each do |anchor|
         href = anchor.attribute('href')

--- a/lib/openstax/cnx/v1/fragment/exercise.rb
+++ b/lib/openstax/cnx/v1/fragment/exercise.rb
@@ -1,11 +1,11 @@
 module OpenStax::Cnx::V1
   class Fragment::Exercise < Fragment
 
-    # CSS to find the exercise embed code attribute(s)
-    EMBED_CODE_CSS = 'a[href^="#ost/api/ex/"]'
+    # CSS to find the embed code attributes
+    EXERCISE_EMBED_CODE_CSS = 'a[href^="#ost/api/ex/"]'
 
     # Regex to extract the appropriate tag from the embed code(s)
-    EMBED_TAG_REGEX = /\A#ost\/api\/ex\/([\w-]+)\z/
+    EXERCISE_EMBED_TAG_REGEX = /\A#ost\/api\/ex\/([\w-]+)\z/
 
     # XPath to find the exercise embed code(s) after the url(s) are absolutized
     ABSOLUTE_EMBED_CODE_XPATH = './/a[contains(@href, "/api/exercises")]'
@@ -15,20 +15,20 @@ module OpenStax::Cnx::V1
 
     attr_reader :embed_tags
 
+    # This code is run in page.rb during import
     def self.absolutize_exercise_urls(node)
-      node.css(EMBED_CODE_CSS).each do |anchor|
+      node.css(EXERCISE_EMBED_CODE_CSS).each do |anchor|
         href = anchor.attribute('href')
-        embed_tag = EMBED_TAG_REGEX.match(href.value).try(:[], 1)
+        embed_tag = EXERCISE_EMBED_TAG_REGEX.match(href.value).try(:[], 1)
         uri = OpenStax::Exercises::V1.uri_for('/api/exercises')
         uri.query_values = { q: "tag:\"#{embed_tag}\"" }
         href.value = uri.to_s
       end
+
+      node
     end
 
     def initialize(node:, title: nil, labels: [])
-      # Absolutized exercise url(s)
-      self.class.absolutize_exercise_urls(node)
-
       super
 
       embed_codes = node.xpath(ABSOLUTE_EMBED_CODE_XPATH).map do |anchor|

--- a/lib/openstax/cnx/v1/fragment/interactive.rb
+++ b/lib/openstax/cnx/v1/fragment/interactive.rb
@@ -10,6 +10,7 @@ class OpenStax::Cnx::V1::Fragment
 
     self.default_width = 960
     self.default_height = 560
+    self.iframe_classes += ['interactive']
 
     # This code is run from lib/openstax/cnx/v1/page.rb during import
     def self.replace_interactive_links_with_iframes(node)
@@ -23,7 +24,7 @@ class OpenStax::Cnx::V1::Fragment
         # Build iframe based on the link's URL
         iframe = Nokogiri::XML::Node.new('iframe', node.document)
         iframe['src'] = link_node['href']
-        iframe['class'] = 'interactive os-embed'
+        iframe['class'] = iframe_classes.join(' ')
         iframe['width'] = default_width
         iframe['height'] = default_height
 

--- a/lib/openstax/cnx/v1/fragment/interactive.rb
+++ b/lib/openstax/cnx/v1/fragment/interactive.rb
@@ -1,8 +1,38 @@
 class OpenStax::Cnx::V1::Fragment
   class Interactive < Embedded
 
+    # CSS to find interactive containers (anything inside may be replaced with an iframe)
+    CONTAINER_CSS = 'figure.ost-embed-container, figure:has-descendants("a.os-interactive-link")'
+
+    # CSS to find links to be embedded inside containers
+    TAGGED_LINK_CSS = 'a.os-embed, a.os-interactive-link'
+    UNTAGGED_LINK_CSS = 'a'
+
     self.default_width = 960
     self.default_height = 560
+
+    # This code is run from lib/openstax/cnx/v1/page.rb during import
+    def self.replace_interactive_links_with_iframes(node)
+      containers = node.css(CONTAINER_CSS, OpenStax::Cnx::V1::CustomCss.instance)
+
+      containers.each do |container|
+        link_node = node.at_css(TAGGED_LINK_CSS) || node.css(UNTAGGED_LINK_CSS).last
+
+        next if link_node.nil?
+
+        # Build iframe based on the link's URL
+        iframe = Nokogiri::XML::Node.new('iframe', node.document)
+        iframe['src'] = link_node['href']
+        iframe['class'] = 'interactive os-embed'
+        iframe['width'] = default_width
+        iframe['height'] = default_height
+
+        # Replace the container with the new iframe
+        container.replace(iframe)
+      end
+
+      node
+    end
 
   end
 end

--- a/lib/openstax/cnx/v1/fragment/reading.rb
+++ b/lib/openstax/cnx/v1/fragment/reading.rb
@@ -5,6 +5,7 @@ module OpenStax::Cnx::V1
 
     def initialize(node:, title: nil, labels: nil)
       super
+
       @to_html = node.to_html
     end
 

--- a/lib/openstax/cnx/v1/fragment/video.rb
+++ b/lib/openstax/cnx/v1/fragment/video.rb
@@ -4,5 +4,12 @@ class OpenStax::Cnx::V1::Fragment
     self.default_width = 560
     self.default_height = 315
 
+    # This code is run from lib/openstax/cnx/v1/page.rb during import
+    def self.replace_video_links_with_iframes(node)
+      # Currently there is no tagging legend markup for video links
+      # that have to be converted to iframes
+      node
+    end
+
   end
 end

--- a/lib/openstax/cnx/v1/fragment/video.rb
+++ b/lib/openstax/cnx/v1/fragment/video.rb
@@ -3,13 +3,7 @@ class OpenStax::Cnx::V1::Fragment
 
     self.default_width = 560
     self.default_height = 315
-
-    # This code is run from lib/openstax/cnx/v1/page.rb during import
-    def self.replace_video_links_with_iframes(node)
-      # Currently there is no tagging legend markup for video links
-      # that have to be converted to iframes
-      node
-    end
+    self.iframe_classes += ['video']
 
   end
 end

--- a/lib/openstax/cnx/v1/fragment_splitter.rb
+++ b/lib/openstax/cnx/v1/fragment_splitter.rb
@@ -38,14 +38,8 @@ module OpenStax::Cnx::V1
 
     protected
 
-    class CustomCss
-      define_method(:'has-descendants') do |node_set, selector, number = 1|
-        node_set.select{ |node| node.css(selector).size >= number }
-      end
-    end
-
     def custom_css
-      @custom_css ||= CustomCss.new
+      OpenStax::Cnx::V1::CustomCss.instance
     end
 
     # Returns an instance of the given fragment class

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -23,8 +23,11 @@ module OpenStax::Cnx::V1
     TEKS_REGEX = /ost-tag-(teks-[\w+-]+)/
 
     def self.feature_node(node, feature_ids)
-      feature_id_css = [feature_ids].flatten.map{ |feature_id| "##{feature_id}" }.join(', ')
-      node.at_css feature_id_css
+      feature_ids = [feature_ids].flatten
+      return if feature_ids.empty?
+
+      feature_id_css = feature_ids.map{ |feature_id| "##{feature_id}" }.join(', ')
+      node.at_css(feature_id_css)
     end
 
     def initialize(hash: {}, id: nil, title: nil, content: nil)

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -24,7 +24,7 @@ module OpenStax::Cnx::V1
 
     def self.feature_node(node, feature_ids)
       feature_id_css = [feature_ids].flatten.map{ |feature_id| "##{feature_id}" }.join(', ')
-      node.at_css(feature_id_css(feature_ids))
+      node.at_css feature_id_css
     end
 
     def initialize(hash: {}, id: nil, title: nil, content: nil)
@@ -97,7 +97,6 @@ module OpenStax::Cnx::V1
       @converted_doc ||= begin
         cd = doc.dup
         cd = OpenStax::Cnx::V1::Fragment::Interactive.replace_interactive_links_with_iframes(cd)
-        cd = OpenStax::Cnx::V1::Fragment::Video.replace_video_links_with_iframes(cd)
         absolutize_and_secure_urls(cd)
       end
     end

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -93,8 +93,8 @@ module OpenStax::Cnx::V1
 
       # Absolutize urls
       @converted_doc ||= begin
-        absolutized_doc = absolutize_urls(doc.dup)
-        OpenStax::Cnx::V1::Fragment::Embedded.replace_embed_links_with_iframes(absolutized_doc)
+        embed_doc = OpenStax::Cnx::V1::Fragment::Embedded.replace_embed_links_with_iframes(doc.dup)
+        absolutize_urls(embed_doc)
       end
     end
 

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -84,17 +84,16 @@ module OpenStax::Cnx::V1
       @root ||= doc.at_css(ROOT_CSS)
     end
 
-    # Changes relative and exercise url attributes in the doc to be absolute
-    # Changes http embedded scripts/images/iframes to https
-    # Replaces links to embeddable sims with iframes
+    # Replaces links to embeddable sims (and maybe videos in the future) with iframes
+    # Changes exercise urls and relative urls in the doc to be absolute
+    # Changes any embedded http url (in a src attribute) to https
     def converted_doc
-      # In the future, change to point to reference material within Tutor
-      return @converted_doc unless @converted_doc.nil?
-
-      # Absolutize urls
+      # In the future, change CNX URLs to point to reference material within Tutor
       @converted_doc ||= begin
-        embed_doc = OpenStax::Cnx::V1::Fragment::Embedded.replace_embed_links_with_iframes(doc.dup)
-        absolutize_urls(embed_doc)
+        cd = doc.dup
+        cd = OpenStax::Cnx::V1::Fragment::Interactive.replace_interactive_links_with_iframes(cd)
+        cd = OpenStax::Cnx::V1::Fragment::Video.replace_video_links_with_iframes(cd)
+        absolutize_and_secure_urls(cd)
       end
     end
 
@@ -182,7 +181,7 @@ module OpenStax::Cnx::V1
 
     protected
 
-    def absolutize_urls(node)
+    def absolutize_and_secure_urls(node)
       # Absolutize exercise urls
       node = OpenStax::Cnx::V1::Fragment::Exercise.absolutize_exercise_urls(node.dup)
 

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -22,6 +22,11 @@ module OpenStax::Cnx::V1
     STD_REGEX = /ost-tag-std-([\w+-]+)/
     TEKS_REGEX = /ost-tag-(teks-[\w+-]+)/
 
+    def self.feature_node(node, feature_ids)
+      feature_id_css = [feature_ids].flatten.map{ |feature_id| "##{feature_id}" }.join(', ')
+      node.at_css(feature_id_css(feature_ids))
+    end
+
     def initialize(hash: {}, id: nil, title: nil, content: nil)
       @hash            = hash
       @id              = id
@@ -107,10 +112,6 @@ module OpenStax::Cnx::V1
 
     def snap_lab_nodes
       converted_root.css(SNAP_LAB_CSS)
-    end
-
-    def feature_node(feature_id)
-      converted_root.at_css("##{feature_id}")
     end
 
     def snap_lab_title(snap_lab)

--- a/spec/lib/openstax/cnx/v1/fragment/interactive_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/interactive_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Interactive, type: :external, vcr: V
       <div data-type="note" data-has-label="true" id="fs-idp38765984" class="note ost-assessed-feature os-interactive virtual-physics ost-tag-lo-k12phys-ch04-s01-lo02" data-label="Virtual Physics: Forces and Motion: Basics">
       <p id="fs-idp92213536">In this simulation, you will first explore net force by placing blue people on the left side of a tug of war rope and red people on the right side of the rope (by clicking people and dragging them with your mouse). Experiment with changing the number and size of people on each side to see how it affects the outcome of the match and the net force. Hit the Go! button to start the match, and the “reset all” button to start over.</p>
       <p id="fs-idp72378080">Next, click on the Friction tab. Try selecting different objects for the person to push. Slide the applied force button to the right to apply force to the right and to the left to apply force to the left. The force will continue to be applied as long as you hold down the button. See the arrow representing friction change in magnitude and direction, depending on how much force you apply. Try increasing or decreasing the friction force to see how this change affects the motion.</p>
-      <iframe src="https://phet.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics_en.html" width="960" height="560"></iframe>
+      <iframe src="https://phet.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics_en.html" class="interactive os-embed" width="960" height="560"></iframe>
        </div>
     EOF
   }

--- a/spec/lib/openstax/cnx/v1/fragment/interactive_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/interactive_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Interactive, type: :external, vcr: V
       <div data-type="note" data-has-label="true" id="fs-idp38765984" class="note ost-assessed-feature os-interactive virtual-physics ost-tag-lo-k12phys-ch04-s01-lo02" data-label="Virtual Physics: Forces and Motion: Basics">
       <p id="fs-idp92213536">In this simulation, you will first explore net force by placing blue people on the left side of a tug of war rope and red people on the right side of the rope (by clicking people and dragging them with your mouse). Experiment with changing the number and size of people on each side to see how it affects the outcome of the match and the net force. Hit the Go! button to start the match, and the “reset all” button to start over.</p>
       <p id="fs-idp72378080">Next, click on the Friction tab. Try selecting different objects for the person to push. Slide the applied force button to the right to apply force to the right and to the left to apply force to the left. The force will continue to be applied as long as you hold down the button. See the arrow representing friction change in magnitude and direction, depending on how much force you apply. Try increasing or decreasing the friction force to see how this change affects the motion.</p>
-      <iframe src="https://phet.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics_en.html" class="interactive os-embed" width="960" height="560"></iframe>
+      <iframe src="https://phet.colorado.edu/sims/html/forces-and-motion-basics/latest/forces-and-motion-basics_en.html" class="os-embed interactive" width="960" height="560"></iframe>
        </div>
     EOF
   }

--- a/spec/lib/openstax/cnx/v1/fragment/video_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/video_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Video, type: :external, vcr: VCR_OPT
       <div data-type="title" class="title">Newton’s First Law of Motion</div>
 
       <p id="fs-idp29827984">This video contrasts the way we thought about motion and force in the time before Galileo’s concept of inertia and Newton’s first law of motion with the way we understand force and motion now.</p>
-       <iframe width="660" height="371.4" src="https://www.khanacademy.org/embed_video?v=5-ZFOhHQS68"></iframe>
+       <div data-type="media" id="fs-idp48266880" data-alt="This link takes you to a lecture that contrasts the way we thought about motion and force before Galileo's concept of inertia and Newton's first law of motion with the way we understand force and motion now." class="os-embed">
+        <iframe width="660" height="371.4" src="https://www.khanacademy.org/embed_video?v=5-ZFOhHQS68"></iframe>
+      </div>
 
 
       </div>

--- a/spec/lib/openstax/cnx/v1/fragment/video_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/video_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Video, type: :external, vcr: VCR_OPT
 
       <p id="fs-idp29827984">This video contrasts the way we thought about motion and force in the time before Galileo’s concept of inertia and Newton’s first law of motion with the way we understand force and motion now.</p>
        <div data-type="media" id="fs-idp48266880" data-alt="This link takes you to a lecture that contrasts the way we thought about motion and force before Galileo's concept of inertia and Newton's first law of motion with the way we understand force and motion now." class="os-embed">
-        <iframe width="660" height="371.4" src="https://www.khanacademy.org/embed_video?v=5-ZFOhHQS68"></iframe>
+        <iframe width="660" height="371.4" src="https://www.khanacademy.org/embed_video?v=5-ZFOhHQS68" class="os-embed video"></iframe>
       </div>
 
 

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
 
     it 'extracts feature nodes by id' do
       feature_id = 'fs-id1164355841632'
-      feature_node = @page.feature_node(feature_id)
+      feature_node = described_class.feature_node(@page.converted_root, feature_id)
       expect(feature_node[:id]).to eq feature_id
     end
   end

--- a/spec/subsystems/content/models/page_spec.rb
+++ b/spec/subsystems/content/models/page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Content::Models::Page, type: :model, vcr: VCR_OPTS do
   it { is_expected.to validate_presence_of(:title) }
 
   it { is_expected.to delegate_method(:is_intro?).to(:parser) }
-  it { is_expected.to delegate_method(:feature_node).to(:parser) }
+  it { is_expected.to delegate_method(:feature_node).to(OpenStax::Cnx::V1::Page) }
 
   context 'with snap lab page' do
 

--- a/spec/subsystems/content/models/page_spec.rb
+++ b/spec/subsystems/content/models/page_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Content::Models::Page, type: :model, vcr: VCR_OPTS do
   it { is_expected.to validate_presence_of(:title) }
 
   it { is_expected.to delegate_method(:is_intro?).to(:parser) }
-  it { is_expected.to delegate_method(:feature_node).to(OpenStax::Cnx::V1::Page) }
 
   context 'with snap lab page' do
 

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -543,6 +543,11 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
                                        tag_type: :id,
                                        ecosystem: ecosystem_model
     end
+    let!(:video_cnxfeature_tag) do
+      FactoryGirl.create :content_tag, value: "context-cnxfeature:fs-video",
+                                       tag_type: :cnxfeature,
+                                       ecosystem: ecosystem_model
+    end
     let!(:interactive_cnxfeature_tag) do
       FactoryGirl.create :content_tag, value: "context-cnxfeature:fs-interactive",
                                        tag_type: :cnxfeature,
@@ -553,6 +558,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       FactoryGirl.create(:content_exercise, page: page, context: video_content).tap do |exercise|
         exercise.tags << cnxmod_tag
         exercise.tags << video_exercise_id_tag
+        exercise.tags << video_cnxfeature_tag
       end
     end
     let!(:interactive_exercise) do
@@ -621,13 +627,15 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
           ),
           OpenStax::Cnx::V1::Fragment::Video.new(
             node: Nokogiri::HTML.fragment(video_content).children.first,
-            title: "Watch Newton use the Force against Robert Hooke"
+            title: "Watch Isaac Newton use the Force against Robert Hooke"
           ),
           OpenStax::Cnx::V1::Fragment::Exercise.new(
-            node: Nokogiri::HTML.fragment(
-              "<div class=\"exercise\">
-                 <a href=#ost/api/ex/#{video_exercise_id_tag.value}>[Link]</a>
-               </div>"
+            node: OpenStax::Cnx::V1::Fragment::Exercise.absolutize_exercise_urls(
+              Nokogiri::HTML.fragment(
+                "<div class=\"exercise\">
+                   <a href=#ost/api/ex/#{video_exercise_id_tag.value}>[Link]</a>
+                 </div>"
+              )
             ).children.first,
             title: nil
           ),


### PR DESCRIPTION
- Fixes the double sim issue
- Provides `interactive` or `video` classes for interactive/video iframes in readings and in exercises (only if loaded through cnxfeature tags) so Patrick can fix the iframe sizes. (Content team has to add classes to iframes that appear directly in exercises)

Exercises PR to allow content team to add classes to iframes is merged but not deployed to production.