### PR TITLE
Made BE-generated info messages make it past terms pages to webview

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,11 @@ class ApplicationController < ActionController::Base
 
   include Lev::HandleWith
 
+  WEBVIEW_FLASH_TYPES = [:webview_notice]
+
+  add_flash_types *WEBVIEW_FLASH_TYPES
+  prepend_before_filter :keep_webview_flash
+
   before_filter :authenticate_user!
 
   protected
@@ -36,6 +41,28 @@ class ApplicationController < ActionController::Base
 
   def allow_iframe_access
     response.headers.except! 'X-Frame-Options'
+  end
+
+  def keep_webview_flash
+    # keep webview flash notices until they are explicitly removed (i.e. when
+    # they are actually conveyed to the webview), helps us get past intermediate
+    # pages like the Terms of Use agreement pages.
+
+    WEBVIEW_FLASH_TYPES.each do |webview_flash_type|
+      flash.keep(webview_flash_type)
+    end
+  end
+
+  def convert_and_clear_webview_flash
+    # When this method is called we want to convert the special `webview_foo`
+    # flash info to just `foo` flash info and then stop keeping the `webview_`
+    # variant.
+
+    WEBVIEW_FLASH_TYPES.each do |webview_flash_type|
+      normal_flash_type = webview_flash_type.to_s.gsub(/webview_/,'').to_sym
+      flash[normal_flash_type] = flash[webview_flash_type] if flash[webview_flash_type].present?
+      flash.delete(webview_flash_type)
+    end
   end
 
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -22,7 +22,10 @@ class CoursesController < ApplicationController
   def confirm_enrollment
     handle_with(CoursesConfirmEnrollment,
                 success: -> {
-                  send_to_student_dashboard(notice: "Enrollment successful! It may take a few minutes to build your assignments.")
+                  send_to_student_dashboard(
+                    notice: "Enrollment successful! It may take a few " \
+                            "minutes to build your assignments."
+                  )
                 },
                 failure: -> {
                   case @handler_result.errors.map(&:code).first
@@ -43,7 +46,7 @@ class CoursesController < ApplicationController
 
   def send_to_student_dashboard(notice: nil)
     course = @handler_result.outputs.course
-    redirect_to student_course_dashboard_path(course), notice: notice
+    redirect_to student_course_dashboard_path(course), webview_notice: notice
   end
 
   def send_to_teacher_dashboard(notice: nil)

--- a/app/controllers/webview_controller.rb
+++ b/app/controllers/webview_controller.rb
@@ -22,7 +22,13 @@ class WebviewController < ApplicationController
   protected
 
   def resolve_layout
-    'home' == action_name ? false : 'webview'
+    if 'home' == action_name
+      false
+    else
+      # since webview layout used, get the webview flash info prepped
+      convert_and_clear_webview_flash
+      'webview'
+    end
   end
 
 end

--- a/app/helpers/webview_helper.rb
+++ b/app/helpers/webview_helper.rb
@@ -2,7 +2,6 @@ module WebviewHelper
 
   # Generates data for the FE to read as it boots up
   def bootstrap_data
-
     Api::V1::BootstrapDataRepresenter.new(current_user).to_json(
       user_options: {
         tutor_notices_url: api_notifications_url,


### PR DESCRIPTION
The student enrollment link approach was trying to send a heads-up message to the frontend that said "Enrollment successful! It may take a few minutes to build your assignments."  Problem was that our code was not accounting for the fact that new users had to go through terms of use signatures before they were redirected to the FE, and this message was getting used up on the first terms of use page instead of being rendered as a pretty banner in the FE.

This PR makes BE-generated info messages that are targeted to be shown on the FE survive until the FE actually loads.