### PR TITLE
Undropped students get assignments from when they were dropped

### DIFF
--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -7,6 +7,7 @@ module CourseMembership
       student.restore(recursive: true)
       student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)
+      ReassignPublishedPeriodTaskPlans[period: student.period]
       outputs[:student] = student
     end
   end

--- a/spec/requests/task_plan_reassignment_works_spec.rb
+++ b/spec/requests/task_plan_reassignment_works_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe 'Task plan reassignment works', type: :request, api: true, version: :v1 do
+  let(:course) { CreateCourse[name: 'Physics'] }
+  let(:period) { CreatePeriod[course: course, name: '1st'] }
+  let(:student_user) { FactoryGirl.create(:user) }
+  let(:teacher_user) { FactoryGirl.create(:user) }
+
+  let!(:teacher_role)    { AddUserAsCourseTeacher[user: teacher_user, course: course] }
+  let!(:teacher)         { teacher_role.teacher }
+  let!(:application)     { FactoryGirl.create :doorkeeper_application }
+  let!(:teacher_token)   { FactoryGirl.create :doorkeeper_access_token,
+                                                application: application,
+                                                resource_owner_id: teacher_user.id }
+
+  let!(:task_plan_1) do
+    FactoryGirl.build(:tasks_task_plan, owner: course).tap do |task_plan|
+      task_plan.tasking_plans.first.target = period.to_model
+      task_plan.save!
+    end
+  end
+
+  scenario 'new students added after assignments published get those assignments' do
+    # Publish the assignment, and no one around to get it...
+    DistributeTasks.call(task_plan_1)
+    expect(Tasks::Models::Tasking.count).to eq 0
+
+    # The student signs up...
+    stub_current_user(student_user)
+    post(confirm_token_enroll_path(period.to_model),
+         enroll: {enrollment_token: period.enrollment_code_for_url})
+
+    # ... and they have the assignment
+    expect(Tasks::Models::Tasking.count).to eq 1
+    expect(student_user.to_model.roles.first.taskings.count).to eq 1
+  end
+
+  scenario 'undropped student gets assignments published while he was dropped' do
+    # The student enrolls...
+    stub_current_user(student_user)
+    post(confirm_token_enroll_path(period.to_model),
+         enroll: {enrollment_token: period.enrollment_code_for_url})
+    expect(CourseMembership::GetPeriodStudentRoles[periods: period]).not_to be_empty
+
+    # The teacher drops the student...
+    stub_current_user(teacher_user)
+    student = CourseMembership::Models::Student.first
+    api_delete("/api/students/#{student.id}", teacher_token)
+    expect(CourseMembership::GetPeriodStudentRoles[periods: period]).to be_empty
+
+    # The teacher publishes an assignment, and no one gets it...
+    DistributeTasks.call(task_plan_1)
+    expect(Tasks::Models::Tasking.count).to eq 0
+
+    # The teacher undrops the student...
+    api_put("/api/students/#{student.id}/undrop", teacher_token)
+
+    # ... and the student has the missing task
+    expect(Tasks::Models::Tasking.count).to eq 1
+    expect(student_user.to_model.roles.first.taskings.count).to eq 1
+  end
+
+end

--- a/spec/subsystems/course_membership/activate_student_spec.rb
+++ b/spec/subsystems/course_membership/activate_student_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 describe CourseMembership::ActivateStudent, type: :routine do
-  let!(:student) { FactoryGirl.create(:course_membership_student) }
-  let!(:course)  { student.course }
+  let!(:course)  { CreateCourse[name: "Physics"] }
+  let!(:period)  { CreatePeriod[course: course, name: "1st"] }
+  let!(:user)    { FactoryGirl.create(:user) }
+  let!(:student) { AddUserAsPeriodStudent.call(user: user, period: period).outputs.student }
 
   context "inactive student" do
     before { student.destroy }


### PR DESCRIPTION
I wrote a test to show two things:

1. that new students added to a course get previously published assignments
2. that undropped students get assignments published while they were dropped.

The first one was working, the second one was not.  This PR adds a call to reassign published task plans for students that were undropped.