### PR TITLE
trim whitespace on task plan title and description

### DIFF
--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -21,6 +21,8 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
 
   json_serialize :settings, Hash
 
+  before_validation :trim_text
+
   validates :title, presence: true
   validates :assistant, presence: true
   validates :ecosystem, presence: true
@@ -102,6 +104,11 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
     return if !is_publish_requested || tasking_plans.none?(&:past_due?)
     errors.add(:due_at, 'cannot be in the past when publishing')
     false
+  end
+
+  def trim_text
+    self.title.try(:strip!)
+    self.description.try(:strip!)
   end
 
 end

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -90,4 +90,12 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).to_not be_valid
   end
 
+  it "trims title and description fields" do
+    task_plan.title = " hi\n\n\r\n "
+    task_plan.description = " \tthere\t "
+    task_plan.save
+    expect(task_plan.title).to eq "hi"
+    expect(task_plan.description).to eq "there"
+  end
+
 end


### PR DESCRIPTION
Fixes problem where lots of trailing newlines leads to a funky UI.  Also just keeps this text neater in general.