### PR TITLE
Make exports with empty periods not cause circular references in Excel

### DIFF
--- a/app/subsystems/tasks/performance_report/export_cc_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_cc_xlsx.rb
@@ -28,6 +28,7 @@ module Tasks
         @helper.standard_package_settings(@package)
 
         setup_styles
+        handle_empty_periods
         write_data_worksheets
         make_first_sheet_active
         save
@@ -85,6 +86,14 @@ module Tasks
           @average_pct = s.add_style b: true,
                                      border: { edges: [:top, :bottom], :color => '000000', :style => :thin},
                                      num_fmt: Axlsx::NUM_FMT_PERCENT, bg_color: 'F2F2F2', border_top: {style: :medium}
+        end
+      end
+
+      def handle_empty_periods
+        @report.each do |period_report|
+          if period_report[:students].empty?
+            period_report[:students].push({first_name: "---", last_name: "EMPTY", student_identifier: "---", data: []})
+          end
         end
       end
 
@@ -419,15 +428,15 @@ module Tasks
             XlsxHelper.cell_ref(row: first_student_row, column: first_column+1) + ":" +
             XlsxHelper.cell_ref(row: last_student_row, column: first_column+1)
 
-          average_columns.push(["#{@eq}AVERAGE(#{correct_range})", {style: average_style}])
-          average_columns.push(["#{@eq}AVERAGE(#{completed_range})", {style: average_style}])
+          average_columns.push(["#{@eq}IFERROR(AVERAGE(#{correct_range}),NA())", {style: average_style}])
+          average_columns.push(["#{@eq}IFERROR(AVERAGE(#{completed_range}),NA())", {style: average_style}])
 
           if format == :counts
             total_range =
               XlsxHelper.cell_ref(row: first_student_row, column: first_column+2) + ":" +
               XlsxHelper.cell_ref(row: last_student_row, column: first_column+2)
 
-            average_columns.push(["#{@eq}AVERAGE(#{total_range})", {style: average_style}])
+            average_columns.push(["#{@eq}IFERROR(AVERAGE(#{total_range}),NA())", {style: average_style}])
           end
 
           average_columns.push(["", {style: @average_R}])

--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -30,6 +30,7 @@ module Tasks
 
         setup_styles
         remove_excluded_tasks
+        handle_empty_periods
         write_data_worksheets
         make_first_sheet_active
         save
@@ -56,6 +57,14 @@ module Tasks
 
           period_report[:students].each do |student|
             student[:data].reject!.with_index {|student, ii| excluded_indices.include?(ii) }
+          end
+        end
+      end
+
+      def handle_empty_periods
+        @report.each do |period_report|
+          if period_report[:students].empty?
+            period_report[:students].push({first_name: "---", last_name: "EMPTY", student_identifier: "---", data: []})
           end
         end
       end
@@ -328,9 +337,9 @@ module Tasks
           ["Class Average", {style: @average_style}],
           ["", {style: @average_style}],
           ["", {style: @average_R}],
-          ["#{@eq}AVERAGEIF(D#{first_student_row}:D#{last_student_row},\"<>#N/A\")", {style: average_style}],
-          ["#{@eq}AVERAGEIF(E#{first_student_row}:E#{last_student_row},\"<>#N/A\")", {style: average_style}],
-          ["#{@eq}AVERAGEIF(F#{first_student_row}:F#{last_student_row},\"<>#N/A\")", {style: average_style_R}]
+          ["#{@eq}IFERROR(AVERAGEIF(D#{first_student_row}:D#{last_student_row},\"<>#N/A\"),NA())", {style: average_style}],
+          ["#{@eq}IFERROR(AVERAGEIF(E#{first_student_row}:E#{last_student_row},\"<>#N/A\"),NA())", {style: average_style}],
+          ["#{@eq}IFERROR(AVERAGEIF(F#{first_student_row}:F#{last_student_row},\"<>#N/A\"),NA())", {style: average_style_R}]
         ]
 
         report[:data_headings].count.times do |index|

--- a/spec/subsystems/tasks/performance_report/export_cc_xlsx_spec.rb
+++ b/spec/subsystems/tasks/performance_report/export_cc_xlsx_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
     end
 
     it 'has % class averages' do
-      expect(cell(16,8,0)).to eq "AVERAGE(H13:H15)"
-      expect(cell(16,9,0)).to eq "AVERAGE(I13:I15)"
+      expect(cell(16,8,0)).to match /AVERAGE\(H13:H15\)/
+      expect(cell(16,9,0)).to match /AVERAGE\(I13:I15\)/
     end
 
     it 'has % student averages' do
@@ -67,6 +67,32 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
       expect(cell(13,6,0)).to eq 0
       expect(cell(13,6,1)).to eq 0
       expect(cell(13,7,1)).to eq 0
+    end
+  end
+
+  context 'when a period has no students' do
+    before(:context) do
+      Dir.mktmpdir do |dir|
+        filepath = Timecop.freeze(Chronic.parse("3/18/2016 1:30PM")) do
+          described_class.call(course_name: "Physics 101",
+                               report: report_with_empty_period,
+                               filename: "#{dir}/testfile",
+                               options: {stringify_formulas: false})
+        end
+
+        # Uncomment this to open the file for visual inspection
+        # `open "#{filepath}"` and sleep(0.5)
+
+        expect{ @wb = Roo::Excelx.new(filepath) }.to_not raise_error
+      end
+    end
+
+    it 'inserts an empty row so it does not explode with a circular reference' do
+      [0,1].each do |sheet_number|
+        expect(cell(13,1,sheet_number)).to eq '---'
+        expect(cell(13,2,sheet_number)).to eq 'EMPTY'
+        expect(cell(13,3,sheet_number)).to eq '---'
+      end
     end
   end
 
@@ -177,6 +203,35 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
             ]
           }
         ]
+      }
+    ]
+  end
+
+  def report_with_empty_period
+    [
+      {
+        period: {
+          name: "1st Period"
+        } ,
+        data_headings: [
+          {
+            cnx_page_id: 'UUID_1',
+            title: "1.1 Intro to Math",
+            type: 'concept_coach',
+            total_average: 0.6,
+            attempted_average: 0.7123,
+            average_actual_and_placeholder_exercise_count: 11
+          },
+          {
+            cnx_page_id: "UUID_2",
+            title: "1.2 Basket weaving is really really really really really (wrap test) hard",
+            type: 'concept_coach',
+            total_average: 0.56789,
+            attempted_average: 0.8,
+            average_actual_and_placeholder_exercise_count: 11
+          }
+        ],
+        students: []
       }
     ]
   end


### PR DESCRIPTION
In cases where periods don't have students, the scores export was generated but it blew up with a circular reference error when opened in Excel.  This PR adds a blank entry in the report so that the formulas don't freak out.

![screenshot 2016-07-05 21 44 59](https://cloud.githubusercontent.com/assets/1001691/16607963/8e0142bc-42fb-11e6-965c-a88c5c8d1094.png)

![screenshot 2016-07-05 21 53 30](https://cloud.githubusercontent.com/assets/1001691/16607965/93d7c5e4-42fb-11e6-88ab-ff65685d5688.png)
