### PR TITLE
Add debugging info for external assistant bug

### DIFF
--- a/app/subsystems/tasks/assistants/external_assignment_assistant.rb
+++ b/app/subsystems/tasks/assistants/external_assignment_assistant.rb
@@ -22,7 +22,12 @@ class Tasks::Assistants::ExternalAssignmentAssistant < Tasks::Assistants::Generi
 
     roles.map do |role|
       student = role_students[role.id]
-      raise StandardError, 'External assignment taskees must all be students' if student.nil?
+
+      if student.nil?
+        raise StandardError, "External assignment taskees must all be students, " \
+                             "plan: #{task_plan.id}, bad role id: #{role.id}, all " \
+                             "role ids: #{role_ids.inspect}"
+      end
 
       build_external_task(role: role, student: student)
     end

--- a/spec/subsystems/tasks/assistants/external_assignment_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/external_assignment_assistant_spec.rb
@@ -77,6 +77,6 @@ RSpec.describe Tasks::Assistants::ExternalAssignmentAssistant, type: :assistant 
     expect {
       DistributeTasks.call(task_plan_2)
     }.to raise_error(StandardError).with_message(
-      'External assignment taskees must all be students')
+      /External assignment taskees must all be students/)
   end
 end


### PR DESCRIPTION
We're getting a lot of exceptions for `External assignment taskees must all be students` and external assignments don't seem to be publishing, at least in a particular class.

This PR adds some debugging information.