### PR TITLE
add lo:uuid tags to exercises during import if no other LOs

### DIFF
--- a/spec/subsystems/content/routines/import_exercises_spec.rb
+++ b/spec/subsystems/content/routines/import_exercises_spec.rb
@@ -168,4 +168,96 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
     end
   end
 
+  context 'adding lo:uuid tags' do
+    before(:all) do
+      DatabaseCleaner.start
+
+      chapter = FactoryGirl.create :content_chapter
+      @ecosystem = chapter.book.ecosystem
+
+      cnx_page = OpenStax::Cnx::V1::Page.new(id: '0e58aa87-2e09-40a7-8bf3-269b2fa16509',
+                                             title: 'Acceleration')
+
+      @page = VCR.use_cassette('Content_Routines_ImportExercises/with_custom_tags', VCR_OPTS) do
+        Content::Routines::ImportPage[cnx_page: cnx_page, chapter: chapter,
+                                      number: 2, book_location: [3, 1]]
+      end
+    end
+
+    after(:all) { DatabaseCleaner.clean }
+
+    it 'adds an lo:uuid tag when there are no LOs or APLOs' do
+      stub_exercise_query([{tags: ['some-id-tag']}])
+      described_class.call(ecosystem: @ecosystem, page: @page, query_hash: {tags: ['some-id-tag']})
+      exercise = Content::Models::Exercise.order(:created_at).last
+      expect(exercise.tags.map(&:value)).to include "lo:0e58aa87-2e09-40a7-8bf3-269b2fa16509"
+      expect(exercise.tags.map(&:tag_type)).to include "lo"
+      expect(exercise.los.first.value).to eq "lo:0e58aa87-2e09-40a7-8bf3-269b2fa16509"
+    end
+
+    it 'does not add an lo:uuid tag when there is an LO' do
+      stub_exercise_query([{tags: ['some-id-tag', 'lo:stax-phys:1-2-3']}])
+      described_class.call(ecosystem: @ecosystem, page: @page, query_hash: {tags: ['some-id-tag']})
+      exercise = Content::Models::Exercise.order(:created_at).last
+      expect(exercise.tags.map(&:value)).not_to include "lo:0e58aa87-2e09-40a7-8bf3-269b2fa16509"
+    end
+
+    it 'does not add an lo:uuid tag when there is an APLO' do
+      stub_exercise_query([{tags: ['some-id-tag', 'aplo:stax-bio:4-5-6']}])
+      described_class.call(ecosystem: @ecosystem, page: @page, query_hash: {tags: ['some-id-tag']})
+      exercise = Content::Models::Exercise.order(:created_at).last
+      expect(exercise.tags.map(&:value)).not_to include "lo:0e58aa87-2e09-40a7-8bf3-269b2fa16509"
+    end
+  end
+
+  context 'MutableWrapper' do
+    it "can add LOs" do
+      original_lo = 'lo:stax-phys:1-2-3'
+      original_lo_hash = {value: original_lo, name: nil, type: :lo}
+
+      new_lo = 'lo:somethingrandom'
+      new_lo_hash = {value: new_lo, name: nil, type: :lo}
+
+      hash = OpenStax::Exercises::V1.fake_client.new_exercise_hash(tags: [original_lo])
+      exercise = OpenStax::Exercises::V1::Exercise.new(content: hash.to_json)
+      mutable = described_class::MutableWrapper.new(exercise)
+
+      expect(mutable.los).to eq [original_lo]
+      expect(mutable.tags).to eq [original_lo]
+      expect(mutable.import_tags).to eq [original_lo]
+      expect(mutable.tag_hashes).to eq [original_lo_hash]
+      expect(mutable.lo_hashes).to eq [original_lo_hash]
+      expect(mutable.import_tag_hashes).to eq [original_lo_hash]
+
+      mutable.add_lo(new_lo)
+
+      expect(mutable.los).to eq [original_lo, new_lo]
+      expect(mutable.tags).to eq [original_lo, new_lo]
+      expect(mutable.import_tags).to eq [original_lo, new_lo]
+
+      expect(mutable.tag_hashes).to eq [original_lo_hash, new_lo_hash]
+      expect(mutable.lo_hashes).to eq [original_lo_hash, new_lo_hash]
+      expect(mutable.import_tag_hashes).to eq [original_lo_hash, new_lo_hash]
+    end
+
+  end
+
+  def stub_exercise_query(array_of_exercise_options={})
+    wrappers = array_of_exercise_options.map.with_index do |exercise_options, index|
+      content_hash = OpenStax::Exercises::V1.fake_client.new_exercise_hash.tap do |hash|
+        exercise_options.each do |key, value|
+          hash[key] = value
+        end
+        hash[:number] = index + 1
+        hash[:version] = 1
+      end
+
+      OpenStax::Exercises::V1::Exercise.new(content: content_hash.to_json)
+    end
+
+    expect(OpenStax::Exercises::V1).to receive(:exercises) do |*args|
+      { 'items' => wrappers }
+    end.once
+  end
+
 end


### PR DESCRIPTION
Some exercises, e.g. those imported from Quadbase, don't have LOs.  Biglearn needs LOs.  Kevin has modified Biglearn to handle an LO of form `lo:whatever`.  This PR adds `lo:page_uuid` during import to all exercises that don't have another LO.

Notes on where LOs are pulled later in the codebase:

1. Calls to create Biglearn exercises use `Content::Models::Exercise#tags` which the specs show is populated with the new LO.  
2. The `FragmentAssistant` uses `Content::Models::Exercise#los` which the specs show is populated with the new LO.
3. One of the content visitors looks to get LOs directly from the JSON, and those won't have the new LO (because we don't jam it into the underlying content, we just make `Content::Models::Tag`s for it).
4. The `ExerciseRepresenter` does spit out the raw content, but it also has a separate `tags` collection which should have the new LO.