### PR TITLE
Allow dropped students to be assigned external assignments

### DIFF
--- a/spec/routines/individualize_tasking_plans_spec.rb
+++ b/spec/routines/individualize_tasking_plans_spec.rb
@@ -123,6 +123,11 @@ RSpec.describe IndividualizeTaskingPlans, type: :routine do
 
       expect(result).to be_empty
     end
+
+    it 'does not create tasking plans for dropped students' do
+      CourseMembership::InactivateStudent[student: student_role_2.student]
+      expect(result.first.target_id).to eq student_role_1.id
+    end
   end
 
 end


### PR DESCRIPTION
External assignments must be assigned to students only, because we sometimes use a student's `deidentifier` field in the contents of the assignment.  The previous implementation required that the assignments be assigned to active (non-dropped) students, but there is no real justification for this requirement in the context of what we do when building external assignments, so this PR allows dropped students, too.  External callers can choose whether or not to assign to dropped students -- it isn't the responsibility of the `ExternalAssignmentAssistant` to make that call.

The above change, while meaningful in itself, helps us get around a problem with older student data.  Prior to our use of `acts_as_paranoid` everywhere, we had an `inactive_at` field just on `CourseMembership::Models::Student`, but importantly no similar field on the related `Enrollment` record.  When we moved to `acts_as_paranoid`, `Student` and `Enrollment` got new `deleted_at` fields and `Student`'s new `deleted_at` field got the former contents of the `inactive_at` field.  When we made this change, we probably should have migrated the `Enrollment` records to have their `deleted_at` field initialized for all students that had been previously inactivated, but we didn't.  The result is that students that were dropped prior to the `acts_as_paranoid` transition have a populated `deleted_at` but those record's related `Enrollment` records do not.  Since the code that distributes tasks gets at taskees via active enrollments, and even though it attempts to get non-dropped enrollments, it can pick up students that were dropped.  

So this PR, while an improvement on doing only what is necessary for this class to function, also has the nice side effect of fixing a problem on QA.