### PR TITLE
Make specs more resilient to ordering errors

### DIFF
--- a/app/routines/import_salesforce_course.rb
+++ b/app/routines/import_salesforce_course.rb
@@ -1,7 +1,7 @@
 class ImportSalesforceCourse
   lev_routine
 
-  uses_routine CreateCourse
+  uses_routine CreateCourse, translations: { outputs: {type: :verbatim} }
   uses_routine SchoolDistrict::GetSchool, as: :get_school
   uses_routine SchoolDistrict::CreateSchool, as: :create_school
   uses_routine CourseContent::AddEcosystemToCourse, as: :set_ecosystem

--- a/spec/controllers/api/v1/cc/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/cc/tasks_controller_spec.rb
@@ -5,8 +5,6 @@ require 'database_cleaner'
 RSpec.describe Api::V1::Cc::TasksController, type: :controller, api: true, version: :v1 do
 
   before(:all) do
-    DatabaseCleaner.start
-
     chapter = FactoryGirl.create :content_chapter
     cnx_page = OpenStax::Cnx::V1::Page.new(id: '7636a3bf-eb80-4898-8b2c-e81c1711b99f',
                                            title: 'Sample module 2')
@@ -54,10 +52,6 @@ RSpec.describe Api::V1::Cc::TasksController, type: :controller, api: true, versi
                                          application: application,
                                          resource_owner_id: nil
     @anon_user_token = nil
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   def show_api_call(token, cnx_book_id: @book.uuid, cnx_page_id: @page.uuid)

--- a/spec/controllers/api/v1/course_exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/course_exercises_controller_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe Api::V1::CourseExercisesController, type: :controller, api: true,
 
   context 'with a real book' do
     before(:all) do
-      DatabaseCleaner.start
-
       VCR.use_cassette('Api_V1_CourseExercisesController/with_book', VCR_OPTS) do
         @ecosystem = FetchAndImportBookAndCreateEcosystem[
           book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -31,10 +29,6 @@ RSpec.describe Api::V1::CourseExercisesController, type: :controller, api: true,
     before(:each) do
       CourseContent::AddEcosystemToCourse.call(course: course, ecosystem: @ecosystem)
       AddUserAsCourseTeacher.call(course: course, user: user_1)
-    end
-
-    after(:all) do
-      DatabaseCleaner.clean
     end
 
     describe '#show' do

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -718,8 +718,6 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                                                resource_owner_id: teacher_user.id }
 
     before(:all)         do
-      DatabaseCleaner.start
-
       @book = FactoryGirl.create :content_book
       @chapter_1 = FactoryGirl.create :content_chapter, book: @book, book_location: [1]
       @chapter_2 = FactoryGirl.create :content_chapter, book: @book, book_location: [2]
@@ -792,10 +790,6 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
       @task_5 = GetConceptCoach[
         user: student_user_2, cnx_book_id: @book.uuid, cnx_page_id: @page_2.uuid
       ]
-    end
-
-    after(:all) do
-      DatabaseCleaner.clean
     end
 
     context 'anonymous' do

--- a/spec/controllers/api/v1/ecosystems_controller_spec.rb
+++ b/spec/controllers/api/v1/ecosystems_controller_spec.rb
@@ -140,8 +140,6 @@ RSpec.describe Api::V1::EcosystemsController, type: :controller, api: true,
 
   context 'with a real book' do
     before(:all) do
-      DatabaseCleaner.start
-
       VCR.use_cassette("Api_V1_EcosystemsController/with_book", VCR_OPTS) do
         @ecosystem = FetchAndImportBookAndCreateEcosystem[
           book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -152,10 +150,6 @@ RSpec.describe Api::V1::EcosystemsController, type: :controller, api: true,
     before(:each) do
       CourseContent::AddEcosystemToCourse.call(course: course, ecosystem: @ecosystem)
       AddUserAsCourseTeacher.call(course: course, user: user_1)
-    end
-
-    after(:all) do
-      DatabaseCleaner.clean
     end
 
     describe "#exercises" do

--- a/spec/controllers/api/v1/pages_controller_spec.rb
+++ b/spec/controllers/api/v1/pages_controller_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
 
   context 'with book' do
     before(:all) do
-      DatabaseCleaner.start
-
       VCR.use_cassette("Api_V1_PagesController/with_book", VCR_OPTS) do
         @ecosystem = FetchAndImportBookAndCreateEcosystem[
           book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -15,10 +13,6 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
       end
 
       @page_uuid = '95e61258-2faf-41d4-af92-f62e1414175a'
-    end
-
-    after(:all) do
-      DatabaseCleaner.clean
     end
 
     it 'returns not found if the version is not found' do

--- a/spec/controllers/api/v1/performance_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/performance_reports_controller_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
 
   context 'with book' do
     before(:all) do
-      DatabaseCleaner.start
-
       VCR.use_cassette("Api_V1_PerformanceReportsController/with_book", VCR_OPTS) do
         @ecosystem = FetchAndImportBookAndCreateEcosystem[
           book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -21,10 +19,6 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
 
     before(:each) do
       CourseContent::AddEcosystemToCourse.call(course: course, ecosystem: @ecosystem)
-    end
-
-    after(:all) do
-      DatabaseCleaner.clean
     end
 
     describe '#index' do

--- a/spec/factories/tasks/assistants.rb
+++ b/spec/factories/tasks/assistants.rb
@@ -1,8 +1,27 @@
-require_relative '../../mocks/assistants/dummy_assistant'
-
 FactoryGirl.define do
   factory :tasks_assistant, class: '::Tasks::Models::Assistant' do
     name { Faker::Name.name }
-    code_class_name "DummyAssistant"
+    code_class_name { Faker::App.name.gsub(/[ \-]/,'') }
+
+    after(:build) do |assistant, evaluator|
+
+      begin
+        # define the code class so it exists; check to make sure
+        # it doesn't exist first
+        klass = Module.const_get(assistant.code_class_name)
+      rescue NameError
+        # doesn't exist, make it
+        Object.const_set(assistant.code_class_name, Class.new {
+          def self.schema
+            "{}"
+          end
+
+          def build_tasks
+            roles.map{ build_task(type: :external, default_title: 'Dummy') }
+          end
+        })
+      end
+
+    end
   end
 end

--- a/spec/lib/openstax/biglearn/v1/real_client_spec.rb
+++ b/spec/lib/openstax/biglearn/v1/real_client_spec.rb
@@ -12,8 +12,6 @@ module OpenStax::Biglearn
 
     context 'with users and pools' do
       before(:all) do
-        DatabaseCleaner.start
-
         biglearn_configuration = OpenStax::Biglearn::V1::Configuration.new
         biglearn_configuration.server_url = 'https://biglearn-dev.openstax.org/'
 
@@ -102,10 +100,6 @@ module OpenStax::Biglearn
 
         use_real_client ? OpenStax::Exchange.use_real_client : OpenStax::Exchange.use_fake_client
         OpenStax::Exchange.reset!
-      end
-
-      after(:all) do
-        DatabaseCleaner.clean
       end
 
       context 'post facts_questions API' do

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
 
   context 'with parts of k12phys' do
     before(:all) do
-      DatabaseCleaner.start
-
       cnx_page_infos = [
         {
           id: '3005b86b-d993-4048-aff0-500256001f42',
@@ -139,7 +137,6 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
         end
       end
     end
-    after(:all)  { DatabaseCleaner.clean }
 
     it 'provides info about the page for the given hash' do
       @hashes_with_pages.each do |hash, page|
@@ -194,13 +191,11 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
 
   context 'with The Scientific Method' do
     before(:all) do
-      DatabaseCleaner.start
       page_info = { id: '9545b9a2-c371-4a31-abb9-3a4a1fff497b@8', title: 'The Scientific Method' }
       @page = VCR.use_cassette('OpenStax_Cnx_V1_Page/with_The_Scientific_Method', VCR_OPTS) do
         page_for(page_info).tap{ |page| page.full_hash }
       end
     end
-    after(:all)  { DatabaseCleaner.clean }
 
     it 'extracts snap lab notes' do
       snap_labs = @page.snap_lab_nodes

--- a/spec/lib/tasks/demo_spec.rb
+++ b/spec/lib/tasks/demo_spec.rb
@@ -5,11 +5,7 @@ require 'tasks/demo/tasks'
 require 'tasks/demo/work'
 require 'tasks/demo/show'
 
-RSpec.describe Demo, type: :request, version: :v1, speed: :slow, vcr: VCR_OPTS do
-  # Transactional fixtures are not compatible with multiple processes
-  self.use_transactional_fixtures = false
-
-  after(:all) { DatabaseCleaner.clean_with :truncation }
+RSpec.describe Demo, type: :request, version: :v1, speed: :slow, truncation: true, vcr: VCR_OPTS do
 
   context 'with the stable book version' do
     it "doesn't catch on fire" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,20 +67,24 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before(:each) do
+  config.before(:all) do
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, :js => true) do
+  config.before(:all, js: true) do
     DatabaseCleaner.strategy = :truncation
   end
 
-  config.before(:each, type: :request) do
+  config.before(:all, type: :request) do
     DatabaseCleaner.strategy = :truncation
   end
 
-  config.before(:each, truncation: true) do
+  config.before(:all, truncation: true) do
     DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:all) do
+    DatabaseCleaner.start
   end
 
   config.before(:each) do
@@ -91,6 +95,10 @@ RSpec.configure do |config|
   #   "It's also recommended to use append_after to ensure DatabaseCleaner.clean
   #    runs after the after-test cleanup capybara/rspec installs."
   config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
+
+  config.append_after(:all) do
     DatabaseCleaner.clean
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,7 +43,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -60,14 +60,39 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.before(:suite) do
-    # Erase the test database with truncation
-    DatabaseCleaner.clean_with :truncation
+  # Use DatabaseCleaner instead of rspec transaction rollbacks
+  # http://tomdallimore.com/blog/taking-the-test-trash-out-with-databasecleaner-and-rspec/
 
-    # From now on, use the transaction strategy
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
     DatabaseCleaner.strategy = :transaction
   end
 
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each, type: :request) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each, truncation: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  # https://github.com/DatabaseCleaner/database_cleaner#rspec-with-capybara-example says:
+  #   "It's also recommended to use append_after to ensure DatabaseCleaner.clean
+  #    runs after the after-test cleanup capybara/rspec installs."
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
 end
 
 # Adds a convenience method to get interpret the body as JSON and convert to a hash;

--- a/spec/representers/api/v1/concept_coach_stats_representer_spec.rb
+++ b/spec/representers/api/v1/concept_coach_stats_representer_spec.rb
@@ -4,8 +4,6 @@ require 'vcr_helper'
 RSpec.describe Api::V1::ConceptCoachStatsRepresenter, type: :representer, speed: :medium do
 
   before(:all) do
-    DatabaseCleaner.start
-
     ecosystem = VCR.use_cassette('Api_V1_ConceptCoachStatsRepresenter/with_book', VCR_OPTS) do
       OpenStax::Cnx::V1.with_archive_url('https://archive.cnx.org/') do
         FetchAndImportBookAndCreateEcosystem[book_cnx_id: 'f10533ca-f803-490d-b935-88899941197f']
@@ -41,8 +39,6 @@ RSpec.describe Api::V1::ConceptCoachStatsRepresenter, type: :representer, speed:
       end
     end
   end
-
-  after(:all) { DatabaseCleaner.clean }
 
   it "represents concept coach stats" do
     task_step = @tasks.first.task_steps.select{ |ts| ts.tasked.exercise? }.first

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -6,8 +6,6 @@ describe CalculateTaskStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
   before(:all) do
     @number_of_students = 8
 
-    DatabaseCleaner.start
-
     begin
       RSpec::Mocks.setup
 
@@ -22,10 +20,6 @@ describe CalculateTaskStats, type: :routine, speed: :slow, vcr: VCR_OPTS do
     ensure
       RSpec::Mocks.teardown
     end
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   context "with an unworked plan" do

--- a/spec/routines/create_period_spec.rb
+++ b/spec/routines/create_period_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe CreatePeriod do
                           })
                           .map(&:id) }
 
-  before(:all) { DatabaseCleaner.start }
-  after(:all) { DatabaseCleaner.clean }
-
   it 'copies existing "coursewide" task plans to the new period' do
     Timecop.freeze do
       expected = FactoryGirl.build(:tasks_task_plan, owner: course, num_tasking_plans: 0)

--- a/spec/routines/export_and_upload_research_data_spec.rb
+++ b/spec/routines/export_and_upload_research_data_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe ExportAndUploadResearchData, type: :routine do
 
   context 'with book' do
     before(:all) do
-      DatabaseCleaner.start
-
       VCR.use_cassette("Api_V1_PerformanceReportsController/with_book", VCR_OPTS) do
         @ecosystem = FetchAndImportBookAndCreateEcosystem[
           book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -51,10 +49,6 @@ RSpec.describe ExportAndUploadResearchData, type: :routine do
                                  students: [student_1, student_2, student_3, student_4],
                                  ecosystem: @ecosystem]
       end
-
-    after(:all) do
-      DatabaseCleaner.clean
-    end
 
     it 'exports research data as a csv file' do
       # We replace the uploading of the research data with the test case itself

--- a/spec/routines/get_cc_dashboard_spec.rb
+++ b/spec/routines/get_cc_dashboard_spec.rb
@@ -4,8 +4,6 @@ require 'vcr_helper'
 describe GetCcDashboard, type: :routine do
 
   before(:all) do
-    DatabaseCleaner.start
-
     @course   = CreateCourse[name: 'Biology 101', is_concept_coach: true]
     @period   = CreatePeriod[course: @course]
     @period_2 = CreatePeriod[course: @course]
@@ -60,8 +58,6 @@ describe GetCcDashboard, type: :routine do
 
     AddEcosystemToCourse[ecosystem: ecosystem, course: @course]
   end
-
-  after(:all) { DatabaseCleaner.clean }
 
   context 'without any work' do
     it "still returns period info for teachers" do

--- a/spec/routines/get_concept_coach_spec.rb
+++ b/spec/routines/get_concept_coach_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe GetConceptCoach, type: :routine, speed: :medium do
   end
 
   before(:all) do
-    DatabaseCleaner.start
-
     ecosystem = VCR.use_cassette('GetConceptCoach/with_book', VCR_OPTS) do
       OpenStax::Cnx::V1.with_archive_url('https://archive.cnx.org/') do
         FetchAndImportBookAndCreateEcosystem[book_cnx_id: 'f10533ca-f803-490d-b935-88899941197f']
@@ -52,10 +50,6 @@ RSpec.describe GetConceptCoach, type: :routine, speed: :medium do
 
     AddUserAsPeriodStudent[user: @user_1, period: period]
     AddUserAsPeriodStudent[user: @user_2, period: period]
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   context 'no existing task' do

--- a/spec/routines/get_history_spec.rb
+++ b/spec/routines/get_history_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe GetHistory, type: :routine, speed: :slow do
   before(:all) do
-    DatabaseCleaner.start
-
     homework_assistant = FactoryGirl.create(
       :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
     )
@@ -67,8 +65,6 @@ describe GetHistory, type: :routine, speed: :slow do
     @homework_task_3 = homework_plan_3.tasks.joins(:taskings)
                                             .find_by(taskings: {entity_role_id: @role.id})
   end
-
-  after(:all) { DatabaseCleaner.clean }
 
   let(:correct_total_count)   { correct_tasks.size }
 

--- a/spec/routines/get_student_guide_spec.rb
+++ b/spec/routines/get_student_guide_spec.rb
@@ -5,7 +5,6 @@ require 'database_cleaner'
 RSpec.describe GetStudentGuide, type: :routine do
 
   before(:all) do
-    DatabaseCleaner.start
     @course = FactoryGirl.create :entity_course
 
     @period = CreatePeriod[course: @course]
@@ -24,10 +23,6 @@ RSpec.describe GetStudentGuide, type: :routine do
         CreateStudentHistory[course: @course, roles: [@role, @second_role]]
       end
     end
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   it 'gets the completed task step counts for the role' do

--- a/spec/routines/get_teacher_guide_spec.rb
+++ b/spec/routines/get_teacher_guide_spec.rb
@@ -5,7 +5,6 @@ require 'database_cleaner'
 RSpec.describe GetTeacherGuide, type: :routine do
 
   before(:all) do
-    DatabaseCleaner.start
     @course = FactoryGirl.create :entity_course
 
     @period = CreatePeriod[course: @course]
@@ -24,10 +23,6 @@ RSpec.describe GetTeacherGuide, type: :routine do
         CreateStudentHistory[course: @course, roles: [@role, @second_role]]
       end
     end
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   it 'returns all course guide periods for teachers' do

--- a/spec/routines/import_salesforce_course_spec.rb
+++ b/spec/routines/import_salesforce_course_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ImportSalesforceCourse, type: :routine do
     candidate = new_osa(book_name: "jimmy", product: "Concept Coach",
                         school: "Rice", account_type: "College/University (4)")
 
-    outputs = described_class[candidate: candidate]
+    outputs = described_class.call(candidate: candidate).outputs
 
     expect(candidate.error).to be_nil
     expect(candidate.num_students).to eq 0
@@ -18,7 +18,7 @@ RSpec.describe ImportSalesforceCourse, type: :routine do
     expect(candidate.num_sections).to eq 0
     expect(candidate.teacher_join_url).to match /http.*\/teach\/[a-f0-9]+\/DO_NOT/
 
-    course = Entity::Course.first
+    course = outputs.course
 
     expect(course.profile.name).to eq "Yo"
     expect(course.profile.school.name).to eq "Rice"

--- a/spec/routines/import_salesforce_courses_spec.rb
+++ b/spec/routines/import_salesforce_courses_spec.rb
@@ -77,13 +77,18 @@ RSpec.describe ImportSalesforceCourses, type: :routine do
 
     expect(sf_record).to receive(:save)
 
+    before_course_ids = Entity::Course.all.map(&:id)
+
     result = nil
     expect {
       result = ImportSalesforceCourses.call
     }.to change{Entity::Course.count}.by(1)
      .and change{Salesforce::Models::AttachedRecord.count}.by(1)
 
-    created_course = Entity::Course.first
+    after_course_ids = Entity::Course.all.map(&:id)
+    new_course_id = (after_course_ids - before_course_ids).first
+
+    created_course = Entity::Course.find(new_course_id)
 
     expect(sf_record.course_id).to eq created_course.id
     expect(sf_record.created_at).to be_a String

--- a/spec/routines/update_clues_spec.rb
+++ b/spec/routines/update_clues_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe UpdateClues, type: :routine, vcr: VCR_OPTS do
                         '3c60e622-9b4f-4e32-97c7-9278f7199013']
 
   before(:all) do
-    DatabaseCleaner.start
-
     @course = FactoryGirl.create :entity_course
 
     @period = CreatePeriod[course: @course]
@@ -60,11 +58,7 @@ RSpec.describe UpdateClues, type: :routine, vcr: VCR_OPTS do
     @real_client = OpenStax::Biglearn::V1.use_real_client
   end
 
-  after(:all) do
-    OpenStax::Biglearn::V1.use_client_named(@original_client_name)
-
-    DatabaseCleaner.clean
-  end
+  after(:all) { OpenStax::Biglearn::V1.use_client_named(@original_client_name) }
 
   before(:each) do
     @original_cache = Rails.cache

--- a/spec/subsystems/content/models/page_spec.rb
+++ b/spec/subsystems/content/models/page_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Content::Models::Page, type: :model, vcr: VCR_OPTS do
   context 'with snap lab page' do
 
     before(:all) do
-      DatabaseCleaner.start
-
       snap_lab_page_content = VCR.use_cassette('Content_Models_Page/with_snap_lab_page',
                                                VCR_OPTS) do
         OpenStax::Cnx::V1::Page.new(id: '9545b9a2-c371-4a31-abb9-3a4a1fff497b@8').content
@@ -24,8 +22,6 @@ RSpec.describe Content::Models::Page, type: :model, vcr: VCR_OPTS do
       @snap_lab_page = FactoryGirl.create :content_page, content: snap_lab_page_content,
                                                          fragments: nil, snap_labs: nil
     end
-
-    after(:all) { DatabaseCleaner.clean }
 
     it 'caches fragments' do
       expect(@snap_lab_page).not_to receive(:parser)

--- a/spec/subsystems/content/routines/import_exercises_spec.rb
+++ b/spec/subsystems/content/routines/import_exercises_spec.rb
@@ -125,8 +125,6 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
     end
 
     before(:all) do
-      DatabaseCleaner.start
-
       chapter = FactoryGirl.create :content_chapter
 
       @ecosystem = chapter.book.ecosystem
@@ -139,8 +137,6 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
                                       number: 2, book_location: [3, 1]]
       end
     end
-
-    after(:all) { DatabaseCleaner.clean }
 
     before do
       expect(OpenStax::Exercises::V1).to receive(:exercises) do |*args|
@@ -170,8 +166,6 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
 
   context 'adding lo:uuid tags' do
     before(:all) do
-      DatabaseCleaner.start
-
       chapter = FactoryGirl.create :content_chapter
       @ecosystem = chapter.book.ecosystem
 
@@ -183,8 +177,6 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
                                       number: 2, book_location: [3, 1]]
       end
     end
-
-    after(:all) { DatabaseCleaner.clean }
 
     it 'adds an lo:uuid tag when there are no LOs or APLOs' do
       stub_exercise_query([{tags: ['some-id-tag']}])
@@ -212,8 +204,6 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
 
   context 'incoming free response exercises' do
     before(:all) do
-      DatabaseCleaner.start
-
       chapter = FactoryGirl.create :content_chapter
       @ecosystem = chapter.book.ecosystem
 
@@ -225,8 +215,6 @@ RSpec.describe Content::Routines::ImportExercises, type: :routine, speed: :slow,
                                       number: 2, book_location: [3, 1]]
       end
     end
-
-    after(:all) { DatabaseCleaner.clean }
 
     it 'skips import of any exercise with no answers' do
       stub_exercise_query([{tags: ['some-id-tag'], remove_answers: true}])

--- a/spec/subsystems/course_content/update_exercise_exclusions_spec.rb
+++ b/spec/subsystems/course_content/update_exercise_exclusions_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe CourseContent::UpdateExerciseExclusions, type: :routine do
 
   context 'with a real book' do
     before(:all) do
-      DatabaseCleaner.start
-
       VCR.use_cassette('CourseContent_UpdateExerciseExclusions/with_book', VCR_OPTS) do
         @ecosystem = FetchAndImportBookAndCreateEcosystem[
           book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -19,10 +17,6 @@ RSpec.describe CourseContent::UpdateExerciseExclusions, type: :routine do
 
     before(:each) do
       CourseContent::AddEcosystemToCourse.call(course: course, ecosystem: @ecosystem)
-    end
-
-    after(:all) do
-      DatabaseCleaner.clean
     end
 
     let(:exercise) { @ecosystem.exercises.first }

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -6,14 +6,8 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
                                                      vcr: VCR_OPTS do
 
   before(:all) do
-    DatabaseCleaner.start
-
     @assistant = \
       FactoryGirl.create(:tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant')
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   context "for Introduction and Force" do

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -6,14 +6,8 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
                                                      vcr: VCR_OPTS do
 
   before(:all) do
-    DatabaseCleaner.start
-
     @assistant = \
       FactoryGirl.create(:tasks_assistant, code_class_name: 'Tasks::Assistants::IReadingAssistant')
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   context "for Introduction and Force" do

--- a/spec/subsystems/tasks/export_performance_report_spec.rb
+++ b/spec/subsystems/tasks/export_performance_report_spec.rb
@@ -4,8 +4,6 @@ require 'vcr_helper'
 RSpec.describe Tasks::ExportPerformanceReport, type: :routine, speed: :slow do
 
   before(:all) do
-    DatabaseCleaner.start
-
     VCR.use_cassette("Tasks_ExportPerformanceReport/with_book", VCR_OPTS) do
       @ecosystem = FetchAndImportBookAndCreateEcosystem[
         book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -21,10 +19,6 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine, speed: :slow do
 
   after(:each) do
     File.delete(@output_filename) if !@output_filename.nil? && File.exist?(@output_filename)
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   it 'does not blow up' do

--- a/spec/subsystems/tasks/get_cc_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_cc_performance_report_spec.rb
@@ -4,8 +4,6 @@ require 'vcr_helper'
 RSpec.describe Tasks::GetCcPerformanceReport, type: :routine, speed: :slow do
 
   before(:all) do
-    DatabaseCleaner.start
-
     VCR.use_cassette("Tasks_GetCcPerformanceReport/with_book", VCR_OPTS) do
       @ecosystem = FetchAndImportBookAndCreateEcosystem[
         book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
@@ -39,10 +37,6 @@ RSpec.describe Tasks::GetCcPerformanceReport, type: :routine, speed: :slow do
 
   after(:each) do
     File.delete(@output_filename) if !@output_filename.nil? && File.exist?(@output_filename)
-  end
-
-  after(:all) do
-    DatabaseCleaner.clean
   end
 
   let(:expected_periods)   { 2 }


### PR DESCRIPTION
Fixes some irregular errors due to ordering of specs.  Even with fixes that make the specs less reliant on things like `SomeRecord.first`, I was still getting intermittent and varying spec failures on full runs.  After reading around, decided to make more use of `DatabaseCleaner`, which resolved the issues.

