### PR TITLE
SF bug fix + reliability improvements

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -56,6 +56,14 @@ class Admin::CoursesController < Admin::BaseController
                 })
   end
 
+  def restore_salesforce
+    Salesforce::Models::AttachedRecord
+      .with_deleted
+      .find(params[:restore_salesforce][:attached_record_id])
+      .restore
+    redirect_to edit_admin_course_path(params[:id], anchor: "salesforce")
+  end
+
   def edit
     get_course_details
   end

--- a/app/handlers/admin/courses_remove_salesforce.rb
+++ b/app/handlers/admin/courses_remove_salesforce.rb
@@ -31,7 +31,12 @@ class Admin::CoursesRemoveSalesforce
 
     # Get rid of all the attached records
     existing_ars.each do |existing_ar|
-      existing_ar.destroy
+      case existing_ar.attached_to_class_name
+      when 'Entity::Course'
+        existing_ar.destroy
+      when 'CourseMembership::Models::Period'
+        existing_ar.really_destroy! # only need soft delete on course ARs
+      end
       transfer_errors_from(existing_ar, {type: :verbatim}, true)
     end
 

--- a/app/handlers/admin/courses_remove_salesforce.rb
+++ b/app/handlers/admin/courses_remove_salesforce.rb
@@ -29,18 +29,20 @@ class Admin::CoursesRemoveSalesforce
 
     fatal_error(code: :no_salesforce_matches_for_this_course) if existing_ars.none?
 
-    # All have the same SF object, so just pull from one
-    sf_object = existing_ars.first.salesforce_object
-
     # Get rid of all the attached records
     existing_ars.each do |existing_ar|
       existing_ar.destroy
       transfer_errors_from(existing_ar, {type: :verbatim}, true)
     end
 
-    # If that all went well, zero the stats on the SF object
-    sf_object.reset_stats
-    fatal_error(code: :could_not_clear_salesforce_stats) if !sf_object.save
+    # All have the same SF object, so just pull from one
+    sf_object = existing_ars.first.salesforce_object
+
+    # If that all went well, and SF object exists, zero the stats on the it
+    if sf_object.present?
+      sf_object.reset_stats
+      fatal_error(code: :could_not_clear_salesforce_stats) if !sf_object.save
+    end
   end
 
 end

--- a/app/routines/import_salesforce_courses.rb
+++ b/app/routines/import_salesforce_courses.rb
@@ -54,7 +54,8 @@ class ImportSalesforceCourses
   def candidate_class_size_records
     search_criteria = {
       concept_coach_approved: true,
-      course_id: nil
+      course_id: nil,
+      term_year: candidate_term_years_array
     }
 
     search_criteria[:school] = 'Denver University' if !include_real_salesforce_data?
@@ -65,12 +66,23 @@ class ImportSalesforceCourses
   def candidate_os_ancillary_records
     search_criteria = {
       status: Salesforce::Remote::OsAncillary::STATUS_APPROVED,
-      course_id: nil
+      course_id: nil,
+      term_year: candidate_term_years_array
     }
 
     search_criteria[:school] = 'Denver University' if !include_real_salesforce_data?
 
     Salesforce::Remote::OsAncillary.where(search_criteria).to_a
+  end
+
+  def candidate_term_years_array
+    array = (Settings::Salesforce.term_years_to_import || '').split(',').map(&:strip)
+
+    # An empty array means for us to not import anything (we are going to explicitly
+    # opt in to various TermYears).  Salesforce explodes for an empty array, and an
+    # array with a blank entry could catch SF objects that don't have a TermYear
+    # populated (not what we want); so use a bogus string to exclude any matches
+    array.empty? ? ['exclude all'] : array
   end
 
   def log(&block)

--- a/app/routines/update_salesforce_course_stats.rb
+++ b/app/routines/update_salesforce_course_stats.rb
@@ -95,7 +95,7 @@ class UpdateSalesforceCourseStats
 
         if course_sf_objects.none?
           notify("No Salesforce object available for period #{period.id} stats reporting",
-                 period: period.id)
+                 period: period.id, course: course.id)
           next
         end
 
@@ -117,7 +117,7 @@ class UpdateSalesforceCourseStats
 
         if eligible_sf_objects.many?
           notify("Multiple Salesforce records are eligible for to period #{period.id} stats reporting",
-                 period: period.id, eligible_sf_objects: eligible_sf_objects.map(&:id))
+                 period: period.id, course: course.id, eligible_sf_objects: eligible_sf_objects.map(&:id))
           next
         end
 
@@ -145,9 +145,11 @@ class UpdateSalesforceCourseStats
         end
 
       rescue Salesforce::OsAncillaryRenewalError => e
-        notify("Salesforce record renewal error for period #{period.id}: #{e.message}")
+        notify("Salesforce record renewal error for period #{period.id} " \
+               "of course #{course.id}: #{e.message}")
       rescue StandardError => e
-        notify("Error attaching Salesforce-orphaned period #{period.id}: #{e.class.name} - #{e.message}")
+        notify("Error attaching Salesforce-orphaned period #{period.id} " \
+               "of course #{course.id}: #{e.class.name} - #{e.message}")
       end
     end
   end

--- a/app/subsystems/salesforce/attached_record.rb
+++ b/app/subsystems/salesforce/attached_record.rb
@@ -17,6 +17,10 @@ module Salesforce
       @strategy.salesforce_object
     end
 
+    def salesforce_id
+      @strategy.salesforce_id
+    end
+
     def attached_to
       @strategy.attached_to
     end

--- a/app/subsystems/salesforce/models/attached_record.rb
+++ b/app/subsystems/salesforce/models/attached_record.rb
@@ -1,6 +1,8 @@
 module Salesforce
   module Models
     class AttachedRecord < Tutor::SubSystems::BaseModel
+      # recovering SF linkage info is hard if not impossible, so soft delete
+      acts_as_paranoid
 
       MAX_IDS_PER_REQUEST = 500
 

--- a/app/subsystems/salesforce/os_ancillary_renewal_error.rb
+++ b/app/subsystems/salesforce/os_ancillary_renewal_error.rb
@@ -1,0 +1,3 @@
+module Salesforce
+  class OsAncillaryRenewalError < StandardError; end
+end

--- a/app/subsystems/salesforce/remote/term_year.rb
+++ b/app/subsystems/salesforce/remote/term_year.rb
@@ -30,7 +30,9 @@ class Salesforce::Remote::TermYear
   end
 
   def self.from_string(string)
-    string.match(/20(\d\d) - (\d\d) (\w+)/)
+    string.match(/20(\d\d) - (\d\d) (\w+)/).tap do |match|
+      raise(ParseError, "Cannot parse '#{string}' as a TermYear") if match.nil?
+    end
 
     term = $3.downcase.to_sym
     start_year = "20#{$1}".to_i
@@ -68,5 +70,7 @@ class Salesforce::Remote::TermYear
   def dup
     self.class.new(start_year: start_year, term: term)
   end
+
+  class ParseError < StandardError; end
 
 end

--- a/app/subsystems/salesforce/renew_os_ancillary.rb
+++ b/app/subsystems/salesforce/renew_os_ancillary.rb
@@ -47,7 +47,11 @@ module Salesforce
               "#{new_os_ancillary.errors.full_messages.join(', ')}"
       end
 
-      new_os_ancillary
+      # Values in the OSA that are derived from other places in SF, e.g. `TermYear`,
+      # cannot be set when creating the record above.  Instead of manually setting them
+      # here, just reload the object from SF so that we know any derived fields are
+      # populated.
+      new_os_ancillary.reload
     end
   end
 

--- a/app/subsystems/salesforce/renew_os_ancillary.rb
+++ b/app/subsystems/salesforce/renew_os_ancillary.rb
@@ -54,6 +54,4 @@ module Salesforce
       new_os_ancillary.reload
     end
   end
-
-  class OsAncillaryRenewalError < StandardError; end
 end

--- a/app/subsystems/salesforce/strategies/direct/attached_record.rb
+++ b/app/subsystems/salesforce/strategies/direct/attached_record.rb
@@ -4,7 +4,7 @@ module Salesforce
       class AttachedRecord < Entity
 
         wraps ::Salesforce::Models::AttachedRecord
-        exposes :salesforce_object, :attached_to, :attached_to_class_name, :attached_to_id
+        exposes :salesforce_object, :salesforce_id, :attached_to, :attached_to_class_name, :attached_to_id
 
         def self.all
           models = ::Salesforce::Models::AttachedRecord.all

--- a/app/views/admin/courses/_salesforce.html.erb
+++ b/app/views/admin/courses/_salesforce.html.erb
@@ -16,12 +16,24 @@
 <%
   find_id = ->(tutor_record) {
     Salesforce::Models::AttachedRecord
+      .with_deleted
       .where(tutor_gid: tutor_record.to_global_id.to_s)
       .map(&:salesforce_id)
   }
 %>
 
-<% course_sf_object_ids = find_id.call(@course) %>
+<style type="text/css">
+  .deleted {
+    color: #aaa;
+    text-decoration: line-through;
+  }
+</style>
+
+<% course_ars = Salesforce::Models::AttachedRecord
+                  .with_deleted
+                  .where(tutor_gid: @course.to_global_id.to_s) %>
+
+<% available_course_sf_object_ids = course_ars.select{|car| !car.deleted? }.map(&:salesforce_id) %>
 
 <h4 style="margin-top:30px">Course Info</h4>
 
@@ -34,20 +46,32 @@
     </tr>
   </thead>
   <tbody>
-    <% course_sf_object_ids.each do |course_sf_object_id| %>
+    <% course_ars.each do |course_ar| %>
     <tr>
       <td></td>
-      <td><%= sf_linker.call(course_sf_object_id) %></td>
+      <td><%= sf_linker.call(course_ar.salesforce_id) %></td>
       <td>
-          <%= lev_form_for :remove_salesforce, url: remove_salesforce_admin_course_path(@course),
-                           method: :delete, html: {class: 'form-inline'} do |f| %>
-            <%= course_sf_object_id %>&nbsp;&nbsp;
-            <%= f.hidden_field :salesforce_id, value: course_sf_object_id %>
-            <%= f.submit 'Remove',
-                         class: 'btn btn-primary btn-xs',
-                         data: { confirm: 'Are you sure?  This will clear this record\'s stats, ' \
-                                          'and unlink any periods that are connected to it.',
-                                 disable_with: "Removing...".html_safe } %>
+          <span class="<%= 'deleted' if course_ar.deleted? %>"><%= course_ar.salesforce_id %></span>&nbsp;&nbsp;
+          <% if !course_ar.deleted? %>
+            <%= lev_form_for :remove_salesforce, url: remove_salesforce_admin_course_path(@course),
+                             method: :delete, html: {class: 'form-inline', style: 'display: inline'} do |f| %>
+
+              <%= f.hidden_field :salesforce_id, value: course_ar.salesforce_id %>
+              <%= f.submit 'Remove',
+                           class: 'btn btn-primary btn-xs',
+                           data: { confirm: 'Are you sure?  This will clear this record\'s stats, ' \
+                                            'and unlink any periods that are connected to it.',
+                                   disable_with: "Removing...".html_safe } %>
+            <% end %>
+          <% else %>
+            <%= lev_form_for :restore_salesforce, url: restore_salesforce_admin_course_path(@course),
+                             method: :put, html: {class: 'form-inline', style: 'display:inline'} do |f| %>
+
+              <%= f.hidden_field :attached_record_id, value: course_ar.id %>
+              <%= f.submit 'Restore',
+                           class: 'btn btn-primary btn-xs',
+                           data: { disable_with: "Restoring...".html_safe } %>
+            <% end %>
           <% end %>
       </td>
     </tr>
@@ -68,26 +92,36 @@
 
 <h4>Period Info</h4>
 
+<small>Grayed out means the period has been deleted / archived.</small>
+
 <table class='table table-striped'>
   <thead>
     <tr>
       <th style="width: 150px">Period</th>
+      <th>Created At</th>
+      <th>Deleted At</th>
       <th style="width: 300px">Link to SF</th>
       <th>Salesforce ID</th>
     </tr>
   </thead>
   <tbody>
-  <% @periods.each_with_index do |period,pp| %>
-    <% period_sf_object_id = find_id.call(period) %>
+  <% @periods.with_deleted.each_with_index do |period,pp| %>
+    <% period_sf_object_id = Salesforce::Models::AttachedRecord
+                               .where(tutor_gid: period.to_global_id.to_s).first.try(:salesforce_id) %>
     <tr>
-      <td><%= period.name %></td>
+      <td><span class="<%= 'deleted' if period.deleted? %>"><%= period.name %><span></td>
+      <td><small><%= period.created_at %></small></td>
+      <td><small><%= period.deleted_at %></small></td>
       <td><%= sf_linker.call(period_sf_object_id) %></td>
       <td>
           <%= lev_form_for :change_salesforce, url: change_salesforce_admin_period_path(period),
                            method: :put, html: {class: 'form-inline'} do |f| %>
 
             <%= f.select :salesforce_id,
-                         options_for_select(course_sf_object_ids.map{|csoid| [csoid, csoid]}, period_sf_object_id),
+                         options_for_select(
+                           available_course_sf_object_ids.map{|csoid| [csoid, csoid]},
+                           period_sf_object_id
+                         ),
                          { include_blank: true },
                          class: 'form-control',
                          id: "period_#{pp}_sf_select",

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -10,6 +10,7 @@ Settings::Db.store.defaults[:excluded_pool_uuid] = ''
 Settings::Db.store.defaults[:import_real_salesforce_courses] = false
 Settings::Db.store.defaults[:default_open_time] = '00:01'
 Settings::Db.store.defaults[:default_due_time] = '07:00'
+Settings::Db.store.defaults[:term_years_to_import] = ''
 
 Settings::Db.store.defaults[:biglearn_client] =
   case Rails.env

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
       import_real_salesforce_courses:
         name: 'Import real Salesforce courses?'
         help_block: 'Unchecked: limits to Denver University'
+      term_years_to_import:
+        name: 'Term years to import'
+        help_block: 'Comma-separated list of Salesforce-formatted term years, e.g. "2015 - 16 Spring, 2016 - 17 Fall", blank to disable import'
       default_open_time:
         name: 'Default task open time'
         help_block: 'In the format HH:MM'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
         post :teachers, controller: :teachers
         post :add_salesforce
         delete :remove_salesforce
+        put :restore_salesforce
       end
 
       post :bulk_update, on: :collection

--- a/db/migrate/20160726045753_add_deleted_at_to_attached_records.rb
+++ b/db/migrate/20160726045753_add_deleted_at_to_attached_records.rb
@@ -1,5 +1,6 @@
 class AddDeletedAtToAttachedRecords < ActiveRecord::Migration
   def change
     add_column :salesforce_attached_records, :deleted_at, :datetime
+    add_index :salesforce_attached_records, :deleted_at
   end
 end

--- a/db/migrate/20160726045753_add_deleted_at_to_attached_records.rb
+++ b/db/migrate/20160726045753_add_deleted_at_to_attached_records.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToAttachedRecords < ActiveRecord::Migration
+  def change
+    add_column :salesforce_attached_records, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160702071446) do
+ActiveRecord::Schema.define(version: 20160726045753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -499,6 +499,7 @@ ActiveRecord::Schema.define(version: 20160702071446) do
     t.string   "salesforce_id",         null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "deleted_at"
   end
 
   add_index "salesforce_attached_records", ["salesforce_id", "salesforce_class_name", "tutor_gid"], name: "salesforce_attached_record_tutor_gid", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -502,6 +502,7 @@ ActiveRecord::Schema.define(version: 20160726045753) do
     t.datetime "deleted_at"
   end
 
+  add_index "salesforce_attached_records", ["deleted_at"], name: "index_salesforce_attached_records_on_deleted_at", using: :btree
   add_index "salesforce_attached_records", ["salesforce_id", "salesforce_class_name", "tutor_gid"], name: "salesforce_attached_record_tutor_gid", unique: true, using: :btree
   add_index "salesforce_attached_records", ["tutor_gid"], name: "index_salesforce_attached_records_on_tutor_gid", using: :btree
 

--- a/lib/settings/salesforce.rb
+++ b/lib/settings/salesforce.rb
@@ -11,6 +11,14 @@ module Settings
         Settings::Db.store.import_real_salesforce_courses = bool
       end
 
+      def term_years_to_import
+        Settings::Db.store.term_years_to_import
+      end
+
+      def term_years_to_import=(string)
+        Settings::Db.store.term_years_to_import = string
+      end
+
     end
 
   end

--- a/spec/features/admin/edit_course_salesforce_spec.rb
+++ b/spec/features/admin/edit_course_salesforce_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Admin changing course Salesforce settings' do
   end
 
   context "when removing a course SF record" do
-    it "removes the same record from the relevant periods" do
+    before(:each) do
       sf_object = fake_sf_object(klass: Salesforce::Remote::OsAncillary, id: 'orig')
       FactoryGirl.create(:salesforce_attached_record, tutor_object: @course,
                                                       salesforce_object: sf_object)
@@ -71,10 +71,21 @@ RSpec.feature 'Admin changing course Salesforce settings' do
       go_to_salesforce_tab
 
       expect(page).to have_content(/orig.*orig/) # maybe not the best test, but meh...
+    end
+
+    it "removes the same record from the relevant periods" do
       expect {
         click_button 'Remove'
       }.to change{Salesforce::Models::AttachedRecord.count}.by(-2)
-      expect(page).not_to have_content 'orig'
+      expect(page).not_to have_content(/orig.*orig/) # should just be one 'orig' now
+    end
+
+    it "can be restored" do
+      click_button 'Remove'
+      expect(page).to have_content(/orig/)
+      expect{
+        click_button 'Restore'
+      }.to change{Salesforce::Models::AttachedRecord.count}.by(1)
     end
   end
 

--- a/spec/handlers/admin/courses_remove_salesforce_spec.rb
+++ b/spec/handlers/admin/courses_remove_salesforce_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe Admin::CoursesRemoveSalesforce, type: :handler do
     expect(fake_sf_object_2.num_students).to eq 38
   end
 
+  it 'does not explode if the SF object is no longer in SF' do
+    disable_sfdc_client
+
+    FactoryGirl.create(:salesforce_attached_record,
+                       tutor_object: course,
+                       salesforce_class_name: "Salesforce::Remote::ClassSize",
+                       salesforce_id: "something",
+                       salesforce_object: nil)
+
+    allow(Salesforce::Remote::ClassSize).to receive(:find).with("something") { nil }
+
+    expect{
+      call(course_id: course.id, salesforce_id: 'something')
+    }.not_to raise_error
+  end
+
   it "can find the methods it needs in potential SF object classes" do
     # Have this check since we're mostly otherwise stubbing these classes
     [Salesforce::Remote::OsAncillary, Salesforce::Remote::ClassSize].each do |sf_class|

--- a/spec/handlers/admin/courses_remove_salesforce_spec.rb
+++ b/spec/handlers/admin/courses_remove_salesforce_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe Admin::CoursesRemoveSalesforce, type: :handler do
     expect(Salesforce::Models::AttachedRecord.all.map(&:tutor_gid))
       .to contain_exactly(course.to_global_id.to_s, period_2.to_global_id.to_s)
 
+    # Course AR should be soft deleted, period AR should be really deleted
+    expect(Salesforce::Models::AttachedRecord.with_deleted.all.map(&:tutor_gid))
+      .to contain_exactly(course.to_global_id.to_s, course.to_global_id.to_s,
+                          period_2.to_global_id.to_s)
+
     expect(fake_sf_object_1.num_students).to eq 0
     expect(fake_sf_object_2.num_students).to eq 38
   end

--- a/spec/routines/update_salesforce_course_stats_spec.rb
+++ b/spec/routines/update_salesforce_course_stats_spec.rb
@@ -155,6 +155,17 @@ RSpec.describe UpdateSalesforceCourseStats, type: :routine do
       described_class.call(write_stats: false)
     end
 
+    it "gracefully handles a bad term year in an SF object" do
+      existing_sf_object = Salesforce::Remote::OsAncillary.new(term_year: "fix formula 2016", id: 'foo')
+      allow(@organizer).to receive(:get_sf_objects) { [existing_sf_object] }
+
+      expect_any_instance_of(described_class)
+        .to receive(:notify)
+        .with(a_string_matching(/Error attaching.*ParseError.*fix formula/))
+
+      expect{described_class.call(write_stats: false)}.not_to raise_error
+    end
+
     it "makes a new SF object if no eligible ones available" do
       term_year = Salesforce::Remote::TermYear.from_string("2015 - 16 Fall")
       existing_sf_object = OpenStruct.new(term_year: term_year.to_s, id: 'foo')

--- a/spec/subsystems/salesforce/remote/term_year_spec.rb
+++ b/spec/subsystems/salesforce/remote/term_year_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Salesforce::Remote::TermYear do
         described_class.from_string("2015 - 17 Fall")
       }.to raise_error(StandardError)
     end
+
+    it "freaks out for bad formats" do
+      expect{
+        described_class.from_string("fix formula 2016")
+      }.to raise_error(described_class::ParseError)
+    end
   end
 
   context "#initialize" do

--- a/spec/subsystems/salesforce/renew_os_ancillary_spec.rb
+++ b/spec/subsystems/salesforce/renew_os_ancillary_spec.rb
@@ -58,6 +58,9 @@ RSpec.describe Salesforce::RenewOsAncillary do
 
     allow_any_instance_of(Salesforce::Remote::OsAncillary).to receive(:save) { true }
 
+    # to guarantee data pulled in by formula is populated...
+    expect_any_instance_of(Salesforce::Remote::OsAncillary).to receive(:reload) { |instance| instance }
+
     returned = described_class.call(based_on: based_on, renew_for_term_year: "fake")
 
     expect(returned).to be_a Salesforce::Remote::OsAncillary


### PR DESCRIPTION
Fixes one Salesforce stats update bug and adds several changes to make the update code less susceptible to oddities in the Salesforce data.

Suggest reviewing with `?w=0` appended to URL to eliminate whitespace changes (a large section was indented)