### PR TITLE
Restore period error message

### DIFF
--- a/app/controllers/api/v1/periods_controller.rb
+++ b/app/controllers/api/v1/periods_controller.rb
@@ -69,13 +69,17 @@ class Api::V1::PeriodsController < Api::V1::ApiController
     Must be a course teacher.
 
     Possible error code: period_is_not_deleted
+                         name_has_already_been_taken
 
     #{json_schema(Api::V1::PeriodRepresenter, include: :readable)}
   EOS
   def restore
+    period_model = @period.to_model
+    return render_api_errors(period_model.errors) unless period_model.valid?
+
     # Paranoia restore triggers .touch several times, so delay_touching is useful here
     ActiveRecord::Base.delay_touching do
-      standard_restore(@period.to_model, Api::V1::PeriodRepresenter)
+      standard_restore(period_model, Api::V1::PeriodRepresenter)
     end
   end
 

--- a/spec/controllers/api/v1/periods_controller_spec.rb
+++ b/spec/controllers/api/v1/periods_controller_spec.rb
@@ -187,5 +187,15 @@ RSpec.describe Api::V1::PeriodsController, type: :controller, api: true, version
       expect(response.body_as_hash[:errors].first[:code]).to eq 'period_is_not_deleted'
       expect(period.to_model.reload).not_to be_deleted
     end
+
+    it 'returns a proper error message if there is a name conflict' do
+      conflicting_period = CreatePeriod[course: course, name: period.name]
+
+      api_put :restore, teacher_token, parameters: { id: period.id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body_as_hash[:errors].first[:code]).to eq 'name_has_already_been_taken'
+      expect(period.to_model.reload).to be_deleted
+    end
   end
 end


### PR DESCRIPTION
Return a proper error message (instead of a 500 error) if a deleted period being restored has a name that conflicts with another period