### PR TITLE
Admin menu improvements

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -15,6 +15,7 @@ $(document).ready(function() {
 $(document).ready(function() {
   //=========== Course teacher auto complete ==============//
   $('#course_teacher').autocomplete({
+    autoFocus: true,
     minLength: 2,
     select: function(event_, ui) {
       $('#course_teacher').val(ui.item.label);

--- a/app/routines/create_period.rb
+++ b/app/routines/create_period.rb
@@ -1,16 +1,14 @@
 class CreatePeriod
   lev_routine express_output: :period
 
-  uses_routine CourseMembership::CreatePeriod,
-    translations: { outputs: { type: :verbatim } },
-    as: :create_period
+  uses_routine CourseMembership::CreatePeriod, translations: { outputs: { type: :verbatim } },
+                                               as: :create_period
 
-  uses_routine Tasks::AssignCoursewideTaskPlansToNewPeriod,
-    as: :assign_coursewide_task_plans
+  uses_routine Tasks::AssignCoursewideTaskPlansToNewPeriod, as: :assign_coursewide_task_plans
 
-  def exec(course:, name: nil)
+  def exec(course:, name: nil, enrollment_code: nil)
     name ||= (course.periods.count + 1).ordinalize
-    run(:create_period, course: course, name: name)
+    run(:create_period, course: course, name: name, enrollment_code: enrollment_code)
     run(:assign_coursewide_task_plans, period: outputs.period)
   end
 end

--- a/app/subsystems/course_membership/create_period.rb
+++ b/app/subsystems/course_membership/create_period.rb
@@ -3,8 +3,8 @@ class CourseMembership::CreatePeriod
 
   protected
 
-  def exec(course:, name:)
-    period = CourseMembership::Models::Period.new(name: name)
+  def exec(course:, name:, enrollment_code: nil)
+    period = CourseMembership::Models::Period.new(name: name, enrollment_code: enrollment_code)
     course.periods << period # fixes association cache bug
     transfer_errors_from(period, {type: :verbatim}, true)
     strategy = CourseMembership::Strategies::Direct::Period.new(period)

--- a/app/views/admin/courses/_teachers.html.erb
+++ b/app/views/admin/courses/_teachers.html.erb
@@ -18,6 +18,7 @@
 
 <%= form_tag(url, method: method, id: 'assign-teachers-form') do |f| %>
   <div class="form-group">
-    <%= text_field_tag :course_teacher, nil, class: 'form-control', placeholder: 'Start typing to search for a user...' %>
+    <%= text_field_tag :course_teacher, nil, class: 'form-control',
+                                             placeholder: 'Start typing to search for a user...' %>
   </div>
 <% end %>

--- a/app/views/admin/periods/_form.html.erb
+++ b/app/views/admin/periods/_form.html.erb
@@ -6,12 +6,10 @@
     <%= f.text_field :name, class: 'form-control' %>
   </div>
 
-  <% unless @period.nil? # new record %>
-    <div class="form-group">
-      <%= f.label :enrollment_code %>
-      <%= f.text_field :enrollment_code, class: 'form-control' %>
-    </div>
-  <% end %>
+  <div class="form-group">
+    <%= f.label :enrollment_code %>
+    <%= f.text_field :enrollment_code, class: 'form-control', placeholder: 'Random' %>
+  </div>
 
   <%= f.submit 'Save', class: 'btn btn-primary' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,9 +168,9 @@ Rails.application.routes.draw do
 
       post :bulk_update, on: :collection
 
-      resources :periods, shallow: true do
+      resources :periods, shallow: true, except: :index do
         member do
-          put 'restore'
+          put :restore
           put :change_salesforce
         end
       end

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Admin editing a course' do
 
     click_link 'Add period'
     expect(page).to have_content('New Period for Physics I')
-    expect(page).not_to have_content('Enrollment code')
+    expect(page).to have_content('Enrollment code')
 
     fill_in 'Name', with: '2nd'
     click_button 'Save'


### PR DESCRIPTION
- Enter key works to add a teacher to a course when you type their name
- Removed non-existent admin periods index route
- Periods run validations on create and edit
- Enrollment code can be supplied (or not) on create and edit, defaults to random