### PR TITLE
Create ShortCode for all types of demo assignments 

### DIFF
--- a/lib/tasks/demo/tasks.rb
+++ b/lib/tasks/demo/tasks.rb
@@ -72,7 +72,7 @@ class Demo::Tasks < Demo::Base
                        opens_at: period.opens_at,
                        due_at: period.due_at)
 
-      ShortCode::Create[task_plan.to_global_id.to_s] if assignment.type == 'homework'
+      ShortCode::Create[task_plan.to_global_id.to_s]
     end
     # Draft plans do not undergo distribution
     if assignment.draft


### PR DESCRIPTION
and not just homework.  Not sure why we had the `if assignment.type == 'homework'` there, maybe the codes were originally for HW only?