### PR TITLE
Remove request spec truncation

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,10 +75,6 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation
   end
 
-  config.before(:all, type: :request) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
   config.before(:all, truncation: true) do
     DatabaseCleaner.strategy = :truncation
   end


### PR DESCRIPTION
Theoretically, request specs use the default Rails request driver, which runs in the same thread as the test and so don't need truncation.