### PR TITLE
Hide archived periods from assignment stats

### DIFF
--- a/app/subsystems/course_membership/models/period.rb
+++ b/app/subsystems/course_membership/models/period.rb
@@ -14,7 +14,7 @@ class CourseMembership::Models::Period < Tutor::SubSystems::BaseModel
 
   has_many :enrollment_changes, dependent: :destroy
 
-  has_many :taskings, subsystem: :tasks, dependent: :nullify
+  has_many :taskings, subsystem: :tasks
   has_many :tasks, through: :taskings
 
   unique_token :enrollment_code, mode: :random_number, length: 6


### PR DESCRIPTION
MIGHT need an FE PR to handle the case where all periods in the assignments are archived.