### PR TITLE
Dont blow up salesforce import if an OsAncillary has a null term_year

### DIFF
--- a/app/routines/update_salesforce_course_stats.rb
+++ b/app/routines/update_salesforce_course_stats.rb
@@ -121,6 +121,9 @@ class UpdateSalesforceCourseStats
           next
         end
 
+        notify("One or more Salesforce objects for course #{course.id} have NULL TermYears",
+               course: course.id) if course_sf_objects.any?{ |sf| sf.term_year_object.nil? }
+
         # Narrow down those SF objects to those that work for this period, reusing if
         # there is one or making if there aren't any.
         #

--- a/app/subsystems/salesforce/remote/class_size.rb
+++ b/app/subsystems/salesforce/remote/class_size.rb
@@ -19,7 +19,7 @@ class Salesforce::Remote::ClassSize < ActiveForce::SObject
   self.table_name = 'Class_Size__c'
 
   def term_year_object
-    Salesforce::Remote::TermYear.from_string(self.term_year)
+    @term_year_object ||= Salesforce::Remote::TermYear.from_string(self.term_year)
   end
 
   def reset_stats

--- a/app/subsystems/salesforce/remote/opportunity.rb
+++ b/app/subsystems/salesforce/remote/opportunity.rb
@@ -7,7 +7,7 @@ class Salesforce::Remote::Opportunity < ActiveForce::SObject
   self.table_name = 'Opportunity'
 
   def term_year_object
-    Salesforce::Remote::TermYear.from_string(self.term_year)
+    @term_year_object ||= Salesforce::Remote::TermYear.from_string(self.term_year)
   end
 
 end

--- a/app/subsystems/salesforce/remote/os_ancillary.rb
+++ b/app/subsystems/salesforce/remote/os_ancillary.rb
@@ -42,7 +42,7 @@ class Salesforce::Remote::OsAncillary < ActiveForce::SObject
   end
 
   def term_year_object
-    Salesforce::Remote::TermYear.from_string(self.term_year)
+    @term_year_object ||= Salesforce::Remote::TermYear.from_string(self.term_year)
   end
 
   def is_college?

--- a/app/subsystems/salesforce/remote/term_year.rb
+++ b/app/subsystems/salesforce/remote/term_year.rb
@@ -30,6 +30,8 @@ class Salesforce::Remote::TermYear
   end
 
   def self.from_string(string)
+    return if string.blank?
+
     string.match(/20(\d\d) - (\d\d) (\w+)/).tap do |match|
       raise(ParseError, "Cannot parse '#{string}' as a TermYear") if match.nil?
     end

--- a/spec/subsystems/salesforce/remote/term_year_spec.rb
+++ b/spec/subsystems/salesforce/remote/term_year_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Salesforce::Remote::TermYear do
       expect(term_year).to be_spring
     end
 
+    it "works for nil" do
+      term_year = described_class.from_string(nil)
+
+      expect(term_year).to be_nil
+    end
+
     it "freaks out for bad years" do
       expect{
         described_class.from_string("2015 - 17 Fall")


### PR DESCRIPTION
This just returns nil instead which is fine for the comparison it is used in.