### PR TITLE
Removed the "Biglearn returned less exercises than requested" email

### DIFF
--- a/app/routines/get_ecosystem_exercises_from_biglearn.rb
+++ b/app/routines/get_ecosystem_exercises_from_biglearn.rb
@@ -73,11 +73,10 @@ class GetEcosystemExercisesFromBiglearn
 
     biglearn_count = numbers.size
 
-    WarningMailer.log_and_deliver({
-      message: "Biglearn returned less exercises than requested.",
-      details: { pools: pools.map(&:uuid), role: role.id,
-                 requested: count, got: biglearn_count, exercise_numbers: numbers }
-    }) if biglearn_count < count
+    Rails.logger.warn do
+      "Biglearn returned less exercises than requested. Pools: #{pools.map(&:uuid)}. Role: #{
+        role.id}. Requested: #{count}. Got: #{biglearn_count}. Exercise numbers: #{numbers}."
+     end if biglearn_count < count
 
     exercises = ecosystem.exercises_by_numbers(numbers)
     fatal_error(code: :missing_local_exercises,

--- a/spec/routines/get_ecosystem_exercises_from_biglearn_spec.rb
+++ b/spec/routines/get_ecosystem_exercises_from_biglearn_spec.rb
@@ -69,20 +69,17 @@ describe GetEcosystemExercisesFromBiglearn, type: :routine do
       expect(Set.new(bl_exercises.map(&:id))).to eq Set.new(exercises.map(&:id))
     end
 
-    it 'sends a warning if Biglearn returns less exercises than requested' do
+    it 'logs a warning if Biglearn returns less exercises than requested' do
       expect(OpenStax::Biglearn::V1).to(
         receive(:get_projection_exercises).once { exercises.first(2).map(&:url) }
       )
 
       expect(ExceptionNotifier).not_to receive(:notify_exception)
-      msg = "Biglearn returned less exercises than requested."
-      expect(Rails.logger).to receive(:warn).with(msg)
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.body).to match(msg)
+      expect(WarningMailer).not_to receive(:log_and_deliver)
+      expect(Rails.logger).to receive(:warn)
 
       bl_exercises = described_class[ecosystem: ecosystem, role: role, pools: pools, count: count]
       expect(Set.new(bl_exercises.map(&:id))).to eq Set.new(exercises.first(2).map(&:id))
-
     end
 
 


### PR DESCRIPTION
Since we now tell Biglearn not to repeat exercises, this situation can happen in legitimate cases if we completely exhaust the available pool of exercises.

It also happened before when doing practice on pages that have less than 5 non-multipart exercises.