### PR TITLE
Add `ui_settings` to user profile

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,4 +23,27 @@ class Api::V1::UsersController < Api::V1::ApiController
     end
   end
 
+  api :POST, '/ui-settings', 'Save settings about the currently logged in user'
+  description <<-EOS
+    Saves the user interface settigs for the current user.
+    The front-end of the application uses this endpoint to save various non-critical settings
+    related to how the interface should behave based on actions the user has performed
+    Returns header forbidden (403) if the user is not logged in or api_errors if the update fails.
+  EOS
+  def ui_settings
+    profile = current_human_user.to_model
+
+    # sure seems like this *should* work, but it raises:
+    #   NoMethodError: undefined method `user_models_profile_url
+    # standard_update(profile, Api::V1::UiSettingsRepresenter)
+
+    OSU::AccessPolicy.require_action_allowed!(:update, current_api_user, profile)
+    consume!(profile, represent_with: Api::V1::UiSettingsRepresenter)
+    if profile.save
+      head :accepted
+    else
+      render_api_errors(model.errors)
+    end
+  end
+
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -31,19 +31,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     Returns header forbidden (403) if the user is not logged in or api_errors if the update fails.
   EOS
   def ui_settings
-    profile = current_human_user.to_model
-
-    # sure seems like this *should* work, but it raises:
-    #   NoMethodError: undefined method `user_models_profile_url
-    # standard_update(profile, Api::V1::UiSettingsRepresenter)
-
-    OSU::AccessPolicy.require_action_allowed!(:update, current_api_user, profile)
-    consume!(profile, represent_with: Api::V1::UiSettingsRepresenter)
-    if profile.save
-      head :accepted
-    else
-      render_api_errors(model.errors)
-    end
+    standard_update(current_human_user.to_model, Api::V1::UiSettingsRepresenter, location: nil)
   end
 
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     end
   end
 
-  api :POST, '/ui-settings', 'Save settings about the currently logged in user'
+  api :PUT, '/ui-settings', 'Save settings about the currently logged in user'
   description <<-EOS
     Saves the user interface settigs for the current user.
     The front-end of the application uses this endpoint to save various non-critical settings

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -61,7 +61,7 @@ class AuthController < ApplicationController
     status = strategy.authorize.body.slice('access_token')
     if !current_user.is_anonymous? && ( stubbed_auth? || terms_agreed? )
       status.merge! Api::V1::BootstrapDataRepresenter.new(current_user).to_hash(
-                      user_options: { tutor_notices_url: api_notifications_url }
+                      user_options: { tutor_api_url: api_root_url }
                     )
     end
     status[:endpoints] = {

--- a/app/helpers/webview_helper.rb
+++ b/app/helpers/webview_helper.rb
@@ -4,7 +4,7 @@ module WebviewHelper
   def bootstrap_data
     Api::V1::BootstrapDataRepresenter.new(current_user).to_json(
       user_options: {
-        tutor_notices_url: api_notifications_url,
+        tutor_api_url: api_root_url,
         flash: flash.to_hash
       }
     )

--- a/app/representers/api/v1/bootstrap_data_representer.rb
+++ b/app/representers/api/v1/bootstrap_data_representer.rb
@@ -11,10 +11,14 @@ module Api::V1
              writeable: false,
              getter: ->(*) { self }
 
-    property :base_accounts_url,
+    property :accounts_api_url,
              readable: true,
              writeable: false,
-             getter: ->(*) { OpenStax::Accounts.configuration.openstax_accounts_url }
+             getter: ->(*) {
+               OpenStax::Utilities.generate_url(
+                 OpenStax::Accounts.configuration.openstax_accounts_url, "api"
+               )
+             }
 
     property :accounts_profile_url,
              readable: true,
@@ -25,10 +29,10 @@ module Api::V1
                )
              }
 
-    property :tutor_notices_url,
+    property :tutor_api_url,
              readable: true,
              writeable: false,
-             getter: ->(user_options:, **) { user_options[:tutor_notices_url] }
+             getter: ->(user_options:, **) { user_options[:tutor_api_url] }
 
     property :flash,
              readable: true,
@@ -41,6 +45,10 @@ module Api::V1
                             "to the message.  These keys can be interpreted as referring to " +
                             "Bootstrap `success`, `info`, `warning`, and `danger` alert stylings."
              }
+
+    property :ui_settings,
+             readable: true,
+             writeable: false
 
     property :courses,
              extend: Api::V1::CoursesRepresenter,

--- a/app/representers/api/v1/ui_settings_representer.rb
+++ b/app/representers/api/v1/ui_settings_representer.rb
@@ -1,0 +1,13 @@
+module Api::V1
+  class UiSettingsRepresenter < Roar::Decorator
+
+    include Roar::JSON
+
+    property :ui_settings,
+             type: Hash,
+             readable: true,
+             writeable: true,
+             schema_info: { required: true }
+
+  end
+end

--- a/app/representers/api/v1/ui_settings_representer.rb
+++ b/app/representers/api/v1/ui_settings_representer.rb
@@ -3,6 +3,12 @@ module Api::V1
 
     include Roar::JSON
 
+    property :previous_ui_settings,
+             type: Hash,
+             readable: true,
+             writeable: true,
+             schema_info: { required: true }
+
     property :ui_settings,
              type: Hash,
              readable: true,

--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -19,12 +19,14 @@ module User
       has_one :customer_service, dependent: :destroy, inverse_of: :profile
       has_one :content_analyst, dependent: :destroy, inverse_of: :profile
 
+      attr_accessor :previous_ui_settings
       json_serialize :ui_settings, Hash
 
       validates :account, presence: true, uniqueness: true
       validates :exchange_read_identifier, presence: true
       validates :exchange_write_identifier, presence: true
       validates :ui_settings, max_json_length: 1000
+      validate  :validate_ui_settings_change_history , on: :update
 
       delegate :username, :first_name, :last_name, :full_name, :title, :name, :casual_name,
                :first_name=, :last_name=, :full_name=, :title=, to: :account
@@ -32,6 +34,15 @@ module User
       def self.anonymous
         ::User::Models::AnonymousProfile.instance
       end
+
+      private
+
+      def validate_ui_settings_change_history
+        if ui_settings_changed? && previous_ui_settings != ui_settings_was
+          errors.add(:previous_ui_settings, "out-of-band update detected. Previous does not match stored value")
+        end
+      end
+
     end
   end
 end

--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -23,6 +23,8 @@ module User
       validates :exchange_read_identifier, presence: true
       validates :exchange_write_identifier, presence: true
 
+      json_serialize :ui_settings, Hash
+
       delegate :username, :first_name, :last_name, :full_name, :title, :name, :casual_name,
                :first_name=, :last_name=, :full_name=, :title=, to: :account
 

--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -19,11 +19,12 @@ module User
       has_one :customer_service, dependent: :destroy, inverse_of: :profile
       has_one :content_analyst, dependent: :destroy, inverse_of: :profile
 
+      json_serialize :ui_settings, Hash
+
       validates :account, presence: true, uniqueness: true
       validates :exchange_read_identifier, presence: true
       validates :exchange_write_identifier, presence: true
-
-      json_serialize :ui_settings, Hash
+      validates :ui_settings, max_json_length: 1000
 
       delegate :username, :first_name, :last_name, :full_name, :title, :name, :casual_name,
                :first_name=, :last_name=, :full_name=, :title=, to: :account

--- a/app/subsystems/user/strategies/direct/user.rb
+++ b/app/subsystems/user/strategies/direct/user.rb
@@ -8,7 +8,7 @@ module User
 
         exposes :account, :exchange_read_identifier, :exchange_write_identifier,
                 :username, :first_name, :last_name, :full_name, :title, :name,
-                :casual_name
+                :casual_name, :ui_settings
 
         class << self
           alias_method :entity_all, :all

--- a/app/subsystems/user/user.rb
+++ b/app/subsystems/user/user.rb
@@ -134,6 +134,10 @@ module User
       !!@strategy.is_content_analyst?
     end
 
+    def ui_settings
+      verify_and_return @strategy.ui_settings, klass: Hash, allow_nil: true, error: StrategyError
+    end
+
     # Necessary, at least temporarily, so we can assign users to external polymorphics,
     # like task_plan owner, tasking_plan target and FinePrint signatures
     def to_model

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,9 @@ Rails.application.routes.draw do
   api :v1, default: true do
     resources :jobs, only: [:index, :show]
 
-    resources :users, only: [:index]
+    resources :users, only: [:index] do
+      put :ui_settings, on: :collection
+    end
 
     resource :user, only: [:show] do
       get 'tasks', on: :collection

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -19,8 +19,7 @@ development:
   demo_user_password: <%= ENV["DEMO_USER_PASSWORD"] || 'password' %>
   cc_origins: # list of url prefixes allowed to access concept coach resources via CORS
     - http://localhost:3001/
-    - http://localhost:8001 # concept coach dev server
-    - http://10.0.2.2:8001  # 10.0.2.2 is the default IP for accessing local resources from inside a virtualbox VM
+    - http://localhost:3005 # concept coach dev server
   ga_tracking_code: ''
   salesforce:
     consumer_key: <%= ENV["SALESFORCE_CONSUMER_KEY"] %>

--- a/db/migrate/20160808204103_add_profile_ui_settings.rb
+++ b/db/migrate/20160808204103_add_profile_ui_settings.rb
@@ -1,0 +1,7 @@
+class AddProfileUiSettings < ActiveRecord::Migration
+  def change
+
+    add_column :user_profiles, :ui_settings, :text
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160802210108) do
+
+ActiveRecord::Schema.define(version: 20160808204103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -836,6 +837,7 @@ ActiveRecord::Schema.define(version: 20160802210108) do
     t.datetime "deleted_at"
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
+    t.text     "ui_settings"
   end
 
   add_index "user_profiles", ["account_id"], name: "index_user_profiles_on_account_id", unique: true, using: :btree

--- a/lib/json_serialize.rb
+++ b/lib/json_serialize.rb
@@ -39,4 +39,15 @@ module JsonSerialize
   end
 end
 
+# validator to go along with JsonSerialize
+class MaxJsonLengthValidator < ActiveModel::EachValidator
+
+  def validate_each(record, attribute, value)
+    if record[attribute].to_s.length > options[:with]
+      record.errors[attribute] << (options[:message] || "is too long")
+    end
+  end
+
+end
+
 ActiveRecord::Base.extend JsonSerialize::ClassMethods

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -66,12 +66,23 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
   end
 
   describe "#ui-settings" do
+    it 'returns api_error when previous is invalid' do
+      api_put :ui_settings, user_1_token, raw_post_data: {
+                'ui_settings' => {is_open: false, answer: 42}
+              }.to_json
+      expect(response.code).to eq('422')
+      expect(response.body).to include('out-of-band update detected')
+    end
+
     it "saves to profile" do
-      api_put :ui_settings, user_1_token, raw_post_data: {'ui_settings' => {is_open: false, answer: 42}}.to_json
-      expect(response.code).to eq('202')
-      expect(response.body).to eq('')
+      api_put :ui_settings, user_1_token, raw_post_data: {
+                'previous_ui_settings' => {},
+                'ui_settings' => {is_open: false, answer: 42}
+              }.to_json
+      expect(response.code).to eq('200')
       expect(user_1.to_model.reload.ui_settings).to eq({'is_open' => false, 'answer' => 42})
     end
+
   end
 
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -65,4 +65,13 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
     end
   end
 
+  describe "#ui-settings" do
+    it "saves to profile" do
+      api_put :ui_settings, user_1_token, raw_post_data: {'ui_settings' => {is_open: false, answer: 42}}.to_json
+      expect(response.code).to eq('202')
+      expect(response.body).to eq('')
+      expect(user_1.to_model.reload.ui_settings).to eq({'is_open' => false, 'answer' => 42})
+    end
+  end
+
 end

--- a/spec/representers/api/v1/bootstrap_data_representer_spec.rb
+++ b/spec/representers/api/v1/bootstrap_data_representer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
   let(:representation) do
     described_class.new(user).to_json(
       user_options: {
-        tutor_notices_url: 'https://example.com/notices',
+        tutor_api_url: 'https://example.com/api',
         flash: { alert: 'Nothing!'}
       }
     )
@@ -16,9 +16,10 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
     expect(JSON.parse representation).to eq(
       "user" =>  Api::V1::UserRepresenter.new(user).as_json,
       "courses" => [], # not testing this since it's too expensive to generate meaningful course data
-      "base_accounts_url" => OpenStax::Accounts.configuration.openstax_accounts_url,
+      "accounts_api_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'api',
       "accounts_profile_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'profile',
-      "tutor_notices_url" => 'https://example.com/notices',
+      "tutor_api_url" => 'https://example.com/api',
+      "ui_settings" => {},
       "flash" => { "alert" => 'Nothing!' }
     )
   end

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -28,6 +28,7 @@ describe "Get authentication status", type: :request, version: :v1 do
                                          :tutor_api_url => a_string_starting_with("http"),
                                          :accounts_profile_url => a_string_starting_with("http"),
                                          :accounts_api_url => a_string_starting_with("http"),
+                                         :ui_settings => {},
                                          :endpoints => {
                                            :is_stubbed=>true,
                                            :logout=>a_string_starting_with("http"),

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -25,9 +25,9 @@ describe "Get authentication status", type: :request, version: :v1 do
       token = Doorkeeper::AccessToken.find_by(resource_owner_id: user.id).token
       expect(response.body_as_hash).to match(
                                          :access_token => token,
-                                         :tutor_notices_url => a_string_starting_with("http"),
+                                         :tutor_api_url => a_string_starting_with("http"),
                                          :accounts_profile_url => a_string_starting_with("http"),
-                                         :base_accounts_url => a_string_starting_with("http"),
+                                         :accounts_api_url => a_string_starting_with("http"),
                                          :endpoints => {
                                            :is_stubbed=>true,
                                            :logout=>a_string_starting_with("http"),

--- a/spec/subsystems/user/models/profile_spec.rb
+++ b/spec/subsystems/user/models/profile_spec.rb
@@ -27,4 +27,10 @@ RSpec.describe User::Models::Profile, type: :model do
     it { is_expected.to delegate_method(method).to(:account).with_arguments('foo') }
   end
 
+  it 'enforces length of ui_settings' do
+    profile = FactoryGirl.build(:user_profile)
+    profile.ui_settings = {test: ('a' * 1000)}
+    expect(profile).to_not be_valid
+    expect(profile.errors[:ui_settings].to_s).to include 'too long'
+  end
 end

--- a/spec/subsystems/user/models/profile_spec.rb
+++ b/spec/subsystems/user/models/profile_spec.rb
@@ -33,4 +33,15 @@ RSpec.describe User::Models::Profile, type: :model do
     expect(profile).to_not be_valid
     expect(profile.errors[:ui_settings].to_s).to include 'too long'
   end
+
+  it 'requires prevsious settings to be valid when changed' do
+    profile = FactoryGirl.create(:user_profile, ui_settings: {'one' => 1})
+    profile.ui_settings = {test: true}
+    expect(profile.save).to be false
+    expect(profile.errors[:previous_ui_settings].to_s).to include 'out-of-band update detected'
+    profile.previous_ui_settings = {'one' => 1}
+    expect(profile.save).to be true
+    expect(profile.errors[:previous_ui_settings]).to be_empty
+  end
+
 end


### PR DESCRIPTION
Needs to be merge along with: https://github.com/openstax/tutor-js/issues/1262

Also renames bootstrap data keys to have uniform names for urls: `tutor_api_url` and `accounts_api_url` 