### PR TITLE
Use `unscoped` to update all records in migration

### DIFF
--- a/db/migrate/20160802210108_add_missing_timestamps.rb
+++ b/db/migrate/20160802210108_add_missing_timestamps.rb
@@ -12,7 +12,7 @@ class AddMissingTimestamps < ActiveRecord::Migration
 
     MODELS_MISSING_TIMESTAMPS.each do |klass|
       add_timestamps klass.table_name, null: true
-      klass.update_all(created_at: time, updated_at: time)
+      klass.unscoped.update_all({created_at: time, updated_at: time})
     end
 
     (MODELS_MISSING_TIMESTAMPS + MODELS_WITH_NULLABLE_TIMESTAMPS).each do |klass|


### PR DESCRIPTION
Otherwise they'll fail the later `set not null`

This is going in my examples of  "default_scope is dangerous" 😁 