### PR TITLE
Display object name instead of the whole object

### DIFF
--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -110,7 +110,7 @@
         <% incomplete_jobs.each do |job| %>
           <tr>
             <td><%= link_to(job.id, @job_path_proc.call(job)) %></td>
-            <td><%= job.state %></td>
+            <td><%= job.state.name %></td>
             <td><%= CourseProfile::Models::Profile.where(
                         entity_course_id: job.data['course_id']
                     ).first.try(:name) if job.data['course_id'] %></td>
@@ -138,7 +138,7 @@
         <% failed_jobs.each do |job| %>
           <tr>
             <td><%= link_to(job.id, @job_path_proc.call(job)) %></td>
-            <td><%= job.state %></td>
+            <td><%= job.state.name %></td>
             <td><%= CourseProfile::Models::Profile.where(
                         entity_course_id: job.data['course_id']
                     ).first.try(:name) if job.data['course_id'] %></td>


### PR DESCRIPTION
Previously the `admin/courses` page showed the object `#<Jobba::State:0x007f66c4a96730>` when instead it should show the object's name only with `job.state.name`.