### PR TITLE
Mark and separate dropped students in scores report data and export

### DIFF
--- a/app/representers/api/v1/performance_report_representer.rb
+++ b/app/representers/api/v1/performance_report_representer.rb
@@ -146,6 +146,10 @@ module Api::V1
                type: Float,
                readable: true
 
+      property :is_dropped,
+               readable: true,
+               writeable: false
+
       collection :data,
                  readable: true,
                  decorator: ->(input:, **) { input.nil? ? Null : StudentData }

--- a/app/subsystems/tasks/get_cc_performance_report.rb
+++ b/app/subsystems/tasks/get_cc_performance_report.rb
@@ -32,7 +32,8 @@ module Tasks
             student_identifier: student.student_identifier,
             role: student.role.id,
             data: data,
-            average_score: average_scores(data.map{|datum| datum.present? ? datum[:task] : nil})
+            average_score: average_scores(data.map{|datum| datum.present? ? datum[:task] : nil}),
+            is_dropped: student.deleted_at.present?
           }
         end.sort_by do |hash|
           sort_name = "#{hash[:last_name]} #{hash[:first_name]}"

--- a/app/subsystems/tasks/get_cc_performance_report.rb
+++ b/app/subsystems/tasks/get_cc_performance_report.rb
@@ -15,8 +15,13 @@ module Tasks
 
       outputs[:performance_report] = course.periods.map do |period|
         period_cc_tasks_map = cc_tasks_map[period] || {}
-        sorted_period_pages = period_cc_tasks_map
-          .values.flat_map(&:keys).uniq.sort{ |a, b| b.book_location <=> a.book_location }
+
+        sorted_period_pages =
+          period_cc_tasks_map.values                 # ignore the roles keys
+                             .flat_map(&:keys)       # ignore the values of page and is_dropped keys
+                             .keep_if{|key| key.is_a? Content::Page} # ignore is_dropped
+                             .uniq
+                             .sort{ |a, b| b.book_location <=> a.book_location }
 
         period_students = period.latest_enrollments
                                 .preload(student: {role: {profile: :account}})

--- a/app/subsystems/tasks/get_tp_performance_report.rb
+++ b/app/subsystems/tasks/get_tp_performance_report.rb
@@ -60,7 +60,8 @@ module Tasks
             student_identifier: student_role.student.student_identifier,
             role: student_role.id,
             data: data,
-            average_score: average_scores(data.map{ |datum| datum.present? ? datum[:task] : nil })
+            average_score: average_scores(data.map{ |datum| datum.present? ? datum[:task] : nil }),
+            is_dropped: student_role.student.deleted_at.present?
           }
         end
 

--- a/spec/controllers/api/v1/performance_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/performance_reports_controller_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             role: resp[0][:students][0][:role],
             student_identifier: 'S1',
             average_score: 1.0,
+            is_dropped: false,
             data: [
               {
                 type: 'homework',
@@ -165,6 +166,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             role: resp[0][:students][1][:role],
             student_identifier: 'S2',
             average_score: be_within(0.01).of(1/3.0),
+            is_dropped: false,
             data: [
               {
                 type: 'homework',
@@ -265,6 +267,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             role: resp[1][:students][0][:role],
             student_identifier: 'S4',
             average_score: 0.0,
+            is_dropped: false,
             data: [
               {
                 type: 'homework',
@@ -338,6 +341,7 @@ RSpec.describe Api::V1::PerformanceReportsController, type: :controller, api: tr
             role: resp[1][:students][1][:role],
             student_identifier: 'S3',
             average_score: 1.0,
+            is_dropped: false,
             data: [
               {
                 type: 'homework',

--- a/spec/subsystems/tasks/performance_report/export_cc_xlsx_spec.rb
+++ b/spec/subsystems/tasks/performance_report/export_cc_xlsx_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
         end
 
         # Uncomment this to open the file for visual inspection
-        #`open "#{filepath}"` and sleep(0.5)
+        # `open "#{filepath}"` and sleep(0.5)
 
         expect{ @wb = Roo::Excelx.new(filepath) }.to_not raise_error
       end
@@ -68,6 +68,12 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
       expect(cell(13,6,0)).to eq 0
       expect(cell(13,6,1)).to eq 0
       expect(cell(13,7,1)).to eq 0
+    end
+
+    it 'puts dropped students at the bottom' do
+      expect(cell(23,1,0)).to eq "Droppy"
+      expect(cell(23,2,0)).to eq "McDropface"
+      expect(cell(23,10,0).strftime("%-m/%-d/%Y")).to eq "3/2/2016"
     end
   end
 
@@ -165,6 +171,29 @@ RSpec.describe Tasks::PerformanceReport::ExportCcXlsx do
                 actual_and_placeholder_exercise_count: 9,
                 completed_exercise_count: 8,
                 correct_exercise_count: 8,
+                recovered_exercise_count: 0
+              }
+            ]
+          },
+          {
+            name: "Droppy McDropface",
+            first_name: "Droppy",
+            last_name: "McDropface",
+            student_identifier: "SID4000",
+            is_dropped: true,
+            role: nil,
+            data: [
+              nil,
+              {
+                late: false,
+                status: 'in_progress',
+                type: 'concept_coach',
+                id: 44,
+                due_at: Chronic.parse("3/15/2016 1PM"),
+                last_worked_at: Chronic.parse("3/2/2016 3PM"),
+                actual_and_placeholder_exercise_count: 9,
+                completed_exercise_count: 7,
+                correct_exercise_count: 6,
                 recovered_exercise_count: 0
               }
             ]

--- a/spec/subsystems/tasks/performance_report/export_xlsx_spec.rb
+++ b/spec/subsystems/tasks/performance_report/export_xlsx_spec.rb
@@ -10,7 +10,7 @@ require 'axlsx'
 require 'xlsx_helper'
 require 'roo'
 require 'timecop'
-# require 'byebug'
+require 'byebug'
 
 RSpec.describe Tasks::PerformanceReport::ExportXlsx, type: :routine do
 
@@ -40,6 +40,12 @@ RSpec.describe Tasks::PerformanceReport::ExportXlsx, type: :routine do
 
     it 'does not include a task due in the future' do
       (7..12).to_a.map{|row| expect(cell(row,17,0)).to be_blank}
+    end
+
+    it 'puts dropped students at the bottom' do
+      expect(cell(19,1,0)).to eq "DROPPED"
+      expect(cell(20,1,0)).to eq "Droppy"
+      expect(cell(20,7,0)).to eq 2/9.0
     end
 
     context 'zeter\'s scores' do
@@ -233,6 +239,32 @@ RSpec.describe Tasks::PerformanceReport::ExportXlsx, type: :routine do
               }
             ],
             # average_score: 2/3.0
+          },
+          {
+            name: "Droppy McDropFace",
+            first_name: "Droppy",
+            last_name: "McDropFace",
+            student_identifier: "SID89",
+            is_dropped: true,
+            data: [
+              {
+                last_worked_at: Chronic.parse("3/13/2016 1PM"),
+                step_count:                             9,
+                completed_step_count:                   4,
+                completed_on_time_step_count:           3,
+                completed_accepted_late_step_count:     1,
+                actual_and_placeholder_exercise_count:  9,
+                completed_exercise_count:               4,
+                completed_on_time_exercise_count:       3,
+                completed_accepted_late_exercise_count: 1,
+                correct_exercise_count:                 2,
+                correct_on_time_exercise_count:         2,
+                correct_accepted_late_exercise_count:   0,
+              },
+              nil,
+              nil,
+              nil
+            ],
           },
           {
             name: "Abby Gail",


### PR DESCRIPTION
## Changes in this PR

* Adds an `is_dropped` field to student data in scores report JSON
* Excludes dropped students from column and overall averages.  Row averages are still computed for dropped students.
* Separates dropped students in the exports to a separate table underneath each main table; the values here are not included in the averages.

## tutor-js changes needed

* Since dropped students are no longer including included in cross-student averages, this PR needs to be merged with a tutor-js PR that hides the dropped students from the online scores.

## Screenshots:

Concept Coach export:
![image](https://cloud.githubusercontent.com/assets/1001691/17628473/4a5e9622-606a-11e6-81f5-f79ecd766f1d.png)

Tutor export:
![image](https://cloud.githubusercontent.com/assets/1001691/17628509/6a014dd0-606a-11e6-8cd8-83d507b8b1ee.png)
