### PR TITLE
Update url rewriting code

### DIFF
--- a/app/subsystems/content/models/book.rb
+++ b/app/subsystems/content/models/book.rb
@@ -24,7 +24,7 @@ class Content::Models::Book < Tutor::SubSystems::BaseModel
   end
 
   def webview_url
-    archive_url.gsub('archive.','')
+    archive_url.sub(/archive-?/, '')
   end
 
   def cnx_id

--- a/app/subsystems/content/models/book.rb
+++ b/app/subsystems/content/models/book.rb
@@ -24,7 +24,7 @@ class Content::Models::Book < Tutor::SubSystems::BaseModel
   end
 
   def webview_url
-    archive_url.sub(/archive-?/, '')
+    archive_url.sub(/archive[\.-]?/, '')
   end
 
   def cnx_id

--- a/app/subsystems/content/routines/update_page_content.rb
+++ b/app/subsystems/content/routines/update_page_content.rb
@@ -1,50 +1,57 @@
 class Content::Routines::UpdatePageContent
 
+  # Extract the uuid and version from paths like:
+  #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b
+  #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@2
+  #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@2#figure-1
+  CNX_ID_REGEX = \
+    /\/contents\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:@([\d\.]+))?/i
+
   lev_routine
 
   protected
 
   def exec(pages:, save: true)
-    # Get all page cnx_ids given
-    page_cnx_ids = pages.map(&:cnx_id)
+    # Get all page uuids and cnx_ids given
+    pages_by_uuid = pages.index_by(&:uuid)
 
     pages.each do |page|
       doc = Nokogiri::HTML(page.content)
       doc.css('[href]').each do |link|
         href_attr = link.attribute('href')
-        change_page_link(href_attr, page_cnx_ids)
+        change_page_link(href_attr, pages_by_uuid)
       end
 
       page.content = doc.to_html
-      # Maybe replace with UPSERT once we have support for it
-      # https://wiki.postgresql.org/wiki/UPSERT
+
+      # Replace individual saves with bulk UPSERT once we have support for it
       page.save! if save
     end
 
     outputs[:pages] = pages
   end
 
-  def change_page_link(href_attr, page_cnx_ids)
-    # if the link goes to a page in the book, change the link to just <uuid><rest-of-path>
+  # If the link goes to a page in the book, change the link to just the page's book_location
+  def change_page_link(href_attr, pages_by_uuid)
     url = Addressable::URI.parse(href_attr.value)
     path = url.path
+    matches = CNX_ID_REGEX.match(path)
 
-    # if the path starts with /contents/
-    if path.starts_with?('/contents/')
-      # extract the uuid from paths like:
-      #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@2
-      #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b
-      #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@2#figure-1
-      cnx_id = path.split('/')[2]
+    # Abort if cnx_id not found
+    return if matches.nil?
 
-      # and the uuid is in the book
-      if page_cnx_ids.include?(cnx_id)
-        # change the link to a relative link, with just <uuid><rest-of-path>
-        url.scheme = nil
-        url.host = nil
-        url.path = path.gsub(/\A\/contents\//, '')
-        href_attr.value = url.to_s
-      end
-    end
+    uuid = matches[1]
+    version = matches[2]
+    page = pages_by_uuid[uuid]
+
+    # Abort if cnx_id not in the book
+    return if page.nil? || (version.present? && page.version != version)
+
+    # Change the link back to a relative link, with just the page's book_location
+    url.scheme = nil
+    url.host = nil
+    url.path = page.book_location.reject(&:zero?).join('.')
+
+    href_attr.value = url.to_s
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20160808204103) do
 
   # These are extensions that must be enabled in order to support this database

--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -38,8 +38,8 @@ module OpenStax::Cnx::V1
     end
   end
 
-  def webview_url_base
-    archive_url_base.sub(/archive-?/, '')
+  def self.webview_url_base
+    archive_url_base.sub(/archive[\.-]?/, '')
   end
 
   # Archive url for the given path

--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -38,10 +38,20 @@ module OpenStax::Cnx::V1
     end
   end
 
+  def webview_url_base
+    archive_url_base.sub(/archive-?/, '')
+  end
+
   # Archive url for the given path
   # Forces /contents/ to be prepended to the path, unless the path begins with /
   def self.archive_url_for(path)
     Addressable::URI.join(archive_url_base, '/contents/', path).to_s
+  end
+
+  # Webview url for the given path
+  # Forces /contents/ to be prepended to the path, unless the path begins with /
+  def self.webview_url_for(path)
+    Addressable::URI.join(webview_url_base, '/contents/', path).to_s
   end
 
   def self.fetch(id)

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -229,7 +229,7 @@ module OpenStax::Cnx::V1
         next if uri.absolute? || uri.path.blank?
 
         # Relative link: make secure and absolute
-        href.value = OpenStax::Cnx::V1.archive_url_for(uri)
+        href.value = OpenStax::Cnx::V1.webview_url_for(uri)
       end
 
       node

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -210,7 +210,7 @@ module OpenStax::Cnx::V1
           # Skip anchor-only links
           next if uri.path.blank?
 
-          src.value = OpenStax::Cnx::V1.archive_url_for(uri)
+          src.value = OpenStax::Cnx::V1.webview_url_for(uri)
         end
       end
 


### PR DESCRIPTION
- Relative links default to using cnx.org instead of archive.cnx.org
- Link rewriting now replaces in-book links with the book_location of the matching page in the format `2` or `2.1` instead of the page UUID