### PR TITLE
Fix placeholder steps marked as completed

### DIFF
--- a/app/routines/task_exercise.rb
+++ b/app/routines/task_exercise.rb
@@ -23,6 +23,10 @@ class TaskExercise
         current_step = Tasks::Models::TaskStep.new(number: next_step_number)
       end
 
+      # Mark the step as incomplete just in case it had been marked as complete before
+      current_step.first_completed_at = nil
+      current_step.last_completed_at = nil
+
       current_step.tasked = Tasks::Models::TaskedExercise.new(
         exercise: exercise.to_model,
         url: exercise.url,

--- a/spec/subsystems/tasks/placeholder_strategies/i_reading_personalized_spec.rb
+++ b/spec/subsystems/tasks/placeholder_strategies/i_reading_personalized_spec.rb
@@ -58,4 +58,22 @@ RSpec.describe Tasks::PlaceholderStrategies::IReadingPersonalized, type: :placeh
     expect(task.exercise_steps_count).to eq 1
     expect(task.placeholder_steps_count).to eq 0
   end
+
+  it 'does not blow up if placeholder steps have been marked as completed' do
+    task.task_steps.each{ |ts| ts.complete.save! }
+
+    expect(GetEcosystemExercisesFromBiglearn).to receive(:[]).and_return(pool_exercises).once
+
+    expect(task.exercise_steps_count).to eq 1
+    expect(task.placeholder_steps_count).to eq 2
+
+    strategy.populate_placeholders(task: task)
+    task.update_step_counts!
+
+    expect(task.exercise_steps_count).to eq 3
+    expect(task.placeholder_steps_count).to eq 0
+
+    new_exercises = task.exercise_steps.last(2).map{ |step| step.tasked.exercise }
+    expect(Set.new new_exercises).to eq Set.new pool_exercises
+  end
 end


### PR DESCRIPTION
Production is exploding because students are somehow managing to mark placeholder steps as completed before they do them.