### PR TITLE
Student Identifier Fixes

### DIFF
--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -3,7 +3,12 @@ module CourseMembership
     lev_routine express_output: :student
 
     def exec(student:)
-      fatal_error(code: :already_active) unless student.deleted?
+      fatal_error(code: :already_active,
+                  message: 'Student is already active') unless student.deleted?
+      fatal_error(code: :student_identifier_has_already_been_taken,
+                  message: 'Student identifier has already been taken') \
+        if student.student_identifier.present? &&
+           CourseMembership::Models::Student.exists?(student_identifier: student.student_identifier)
       student.restore(recursive: true)
       student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)

--- a/app/subsystems/course_membership/inactivate_student.rb
+++ b/app/subsystems/course_membership/inactivate_student.rb
@@ -3,7 +3,8 @@ module CourseMembership
     lev_routine express_output: :student
 
     def exec(student:)
-      fatal_error(code: :already_inactive) if student.deleted?
+      fatal_error(code: :already_inactive,
+                  message: 'Student is already inactive') if student.deleted?
       student.destroy
       student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)

--- a/db/migrate/20160829164149_change_student_identifier_index.rb
+++ b/db/migrate/20160829164149_change_student_identifier_index.rb
@@ -1,0 +1,13 @@
+class ChangeStudentIdentifierIndex < ActiveRecord::Migration
+  def change
+    remove_index "course_membership_students",
+                 column: ["entity_course_id", "student_identifier"],
+                 name: "index_course_membership_students_on_e_c_id_and_s_identifier",
+                 unique: true
+
+    add_index "course_membership_students", ["entity_course_id", "student_identifier"],
+              where: "deleted_at IS NULL",
+              name: "index_course_membership_students_on_e_c_id_and_s_identifier",
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -271,7 +271,7 @@ ActiveRecord::Schema.define(version: 20160830235417) do
 
   add_index "course_membership_students", ["deidentifier"], name: "index_course_membership_students_on_deidentifier", unique: true, using: :btree
   add_index "course_membership_students", ["deleted_at"], name: "index_course_membership_students_on_deleted_at", using: :btree
-  add_index "course_membership_students", ["entity_course_id", "student_identifier"], name: "index_course_membership_students_on_e_c_id_and_s_identifier", unique: true, using: :btree
+  add_index "course_membership_students", ["entity_course_id", "student_identifier"], name: "index_course_membership_students_on_e_c_id_and_s_identifier", unique: true, where: "(deleted_at IS NULL)", using: :btree
   add_index "course_membership_students", ["entity_role_id"], name: "index_course_membership_students_on_entity_role_id", unique: true, using: :btree
 
   create_table "course_membership_teachers", force: :cascade do |t|

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -99,18 +99,35 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
 
   describe '#update_self' do
     let(:valid_params) { { course_id: course.id } }
-    let(:valid_body)   { { student_identifier: 'new identifier' } }
+    let(:new_id)       { '123456789' }
+    let(:valid_body)   { { student_identifier: new_id } }
 
     context 'caller has an authorization token' do
       context 'caller is a course student' do
-        it 'updates the student\'s identifier' do
-          api_patch :update_self, student_token, parameters: valid_params,
-                                                 raw_post_data: valid_body
-          expect(response).to have_http_status(:ok)
-          expect(response.body_as_hash).to eq({
-            student_identifier: 'new identifier'
-          })
-          expect(student.reload.student_identifier).to eq 'new identifier'
+        context 'updating the student\'s identifier' do
+          it 'succeeds if the identifier is available' do
+            api_patch :update_self, student_token, parameters: valid_params,
+                                                   raw_post_data: valid_body
+            expect(response).to have_http_status(:ok)
+            expect(response.body_as_hash[:student_identifier]).to eq new_id
+            expect(student.reload.student_identifier).to eq new_id
+          end
+
+          it 'fails if the identifier has already been taken' do
+            FactoryGirl.create :course_membership_student, course: course,
+                                                           student_identifier: new_id
+            api_patch :update_self, student_token, parameters: valid_params,
+                                                   raw_post_data: valid_body
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response.body_as_hash[:status]).to eq 422
+            expect(response.body_as_hash[:errors].first[:code]).to(
+              eq 'student_identifier_has_already_been_taken'
+            )
+            expect(response.body_as_hash[:errors].first[:message]).to(
+              eq 'Student identifier has already been taken'
+            )
+            expect(student.reload.student_identifier).to be_nil
+          end
         end
       end
 
@@ -148,34 +165,54 @@ describe Api::V1::StudentsController, type: :controller, api: true, version: :v1
 
     context 'caller has an authorization token' do
       context 'caller is a course teacher' do
-        it 'moves the student to another period' do
-          api_patch :update, teacher_token, parameters: valid_params, raw_post_data: valid_body
-          expect(response).to have_http_status(:ok)
-          new_student = CourseMembership::Models::Student.find(response.body_as_hash[:id])
-          expect(response.body_as_hash).to eq({
-            id: student.id.to_s,
-            first_name: student.first_name,
-            last_name: student.last_name,
-            name: student.name,
-            period_id: period_2.id.to_s,
-            role_id: student.entity_role_id.to_s,
-            deidentifier: student.deidentifier,
-            is_active: true
-          })
-          expect(student.reload.period).to eq period_2.to_model
-        end
+        context 'moving the student to another period' do
+          it 'succeeds' do
+            api_patch :update, teacher_token, parameters: valid_params, raw_post_data: valid_body
+            expect(response).to have_http_status(:ok)
+            new_student = CourseMembership::Models::Student.find(response.body_as_hash[:id])
+            expect(response.body_as_hash).to eq({
+              id: student.id.to_s,
+              first_name: student.first_name,
+              last_name: student.last_name,
+              name: student.name,
+              period_id: period_2.id.to_s,
+              role_id: student.entity_role_id.to_s,
+              deidentifier: student.deidentifier,
+              is_active: true
+            })
+            expect(student.reload.period).to eq period_2.to_model
+          end
 
-        it 'updates student identifier' do
-          new_id = '123456789'
-          api_patch :update, teacher_token, parameters: valid_params, raw_post_data: valid_body.merge({
-            student_identifier: new_id
-          })
-          expect(response).to have_http_status(:ok)
-          expect(response.body_as_hash[:student_identifier]).to eq(new_id)
-          expect(student.reload.student_identifier).to eq(new_id)
-          expect(student.reload.period).to eq period_2.to_model
-        end
+          context 'and updating the student\'s identifier' do
+            let(:new_id) { '123456789' }
 
+            it 'succeeds if the identifier is available' do
+              api_patch :update, teacher_token, parameters: valid_params,
+                                 raw_post_data: valid_body.merge({ student_identifier: new_id })
+              expect(response).to have_http_status(:ok)
+              expect(response.body_as_hash[:student_identifier]).to eq(new_id)
+              expect(student.reload.student_identifier).to eq(new_id)
+              expect(student.reload.period).to eq period_2.to_model
+            end
+
+            it 'fails if the identifier has already been taken' do
+              FactoryGirl.create :course_membership_student, course: course,
+                                                             student_identifier: new_id
+              api_patch :update, teacher_token, parameters: valid_params,
+                                 raw_post_data: valid_body.merge({ student_identifier: new_id })
+              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response.body_as_hash[:status]).to eq 422
+              expect(response.body_as_hash[:errors].first[:code]).to(
+                eq 'student_identifier_has_already_been_taken'
+              )
+              expect(response.body_as_hash[:errors].first[:message]).to(
+                eq 'Student identifier has already been taken'
+              )
+              expect(student.reload.student_identifier).to be_nil
+              expect(student.reload.period).to eq period.to_model
+            end
+          end
+        end
       end
 
       context 'caller is not a course teacher' do


### PR DESCRIPTION
- Changed student_identifier unique index to apply only to records that are not deleted
- Added a check for duplicate student identifiers when undropping students
- Added error messages for duplicate student identifiers when updating and undropping students
- Specs