### PR TITLE
Create routine to collect import jobs data

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -20,13 +20,9 @@ class Admin::CoursesController < Admin::BaseController
     ).try(:paginate, params_for_pagination)
 
     @ecosystems = Content::ListEcosystems[]
-    @incomplete_jobs = Jobba.where(state: :incomplete).to_a.select do |job|
-      job.data.try :[], 'course_ecosystem'
-    end
-    @failed_jobs = Jobba.where(state: :failed).to_a.select do |job|
-      job.data.try :[], 'course_ecosystem'
-    end
-    @job_path_proc = ->(job) { admin_job_path(job.id) }
+    @incomplete_jobs = CollectImportJobsData[state: :incomplete]
+    @failed_jobs = CollectImportJobsData[state: :failed]
+    @job_path_proc = ->(job_id) { admin_job_path(job_id) }
   end
 
   def new

--- a/app/controllers/customer_service/courses_controller.rb
+++ b/app/controllers/customer_service/courses_controller.rb
@@ -5,11 +5,17 @@ class CustomerService::CoursesController < CustomerService::BaseController
 
   def index
     @query = params[:query]
+    courses = SearchCourses.call(query: params[:query], order_by: params[:order_by]).outputs
+    params[:per_page] = courses.total_count if params[:per_page] == "all"
     params_for_pagination = {page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 25)}
-    courses = SearchCourses[query: @query, order_by: params[:order_by]].try(:paginate, params_for_pagination)
-    @total_courses = courses.try(:count)
-    @course_infos = CollectCourseInfo[courses: courses,
-                                      with: [:teacher_names, :ecosystem_book]]
+    @total_courses = courses.try(:total_count)
+    @course_infos = courses.items.preload(
+      [
+        :profile, { teachers: { role: [:role_user, :profile] }, periods_with_deleted: :latest_enrollments_with_deleted }
+      ],
+      [ ecosystems: [:books] ],
+      [ :periods ]
+    ).try(:paginate, params_for_pagination)
   end
 
   def show

--- a/app/controllers/customer_service/courses_controller.rb
+++ b/app/controllers/customer_service/courses_controller.rb
@@ -7,15 +7,14 @@ class CustomerService::CoursesController < CustomerService::BaseController
     @query = params[:query]
     courses = SearchCourses.call(query: params[:query], order_by: params[:order_by]).outputs
     params[:per_page] = courses.total_count if params[:per_page] == "all"
-    params_for_pagination = {page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 25)}
-    @total_courses = courses.try(:total_count)
+    @total_courses = courses.total_count
     @course_infos = courses.items.preload(
       [
         :profile, { teachers: { role: [:role_user, :profile] }, periods_with_deleted: :latest_enrollments_with_deleted }
       ],
       [ ecosystems: [:books] ],
       [ :periods ]
-    ).try(:paginate, params_for_pagination)
+    ).paginate(page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 25))
   end
 
   def show

--- a/app/routines/collect_import_jobs_data.rb
+++ b/app/routines/collect_import_jobs_data.rb
@@ -10,7 +10,7 @@ class CollectImportJobsData
     course_ids = jobbas_with_course_ecosystem.map{|job| job.data["course_id"]}
 
 
-    courses =  course_ids.blank? ? {} : CourseProfile::Models::Profile.where(entity_course_id: course_ids).pluck(:id, :name).to_h
+    courses =  course_ids.blank? ? {} : CourseProfile::Models::Profile.where(entity_course_id: course_ids).pluck(:entity_course_id, :name).to_h
     jobbas_with_course_ecosystem.each do |job|
       course_id = job.data["course_id"]
       course_name = courses[course_id]

--- a/app/routines/collect_import_jobs_data.rb
+++ b/app/routines/collect_import_jobs_data.rb
@@ -1,0 +1,22 @@
+class CollectImportJobsData
+  lev_routine express_output: :import_jobs_data
+
+  protected
+
+  def exec(state:)
+    data = []
+    jobbas = Jobba.where(state: state).to_a
+    jobbas_with_course_ecosystem = jobbas.select{ |j| j.try(:data).try(:[], "course_ecosystem") }
+    course_ids = jobbas_with_course_ecosystem.map{|job| job.data["course_id"]}
+
+
+    courses =  course_ids.blank? ? {} : CourseProfile::Models::Profile.where(entity_course_id: course_ids).pluck(:id, :name).to_h
+    jobbas_with_course_ecosystem.each do |job|
+      course_id = job.data["course_id"]
+      course_name = courses[course_id]
+      data << {id: job.id, state_name: job.state.name, course_ecosystem: job.data["course_ecosystem"], course_profile_profile_name: course_name}
+    end
+
+    outputs[:import_jobs_data] = data
+  end
+end

--- a/app/views/customer_service/courses/index.html.erb
+++ b/app/views/customer_service/courses/index.html.erb
@@ -5,13 +5,20 @@
 <br>
 <%= render partial: 'manager/courses/search', locals: { query: @query } %>
 
+Results per page:
+<%= select_tag "Results per page", options_for_select([25, 50, 100, 200, 400, "all"], params[:per_page]), id: "search-courses-results-pp" %>
+
 <%= render partial: 'manager/courses/index',
            locals: { course_infos: @course_infos,
                      extra_headers: 'Actions',
+                     page: params.fetch(:page, 1),
+                     per_page: params.fetch(:per_page, 25),
+                     incomplete_jobs: @incomplete_jobs,
+                     failed_jobs: @failed_jobs,
                      extra_fields_procs: lambda do |course_info| %>
   <td>
     <%= link_to 'List Students', customer_service_course_students_path(course_info.id),
-                                 class: 'btn btn-xs btn-primary' %>
-    <%= link_to 'Show', customer_service_course_path(course_info.id), class: "btn btn-xs btn-primary" %>
+                                 class: 'btn btn-sm btn-primary course-stats-button' %>
+    <%= link_to 'Show', customer_service_course_path(course_info.id), class: "btn btn-sm btn-primary  course-stats-button" %>
   </td>
 <% end } %>

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -88,7 +88,7 @@
     <% end %>
   </div>
 
-  <% unless incomplete_jobs.empty? %>
+  <% unless incomplete_jobs.blank? %>
     <div role="tabpanel" class="tab-pane" id="incomplete">
       <table class="table table-striped">
         <thead>
@@ -102,12 +102,10 @@
         <tbody>
         <% incomplete_jobs.each do |job| %>
           <tr>
-            <td><%= link_to(job.id, @job_path_proc.call(job)) %></td>
-            <td><%= job.state.name %></td>
-            <td><%= CourseProfile::Models::Profile.where(
-                        entity_course_id: job.data['course_id']
-                    ).first.try(:name) if job.data['course_id'] %></td>
-            <td><%= job.data['course_ecosystem'] %></td>
+            <td><%= link_to(job["id"], @job_path_proc.call(job["id"])) %></td>
+            <td><%= job["state_name"] %></td>
+            <td><%= job["course_profile_profile_name"] %></td>
+            <td><%= job["course_ecosystem"] %></td>
           </tr>
         <% end %>
       </table>
@@ -130,12 +128,10 @@
         <tbody>
         <% failed_jobs.each do |job| %>
           <tr>
-            <td><%= link_to(job.id, @job_path_proc.call(job)) %></td>
-            <td><%= job.state.name %></td>
-            <td><%= CourseProfile::Models::Profile.where(
-                        entity_course_id: job.data['course_id']
-                    ).first.try(:name) if job.data['course_id'] %></td>
-            <td><%= job.data['course_ecosystem'] %></td>
+            <td><%= link_to(job["id"], @job_path_proc.call(job["id"])) %></td>
+            <td><%= job["state_name"] %></td>
+            <td><%= job["course_profile_profile_name"] %></td>
+            <td><%= job["course_ecosystem"] %></td>
           </tr>
         <% end %>
       </table>

--- a/spec/controllers/customer_service/courses_controller_spec.rb
+++ b/spec/controllers/customer_service/courses_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CustomerService::CoursesController, type: :controller do
     end
 
     it 'passes the query param to SearchCourses along with order_by params' do
-      expect(SearchCourses).to receive(:[]).with(query: 'test', order_by: 'name').once
+      expect(SearchCourses).to receive(:call).with(query: 'test', order_by: 'name').once.and_call_original
       get :index, query: 'test', order_by: 'name'
     end
 
@@ -26,10 +26,10 @@ RSpec.describe CustomerService::CoursesController, type: :controller do
           expect(CourseProfile::Models::Profile.count).to eq(4)
 
           get :index, page: 1, per_page: 2
-          expect(assigns[:course_infos].count).to eq(2)
+          expect(assigns[:course_infos].length).to eq(2)
 
           get :index, page: 2, per_page: 2
-          expect(assigns[:course_infos].count).to eq(2)
+          expect(assigns[:course_infos].length).to eq(2)
         end
       end
 

--- a/spec/routines/collect_import_jobs_data_spec.rb
+++ b/spec/routines/collect_import_jobs_data_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe CollectImportJobsData, type: :routine do
+  context "when there are any" do
+    let!(:school) { FactoryGirl.build :school_district_school }
+    let!(:course_profile) { FactoryGirl.create :course_profile_profile, school: school, name: "Learn how to learn" }
+
+    before(:each) do
+      Jobba.all.delete_all!
+      expect(Jobba.all.count).to eq 0
+    end
+
+    context "incomplete (queued) jobs" do
+      before(:each) do
+        2.times{
+          job = Jobba.create!
+          job.save({ course_id: course_profile.entity_course_id, course_ecosystem: "Physics (334f8b61-30eb-4475-8e05-5260a4866b4b@7.42) - 2016-08-10 18:10:50 UTC" })
+          Jobba.find!(job.id).queued!
+        }
+        expect(Jobba.where(state: :incomplete).to_a.count).to eq 2
+      end
+
+      let!(:incomplete_jobs) { described_class[state: :incomplete] }
+
+      it "returns the incomplete jobs with their associated data as an array of hashes" do
+        expect(incomplete_jobs).to be_a Array
+        expect(incomplete_jobs.first).to be_a Hash
+      end
+
+      it "returns a hash with the specified keys for each item in the array" do
+        job =Jobba.where(state: :incomplete).to_a.last
+        expected_result = { id: job.id, state_name: job.state.name, course_ecosystem: job.data["course_ecosystem"],
+                            course_profile_profile_name: course_profile.name }
+        expect(incomplete_jobs.last).to match expected_result
+      end
+    end
+
+    context "failed jobs" do
+      before(:each) do
+        2.times{
+          job = Jobba.create!
+          job.save({ course_id: course_profile.entity_course_id, course_ecosystem: "Physics (334f8b61-30eb-4475-8e05-5260a4866b4b@7.42) - 2016-08-10 18:10:50 UTC" })
+          Jobba.find!(job.id).failed!
+        }
+        expect(Jobba.where(state: :failed).to_a.count).to eq 2
+      end
+      let!(:failed_jobs) { described_class[state: :failed] }
+
+      it "returns the failed jobs with their associated data as an array of hashes" do
+        expect(failed_jobs.count).to eq 2
+        expect(failed_jobs).to be_a Array
+        expect(failed_jobs.first).to be_a Hash
+      end
+
+      it "returns a hash with the specified keys for each item in the array" do
+        job = Jobba.where(state: :failed).to_a.last
+        expected_result = { id: job.id, state_name: job.state.name, course_ecosystem: job.data["course_ecosystem"],
+                            course_profile_profile_name: course_profile.name }
+        expect(failed_jobs.last).to match expected_result
+      end
+    end
+  end
+
+  context "when there are no results" do
+    before(:each) do
+      Jobba.all.delete_all!
+      expect(Jobba.all.count).to eq 0
+    end
+
+    it "doesn't blow up" do
+      expect{described_class[state: :incomplete]}.to_not raise_error
+    end
+
+    it "returns an empty array" do
+      result = described_class[state: :incomplete]
+      expect(result).to eq []
+    end
+  end
+
+  context "when the results have no data hash" do
+    before(:each) do
+      Jobba.all.delete_all!
+      expect(Jobba.all.count).to eq 0
+
+      2.times {
+        job = Jobba.create!
+        Jobba.find!(job.id).queued!
+      }
+      expect(Jobba.where(state: :queued).to_a.count).to eq 2
+    end
+
+    it "doesn't blow up" do
+      expect{described_class[state: :queued]}.to_not raise_error
+    end
+
+    it "returns an empty array" do
+      result = described_class[state: :queued]
+      expect(result).to eq []
+    end
+  end
+end

--- a/spec/routines/collect_import_jobs_data_spec.rb
+++ b/spec/routines/collect_import_jobs_data_spec.rb
@@ -12,15 +12,13 @@ RSpec.describe CollectImportJobsData, type: :routine do
 
     context "incomplete (queued) jobs" do
       before(:each) do
-        2.times{
-          job = Jobba.create!
-          job.save({ course_id: course_profile.entity_course_id, course_ecosystem: "Physics (334f8b61-30eb-4475-8e05-5260a4866b4b@7.42) - 2016-08-10 18:10:50 UTC" })
-          Jobba.find!(job.id).queued!
-        }
-        expect(Jobba.where(state: :incomplete).to_a.count).to eq 2
+        job = Jobba.create!
+        job.save({ course_id: course_profile.entity_course_id, course_ecosystem: "Physics (334f8b61-30eb-4475-8e05-5260a4866b4b@7.42) - 2016-08-10 18:10:50 UTC" })
+        job.queued!
+        expect(Jobba.where(state: :incomplete).to_a.count).to eq 1
       end
 
-      let!(:incomplete_jobs) { described_class[state: :incomplete] }
+      let(:incomplete_jobs) { described_class[state: :incomplete] }
 
       it "returns the incomplete jobs with their associated data as an array of hashes" do
         expect(incomplete_jobs).to be_a Array
@@ -28,35 +26,33 @@ RSpec.describe CollectImportJobsData, type: :routine do
       end
 
       it "returns a hash with the specified keys for each item in the array" do
-        job =Jobba.where(state: :incomplete).to_a.last
+        job =Jobba.where(state: :incomplete).to_a.first
         expected_result = { id: job.id, state_name: job.state.name, course_ecosystem: job.data["course_ecosystem"],
                             course_profile_profile_name: course_profile.name }
-        expect(incomplete_jobs.last).to match expected_result
+        expect(incomplete_jobs.first).to match expected_result
       end
     end
 
     context "failed jobs" do
       before(:each) do
-        2.times{
-          job = Jobba.create!
-          job.save({ course_id: course_profile.entity_course_id, course_ecosystem: "Physics (334f8b61-30eb-4475-8e05-5260a4866b4b@7.42) - 2016-08-10 18:10:50 UTC" })
-          Jobba.find!(job.id).failed!
-        }
-        expect(Jobba.where(state: :failed).to_a.count).to eq 2
+        job = Jobba.create!
+        job.save({ course_id: course_profile.entity_course_id, course_ecosystem: "Physics (334f8b61-30eb-4475-8e05-5260a4866b4b@7.42) - 2016-08-10 18:10:50 UTC" })
+        job.failed!
+        expect(Jobba.where(state: :failed).to_a.count).to eq 1
       end
-      let!(:failed_jobs) { described_class[state: :failed] }
+      let(:failed_jobs) { described_class[state: :failed] }
 
       it "returns the failed jobs with their associated data as an array of hashes" do
-        expect(failed_jobs.count).to eq 2
+        expect(failed_jobs.count).to eq 1
         expect(failed_jobs).to be_a Array
         expect(failed_jobs.first).to be_a Hash
       end
 
       it "returns a hash with the specified keys for each item in the array" do
-        job = Jobba.where(state: :failed).to_a.last
+        job = Jobba.where(state: :failed).to_a.first
         expected_result = { id: job.id, state_name: job.state.name, course_ecosystem: job.data["course_ecosystem"],
                             course_profile_profile_name: course_profile.name }
-        expect(failed_jobs.last).to match expected_result
+        expect(failed_jobs.first).to match expected_result
       end
     end
   end


### PR DESCRIPTION
Created `CollectImportJobsData` to clean up the controller but more importantly, to get rid of an N+1 query due to `where` statements inside of the views.