### PR TITLE
Display an error when student attempts to join after drop or period is archived

### DIFF
--- a/app/assets/stylesheets/enroll.scss
+++ b/app/assets/stylesheets/enroll.scss
@@ -60,3 +60,27 @@
     margin-top: 15px;
   }
 }
+
+.enrollment-failure {
+  .explain {
+    font-size: 25px;
+    max-width: 600px;
+    margin: 30px auto;
+  }
+  .continue {
+    text-align: center;
+    font-size: 16px;
+  }
+  &.archived {
+    .continue .btn {
+      background-color: $btn-primary-bg;
+      color: $btn-primary-color;
+    }
+  }
+  &.dropped {
+    .continue .btn {
+      background-color: $btn-success-bg;
+      color: $btn-success-color;
+    }
+  }
+}

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -8,14 +8,7 @@ class CoursesController < ApplicationController
     handle_with(CoursesEnroll,
                 success: -> {},
                 failure: -> {
-                  case @handler_result.errors.map(&:code).first
-                  when :user_is_already_a_course_student
-                    send_to_student_dashboard(notice: "You are already enrolled in this course.")
-                  when :enrollment_code_not_found
-                    enrollment_code_not_found
-                  else
-                    raise StandardError, "Student URL enrollment failed: #{@handler_result.errors}"
-                  end
+                  handle_enrollment_failures(@handler_result.errors.map(&:code).first)
                 })
   end
 
@@ -28,21 +21,31 @@ class CoursesController < ApplicationController
                   )
                 },
                 failure: -> {
-                  case @handler_result.errors.map(&:code).first
-                  when :user_is_already_a_course_student
-                    send_to_student_dashboard(notice: "You are already enrolled in this course.")
-                  when :enrollment_code_not_found
-                    enrollment_code_not_found
-                  when :taken
-                    flash[:error] = "That school-issued ID is already in use."
-                    redirect_to token_enroll_path(params[:enroll][:enrollment_token])
-                  else
-                    raise StandardError, "Student URL enrollment confirmation failed: #{@handler_result.errors}"
-                  end
+                  handle_enrollment_failures(@handler_result.errors.map(&:code).first)
                 })
   end
 
   private
+
+  def handle_enrollment_failures(error_code)
+    case error_code
+    when :user_is_already_a_course_student
+      send_to_student_dashboard(notice: "You are already enrolled in this course.")
+    when :user_is_an_inactive_student
+      send_to_dashboard(notice: "Your membership in the course is inactive.")
+    when :enrollment_code_not_found
+      enrollment_code_not_found
+    when :taken
+      flash[:error] = "That school-issued ID is already in use."
+      redirect_to token_enroll_path(params[:enroll][:enrollment_token])
+    else
+      raise StandardError, "Student URL enrollment failed: #{@handler_result.errors}"
+    end
+  end
+
+  def send_to_dashboard(notice: nil)
+    redirect_to dashboard_path, webview_notice: notice
+  end
 
   def send_to_student_dashboard(notice: nil)
     course = @handler_result.outputs.course

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,7 @@
 class CoursesController < ApplicationController
 
+  skip_before_filter :authenticate_user!, if: :period_is_archived?
+
   def teach
     handle_with(CoursesTeach, complete: -> { send_to_teacher_dashboard })
   end
@@ -26,6 +28,12 @@ class CoursesController < ApplicationController
   end
 
   private
+
+  def period_is_archived?
+    return false if params[:enroll_token].blank?
+    period = CourseMembership::GetPeriod[ enrollment_code: params[:enroll_token] ]
+    period.nil? || period.deleted?
+  end
 
   def handle_enrollment_failures(error_code)
     case error_code

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -32,7 +32,7 @@ class CoursesController < ApplicationController
     when :user_is_already_a_course_student
       send_to_student_dashboard(notice: "You are already enrolled in this course.")
     when :user_is_an_inactive_student
-      send_to_dashboard(notice: "Your membership in the course is inactive.")
+      send_to_dashboard(notice: "Your membership in the course is inactive.  Please contact the instructor for assistance.")
     when :enrollment_code_not_found
       enrollment_code_not_found
     when :taken

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -59,12 +59,12 @@ class CoursesController < ApplicationController
 
   def send_to_student_dashboard(notice: nil)
     course = @handler_result.outputs.course
-    redirect_to student_course_dashboard_path(course), webview_notice: notice
+    redirect_to student_course_dashboard_path(course.id), webview_notice: notice
   end
 
   def send_to_teacher_dashboard(notice: nil)
     course = @handler_result.outputs.course
-    redirect_to course_dashboard_path(course), notice: notice
+    redirect_to course_dashboard_path(course.id), notice: notice
   end
 
   def enrollment_code_not_found

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -29,10 +29,12 @@ class CoursesController < ApplicationController
 
   def handle_enrollment_failures(error_code)
     case error_code
+    when :period_is_archived
+      render :archived_enrollment
     when :user_is_already_a_course_student
       send_to_student_dashboard(notice: "You are already enrolled in this course.")
-    when :user_is_an_inactive_student
-      send_to_dashboard(notice: "Your membership in the course is inactive.  Please contact the instructor for assistance.")
+    when :user_is_dropped
+      render :dropped_student
     when :enrollment_code_not_found
       enrollment_code_not_found
     when :taken

--- a/app/handlers/courses_enroll.rb
+++ b/app/handlers/courses_enroll.rb
@@ -23,7 +23,7 @@ class CoursesEnroll
                if user_test.is_dropped || user_test.is_archived
 
     fatal_error(code: :user_is_already_a_course_student) \
-               unless user_test.is_course_student
+               if user_test.user_is_course_student
 
     run(:collect_course_info, courses: outputs.period.course, with: [:teacher_names])
   end

--- a/app/handlers/courses_enroll.rb
+++ b/app/handlers/courses_enroll.rb
@@ -14,8 +14,16 @@ class CoursesEnroll
     fatal_error(code: :enrollment_code_not_found) if outputs.period.nil?
     outputs.course = outputs.period.course
 
+    user_test = UserIsCourseStudent.call(
+      course: outputs.period.course, user: caller,
+      include_dropped: true, include_archived: true
+    ).outputs
+
+    fatal_error(code: :user_is_an_inactive_student) \
+               if user_test.is_dropped || user_test.is_archived
+
     fatal_error(code: :user_is_already_a_course_student) \
-      if UserIsCourseStudent[course: outputs.period.course, user: caller]
+               unless user_test.is_course_student
 
     run(:collect_course_info, courses: outputs.period.course, with: [:teacher_names])
   end

--- a/app/handlers/courses_enroll.rb
+++ b/app/handlers/courses_enroll.rb
@@ -1,11 +1,9 @@
 class CoursesEnroll
   lev_handler
 
-  uses_routine CourseMembership::GetPeriod,             as: :get_period,       translations: { outputs: { type: :verbatim } }
-
-  uses_routine CollectCourseInfo,                       as: :get_course_info,  translations: { outputs: {type: :verbatim  } }
-
-  uses_routine UserIsCourseStudent,                     as: :is_student,       translations: { outputs: {type: :verbatim  } }
+  uses_routine CourseMembership::GetPeriod, as: :get_period,       translations: { outputs: { type: :verbatim } }
+  uses_routine CollectCourseInfo,           as: :get_course_info,  translations: { outputs: { type: :verbatim } }
+  uses_routine UserIsCourseStudent,         as: :is_student,       translations: { outputs: { type: :verbatim } }
 
   protected
 

--- a/app/handlers/courses_enroll.rb
+++ b/app/handlers/courses_enroll.rb
@@ -4,7 +4,7 @@ class CoursesEnroll
   uses_routine CourseMembership::GetPeriod, as: :get_period,       translations: { outputs: { type: :verbatim } }
   uses_routine CollectCourseInfo,           as: :get_course_info,  translations: { outputs: { type: :verbatim } }
   uses_routine UserIsCourseStudent,         as: :is_student,       translations: { outputs: { type: :verbatim } }
-
+  uses_routine GetUserCourses,              as: :get_courses
   protected
 
   def authorized?; true; end
@@ -13,9 +13,12 @@ class CoursesEnroll
     run(:get_period, enrollment_code: params[:enroll_token])
     fatal_error(code: :enrollment_code_not_found) if outputs.period.nil?
 
-    outputs.course = outputs.period.course
+    run(:get_course_info, with: [:teacher_names], courses: outputs.period.course)
+    outputs.course = outputs.courses.first
 
-    run(:is_student, course: outputs.course, user: caller,
+    outputs.current_courses = run(:get_courses, user: caller).outputs.courses.reject{|c| c.id == outputs.period.course.id }
+
+    run(:is_student, course: outputs.period.course, user: caller,
         include_dropped: true, include_archived: false)
 
     fatal_error(code: :period_is_archived) if outputs.period.deleted?
@@ -23,8 +26,6 @@ class CoursesEnroll
 
     fatal_error(code: :user_is_already_a_course_student) \
                if outputs.user_is_course_student && !outputs.is_dropped
-
-    run(:get_course_info, courses: outputs.course, with: [:teacher_names])
   end
 
 end

--- a/app/handlers/courses_enroll.rb
+++ b/app/handlers/courses_enroll.rb
@@ -1,9 +1,11 @@
 class CoursesEnroll
   lev_handler
 
-  uses_routine CourseMembership::GetPeriod, as: :get_period,
-                                            translations: { outputs: { type: :verbatim } }
-  uses_routine CollectCourseInfo, translations: { outputs: {type: :verbatim} }
+  uses_routine CourseMembership::GetPeriod,             as: :get_period,       translations: { outputs: { type: :verbatim } }
+
+  uses_routine CollectCourseInfo,                       as: :get_course_info,  translations: { outputs: {type: :verbatim  } }
+
+  uses_routine UserIsCourseStudent,                     as: :is_student,       translations: { outputs: {type: :verbatim  } }
 
   protected
 
@@ -12,20 +14,19 @@ class CoursesEnroll
   def handle
     run(:get_period, enrollment_code: params[:enroll_token])
     fatal_error(code: :enrollment_code_not_found) if outputs.period.nil?
+
     outputs.course = outputs.period.course
 
-    user_test = UserIsCourseStudent.call(
-      course: outputs.period.course, user: caller,
-      include_dropped: true, include_archived: true
-    ).outputs
+    run(:is_student, course: outputs.course, user: caller,
+        include_dropped: true, include_archived: false)
 
-    fatal_error(code: :user_is_an_inactive_student) \
-               if user_test.is_dropped || user_test.is_archived
+    fatal_error(code: :period_is_archived) if outputs.period.deleted?
+    fatal_error(code: :user_is_dropped)    if outputs.is_dropped
 
     fatal_error(code: :user_is_already_a_course_student) \
-               if user_test.user_is_course_student
+               if outputs.user_is_course_student && !outputs.is_dropped
 
-    run(:collect_course_info, courses: outputs.period.course, with: [:teacher_names])
+    run(:get_course_info, courses: outputs.course, with: [:teacher_names])
   end
 
 end

--- a/app/routines/add_user_as_period_student.rb
+++ b/app/routines/add_user_as_period_student.rb
@@ -14,14 +14,10 @@ class AddUserAsPeriodStudent
     result = run(UserIsCourseTeacher, user: user, course: course)
 
     unless result.outputs.user_is_course_teacher
-      user_test = run(UserIsCourseStudent, user: user, course: course,
-                      include_dropped: true, include_archived: true).outputs
-
-      fatal_error(code: :user_is_an_inactive_student, offending_inputs: [user, course]) \
-                 if user_test.is_dropped || user_test.is_archived
+      result = run(UserIsCourseStudent, user: user, course: course, include_dropped: true)
 
       fatal_error(code: :user_is_already_a_course_student, offending_inputs: [user, course]) \
-                 if user_test.user_is_course_student
+        if result.outputs.user_is_course_student
     end
 
     run(Role::CreateUserRole, user, :student)
@@ -29,5 +25,4 @@ class AddUserAsPeriodStudent
                                       student_identifier: student_identifier,
                                       assign_published_period_tasks: assign_published_period_tasks)
   end
-
 end

--- a/app/routines/add_user_as_period_student.rb
+++ b/app/routines/add_user_as_period_student.rb
@@ -18,6 +18,9 @@ class AddUserAsPeriodStudent
 
       fatal_error(code: :user_is_already_a_course_student, offending_inputs: [user, course]) \
         if result.outputs.user_is_course_student
+
+      fatal_error(code: :period_is_archived, offending_inputs: [user, course]) \
+        if period.deleted?
     end
 
     run(Role::CreateUserRole, user, :student)

--- a/app/routines/add_user_as_period_student.rb
+++ b/app/routines/add_user_as_period_student.rb
@@ -14,10 +14,14 @@ class AddUserAsPeriodStudent
     result = run(UserIsCourseTeacher, user: user, course: course)
 
     unless result.outputs.user_is_course_teacher
-      result = run(UserIsCourseStudent, user: user, course: course, include_dropped: true)
+      user_test = run(UserIsCourseStudent, user: user, course: course,
+                      include_dropped: true, include_archived: true).outputs
+
+      fatal_error(code: :user_is_an_inactive_student, offending_inputs: [user, course]) \
+                 if user_test.is_dropped || user_test.is_archived
 
       fatal_error(code: :user_is_already_a_course_student, offending_inputs: [user, course]) \
-        if result.outputs.user_is_course_student
+                 if user_test.user_is_course_student
     end
 
     run(Role::CreateUserRole, user, :student)
@@ -25,4 +29,5 @@ class AddUserAsPeriodStudent
                                       student_identifier: student_identifier,
                                       assign_published_period_tasks: assign_published_period_tasks)
   end
+
 end

--- a/app/subsystems/course_membership/get_period.rb
+++ b/app/subsystems/course_membership/get_period.rb
@@ -8,7 +8,7 @@ class CourseMembership::GetPeriod
       CourseMembership::Models::Period.with_deleted.preload(:course).find(id)
     elsif enrollment_code.present?
       enrollment_code = enrollment_code.gsub(/-/,' ') # for codes from URLs
-      CourseMembership::Models::Period.find_by(enrollment_code: enrollment_code)
+      CourseMembership::Models::Period.with_deleted.find_by(enrollment_code: enrollment_code)
     else
       raise IllegalArgument, "One of `id` or `enrollment_code` must be given."
     end

--- a/app/subsystems/course_membership/is_course_student.rb
+++ b/app/subsystems/course_membership/is_course_student.rb
@@ -12,5 +12,17 @@ class CourseMembership::IsCourseStudent
     outputs[:is_course_student] = students.any? do |student|
       student.present? && (include_archived || !student.period.deleted?)
     end
+
+    if include_dropped
+      outputs[:is_dropped] = students.all? do |student|
+        student.present? && student.deleted?
+      end
+    end
+
+    if include_archived
+      outputs[:is_archived] = students.all? do |student|
+        student.present? && student.period.deleted?
+      end
+    end
   end
 end

--- a/app/subsystems/course_membership/is_course_student.rb
+++ b/app/subsystems/course_membership/is_course_student.rb
@@ -9,20 +9,18 @@ class CourseMembership::IsCourseStudent
     relation = relation.with_deleted if include_dropped
     students = relation.where(entity_role_id: roles)
 
-    outputs[:is_course_student] = students.any? do |student|
-      student.present? && (include_archived || !student.period.deleted?)
+    valid_student = students.detect do | student |
+      ! ( student.deleted? || student.period.deleted? )
     end
 
     if include_dropped
-      outputs[:is_dropped] = students.all? do |student|
-        student.present? && student.deleted?
-      end
+      outputs[:is_dropped] = valid_student.nil? && students.any? { | student | student.deleted? }
     end
 
     if include_archived
-      outputs[:is_archived] = students.all? do |student|
-        student.present? && student.period.deleted?
-      end
+      outputs[:is_archived] = valid_student.nil? && students.any? { | student | student.period.deleted? }
     end
+
+    outputs[:is_course_student] = !!(valid_student.present? || outputs[:is_dropped] || outputs[:is_archived])
   end
 end

--- a/app/views/courses/_course_identifier_sentence.html.erb
+++ b/app/views/courses/_course_identifier_sentence.html.erb
@@ -1,0 +1,4 @@
+<% teacher_names = courses.find{|c| c['id'] == period.course.id}['teacher_names'] %>
+<%= period.course.name %> (<%= period.name %>)
+<br />
+<%= "Instructor".pluralize(teacher_names.count) %>: <%= teacher_names.to_sentence %>

--- a/app/views/courses/archived_enrollment.html.erb
+++ b/app/views/courses/archived_enrollment.html.erb
@@ -1,0 +1,1 @@
+inactive

--- a/app/views/courses/archived_enrollment.html.erb
+++ b/app/views/courses/archived_enrollment.html.erb
@@ -1,1 +1,15 @@
-inactive
+<div class="enrollment-failure archived">
+  <p class="explain">
+    This is a link to a past course or one that is inactive.
+    Please contact the instructor of the course you would like to enroll in for assistance.
+  </p>
+  <p class="continue">
+    <% if current_user.is_anonymous? %>
+      <%= link_to 'Sign in', openstax_accounts.login_path, class: 'btn' %> to view your current courses
+    <% elsif @handler_result.outputs.current_courses.any? %>
+      <%= link_to 'Continue', dashboard_path, class: 'btn' %> to view your current courses
+    <% else %>
+      <%= link_to 'Continue', openstax_accounts.profile_path, class: 'btn' %> to your account info
+    <% end %>
+  </p>
+</div>

--- a/app/views/courses/dropped_student.html.erb
+++ b/app/views/courses/dropped_student.html.erb
@@ -1,0 +1,1 @@
+dropped

--- a/app/views/courses/dropped_student.html.erb
+++ b/app/views/courses/dropped_student.html.erb
@@ -1,1 +1,18 @@
-dropped
+<div class="enrollment-failure dropped">
+  <p class="explain">
+
+    Our records show you have been dropped from
+    <br />
+    <%= render partial: 'course_identifier_sentence', locals: @handler_result.outputs.to_hash.symbolize_keys.slice(:courses, :period) %>
+    <br />
+    Please contact the instructor of the course you would like to enroll in for assistance.
+  </p>
+
+  <p class="continue">
+    <% if @handler_result.outputs.current_courses.any? %>
+      <%= link_to 'Continue', dashboard_path, class: 'btn' %> to view your current courses
+    <% else %>
+      <%= link_to 'Continue', openstax_accounts.profile_path, class: 'btn' %> to your account info
+    <% end %>
+  </p>
+</div>

--- a/app/views/courses/enroll.html.erb
+++ b/app/views/courses/enroll.html.erb
@@ -1,8 +1,9 @@
-<% course = @handler_result.outputs.courses.first %>
-<% period = @handler_result.outputs.period %>
-
 <div id="enroll" class="well">
-  <h2>You are joining<br/><%= course.name %> (<%= period.name %>)<br/><%= "Instructor".pluralize(course.teacher_names.count) %>: <%= course.teacher_names.to_sentence %></h2>
+  <h2>
+    You are joining
+    <br/>
+    <%= render partial: 'course_identifier_sentence', locals: @handler_result.outputs.to_hash.symbolize_keys.slice(:courses, :period) %>
+  </h2>
   <hr/>
 
   <%= lev_form_for :enroll, url: confirm_token_enroll_path, method: 'post', html: {class: 'form-inline'} do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
 
   root 'webview#home'
 
-  get '/dashboard', to: 'webview#index'
+  get '/dashboard', to: 'webview#index', as: :dashboard
 
   scope module: 'static_pages' do
     get 'about'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
 
   root 'webview#home'
 
-  get '/dashboard', to: 'webview#index', as: :dashboard
+  get '/dashboard', to: 'webview#index'
 
   scope module: 'static_pages' do
     get 'about'

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe 'Students enrolling via URL' do
       visit token_enroll_path(period1.enrollment_code_for_url)
       expect(current_path).to eq(openstax_accounts.dev_accounts_path)
     end
+    context 'when period is archived' do
+      before { period1.to_model.destroy }
+      it 'displayes error page' do
+        visit token_enroll_path(period1.enrollment_code_for_url)
+        expect(page.body).to have_content 'inactive'
+      end
+    end
   end
 
   context 'authenticated' do

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Students enrolling via URL' do
         it "redirects to dashboard and displays an error" do
           visit token_enroll_path(period1.enrollment_code_for_url)
           expect(current_path).to eq(dashboard_path)
-          expect(page.body).to match have_content '"notice":"Your membership in the course is inactive."'
+          expect(page.body).to have_content '"notice":"Your membership in the course is inactive.'
         end
 
       end
@@ -104,7 +104,7 @@ RSpec.describe 'Students enrolling via URL' do
         it "redirects to dashboard and displays an error" do
           visit token_enroll_path(period1.enrollment_code_for_url)
           expect(current_path).to eq(dashboard_path)
-          expect(page.body).to match have_content '"notice":"Your membership in the course is inactive."'
+          expect(page.body).to have_content '"notice":"Your membership in the course is inactive.'
         end
 
       end

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -65,6 +65,25 @@ RSpec.describe 'Students enrolling via URL' do
 
       end
 
+      context 'when a student of a different course that uses same ecosystem' do
+        let(:other_course) { CreateCourse[name: 'Biology'] }
+        let(:other_period) { CreatePeriod[course: other_course, name: '1st'] }
+
+        before {
+          AddUserAsPeriodStudent[period: other_period, user: user, student_identifier: '12345']
+        }
+
+        it 'registers for new course and stays in current' do
+          visit token_enroll_path(period1.enrollment_code_for_url)
+          fill_in 'enroll_student_id', with: '12345'
+          click_button 'Continue'
+          # member of new course
+          expect(UserIsCourseStudent[course: course, user: user]).to be_truthy
+          # and still a member of other course
+          expect(UserIsCourseStudent[course: other_course, user: user]).to be_truthy
+        end
+      end
+
       context 'when dropped' do
         before { AddUserAsPeriodStudent.call(user: user, period: period1).outputs.student.destroy }
 

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -65,6 +65,31 @@ RSpec.describe 'Students enrolling via URL' do
 
       end
 
+      context 'when dropped' do
+        before { AddUserAsPeriodStudent.call(user: user, period: period1).outputs.student.destroy }
+
+        it "redirects to dashboard and displays an error" do
+          visit token_enroll_path(period1.enrollment_code_for_url)
+          expect(current_path).to eq(dashboard_path)
+          expect(page.body).to match have_content '"notice":"Your membership in the course is inactive."'
+        end
+
+      end
+
+      context 'when period is archived' do
+        before {
+          AddUserAsPeriodStudent[user: user, period: period1]
+          period1.to_model.destroy
+        }
+
+        it "redirects to dashboard and displays an error" do
+          visit token_enroll_path(period1.enrollment_code_for_url)
+          expect(current_path).to eq(dashboard_path)
+          expect(page.body).to match have_content '"notice":"Your membership in the course is inactive."'
+        end
+
+      end
+
       context 'when already a student of targeted period' do
         before { AddUserAsPeriodStudent[user: user, period: period1] }
 

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Students enrolling via URL' do
           expect(UserIsCourseStudent[course: course, user: user]).to be_truthy
           expect(CourseMembership::Models::Enrollment.last.period).to eq period1.to_model
           expect(current_path).to eq(student_course_dashboard_path(course))
-          expect(page.body).to match /notice\":\"Enrollment successful! It may take/
+          expect(page.body).to match(/notice\":\"Enrollment successful! It may take/)
           expect(CourseMembership::Models::Student.last.student_identifier).to eq '12345'
         end
 
@@ -62,7 +62,6 @@ RSpec.describe 'Students enrolling via URL' do
           expect(page).to have_content 'Enter your school-issued'
           expect(UserIsCourseStudent[course: course, user: user]).to be_falsy
         end
-
       end
 
       context 'when a student of a different course that uses same ecosystem' do
@@ -89,8 +88,7 @@ RSpec.describe 'Students enrolling via URL' do
 
         it "redirects to dashboard and displays an error" do
           visit token_enroll_path(period1.enrollment_code_for_url)
-          expect(current_path).to eq(dashboard_path)
-          expect(page.body).to have_content '"notice":"Your membership in the course is inactive.'
+          expect(page.body).to have_content 'dropped'
         end
 
       end
@@ -102,10 +100,6 @@ RSpec.describe 'Students enrolling via URL' do
         }
 
         context 'and a different period is joined' do
-          before {
-            AddUserAsPeriodStudent[user: user, period: period2]
-          }
-
           it 'works when student ID is supplied' do
             visit token_enroll_path(period2.enrollment_code_for_url)
             expect(page).to have_content('school-issued')
@@ -119,11 +113,11 @@ RSpec.describe 'Students enrolling via URL' do
         context 'and is joined' do
           it 'redirects to dashboard and displays an error' do
             visit token_enroll_path(period1.enrollment_code_for_url)
-            expect(current_path).to eq(dashboard_path)
-            expect(page.body).to have_content '"notice":"Your membership in the course is inactive.'
+            expect(page.body).to have_content 'inactive'
           end
-
         end
+
+
       end
 
       context 'when already a student of targeted period' do

--- a/spec/routines/add_user_as_period_student_spec.rb
+++ b/spec/routines/add_user_as_period_student_spec.rb
@@ -32,6 +32,31 @@ describe AddUserAsPeriodStudent, type: :routine do
         expect(result.errors).to_not be_empty
       end
     end
+
+    context "and is a previously dropped student" do
+      before(:each) do
+        student = AddUserAsPeriodStudent.call(user: user, period: period)
+                  .outputs.student
+        student.destroy
+      end
+      it "has inactive student error" do
+        result = AddUserAsPeriodStudent.call(user: user, period: period)
+        expect(result.errors).to_not be_empty
+        expect(result.errors.map(&:code).first).to be :user_is_an_inactive_student
+      end
+    end
+
+    context "and the period is archived" do
+      before(:each) do
+        AddUserAsPeriodStudent.call(user: user, period: period)
+        period.to_model.destroy
+      end
+      fit "has inactive student error" do
+        result = AddUserAsPeriodStudent.call(user: user, period: period)
+        expect(result.errors).to_not be_empty
+        expect(result.errors.map(&:code).first).to be :user_is_an_inactive_student
+      end
+    end
   end
 
   context "when the given user is a teacher in the given course" do

--- a/spec/routines/add_user_as_period_student_spec.rb
+++ b/spec/routines/add_user_as_period_student_spec.rb
@@ -42,7 +42,7 @@ describe AddUserAsPeriodStudent, type: :routine do
       it "has inactive student error" do
         result = AddUserAsPeriodStudent.call(user: user, period: period)
         expect(result.errors).to_not be_empty
-        expect(result.errors.map(&:code).first).to be :user_is_an_inactive_student
+        expect(result.errors.map(&:code).first).to be :user_is_already_a_course_student
       end
     end
 
@@ -54,7 +54,7 @@ describe AddUserAsPeriodStudent, type: :routine do
       it "has inactive student error" do
         result = AddUserAsPeriodStudent.call(user: user, period: period)
         expect(result.errors).to_not be_empty
-        expect(result.errors.map(&:code).first).to be :user_is_an_inactive_student
+        expect(result.errors.map(&:code).first).to be :period_is_archived
       end
     end
   end

--- a/spec/routines/add_user_as_period_student_spec.rb
+++ b/spec/routines/add_user_as_period_student_spec.rb
@@ -51,7 +51,7 @@ describe AddUserAsPeriodStudent, type: :routine do
         AddUserAsPeriodStudent.call(user: user, period: period)
         period.to_model.destroy
       end
-      fit "has inactive student error" do
+      it "has inactive student error" do
         result = AddUserAsPeriodStudent.call(user: user, period: period)
         expect(result.errors).to_not be_empty
         expect(result.errors.map(&:code).first).to be :user_is_an_inactive_student

--- a/spec/subsystems/course_membership/is_course_student_spec.rb
+++ b/spec/subsystems/course_membership/is_course_student_spec.rb
@@ -48,10 +48,7 @@ describe CourseMembership::IsCourseStudent do
     let(:target_course)       { Entity::Course.create! }
     let(:target_period)       { CreatePeriod[course: target_course] }
     let(:target_student_role) { Entity::Role.create! }
-
-    before(:each) do
-      CourseMembership::AddStudent.call(period: target_period, role: target_student_role)
-    end
+    let!(:student) { CourseMembership::AddStudent[period: target_period, role: target_student_role] }
 
     context "when a single role is given" do
       it "returns true" do
@@ -68,6 +65,7 @@ describe CourseMembership::IsCourseStudent do
 
         result = CourseMembership::IsCourseStudent.call(course: target_course, roles: roles)
         expect(result.errors).to be_empty
+        expect(result.outputs.is_archived).to be_nil
         expect(result.outputs.is_course_student).to be_truthy
       end
     end
@@ -80,6 +78,32 @@ describe CourseMembership::IsCourseStudent do
         expect(is_course_student).to be_truthy
       end
     end
+    context "when period is archived" do
+      before(:each) do
+        target_period.to_model.destroy
+      end
+      it "returns is_archived" do
+        result = CourseMembership::IsCourseStudent.call(
+          course: target_course, roles: target_student_role, include_archived: true
+        )
+        expect(result.outputs.is_archived).to be true
+      end
+    end
+
+    context "when student is dropped" do
+      before(:each) do
+        student.destroy
+      end
+      it "returns is_dropped" do
+        result = CourseMembership::IsCourseStudent.call(
+          course: target_course, roles: target_student_role, include_dropped: true
+        )
+        expect(result.outputs.is_archived).to be_nil
+        expect(result.outputs.is_dropped).to be true
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
Fixes a bug where if a student was dropped or the period was archived, but the student still has an enrollment url and uses it.

In that case we would seemingly accept the url and ask for a student id.  The BE would seem to accept the id, and then redirect to the course's dashboard.  The FE would then have a JS error when it didn't find an active course membership (because dropped/inactive), and would display a blank page.


When student has been dropped:
![screen shot 2016-09-16 at 3 02 41 pm](https://cloud.githubusercontent.com/assets/79566/18599548/a6e4a682-7c1e-11e6-8fd4-d790fa50b603.png)




When course is archived:
![screen shot 2016-09-16 at 10 05 29 am](https://cloud.githubusercontent.com/assets/79566/18599496/41e89428-7c1e-11e6-9de7-29c8b846286b.png)



