### PR TITLE
Touch task when tasking_plans are updated, test concurrent locks

### DIFF
--- a/app/subsystems/tasks/models/tasking_plan.rb
+++ b/app/subsystems/tasks/models/tasking_plan.rb
@@ -4,7 +4,7 @@ class Tasks::Models::TaskingPlan < Tutor::SubSystems::BaseModel
 
   belongs_to_time_zone :opens_at, :due_at, suffix: :ntz
 
-  belongs_to :task_plan, -> { with_deleted }, inverse_of: :tasking_plans
+  belongs_to :task_plan, -> { with_deleted }, inverse_of: :tasking_plans, touch: true
   belongs_to :target, -> { respond_to?(:with_deleted) ? with_deleted : all }, polymorphic: true
 
   validates :target, presence: true

--- a/lib/fork_with_connection.rb
+++ b/lib/fork_with_connection.rb
@@ -35,7 +35,7 @@ module Tutor
 
       ensure
         ActiveRecord::Base.remove_connection
-        Process.exit! exit_status.to_i
+        Process.exit! exit_status.is_a?(Fixnum) ? exit_status : 0
       end
     end
 

--- a/lib/fork_with_connection.rb
+++ b/lib/fork_with_connection.rb
@@ -12,8 +12,14 @@ module Tutor
 
       begin
         ActiveRecord::Base.establish_connection(ar_connection_config)
+        # settings are cached in Redis by rails-settings-cached
+        Rails.cache.reconnect
 
         Jobba.redis.client.reconnect
+
+        # reconnect fake client if Biglearn stubbing is enabled
+        OpenStax::Biglearn::V1.client.store.reconnect \
+          if OpenStax::Biglearn::V1.client.is_a? OpenStax::Biglearn::V1::FakeClient
 
         # This is needed to re-initialize the random number generator after forking (if you want diff random numbers generated in the forks)
         srand

--- a/lib/fork_with_connection.rb
+++ b/lib/fork_with_connection.rb
@@ -1,0 +1,42 @@
+# Logic for forking connections
+
+module Tutor
+  def self.fork_with_connection
+
+    # Store the ActiveRecord connection information
+    ar_connection_config = ActiveRecord::Base.remove_connection
+
+    pid = fork do
+      # tracking if the op failed for the Process exit
+      exit_status = 0
+
+      begin
+        ActiveRecord::Base.establish_connection(ar_connection_config)
+
+        Jobba.redis.client.reconnect
+
+        # This is needed to re-initialize the random number generator after forking (if you want diff random numbers generated in the forks)
+        srand
+
+        # Run the closure passed to the fork_with_new_connection method
+        exit_status = yield
+
+      rescue => e
+        STDERR.puts "Forked operation failed with exception: #{e}"
+
+        # the op failed, so note it for the Process exit
+        exit_status = 1
+
+      ensure
+        ActiveRecord::Base.remove_connection
+        Process.exit! exit_status.to_i
+      end
+    end
+
+    # Restore the ActiveRecord connection information
+    ActiveRecord::Base.establish_connection(ar_connection_config)
+
+    #return the process id
+    pid
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
   config.include CaptureStdoutHelper
   config.include WithoutException
   config.include SigninHelper
+  config.include PopulateExerciseContent
   config.extend VcrConfigurationHelper
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
 
     end
 
+    # Note - this isn't 100% guaranteed to fail.  There's still a chance that the forked children will process
+    # distribution in a way that doesn't trigger IsolationConflict exceptions.
+    # If this spec starts to fail in indeterminate ways and can't be fixed it can be removed
     it 'cannot be distributed concurrently' do
       plan = homework_plan
       pids = []

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -12,71 +12,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
 
   context "for Introduction and Force" do
     before(:all) do
-      cnx_page_hashes = [
-        { 'id' => '1bb611e9-0ded-48d6-a107-fbb9bd900851', 'title' => 'Introduction' },
-        { 'id' => '95e61258-2faf-41d4-af92-f62e1414175a', 'title' => 'Force' }
-      ]
-
-      @intro_step_gold_data = {
-        klass: Tasks::Models::TaskedReading,
-        title: "Forces and Newton's Laws of Motion",
-        related_content: [{title: "Forces and Newton's Laws of Motion",
-                           book_location: [8, 1]}]
-      }
-
-      @core_step_gold_data = [
-        @intro_step_gold_data,
-        { klass: Tasks::Models::TaskedReading,
-          title: "Force",
-          related_content: [{title: "Force",
-                             book_location: [8, 2]}] }
-      ]
-
-      @spaced_practice_step_gold_data = [
-        { klass: Tasks::Models::TaskedExercise,
-          title: nil,
-          related_content: [{title: "Force",
-                            book_location: [8, 2]}] },
-        { klass: Tasks::Models::TaskedExercise,
-          title: nil,
-          related_content: [{title: "Force",
-                             book_location: [8, 2]}] },
-      ]
-
-      @personalized_step_gold_data = [
-        { klass: Tasks::Models::TaskedPlaceholder,
-          title: nil,
-          related_content: [] }
-      ]
-
-      @task_step_gold_data = \
-        @core_step_gold_data + @spaced_practice_step_gold_data + @personalized_step_gold_data
-
-      cnx_pages = cnx_page_hashes.map do |hash|
-        OpenStax::Cnx::V1::Page.new(hash: hash)
-      end
-
-      chapter = FactoryGirl.create :content_chapter, title: "Forces and Newton's Laws of Motion"
-
-      ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(chapter.book.ecosystem)
-      @ecosystem = ::Content::Ecosystem.new(strategy: ecosystem_strategy)
-
-      @content_pages = VCR.use_cassette(
-                 'Tasks_Assistants_HomeworkAssistant/for_Introduction_and_Force/with_pages',
-                 VCR_OPTS
-               ) do
-        cnx_pages.map.with_index do |cnx_page, ii|
-          Content::Routines::ImportPage.call(
-            cnx_page:  cnx_page,
-            chapter: chapter,
-            book_location: [8, ii+1]
-          ).outputs.page.reload
-        end
-      end
-
-      @pages = @content_pages.map{ |content_page| Content::Page.new(strategy: content_page.wrap) }
-
-      Content::Routines::PopulateExercisePools[book: chapter.book]
+      generate_test_exercise_content
     end
 
     let(:core_pools)                     { @ecosystem.homework_core_pools(pages: @pages) }

--- a/spec/support/populate_exercise_content.rb
+++ b/spec/support/populate_exercise_content.rb
@@ -1,0 +1,72 @@
+require 'vcr_helper'
+
+module PopulateExerciseContent
+
+  def generate_test_exercise_content
+
+    cnx_page_hashes = [
+      { 'id' => '1bb611e9-0ded-48d6-a107-fbb9bd900851', 'title' => 'Introduction' },
+      { 'id' => '95e61258-2faf-41d4-af92-f62e1414175a', 'title' => 'Force' }
+    ]
+
+    @intro_step_gold_data = {
+      klass: Tasks::Models::TaskedReading,
+      title: "Forces and Newton's Laws of Motion",
+      related_content: [{title: "Forces and Newton's Laws of Motion",
+                         book_location: [8, 1]}]
+    }
+
+    @core_step_gold_data = [
+      @intro_step_gold_data,
+      { klass: Tasks::Models::TaskedReading,
+        title: "Force",
+        related_content: [{title: "Force",
+                           book_location: [8, 2]}] }
+    ]
+
+    @spaced_practice_step_gold_data = [
+      { klass: Tasks::Models::TaskedExercise,
+        title: nil,
+        related_content: [{title: "Force",
+                           book_location: [8, 2]}] },
+      { klass: Tasks::Models::TaskedExercise,
+        title: nil,
+        related_content: [{title: "Force",
+                           book_location: [8, 2]}] },
+    ]
+
+    @personalized_step_gold_data = [
+      { klass: Tasks::Models::TaskedPlaceholder,
+        title: nil,
+        related_content: [] }
+    ]
+
+    @task_step_gold_data = \
+    @core_step_gold_data + @spaced_practice_step_gold_data + @personalized_step_gold_data
+
+    cnx_pages = cnx_page_hashes.map do |hash|
+      OpenStax::Cnx::V1::Page.new(hash: hash)
+    end
+
+    @chapter = FactoryGirl.create :content_chapter, title: "Forces and Newton's Laws of Motion"
+
+    @ecosystem = ::Content::Ecosystem.new(strategy: ::Content::Strategies::Direct::Ecosystem.new(@chapter.book.ecosystem))
+
+    @content_pages = VCR.use_cassette(
+      'Tasks_Assistants_HomeworkAssistant/for_Introduction_and_Force/with_pages',
+      VCR_OPTS
+    ) do
+      cnx_pages.map.with_index do |cnx_page, ii|
+        Content::Routines::ImportPage.call(
+          cnx_page:  cnx_page,
+          chapter: @chapter,
+          book_location: [8, ii+1]
+        ).outputs.page.reload
+      end
+    end
+
+    @pages = @content_pages.map{ |content_page| Content::Page.new(strategy: content_page.wrap) }
+
+    Content::Routines::PopulateExercisePools[book: @chapter.book]
+  end
+end


### PR DESCRIPTION
Adds a new `Tutor.fork_with_connection` helper method and uses it to test that concurrent updates deadlock.