### PR TITLE
When locking task steps, lock the entire task before locking the step

### DIFF
--- a/app/routines/mark_task_step_completed.rb
+++ b/app/routines/mark_task_step_completed.rb
@@ -6,20 +6,18 @@ class MarkTaskStepCompleted
 
   def exec(task_step:, completion_time: Time.current)
     # Pessimistic locking to prevent race conditions with the update logic
+    task_step.task.lock!
     task_step.lock!
 
-    # Get the task after the reload so we have its updated state
-    task = task_step.task
-
-    task_step.complete(completion_time: completion_time)
-    task_step.save
+    # The task_step save causes the task to be updated (touched), as required for the lock to work
+    task_step.complete(completion_time: completion_time).save
     transfer_errors_from(task_step, {type: :verbatim}, true)
 
     task_step.tasked.try(:handle_task_step_completion!)
     transfer_errors_from(task_step.tasked, {type: :verbatim}, true)
 
-    task.handle_task_step_completion!(completion_time: completion_time)
-    transfer_errors_from(task, {type: :verbatim}, true)
+    task_step.task.handle_task_step_completion!(completion_time: completion_time)
+    transfer_errors_from(task_step.task, {type: :verbatim}, true)
   end
 
 end

--- a/app/routines/mark_task_step_completed.rb
+++ b/app/routines/mark_task_step_completed.rb
@@ -6,7 +6,6 @@ class MarkTaskStepCompleted
 
   def exec(task_step:, completion_time: Time.current)
     # Pessimistic locking to prevent race conditions with the update logic
-    task_step.task.lock!
     task_step.lock!
 
     # The task_step save causes the task to be updated (touched), as required for the lock to work

--- a/app/subsystems/tasks/add_related_exercise_after_step.rb
+++ b/app/subsystems/tasks/add_related_exercise_after_step.rb
@@ -11,8 +11,7 @@ class Tasks::AddRelatedExerciseAfterStep
   protected
 
   def exec(task_step:)
-    # These locks are here to prevent double clicks on the Try Another/Try One buttons
-    task_step.task.lock!
+    # This lock is here to prevent double clicks on the Try Another/Try One buttons
     fatal_error(code: :related_exercise_not_available) unless task_step.lock!.can_be_recovered?
 
     related_exercise = get_related_exercise_for(task_step: task_step)

--- a/app/subsystems/tasks/add_related_exercise_after_step.rb
+++ b/app/subsystems/tasks/add_related_exercise_after_step.rb
@@ -2,8 +2,7 @@ class Tasks::AddRelatedExerciseAfterStep
 
   lev_routine
 
-  uses_routine TaskExercise, as: :task_exercise,
-                             translations: { outputs: { type: :verbatim } }
+  uses_routine TaskExercise, as: :task_exercise, translations: { outputs: { type: :verbatim } }
   uses_routine GetEcosystemFromIds, as: :get_ecosystem
   uses_routine GetHistory, as: :get_history
   uses_routine FilterExcludedExercises, as: :filter
@@ -12,7 +11,8 @@ class Tasks::AddRelatedExerciseAfterStep
   protected
 
   def exec(task_step:)
-    # This lock is here to prevent double clicks on the Try Another/Try One buttons
+    # These locks are here to prevent double clicks on the Try Another/Try One buttons
+    task_step.task.lock!
     fatal_error(code: :related_exercise_not_available) unless task_step.lock!.can_be_recovered?
 
     related_exercise = get_related_exercise_for(task_step: task_step)

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -25,6 +25,12 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
 
   scope :exercises,  -> { where{tasked_type == Tasks::Models::TaskedExercise.name} }
 
+  def lock!(*args)
+    task.try! :lock!, *args
+
+    super
+  end
+
   def exercise?
     tasked_type == Tasks::Models::TaskedExercise.name
   end

--- a/spec/routines/mark_task_step_completed_spec.rb
+++ b/spec/routines/mark_task_step_completed_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MarkTaskStepCompleted, type: :routine do
     task_step = tasked_reading.task_step
     task = task_step.task
 
-    expect(task_step).to receive(:complete)
+    expect(task_step).to receive(:complete).and_call_original
     expect(task_step).to receive(:save)
     allow(task_step).to receive(:task).and_return(task)
     expect(task).to receive(:handle_task_step_completion!)
@@ -35,6 +35,7 @@ RSpec.describe MarkTaskStepCompleted, type: :routine do
 
   it 'instructs the associated Tasked to handle completion-related activities' do
     # lock! calls reload, which reloads the instances of task_step's associations
+    # this is why we use expect_any_instance_of
     expect_any_instance_of(tasked_exercise.class).to receive(:handle_task_step_completion!)
     result = MarkTaskStepCompleted.call(task_step: tasked_exercise.task_step)
     expect(result.errors).to be_empty


### PR DESCRIPTION
This is an attempt to prevent a deadlock that happened on Staging. I believe this is caused by `MarkTaskStepCompleted` locking the task step but modifying the entire task (the step touches the entire task and updates step counts). Workaround in that case would be to always lock the task before locking the task step.