### PR TITLE
Hide archived periods from CC enrollments

### DIFF
--- a/app/representers/api/v1/enrollment_change_representer.rb
+++ b/app/representers/api/v1/enrollment_change_representer.rb
@@ -18,6 +18,8 @@ module Api::V1
     property :from_period,
              as: :from,
              extend: Api::V1::Enrollment::PeriodWithCourseRepresenter,
+             # If the previous period is archived, then the enrollment is
+             # considered a fresh join, and "from" shouldn't be included
              if: ->(*) { from_period.try(:deleted?) == false },
              readable: true,
              writeable: false

--- a/app/representers/api/v1/enrollment_change_representer.rb
+++ b/app/representers/api/v1/enrollment_change_representer.rb
@@ -18,6 +18,7 @@ module Api::V1
     property :from_period,
              as: :from,
              extend: Api::V1::Enrollment::PeriodWithCourseRepresenter,
+             if: ->(*) { from_period.try(:deleted?) == false },
              readable: true,
              writeable: false
 

--- a/app/subsystems/course_membership/create_enrollment_change.rb
+++ b/app/subsystems/course_membership/create_enrollment_change.rb
@@ -5,11 +5,9 @@ class CourseMembership::CreateEnrollmentChange
   uses_routine GetCourseEcosystem, as: :get_ecosystem
 
   def exec(user:, period:, book_uuid: nil, requires_enrollee_approval: true)
-    student_roles = run(:get_roles, user, 'student').outputs.roles.reject do | r |
-        r.student.period.deleted?
-    end
+    student_roles = run(:get_roles, user, 'student').outputs.roles.reject{ |r| r.student.period.deleted? }
 
-   course = period.course
+    course = period.course
 
     ecosystem = run(:get_ecosystem, course: course).outputs.ecosystem
     # Assumes 1 book in the ecosystem

--- a/app/subsystems/course_membership/create_enrollment_change.rb
+++ b/app/subsystems/course_membership/create_enrollment_change.rb
@@ -5,9 +5,11 @@ class CourseMembership::CreateEnrollmentChange
   uses_routine GetCourseEcosystem, as: :get_ecosystem
 
   def exec(user:, period:, book_uuid: nil, requires_enrollee_approval: true)
-    student_roles = run(:get_roles, user, 'student').outputs.roles
+    student_roles = run(:get_roles, user, 'student').outputs.roles.reject do | r |
+        r.student.period.deleted?
+    end
 
-    course = period.course
+   course = period.course
 
     ecosystem = run(:get_ecosystem, course: course).outputs.ecosystem
     # Assumes 1 book in the ecosystem

--- a/spec/representers/api/v1/enrollment_change_representer_spec.rb
+++ b/spec/representers/api/v1/enrollment_change_representer_spec.rb
@@ -37,4 +37,12 @@ RSpec.describe Api::V1::EnrollmentChangeRepresenter, type: :representer do
           'last_name'  => teacher_role.last_name
         }])
   end
+
+  it 'hides deleted from periods' do
+    deleted_period = ::CreatePeriod[course: course]
+    AddUserAsPeriodStudent[user: user, period: deleted_period]
+    deleted_period.to_model.destroy
+    expect(representation['from']).to be_nil
+  end
+
 end

--- a/spec/representers/api/v1/enrollment_change_representer_spec.rb
+++ b/spec/representers/api/v1/enrollment_change_representer_spec.rb
@@ -37,12 +37,14 @@ RSpec.describe Api::V1::EnrollmentChangeRepresenter, type: :representer do
           'last_name'  => teacher_role.last_name
         }])
   end
-
-  it 'hides deleted from periods' do
-    deleted_period = ::CreatePeriod[course: course]
-    AddUserAsPeriodStudent[user: user, period: deleted_period]
-    deleted_period.to_model.destroy
-    expect(representation['from']).to be_nil
+  context "when other section is archived" do
+    # If a "from" period is included in the output, the FE will display it as a transfer
+    # If the previous period is archived, then the enrollment should be considered a fresh join
+    it 'is not included as a "from" source' do
+      deleted_period = ::CreatePeriod[course: course]
+      AddUserAsPeriodStudent[user: user, period: deleted_period]
+      deleted_period.to_model.destroy
+      expect(representation['from']).to be_nil
+    end
   end
-
 end

--- a/spec/subsystems/course_membership/create_enrollment_change_spec.rb
+++ b/spec/subsystems/course_membership/create_enrollment_change_spec.rb
@@ -47,6 +47,20 @@ describe CourseMembership::CreateEnrollmentChange, type: :routine do
 
       let(:enrollment) { role.student.latest_enrollment }
 
+      context 'when other period is archived' do
+          before{ period_2.to_model.destroy }
+
+          it 'does not mention previous period' do
+              result = nil
+              expect{ result = described_class.call(args) }
+                  .to change{ CourseMembership::Models::EnrollmentChange.count }.by(1)
+              expect(result.errors).to be_empty
+              expect(result.outputs.enrollment_change.from_period).to be_nil
+              expect(result.outputs.enrollment_change.status).to eq :pending
+              expect(result.outputs.enrollment_change.enrollee_approved_at).to be_nil
+          end
+      end
+
       it 'creates an EnrollmentChange with a from_period' do
         result = nil
         expect{ result = described_class.call(args) }


### PR DESCRIPTION
https://trello.com/c/9XeBgaGp/128-bug-cc-students-archived-students-re-enrolling-get-the-changing-section-message-maybe-on-tutor-also-maybe-dropped-also

If the period is shown to CC then it thinks it's a move and displays the wrong message.  

A different approach we could do is send the period, but flag it as "archived", then fix the FE to ignore it.  I don't see any reason for the FE to know anything about it though, so this just hides it.