### PR TITLE
Only query "new" opportunities

### DIFF
--- a/app/subsystems/salesforce/remote/opportunity.rb
+++ b/app/subsystems/salesforce/remote/opportunity.rb
@@ -3,7 +3,7 @@ class Salesforce::Remote::Opportunity < ActiveForce::SObject
   field :term_year,                    from: "TermYear__c"
   field :book_name,                    from: "Book_Text__c"
   field :contact_id,                   from: "Contact__c"
-  field :new,                          from: "New__c"
+  field :new,                          from: "New__c",       as: :boolean
 
   self.table_name = 'Opportunity'
 

--- a/app/subsystems/salesforce/remote/opportunity.rb
+++ b/app/subsystems/salesforce/remote/opportunity.rb
@@ -3,11 +3,12 @@ class Salesforce::Remote::Opportunity < ActiveForce::SObject
   field :term_year,                    from: "TermYear__c"
   field :book_name,                    from: "Book_Text__c"
   field :contact_id,                   from: "Contact__c"
+  field :new,                          from: "New__c"
 
   self.table_name = 'Opportunity'
 
   def term_year_object
-    @term_year_object ||= Salesforce::Remote::TermYear.from_string(self.term_year)
+    @term_year_object ||= Salesforce::Remote::TermYear.from_string(term_year)
   end
 
 end

--- a/app/subsystems/salesforce/renew_os_ancillary.rb
+++ b/app/subsystems/salesforce/renew_os_ancillary.rb
@@ -11,7 +11,8 @@ module Salesforce
       target_opportunity_criteria = {
         contact_id: based_on_opportunity.contact_id,
         book_name: based_on_opportunity.book_name,
-        term_year: renew_for_term_year.to_s
+        term_year: renew_for_term_year.to_s,
+        new: true
       }
 
       target_opportunities = Salesforce::Remote::Opportunity.where(target_opportunity_criteria).to_a

--- a/spec/subsystems/salesforce/renew_os_ancillary_spec.rb
+++ b/spec/subsystems/salesforce/renew_os_ancillary_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Salesforce::RenewOsAncillary do
     expect(Salesforce::Remote::Opportunity).to receive(:where).with({
       contact_id: "123",
       book_name: "A & P",
-      term_year: "2015 - 16 Fall"
+      term_year: "2015 - 16 Fall",
+      new: true
     })
 
     described_class.call(based_on: based_on, renew_for_term_year: term_year) rescue StandardError

--- a/spec/subsystems/salesforce/renew_os_ancillary_spec.rb
+++ b/spec/subsystems/salesforce/renew_os_ancillary_spec.rb
@@ -26,16 +26,17 @@ RSpec.describe Salesforce::RenewOsAncillary do
     term_year = Salesforce::Remote::TermYear.from_string("2015 - 16 Fall")
 
     # Cause early termination
-    allow(Salesforce::Remote::Opportunity).to receive(:where) { [] }
-
     expect(Salesforce::Remote::Opportunity).to receive(:where).with({
       contact_id: "123",
       book_name: "A & P",
       term_year: "2015 - 16 Fall",
       new: true
-    })
+    }).and_return([])
 
-    described_class.call(based_on: based_on, renew_for_term_year: term_year) rescue StandardError
+    begin
+      described_class.call(based_on: based_on, renew_for_term_year: term_year)
+    rescue Salesforce::OsAncillaryRenewalError
+    end
   end
 
   it "reuses an existing OSA if available" do


### PR DESCRIPTION
According to Denver, this is needed to fix the current Salesforce reporting errors.