### PR TITLE
More demo scripts for QA review

### DIFF
--- a/app/subsystems/content/exercise.rb
+++ b/app/subsystems/content/exercise.rb
@@ -77,6 +77,10 @@ module Content
       !!@strategy.is_excluded
     end
 
+    def is_multipart?
+      !!@strategy.is_multipart?
+    end
+
     def has_interactive
       !!@strategy.has_interactive
     end

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -1,7 +1,8 @@
 class Content::ImportBook
 
   # Kind of a hack to limit how many exercises we request at a time and avoid timeouts
-  MAX_EXERCISES_REQUEST_LENGTH = 1000
+  # It is set to 2020 in the test environment so as to not break basically all the cassettes
+  MAX_EXERCISES_REQUEST_LENGTH = Rails.env.test? ? 2020 : 1000
 
   lev_routine
 

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -1,6 +1,7 @@
 class Content::ImportBook
 
-  MAX_URL_LENGTH = 2020
+  # Kind of a hack to limit how many exercises we request at a time and avoid timeouts
+  MAX_EXERCISES_REQUEST_LENGTH = 1000
 
   lev_routine
 
@@ -52,7 +53,7 @@ class Content::ImportBook
     if exercise_uids.nil?
       # Split the tag queries to avoid exceeding the URL limit
       max_tag_length = import_page_tags.map{ |pt| pt.tag.value.size }.max || 1
-      tags_per_query = MAX_URL_LENGTH/max_tag_length
+      tags_per_query = MAX_EXERCISES_REQUEST_LENGTH/max_tag_length
       import_page_tags.each_slice(tags_per_query) do |page_tags|
         query_hash = { tag: page_tags.map{ |pt| pt.tag.value } }
 
@@ -66,7 +67,7 @@ class Content::ImportBook
     else
       # Split the uid queries to avoid exceeding the URL limit
       max_uid_length = exercise_uids.map(&:size).max || 1
-      uids_per_query = MAX_URL_LENGTH/max_uid_length
+      uids_per_query = MAX_EXERCISES_REQUEST_LENGTH/max_uid_length
       exercise_uids.each_slice(uids_per_query) do |uids|
         query_hash = { id: uids }
 

--- a/app/subsystems/content/strategies/direct/exercise.rb
+++ b/app/subsystems/content/strategies/direct/exercise.rb
@@ -6,8 +6,8 @@ module Content
         wraps ::Content::Models::Exercise
 
         exposes :page, :tags, :los, :aplos, :url, :title, :preview, :context, :content, :uid,
-                :number, :version, :content_hash, :pool_types, :is_excluded, :has_interactive,
-                :has_video, :content_as_independent_questions, :feature_ids
+                :number, :version, :content_hash, :pool_types, :is_excluded, :is_multipart?,
+                :has_interactive, :has_video, :content_as_independent_questions, :feature_ids
 
         def to_model
           repository

--- a/lib/tasks/demo/base.rb
+++ b/lib/tasks/demo/base.rb
@@ -233,8 +233,9 @@ class Demo::Base
         task_step.tasked_type.demodulize.sub('Tasked', '').first.downcase
       end
 
-      raise "Steps in config (#{@step_types}) don't match actual steps (#{actual_step_types})" \
-        if !@step_types.nil? && @step_types != actual_step_types
+      Rails.logger.warn do
+        "Steps in config (#{@step_types}) don't match actual steps (#{actual_step_types})"
+      end if !@step_types.nil? && @step_types != actual_step_types
 
       responses = self[task].responses
 

--- a/lib/tasks/demo/config/people.yml
+++ b/lib/tasks/demo/config/people.yml
@@ -3,14 +3,15 @@ content_analyst: Content Analyst
 customer_service: Customer Service
 
 teachers:
-  cm: {name: Charles Morris, username: teacher01 }
-  rb: {name: Redmond Blake,  username: teacher02 }
-  ct: {name: C. E. Tripp,    username: teacher03 }
-  jb: {name: J. D. Ballard,  username: teacher04 }
-  td: {name: Trent Deckow,   username: teacher05 }
-  ak: {name: Adah Kuhn,      username: teacher06 }
-  yr: {name: Yoshiko Roob,   username: teacher07 }
-  og: {name: Okey Gottlieb,  username: teacher08 }
+  cm: {name: Charles Morris,           username: teacher01 }
+  rb: {name: Redmond Blake,            username: teacher02 }
+  ct: {name: C. E. Tripp,              username: teacher03 }
+  jb: {name: J. D. Ballard,            username: teacher04 }
+  td: {name: Trent Deckow,             username: teacher05 }
+  ak: {name: Adah Kuhn,                username: teacher06 }
+  yr: {name: Yoshiko Roob,             username: teacher07 }
+  og: {name: Okey Gottlieb,            username: teacher08 }
+  rt: {name: Review Teacher,           username: reviewteacher }
 
 students:
   af:  { name: Atticus Finch,          username: student01  }
@@ -163,3 +164,9 @@ students:
   ms1: { name: Matt Shively,           username: student148 }
   dc1: { name: Diego Catano,           username: student149 }
   cs3: { name: Carly Schroeder,        username: student150 }
+  rs1: { name: Review Student1,        username: reviewstudent1 }
+  rs2: { name: Review Student2,        username: reviewstudent2 }
+  rs3: { name: Review Student3,        username: reviewstudent3 }
+  rs4: { name: Review Student4,        username: reviewstudent4 }
+  rs5: { name: Review Student5,        username: reviewstudent5 }
+  rs6: { name: Review Student6,        username: reviewstudent6 }

--- a/lib/tasks/demo/config/qa/cw/base.yml
+++ b/lib/tasks/demo/config/qa/cw/base.yml
@@ -1,0 +1,7 @@
+archive_url_base: https://archive.cnx.org/contents/
+webview_url_base: https://qa.cnx.org/contents/
+is_concept_coach: false
+is_college: true
+
+teachers:
+  - rt

--- a/lib/tasks/demo/config/qa/cw/bio.yml
+++ b/lib/tasks/demo/config/qa/cw/bio.yml
@@ -1,0 +1,132 @@
+<%= File.read(File.join(File.dirname(__FILE__), 'base.yml')) %>
+
+course_name: Biology with Courseware Review
+salesforce_book_name: Biology w Courseware
+appearance_code: college_biology
+cnx_book_id: 185cbf87-c72e-48f5-b51e-f14f21b5eabd
+
+periods:
+  - id: p1
+    name: 1st
+    students: [rs1, rs2, rs3]
+  - id: p2
+    name: 2nd
+    students: [rs4, rs5, rs6]
+
+assignments:
+  - type: reading
+    book_locations: [[1, 0], [1, 1], [1, 2]]
+    title: Read Chapter 1
+    periods:
+      - id: p1
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[2, 0], [2, 1], [2, 2]]
+    title: Read Chapter 2
+    periods:
+      - id: p1
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[3, 0], [3, 1], [3, 2]]
+    title: Read Chapter 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[4, 0], [4, 1], [4, 2]]
+    title: Read Chapter 4
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[1, 0], [1, 1], [1, 2]]
+    title: HW Chapter 1
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[2, 0], [2, 1], [2, 2]]
+    title: HW Chapter 2
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[3, 0], [3, 1], [3, 2]]
+    title: HW Chapter 3
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[4, 0], [4, 1], [4, 2]]
+    title: HW Chapter 4
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+reading_processing_instructions:
+- css: .multiple-choice, .free-response, .art-exercise, .interactive-embedded-homework,
+    .scientific, [data-type="glossary"]
+  fragments: []
+- css: .interactive-embedded-reading
+  fragments:
+  - node
+  - exercise

--- a/lib/tasks/demo/config/qa/cw/phys.yml
+++ b/lib/tasks/demo/config/qa/cw/phys.yml
@@ -1,0 +1,140 @@
+<%= File.read(File.join(File.dirname(__FILE__), 'base.yml')) %>
+
+course_name: Physics with Courseware Review
+salesforce_book_name: Physics w Courseware
+appearance_code: college_physics
+cnx_book_id: 405335a3-7cff-4df2-a9ad-29062a4af261
+
+periods:
+  - id: p1
+    name: 1st
+    students: [rs1, rs2, rs3]
+  - id: p2
+    name: 2nd
+    students: [rs4, rs5, rs6]
+
+assignments:
+  - type: reading
+    book_locations: [[1, 0], [1, 1], [1, 2]]
+    title: Read Chapter 1
+    periods:
+      - id: p1
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[2, 0], [2, 1], [2, 2]]
+    title: Read Chapter 2
+    periods:
+      - id: p1
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[3, 0], [3, 1], [3, 2]]
+    title: Read Chapter 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[4, 0], [4, 1], [4, 2]]
+    title: Read Chapter 4
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[1, 0], [1, 1], [1, 2]]
+    title: HW Chapter 1
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[2, 0], [2, 1], [2, 2]]
+    title: HW Chapter 2
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[3, 0], [3, 1], [3, 2]]
+    title: HW Chapter 3
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[4, 0], [4, 1], [4, 2]]
+    title: HW Chapter 4
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+reading_processing_instructions:
+- css: .conceptual-questions, .problems-exercises, [data-element-type="conceptual-questions"],
+    [data-element-type="problems-exercises"], [data-element-type="check-understanding"],
+    [data-type="glossary"]
+  fragments: []
+- css: .phet-explorations-embedded
+  fragments:
+  - interactive
+  - exercise
+- css: .watch-physics
+  fragments:
+  - video
+  - exercise
+- css: .example-video, [data-type="example"]
+  fragments:
+  - reading

--- a/lib/tasks/demo/config/qa/cw/soc.yml
+++ b/lib/tasks/demo/config/qa/cw/soc.yml
@@ -1,0 +1,129 @@
+<%= File.read(File.join(File.dirname(__FILE__), 'base.yml')) %>
+
+course_name: Sociology with Courseware Review
+salesforce_book_name: Sociology w Courseware
+appearance_code: intro_sociology
+cnx_book_id: 02040312-72c8-441e-a685-20e9333f3e1d
+
+periods:
+  - id: p1
+    name: 1st
+    students: [rs1, rs2, rs3]
+  - id: p2
+    name: 2nd
+    students: [rs4, rs5, rs6]
+
+assignments:
+  - type: reading
+    book_locations: [[1, 0], [1, 1], [1, 2]]
+    title: Read Chapter 1
+    periods:
+      - id: p1
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[2, 0], [2, 1], [2, 2]]
+    title: Read Chapter 2
+    periods:
+      - id: p1
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[3, 0], [3, 1], [3, 2]]
+    title: Read Chapter 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: reading
+    book_locations: [[4, 0], [4, 1], [4, 2]]
+    title: Read Chapter 4
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[1, 0], [1, 1], [1, 2]]
+    title: HW Chapter 1
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_three_days_ago %>
+        due_at: <%= due_two_days_ago %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[2, 0], [2, 1], [2, 2]]
+    title: HW Chapter 2
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_two_days_ago %>
+        due_at: <%= due_yesterday %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[3, 0], [3, 1], [3, 2]]
+    title: HW Chapter 3
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_tomorrow %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+  - type: homework
+    book_locations: [[4, 0], [4, 1], [4, 2]]
+    title: HW Chapter 4
+    num_exercises: 3
+    periods:
+      - id: p1
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs1: 100, rs2: 80, rs3: i}
+      - id: p2
+        opens_at: <%= open_yesterday %>
+        due_at: <%= due_two_days_from_now %>
+        students: {rs4: ns, rs5: ns, rs6: ns}
+
+reading_processing_instructions:
+- css: .section-quiz, .short-answer, .further-research, [data-element-type="section-quiz"],
+    [data-element-type="short-answer"], [data-element-type="further-research"],
+    [data-type="glossary"]
+  fragments: []

--- a/lib/tasks/demo/content.rb
+++ b/lib/tasks/demo/content.rb
@@ -40,11 +40,13 @@ class Demo::Content < Demo::Base
     run(:set_customer_service, user: cs_user, customer_service: true)
     log("Customer Service user: #{cs_user.name}")
 
-    (0..99).to_a.each do |ii|
-      username = "zz_#{ii.to_s.rjust(2,"0")}"
-      user_for_username(username) || new_user(username: username, name: username.gsub('_',' '))
-    end
-    log("Made 100 extra 'zz' users who are not in any course.")
+    new_zz_users = (0..99).map do |ii|
+      username = "zz_#{ii.to_s.rjust(2, "0")}"
+      next if user_for_username(username)
+      new_user(username: username, name: username.gsub('_', ' '))
+    end.compact
+    log("Made #{new_zz_users.size} extra 'zz' users who are not in any course.") \
+      unless new_zz_users.empty?
   end
 
   def configure_course_teacher(course, teacher)

--- a/lib/tasks/demo/content_configuration.rb
+++ b/lib/tasks/demo/content_configuration.rb
@@ -38,8 +38,7 @@ class Demo::ContentConfiguration
     # The directory for the config files can be either set using either
     # config_directory block (which sets it's value using RequestStore.store),
     # the CONFIG environmental variable or the default
-    config_directory = RequestStore.store[:config_directory] ||
-                       ENV['CONFIG'] || DEFAULT_CONFIG_DIR
+    config_directory = RequestStore.store[:config_directory] || ENV['CONFIG'] || DEFAULT_CONFIG_DIR
 
     all_files = Dir[File.join(config_directory, '**/*.yml')]
 
@@ -131,10 +130,12 @@ class Demo::ContentConfiguration
       assignment.periods.each_with_index do | period, index |
         period_config = get_period(period.id)
         if period_config.nil?
-          raise "Unable to find period # #{index} id #{period.id} for assignment #{assignment.title}"
+          raise "Unable to find period # #{index} id #{
+                period.id} for assignment #{assignment.title}"
         end
-        if period_config.students.sort != period.students.keys.sort
-          raise "Students assignments for #{course_name} period #{period_config.name} do not match for assignment #{assignment.title}"
+        if period.students.nil? || period_config.students.sort != period.students.keys.sort
+          raise "Students assignments for #{course_name} period #{period_config.name
+                } do not match for assignment #{assignment.title}"
         end
       end
     end

--- a/lib/tasks/fix_multi_enrollments.rake
+++ b/lib/tasks/fix_multi_enrollments.rake
@@ -7,7 +7,7 @@ task :fix_multi_enrollments, [:run_mode] => :environment do |t, args|
   double_enrollments_array = []
 
   ActiveRecord::Base.transaction do
-    CSV.open('multi-enrollments.csv', 'w+') do |csv|
+    CSV.open('tmp/multi-enrollments.csv', 'w+') do |csv|
       csv << ['Student Name', 'Teacher(s)', 'School']
 
       User::Models::Profile.preload(roles: [:teacher, {student: :course}]).find_each do |user|

--- a/spec/fixtures/demo/hs/bio.yml
+++ b/spec/fixtures/demo/hs/bio.yml
@@ -18,7 +18,7 @@ periods:
 
 assignments:
   - type: reading
-    step_types: [ r, r, e, r, r, e, r, r, e, r, r, e, r, e, r, p, e, e, r, r, e ]
+    step_types: [ r, r, r, r, r, e, e, e, r, r, r, r, r, r, e, r, r, e, r, e, r, e, e, e ]
     book_locations: [[1, 0], [1, 1], [1, 2]]
     title: Read Chapter 1. The Study of Life
     periods:

--- a/spec/fixtures/demo/hs/phys.yml
+++ b/spec/fixtures/demo/hs/phys.yml
@@ -17,7 +17,7 @@ assignments:
   - type: reading
     title: Read 3.1 Acceleration Pt1
     book_locations: [[3, 0], [3, 1]]
-    step_types: [ r, r, r, i, e, r, e, v, e, p ]
+    step_types: [ r, r, i, e, r, r, e, v, e, e, e, e ]
     periods:
       - id: p1
         opens_at: <%= open_three_days_ago %>
@@ -27,13 +27,13 @@ assignments:
   - type: reading
     title: Read 3.2 Acceleration Pt2
     book_locations: [[3, 2]]
-    step_types: [ r, i, e, r, r, e, r, r, r, e, r, e, p]
+    step_types: [ r, i, e, r, r, e, r, r, r, e, r, e, e, e, e ]
     periods:
       - id: p1
         opens_at: <%= open_three_days_ago %>
         due_at: <%= due_today %>
         students:
-          sd: [ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1 ]
+          sd: [ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1 ]
           vw: ns
 
   - type: homework

--- a/spec/lib/tasks/fix_multi_enrollments_spec.rb
+++ b/spec/lib/tasks/fix_multi_enrollments_spec.rb
@@ -59,7 +59,7 @@ describe "fix_multi_enrollments", type: :rake do
     @task_3.taskings.first.update_attribute :created_at, Time.now
   end
 
-  after(:all)  { FileUtils.rm_f 'multi-enrollments.csv' }
+  after(:all)  { FileUtils.rm_f 'tmp/multi-enrollments.csv' }
 
   context 'dry run' do
     it "does not modify any tasks or taskings" do
@@ -75,7 +75,7 @@ describe "fix_multi_enrollments", type: :rake do
     it "writes fixed user, teacher and school names to a csv file" do
       expect(capture_stdout{call}).to be_blank
 
-      content = File.open('multi-enrollments.csv', 'r').read
+      content = File.open('tmp/multi-enrollments.csv', 'r').read
       expect(content).to include(@user_1.name.strip)
       expect(content).to include(@user_3.name.strip)
       expect(content).to include(@school.name)
@@ -98,7 +98,7 @@ describe "fix_multi_enrollments", type: :rake do
     it "writes fixed user, teacher and school names to a csv file" do
       expect(capture_stdout{call('real')}).to be_blank
 
-      content = File.open('multi-enrollments.csv', 'r').read
+      content = File.open('tmp/multi-enrollments.csv', 'r').read
       expect(content).to include(@user_1.name.strip)
       expect(content).to include(@user_3.name.strip)
       expect(content).to include(@school.name)


### PR DESCRIPTION
- New demo scripts for QA assignment review
- Specifying step types for the demo script is now optional
- Reduced number of imported exercises at a time to prevent Exercises timeouts in Physics/Biology (timeouts were causing the demo script to fail)

Other misc changes:
- Added `is_multipart?` method to `Content::Exercises` (I ended up not needing this because I changed the step types array to be optional)
- Changed `fix_multi_enrollments` rake task to put its csv file in the `tmp` folder to stop it from polluting the app folder