### PR TITLE
warn about not creating duplicate accounts when student id is taken

### DIFF
--- a/app/assets/stylesheets/enroll.scss
+++ b/app/assets/stylesheets/enroll.scss
@@ -55,7 +55,10 @@
       }
     }
   }
-
+  .enrollment-flash {
+    max-width: 800px;
+    margin: 20px auto;
+  }
   span.help {
     display: block;
     font-size: 12px;

--- a/app/assets/stylesheets/enroll.scss
+++ b/app/assets/stylesheets/enroll.scss
@@ -1,4 +1,9 @@
+// the enrollment page displays the flash itself
+.courses-enroll .application-flash { display: none; }
+
 #enroll {
+  margin-top: 20px;
+
   &.well {
     margin-bottom: 0px;
   }

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -355,3 +355,7 @@ footer p a:hover {
   }
 
 }
+
+.application-flash {
+  margin-top: 20px;
+}

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -46,9 +46,9 @@ class CoursesController < ApplicationController
     when :enrollment_code_not_found
       enrollment_code_not_found
     when :taken
-      flash[:error] = 'That school-issued ID is already in use. ' \
-                      'If you already have an account, please do not create ' \
-                      'a duplicate or you may lose work.'
+      flash[:error] = 'That school-issued ID is already in use. If you already have an account, ' \
+                      'please do not create another account or you may lose previous work. ' \
+                      'Click Logout above, and sign in to your original account.'
       redirect_to token_enroll_path(params[:enroll][:enrollment_token])
     else
       raise StandardError, "Student URL enrollment failed: #{@handler_result.errors}"

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -46,7 +46,9 @@ class CoursesController < ApplicationController
     when :enrollment_code_not_found
       enrollment_code_not_found
     when :taken
-      flash[:error] = "That school-issued ID is already in use."
+      flash[:error] = 'That school-issued ID is already in use. ' \
+                      'If you already have an account, please do not create ' \
+                      'a duplicate or you may lose work.'
       redirect_to token_enroll_path(params[:enroll][:enrollment_token])
     else
       raise StandardError, "Student URL enrollment failed: #{@handler_result.errors}"

--- a/app/views/courses/enroll.html.erb
+++ b/app/views/courses/enroll.html.erb
@@ -5,9 +5,9 @@
     <%= render partial: 'course_identifier_sentence', locals: @handler_result.outputs.to_hash.symbolize_keys.slice(:courses, :period) %>
   </h2>
   <hr/>
-
+  <div class="enrollment-flash">
   <%= render 'layouts/flash_messages' %>
-
+  </div>
   <%= lev_form_for :enroll, url: confirm_token_enroll_path, method: 'post', html: {class: 'form-inline'} do |f| %>
 
     <%= f.hidden_field :enrollment_token, value: params[:enroll_token] %>

--- a/app/views/courses/enroll.html.erb
+++ b/app/views/courses/enroll.html.erb
@@ -6,6 +6,8 @@
   </h2>
   <hr/>
 
+  <%= render 'layouts/flash_messages' %>
+
   <%= lev_form_for :enroll, url: confirm_token_enroll_path, method: 'post', html: {class: 'form-inline'} do |f| %>
 
     <%= f.hidden_field :enrollment_token, value: params[:enroll_token] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,19 +10,15 @@
     <%= csrf_meta_tags %>
   </head>
 
-  <body id="home">
+  <body id="home" class="<%= controller.controller_name %>-<%= controller.action_name %>">
     <div class="body">
 
       <%= render 'layouts/header' %>
 
-
-
-
-
       <div class="container" style="margin: 60px auto 20px">
         <div class="row">
 
-          <div style="margin-top: 20px">
+          <div class="application-flash">
             <%= render 'layouts/flash_messages' %>
           </div>
 
@@ -38,10 +34,3 @@
   </body>
 
 </html>
-
-
-
-
-
-
-

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Students enrolling via URL' do
           click_button 'Continue'
 
           expect(page).to have_content 'is already in use'
-          expect(page).to have_content 'do not create a duplicate'
+          expect(page).to have_content 'do not create another account'
           expect(page).to have_content 'Enter your school-issued'
           expect(UserIsCourseStudent[course: course, user: user]).to be_falsy
         end

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'Students enrolling via URL' do
           click_button 'Continue'
 
           expect(page).to have_content 'is already in use'
+          expect(page).to have_content 'do not create a duplicate'
           expect(page).to have_content 'Enter your school-issued'
           expect(UserIsCourseStudent[course: course, user: user]).to be_falsy
         end


### PR DESCRIPTION
Updates the error message to warn students not to create a new account.
![screen shot 2016-09-27 at 11 20 04 am](https://cloud.githubusercontent.com/assets/79566/18882405/a10a8306-84a4-11e6-98e0-a15eae000dc7.png)
