### PR TITLE
Fixes and improvements to admin dashboard

### DIFF
--- a/app/assets/javascripts/manager.js
+++ b/app/assets/javascripts/manager.js
@@ -70,9 +70,8 @@ $(document).ready(function() {
 
     var setPerPage = function(val){
       var paramsObj = locationSearchInJSON();
-      paramsObj.per_page = val;
-
-      window.location.search = $.param(paramsObj);
+      paramsObj.per_page = Number(val);
+      window.location.search = decodeURIComponent($.param(paramsObj));
     }
 
     setPerPage(perPage);
@@ -91,7 +90,6 @@ function locationSearchInJSON(){
      var keyValues = item.split("=");
      paramsJSON[keyValues[0]] = keyValues[1]
   })
-
   paramsJSON.utf8 = "✓";
 
   return paramsJSON;

--- a/app/assets/javascripts/manager.js
+++ b/app/assets/javascripts/manager.js
@@ -63,6 +63,33 @@ $(document).ready(function() {
     }
   });
 
+  //========== Order by selected =============//
+  $(".course-info-name").click(function(){
+    var paramsObj = locationSearchInJSON();
+    paramsObj.order_by = "name";
+    window.location.search = decodeURIComponent($.param(paramsObj));
+  });
+
+  $(".ecosystem-created-at").click(function(){
+    var paramsObj = locationSearchInJSON();
+    paramsObj.order_by = "created_at";
+    window.location.search = decodeURIComponent($.param(paramsObj));
+  });
+
+  $(".course-info-id").click(function(){
+    var paramsObj = locationSearchInJSON();
+    paramsObj.order_by = "id";
+    window.location.search = decodeURIComponent($.param(paramsObj));
+  });
+
+  $(".course-info-profile-school").click(function(){
+    var paramsObj = locationSearchInJSON();
+    paramsObj.order_by = "school";
+    window.location.search = decodeURIComponent($.param(paramsObj));
+  });
+
+
+  //========== Change results per page =============//
   $("#search-courses-results-pp").change(function(e){
     e.preventDefault();
 

--- a/app/assets/stylesheets/manager.scss
+++ b/app/assets/stylesheets/manager.scss
@@ -42,7 +42,7 @@ nav.navbar.production {
   height: auto;
   border: #777 3px solid;
   margin-bottom: 35px;
-  /*overflow: auto;*/
+  overflow-y: auto;
   border-radius: 8px;
 
   .card-header {
@@ -97,6 +97,6 @@ nav.navbar.production {
 
   .course-stats-button {
     display: block;
-    overflow: auto;
+    overflow: hidden;
   }
 }

--- a/app/assets/stylesheets/manager.scss
+++ b/app/assets/stylesheets/manager.scss
@@ -54,43 +54,49 @@ nav.navbar.production {
     }
   }
 
-  .card-content {
+  .card-body {
+    width: 100%;
     position: relative;
     padding: 10px;
+    float: left;
+    display: inline-block;
 
-    .content-top {
-    }
-    .content-top {
+    .card-content-left {
+      max-width: 80%;
       float: left;
-    }
-    .content-middle {
-      float: left;
-      clear: left;
-      width: 50%;
-      margin-left: 40px;
-      color: #666;
-    }
-    .content-bottom {
-      float: left;
-      clear: left;
-      margin-top: 10px;
-      padding-bottom: 15px;
 
-      .bread-crumb {
+      .card-body-left {
 
+        .content-top {
+          float: left;
+        }
+        .content-middle {
+          float: left;
+          clear: left;
+          width: 50%;
+          margin-left: 40px;
+          color: #666;
+        }
+        .content-bottom {
+          float: left;
+          clear: left;
+          margin-top: 10px;
+          padding-bottom: 15px;
+
+          .bread-crumb {
+
+          }
+        }
       }
     }
     .card-content-right {
-      position: absolute;
-      right: 0;
-      button {
-        float: right;
-        clear: right;
-      }
+      max-width: 20%;
+      float: right;
     }
   }
 
   .course-stats-button {
     display: block;
+    overflow: auto;
   }
 }

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -7,7 +7,7 @@ class Admin::CoursesController < Admin::BaseController
 
   def index
     @query = params[:query]
-    courses = SearchCourses.call(query: params[:query], order_by: params[:order_by]).outputs
+    courses = SearchCourses.call(query: params[:query], order_by: params[:order_by] || 'id').outputs
     params[:per_page] = courses.total_count if params[:per_page] == "all"
     params_for_pagination = {page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 25)}
 

--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -7,6 +7,7 @@ class SearchCourses
                translations: { outputs: { type: :verbatim } }
 
   SORTABLE_FIELDS = {
+    'id' => Entity::Course.arel_table[:id],
     'name' => CourseProfile::Models::Profile.arel_table[:name],
     'school' => SchoolDistrict::Models::School.arel_table[:name],
     'offering' => Catalog::Models::Offering.arel_table[:salesforce_book_name],
@@ -18,7 +19,7 @@ class SearchCourses
   protected
 
   def exec(params = {}, options = {})
-    params[:ob] ||= :name
+    params[:order_by] ||= :id
     relation = Entity::Course.joins{
             [profile.school.outer,
              profile.offering.outer,

--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -11,7 +11,6 @@ class SearchCourses
     'name' => CourseProfile::Models::Profile.arel_table[:name],
     'school' => SchoolDistrict::Models::School.arel_table[:name],
     'offering' => Catalog::Models::Offering.arel_table[:salesforce_book_name],
-    'ecosystem' => Content::Models::Ecosystem.arel_table[:title],
     'created_at' => :created_at,
     'updated_at' => :updated_at
   }
@@ -19,7 +18,7 @@ class SearchCourses
   protected
 
   def exec(params = {}, options = {})
-    params[:order_by] ||= :id
+    params[:order_by] ||= :name
     relation = Entity::Course.joins{
             [profile.school.outer,
              profile.offering.outer,

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -42,8 +42,14 @@
                                 id: "course_id_#{course_info.id}" %>
             <% end %>
 
-          <%= "#{course_info.id}" %><%= " #{course_info.name}" %><%= " / #{course_info.teachers.map(&:name).to_sentence}" unless course_info.teachers.blank? %>
-          <%= " / #{course_info.profile.school.name}" if course_info.profile.try(:school) %>
+          <span class="course-info-id">
+            <%= "#{course_info.id}" %>
+          </span>
+          <span class="course-info-name"><%= " #{course_info.name}" %></span>
+          <%= " / #{course_info.teachers.map(&:name).to_sentence}" unless course_info.teachers.blank? %>
+          <span class="course-info-profile-school">
+            <%= " / #{course_info.profile.school.name}" if course_info.profile.try(:school) %>
+          </span>
         </div>
         <div class="card-body">
           <div class="card-content-left">
@@ -54,7 +60,7 @@
               <% unless book.blank? %>
                 <%= "(ID #{book.id})" %> <%= book.title %> <%= "(#{book.uuid}@#{book.version})" %>
               <% end %>
-              <span style="white-space: nowrap;">
+              <span class="ecosystem-created-at" style="white-space: nowrap;">
                 <%= "(#{ecosystem.created_at})" if ecosystem %>
               </span>
             </div>

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -45,22 +45,26 @@
           <%= "#{course_info.id}" %><%= " #{course_info.name}" %><%= " / #{course_info.teachers.map(&:name).to_sentence}" unless course_info.teachers.blank? %>
           <%= " / #{course_info.profile.school.name}" if course_info.profile.try(:school) %>
         </div>
-        <div class="card-content">
-          <div class="content-top">
-            <% ecosystem = course_info.ecosystems.first %>
-            <% book = ecosystem.nil? ? '' : ecosystem.books.first %>
+        <div class="card-body">
+          <div class="card-content-left">
+            <div class="content-top">
+              <% ecosystem = course_info.ecosystems.first %>
+              <% book = ecosystem.nil? ? '' : ecosystem.books.first %>
 
-            <% unless book.blank? %>
-              <%= "(ID #{book.id})" %> <%= book.title %> <%= "(#{book.uuid}@#{book.version})" %>
-            <% end %>
-            <%= "(#{ecosystem.created_at})" if ecosystem %>
-          </div>
-          <div class="content-middle">
-            <%= ecosystem.try(:comments) %>
-          </div>
-          <div class="content-bottom">
-            <%= "CC / " if course_info.is_concept_coach %> <%= "College / " if course_info.is_college %>
-            <%= "#{course_info.periods_with_deleted.map{|p| p.latest_enrollments_with_deleted.length}.reduce(0, :+)} students" %> <%= " / #{course_info.periods_with_deleted.length} periods" %>
+              <% unless book.blank? %>
+                <%= "(ID #{book.id})" %> <%= book.title %> <%= "(#{book.uuid}@#{book.version})" %>
+              <% end %>
+              <span style="white-space: nowrap;">
+                <%= "(#{ecosystem.created_at})" if ecosystem %>
+              </span>
+            </div>
+            <div class="content-middle">
+              <%= ecosystem.try(:comments) %>
+            </div>
+            <div class="content-bottom">
+              <%= "CC / " if course_info.is_concept_coach %> <%= "College / " if course_info.is_college %>
+              <%= "#{course_info.periods_with_deleted.map{|p| p.latest_enrollments_with_deleted.length}.reduce(0, :+)} students" %> <%= " / #{course_info.periods_with_deleted.length} periods" %>
+            </div>
           </div>
           <div class="card-content-right">
             <% [extra_fields_procs].flatten.each do |extra_fields_proc| %>


### PR DESCRIPTION
Changes requested by Kajal and Greg (plus the last one by Dante)
- Change default `order`ing by `id`!
- Allow changing the order `on click`
- Fix `course`s "card" styling on smaller than huge screens
- Fix the "ability to change `results per page`" feature. Weird bug: if there was a search query in the search form, and then you changed the results per page, all except letter characters got escaped essentially breaking the search form.