### PR TITLE
Fix: Show all courses in admin courses controller

### DIFF
--- a/app/assets/javascripts/manager.js
+++ b/app/assets/javascripts/manager.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
 
     var setPerPage = function(val){
       var paramsObj = locationSearchInJSON();
-      paramsObj.per_page = Number(val);
+      paramsObj.per_page = Number(val) || val;
       window.location.search = decodeURIComponent($.param(paramsObj));
     }
 

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -9,7 +9,7 @@ class Admin::CoursesController < Admin::BaseController
     @query = params[:query]
     courses = SearchCourses.call(query: params[:query], order_by: params[:order_by] || 'id')
     params[:per_page] = courses.outputs.total_count if params[:per_page] == "all"
-    params_for_pagination = {page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 25)}
+    params_for_pagination = { page: (params[:page] || 1), per_page: (params[:per_page] || 25) }
 
     if courses.errors.any?
       flash[:error] = "Invalid search"

--- a/app/routines/get_excluded_exercises.rb
+++ b/app/routines/get_excluded_exercises.rb
@@ -192,12 +192,16 @@ class GetExcludedExercises
       File.join EE_STATS_FOLDER, filename_by_exercise
     end
 
+    def current_time
+      @current_time ||= Time.current.strftime("%Y%m%dT%H%M%SZ")
+    end
+
     def filename_by_course
-      "excluded_exercises_stats_by_course_#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}.csv"
+      "excluded_exercises_stats_by_course_#{current_time}.csv"
     end
 
     def filename_by_exercise
-      "excluded_exercises_stats_by_exercise_#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}.csv"
+      "excluded_exercises_stats_by_exercise_#{current_time}.csv"
     end
 
     def filepath_by_course

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -9,6 +9,8 @@
 
 <% page ||= 1 %>
 <% per_page ||= 25 %>
+<% per_page = per_page.to_i %>
+<% per_page = 25 if per_page == 0 %>
 
 <div class="tab-content">
   <div role="tabpanel" class="tab-pane active" id="main">

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -20,21 +20,43 @@ RSpec.describe Admin::CoursesController, type: :controller do
     end
 
     context "pagination" do
-      context "when the are any results" do
-        it "paginates the results" do
-          3.times {FactoryGirl.create(:course_profile_profile, name: "Algebra #{rand(1000)}")}
-          expect(CourseProfile::Models::Profile.count).to eq(3)
+      it "paginates the results" do
+        3.times { FactoryGirl.create(:course_profile_profile) }
 
-          get :index, page: 1, per_page: 2
-          expect(assigns[:course_infos].length).to eq(2)
+        get :index, page: 1, per_page: 2
+        expect(assigns[:course_infos].length).to eq(2)
 
-          get :index, page: 2, per_page: 2
-          expect(assigns[:course_infos].length).to eq(1)
+        get :index, page: 2, per_page: 2
+        expect(assigns[:course_infos].length).to eq(1)
+      end
+
+      context "with more than 25 courses" do
+        before(:each) do
+          26.times { FactoryGirl.create(:course_profile_profile) }
+        end
+
+        context "with per_page param" do
+          context "equal to \"all\"" do
+            it "assigns all courses" do
+              get :index, page: 1, per_page: "all"
+              expect(assigns[:course_infos].length).to eq(26)
+            end
+          end
+
+          context "equal to nil" do
+            it "assigns 25 courses per page" do
+              get :index, page: 1, per_page: nil
+              expect(assigns[:course_infos].length).to eq(25)
+
+              get :index, page: 2, per_page: nil
+              expect(assigns[:course_infos].length).to eq(1)
+            end
+          end
         end
       end
 
       context "when there are no results" do
-        it "doesn't blow up" do
+        it "returns http status OK" do
           expect(CourseProfile::Models::Profile.count).to eq(0)
 
           get :index, page: 1


### PR DESCRIPTION
There was a bug in [manager.js](https://github.com/openstax/tutor-server/compare/fix_infinity_on_admin_courses_index?expand=1#diff-93b8e3f1c5f6bf274f1b956aad113aa1R100): it expected a `Number`, so when the `per_page` param was set to `"all"` the page broke. This PR fixes that.

I also added more test coverage.