### PR TITLE
Update routes to redirect to new unified dashboard

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -3,7 +3,7 @@ class CoursesController < ApplicationController
   skip_before_filter :authenticate_user!, if: :period_is_archived?
 
   def teach
-    handle_with(CoursesTeach, complete: -> { send_to_teacher_dashboard })
+    handle_with(CoursesTeach, complete: -> { send_to_course_dashboard })
   end
 
   def enroll
@@ -17,7 +17,7 @@ class CoursesController < ApplicationController
   def confirm_enrollment
     handle_with(CoursesConfirmEnrollment,
                 success: -> {
-                  send_to_student_dashboard(
+                  send_to_course_dashboard(
                     notice: "Enrollment successful! It may take a few " \
                             "minutes to build your assignments."
                   )
@@ -40,7 +40,7 @@ class CoursesController < ApplicationController
     when :period_is_archived
       render :archived_enrollment
     when :user_is_already_a_course_student
-      send_to_student_dashboard(notice: "You are already enrolled in this course.")
+      send_to_course_dashboard(notice: "You are already enrolled in this course.")
     when :user_is_dropped
       render :dropped_student
     when :enrollment_code_not_found
@@ -59,15 +59,11 @@ class CoursesController < ApplicationController
     redirect_to dashboard_path, webview_notice: notice
   end
 
-  def send_to_student_dashboard(notice: nil)
+  def send_to_course_dashboard(notice: nil)
     course = @handler_result.outputs.course
-    redirect_to student_course_dashboard_path(course.id), webview_notice: notice
+    redirect_to course_dashboard_path(course.id), webview_notice: notice
   end
 
-  def send_to_teacher_dashboard(notice: nil)
-    course = @handler_result.outputs.course
-    redirect_to course_dashboard_path(course.id), notice: notice
-  end
 
   def enrollment_code_not_found
     render 'static_pages/generic_error',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,8 +284,7 @@ Rails.application.routes.draw do
   get '/enroll/:enroll_token(/:ignore)' => 'courses#enroll', as: :token_enroll
   post '/enroll/confirm' => 'courses#confirm_enrollment', as: :confirm_token_enroll
 
-  get '/courses/:id', to: 'webview#index', as: :course_dashboard
-  get '/courses/:id/list', to: 'webview#index', as: :student_course_dashboard
+  get '/course/:id', to: 'webview#index', as: :course_dashboard
 
   namespace :content_analyst do
     root to: 'console#index'

--- a/spec/features/join_by_url/student_url_enroll_spec.rb
+++ b/spec/features/join_by_url/student_url_enroll_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Students enrolling via URL' do
 
           expect(UserIsCourseStudent[course: course, user: user]).to be_truthy
           expect(CourseMembership::Models::Enrollment.last.period).to eq period1.to_model
-          expect(current_path).to eq(student_course_dashboard_path(course))
+          expect(current_path).to eq(course_dashboard_path(course))
           expect(page.body).to match(/notice\":\"Enrollment successful! It may take/)
           expect(CourseMembership::Models::Student.last.student_identifier).to eq '12345'
         end
@@ -53,7 +53,7 @@ RSpec.describe 'Students enrolling via URL' do
 
           expect(UserIsCourseStudent[course: course, user: user]).to be_truthy
           expect(CourseMembership::Models::Enrollment.last.period).to eq period1.to_model
-          expect(current_path).to eq(student_course_dashboard_path(course))
+          expect(current_path).to eq(course_dashboard_path(course))
           expect(CourseMembership::Models::Student.last.student_identifier).to be_nil
         end
 
@@ -173,7 +173,7 @@ RSpec.describe 'Students enrolling via URL' do
 
         it 'drops straight into course' do
           visit token_enroll_path(period1.enrollment_code_for_url)
-          expect(current_path).to eq(student_course_dashboard_path(course))
+          expect(current_path).to eq(course_dashboard_path(course))
           expect(page.body).to have_content "notice\":\"You are already enrolled"
         end
       end
@@ -182,7 +182,7 @@ RSpec.describe 'Students enrolling via URL' do
         it 'drops the user straight into the course' do
           AddUserAsPeriodStudent[period: period2, user: user]
           visit token_enroll_path(period1.enrollment_code_for_url)
-          expect(current_path).to eq(student_course_dashboard_path(course))
+          expect(current_path).to eq(course_dashboard_path(course))
         end
       end
 
@@ -230,7 +230,7 @@ RSpec.describe 'Students enrolling via URL' do
         click_button 'I Agree'
       end
 
-      expect(current_path).to eq(student_course_dashboard_path(course))
+      expect(current_path).to eq(course_dashboard_path(course))
       expect(page.body).to match /\"notice\":\"Enrollment successful! It may take/
     end
   end


### PR DESCRIPTION
After the recent upgrade the FE now uses /course/<id> for the dashboard and selected the appropriate teacher/student view dynamically.