### PR TITLE
Preview assignments

### DIFF
--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -379,7 +379,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
   def update_task_plan!(task_plan)
     # If no tasks are open, just call Roar's consume! like usual
     return consume!(task_plan, represent_with: Api::V1::TaskPlanRepresenter) \
-      unless task_plan.tasks_past_open?
+      unless task_plan.available_to_students?
 
     # Store current open dates for each TaskingPlan that is already open in the TaskPlan
     opens_at_ntzs = Hash.new{ |hash, key| hash[key] = {} }
@@ -402,8 +402,8 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
   # Returns the job uuid, if any, or nil if the request was completed inline
   def distribute_or_update_tasks(task_plan)
     should_publish_or_update = task_plan.is_publish_requested || task_plan.is_published?
-    should_publish = should_publish_or_update && !task_plan.tasks_past_open?
-    # should_update = should_publish_or_update && task_plan.tasks_past_open?
+    should_publish = should_publish_or_update && !task_plan.available_to_students?
+    # should_update = should_publish_or_update && task_plan.available_to_students?
 
     task_plan.publish_last_requested_at = Time.current if should_publish
     task_plan.save

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -412,7 +412,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
 
     if should_publish
       # Publish requested or already published but tasks not open: trigger publish
-      uuid = DistributeTasks.perform_later(task_plan)
+      uuid = DistributeTasks.perform_later(task_plan: task_plan)
       task_plan.update_attribute(:publish_job_uuid, uuid)
       uuid
     else # elsif should_update

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -379,7 +379,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
   def update_task_plan!(task_plan)
     # If no tasks are open, just call Roar's consume! like usual
     return consume!(task_plan, represent_with: Api::V1::TaskPlanRepresenter) \
-      unless task_plan.available_to_students?
+      unless task_plan.out_to_students?
 
     # Store current open dates for each TaskingPlan that is already open in the TaskPlan
     opens_at_ntzs = Hash.new{ |hash, key| hash[key] = {} }
@@ -401,28 +401,26 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
   # Distributes or updates distributed tasks for the given task_plan
   # Returns the job uuid, if any, or nil if the request was completed inline
   def distribute_or_update_tasks(task_plan)
-    should_publish_or_update = task_plan.is_publish_requested || task_plan.is_published?
-    should_publish = should_publish_or_update && !task_plan.available_to_students?
-    # should_update = should_publish_or_update && task_plan.available_to_students?
+    preview_only = !task_plan.is_publish_requested && !task_plan.is_published?
+    update_only = task_plan.out_to_students?
 
-    task_plan.publish_last_requested_at = Time.current if should_publish
+    task_plan.publish_last_requested_at = Time.current unless preview_only || update_only
     task_plan.save
-
     return if task_plan.errors.any?
 
-    if should_publish_or_update
-      if should_publish
-        # Publish requested or already published but tasks not open: trigger publish
-        uuid = DistributeTasks.perform_later(task_plan: task_plan)
-        task_plan.update_attribute(:publish_job_uuid, uuid)
-        uuid
-      else # elsif should_update
-        # Tasks already open: propagate updates
-        PropagateTaskPlanUpdates.call(task_plan: task_plan)
-        nil
-      end
-    else #elsif !should_publish_or_update
+    if preview_only
+      # Task not published and publication not requested: preview only
       DistributeTasks.call(task_plan: task_plan, preview: true)
+      nil
+    elsif update_only
+      # Tasks already open: propagate updates
+      PropagateTaskPlanUpdates.call(task_plan: task_plan)
+      nil
+    else
+      # Tasks not open: trigger publication
+      uuid = DistributeTasks.perform_later(task_plan: task_plan)
+      task_plan.update_attribute(:publish_job_uuid, uuid)
+      uuid
     end
   end
 

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -6,25 +6,46 @@ class DistributeTasks
 
   protected
 
-  def exec(task_plan, publish_time = Time.current, protect_unopened_tasks = false)
+  def exec(task_plan:, publish_time: Time.current, protect_unopened_tasks: false, preview: false)
+    # Lock the plan to prevent concurrent publication
     task_plan.lock!
 
+    # Abort if it seems like someone already published this plan
     fatal_error(code: :publish_last_requested_at_must_be_in_the_past) \
       if task_plan.publish_last_requested_at.present? &&
          task_plan.publish_last_requested_at > publish_time
 
+    # Get all tasks for this plan
     tasks = task_plan.tasks.preload(:taskings)
 
-    # Delete pre-existing assignments only if
-    # no assignments are open and protect_unopened_tasks is false
-    tasks.each(&:really_destroy!) \
-      if !protect_unopened_tasks && !task_plan.available_to_students?(current_time: publish_time)
+    # Task deletion (re-publishing)
+    unless task_plan.available_to_students?(current_time: publish_time)
+      # Only delete anything if tasks are not yet available to students
+      if preview
+        # Delete preview tasks only if no assignments are open
+        tasks.select do |task|
+          task.taskings.all?{ |tasking| tasking.role.teacher_student? }
+        end.each(&:really_destroy!)
+      elsif !protect_unopened_tasks
+        # Delete pre-existing assignments only if protect_unopened_tasks is false
+        tasks.each(&:really_destroy!)
+      end
+    end
 
+    # Make a list of all role_ids that still have tasks
     tasked_role_ids = tasks.reject(&:destroyed?).flat_map do |task|
       task.taskings.map(&:entity_role_id)
     end
 
-    tasking_plans = run(:individualize_tasking_plans, task_plan).outputs.tasking_plans
+    itp_args = { task_plan: task_plan }
+
+    # If preview is true, only assign to teacher_student roles
+    itp_args[:role_type] = :teacher_student_role if preview
+
+    # Convert tasking_plans to point to individual roles
+    tasking_plans = run(:individualize_tasking_plans, itp_args).outputs.tasking_plans
+
+    # Keep only the tasking_plans that point to roles that don't have a task from this plan
     untasked_tasking_plans = tasking_plans.reject do |tasking_plan|
       tasked_role_ids.include? tasking_plan.target_id
     end
@@ -36,14 +57,17 @@ class DistributeTasks
       task_plan: task_plan, individualized_tasking_plans: untasked_tasking_plans
     )
 
+    # Abort if the task type is supposed to have steps and any task has 0 steps
     fatal_error(
       code: :empty_tasks, message: 'Tasks could not be published because some tasks were empty'
     ) if tasks.any?{ |task| !task.stepless? && task.task_steps.empty? }
 
     save(tasks)
 
+    # Update last_published_at (and first_published_at if this is the first publication)
     task_plan.first_published_at = publish_time if task_plan.first_published_at.nil?
     task_plan.last_published_at = publish_time
+
     # We are only changing timestamps here, so no reason to validate the record
     task_plan.save(validate: false) if task_plan.persisted?
 

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -18,8 +18,7 @@ class DistributeTasks
     # Delete pre-existing assignments only if
     # no assignments are open and protect_unopened_tasks is false
     tasks.each(&:really_destroy!) \
-      if !protect_unopened_tasks &&
-         tasks.none?{ |task| task.past_open?(current_time: publish_time) }
+      if !protect_unopened_tasks && !task_plan.available_to_students?(current_time: publish_time)
 
     tasked_role_ids = tasks.reject(&:destroyed?).flat_map do |task|
       task.taskings.map(&:entity_role_id)

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -19,13 +19,11 @@ class DistributeTasks
     tasks = task_plan.tasks.preload(:taskings)
 
     # Task deletion (re-publishing)
-    unless task_plan.available_to_students?(current_time: publish_time)
+    unless task_plan.out_to_students?(current_time: publish_time)
       # Only delete anything if tasks are not yet available to students
       if preview
         # Delete preview tasks only if no assignments are open
-        tasks.select do |task|
-          task.taskings.all?{ |tasking| tasking.role.teacher_student? }
-        end.each(&:really_destroy!)
+        tasks.select(&:preview?).each(&:really_destroy!)
       elsif !protect_unopened_tasks
         # Delete pre-existing assignments only if protect_unopened_tasks is false
         tasks.each(&:really_destroy!)

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -40,7 +40,7 @@ class DistributeTasks
     itp_args = { task_plan: task_plan }
 
     # If preview is true, only assign to teacher_student roles
-    itp_args[:role_type] = :teacher_student_role if preview
+    itp_args[:role_type] = :teacher_student if preview
 
     # Convert tasking_plans to point to individual roles
     tasking_plans = run(:individualize_tasking_plans, itp_args).outputs.tasking_plans

--- a/app/routines/individualize_tasking_plans.rb
+++ b/app/routines/individualize_tasking_plans.rb
@@ -4,11 +4,12 @@ class IndividualizeTaskingPlans
 
   protected
 
-  def exec(task_plan)
+  def exec(task_plan:, role_type: nil)
     tasking_plans = task_plan.tasking_plans
     tasking_plans = tasking_plans.preload(:time_zone) if task_plan.persisted?
     outputs[:tasking_plans] = tasking_plans.flat_map do |tasking_plan|
       target = tasking_plan.target
+
       # For example, a deleted period
       next [] if target.nil? || target.respond_to?(:deleted?) && target.deleted?
 
@@ -29,6 +30,8 @@ class IndividualizeTaskingPlans
       else
         raise NotYetImplemented
       end
+
+      roles = roles.select{ |role| role.role_type == role_type.to_s } unless role_type.nil?
 
       [roles].flatten.map do |role|
         Tasks::Models::TaskingPlan.new(task_plan: task_plan,

--- a/app/routines/populate_trial_course_content.rb
+++ b/app/routines/populate_trial_course_content.rb
@@ -108,7 +108,7 @@ class PopulateTrialCourseContent
       end
       reading_tp.save!
 
-      run(:distribute_tasks, reading_tp)
+      run(:distribute_tasks, task_plan: reading_tp)
 
       exercises_count_dynamic = [4 - index/2, 2].max
 
@@ -130,7 +130,7 @@ class PopulateTrialCourseContent
       end
       homework_tp.save!
 
-      run(:distribute_tasks, homework_tp)
+      run(:distribute_tasks, task_plan: homework_tp)
     end
 
     # Work tasks

--- a/app/routines/reassign_published_period_task_plans.rb
+++ b/app/routines/reassign_published_period_task_plans.rb
@@ -19,7 +19,9 @@ class ReassignPublishedPeriodTaskPlans
 
     published_task_plans.each_with_index do |tp, ii|
       status.set_progress(ii, published_task_plans.size)
-      run(:distribute, tp, Time.current, protect_unopened_tasks)
+      run(:distribute, task_plan: tp,
+                       publish_time: Time.current,
+                       protect_unopened_tasks: protect_unopened_tasks)
     end
   end
 

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -125,6 +125,10 @@ class Tasks::Models::Task < Tutor::SubSystems::BaseModel
     page_practice? || chapter_practice? || mixed_practice?
   end
 
+  def preview?
+    taskings.none?{ |tasking| tasking.role.try!(:student?) }
+  end
+
   def core_task_steps(preload_tasked: false)
     task_steps = preload_tasked ? self.task_steps.preload(:tasked) : self.task_steps
     task_steps.to_a.select(&:core_group?)

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -40,9 +40,9 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
     preload(:tasking_plans, owner: :time_zone, tasks: [:taskings, task_steps: :tasked])
   }
 
-  def available_to_students?(current_time: Time.current)
+  def out_to_students?(current_time: Time.current)
     tasks.any? do |task|
-      task.past_open?(current_time: current_time) && task.taskings.first.try!(:role).try!(:student?)
+      task.past_open?(current_time: current_time) && !task.preview?
     end
   end
 
@@ -105,7 +105,7 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
   end
 
   def changes_allowed
-    return unless available_to_students?
+    return unless out_to_students?
     forbidden_attributes = changes.except(*UPDATABLE_ATTRIBUTES_AFTER_OPEN)
     return if forbidden_attributes.empty?
 

--- a/lib/tasks/demo/base.rb
+++ b/lib/tasks/demo/base.rb
@@ -433,7 +433,7 @@ class Demo::Base
   end
 
   def distribute_tasks(task_plan:)
-    tasks = run(DistributeTasks, task_plan).outputs.tasks
+    tasks = run(DistributeTasks, task_plan: task_plan).outputs.tasks
 
     log("Assigned #{task_plan.type} #{tasks.count} times")
     log("One task looks like: " + print_task(task: tasks.first)) if tasks.any?

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -2,65 +2,71 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, version: :v1 do
 
-  let(:course)    { FactoryGirl.create :course_profile_course, :with_assistants }
-  let(:period)    { FactoryGirl.create :course_membership_period, course: course }
+  before(:all) do
+    @course = FactoryGirl.create :course_profile_course, :with_assistants
+    period = FactoryGirl.create :course_membership_period, course: @course
 
-  let(:user)      { FactoryGirl.create(:user) }
-  let(:teacher)   { FactoryGirl.create(:user) }
-  let(:student)   { FactoryGirl.create(:user) }
+    @user = FactoryGirl.create(:user)
+    @teacher = FactoryGirl.create(:user)
+    student = FactoryGirl.create(:user)
+    @unaffiliated_teacher = FactoryGirl.create(:user)
 
-  let!(:published_task_plan) do
-    FactoryGirl.create(:tasked_task_plan,
-                       number_of_students: 0,
-                       owner: course,
-                       assistant: get_assistant(course: course, task_plan_type: 'reading'),
-                       published_at: Time.current)
-  end
-  let(:ecosystem)  { published_task_plan.ecosystem }
-  let(:page)       { ecosystem.pages.first }
+    @published_task_plan = FactoryGirl.create(
+      :tasked_task_plan,
+      number_of_students: 0,
+      owner: @course,
+      assistant: get_assistant(course: @course, task_plan_type: 'reading'),
+      published_at: Time.current
+    )
 
-  let(:task_plan)  do
-    FactoryGirl.build(:tasks_task_plan,
-                      owner: course,
-                      assistant: get_assistant(course: course, task_plan_type: 'reading'),
-                      content_ecosystem_id: ecosystem.id,
-                      settings: { page_ids: [page.id.to_s] },
-                      type: 'reading',
-                      num_tasking_plans: 0)
-  end
+    @ecosystem = @published_task_plan.ecosystem
+    @page = @ecosystem.pages.first
 
-  let!(:tasking_plan) do
-    FactoryGirl.create :tasks_tasking_plan,
-                       task_plan: task_plan,
-                       target: period.to_model,
-                       opens_at: Time.current.tomorrow
-  end
+    @task_plan = FactoryGirl.build(
+      :tasks_task_plan,
+      owner: @course,
+      assistant: get_assistant(course: @course, task_plan_type: 'reading'),
+      content_ecosystem_id: @ecosystem.id,
+      settings: { page_ids: [@page.id.to_s] },
+      type: 'reading',
+      num_tasking_plans: 0
+    )
 
-  let(:unaffiliated_teacher) { FactoryGirl.create(:user) }
+    FactoryGirl.create(
+      :tasks_tasking_plan,
+      task_plan: @task_plan,
+      target: period.to_model,
+      opens_at: Time.current.tomorrow
+    )
 
-  before do
-    course.time_zone.update_attribute(:name, 'Pacific Time (US & Canada)')
-    AddUserAsCourseTeacher.call(course: course, user: teacher)
+    teacher_student_task = FactoryGirl.create :tasks_task, tasked_to: [period.teacher_student_role]
+
+    @course.time_zone.update_attribute(:name, 'Pacific Time (US & Canada)')
+
+    AddUserAsCourseTeacher.call(course: @course, user: @teacher)
     AddUserAsPeriodStudent.call(period: period, user: student)
   end
 
+  # Workaround for PostgreSQL rollback bug
+  before{ @task_plan.reload.touch }
+
   context '#index' do
     before do
-      task_plan.destroy!
+      @task_plan.destroy!
 
-      controller.sign_in teacher
+      controller.sign_in @teacher
     end
 
     let(:opts) { { exclude_job_info: true } }
 
-    let!(:orig_course)      { course }
-    let!(:orig_task_plan_1) { published_task_plan }
+    let!(:orig_course)      { @course }
+    let!(:orig_task_plan_1) { @published_task_plan.reload }
 
     let!(:cloned_course) do
-      CloneCourse[course: course, teacher_user: teacher, copy_question_library: false].tap do |cc|
-        cc.year = course.year
-        cc.starts_at = course.starts_at
-        cc.ends_at = course.ends_at
+      CloneCourse[course: @course, teacher_user: @teacher, copy_question_library: false].tap do |cc|
+        cc.year = @course.year
+        cc.starts_at = @course.starts_at
+        cc.ends_at = @course.ends_at
       end
     end
 
@@ -68,8 +74,8 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
       FactoryGirl.create(:tasks_task_plan,
                          owner: orig_course,
                          assistant: get_assistant(course: orig_course, task_plan_type: 'reading'),
-                         content_ecosystem_id: ecosystem.id,
-                         settings: { page_ids: [page.id.to_s] },
+                         content_ecosystem_id: @ecosystem.id,
+                         settings: { page_ids: [@page.id.to_s] },
                          type: 'reading')
     end
 
@@ -77,8 +83,8 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
       FactoryGirl.create(:tasks_task_plan,
                          owner: cloned_course,
                          assistant: get_assistant(course: cloned_course, task_plan_type: 'reading'),
-                         content_ecosystem_id: ecosystem.id,
-                         settings: { page_ids: [page.id.to_s] },
+                         content_ecosystem_id: @ecosystem.id,
+                         settings: { page_ids: [@page.id.to_s] },
                          type: 'reading',
                          cloned_from: orig_task_plan_1)
     end
@@ -87,8 +93,8 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
       FactoryGirl.create(:tasks_task_plan,
                          owner: cloned_course,
                          assistant: get_assistant(course: cloned_course, task_plan_type: 'reading'),
-                         content_ecosystem_id: ecosystem.id,
-                         settings: { page_ids: [page.id.to_s] },
+                         content_ecosystem_id: @ecosystem.id,
+                         settings: { page_ids: [@page.id.to_s] },
                          type: 'reading')
     end
 
@@ -202,74 +208,71 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
 
   context '#show' do
     it 'cannot be requested by unrelated teachers' do
-      controller.sign_in unaffiliated_teacher
+      controller.sign_in @unaffiliated_teacher
       expect {
-        api_get :show, nil, parameters: {id: task_plan.id}
+        api_get :show, nil, parameters: {id: @task_plan.id}
       }.to raise_error(SecurityTransgression)
     end
 
     it "can be requested by the course's teacher" do
-      controller.sign_in teacher
+      controller.sign_in @teacher
       expect {
-        api_get :show, nil, parameters: {id: task_plan.id}
+        api_get :show, nil, parameters: {id: @task_plan.id}
       }.to_not raise_error
     end
 
     it "allows a teacher to view their course's task_plan" do
-      controller.sign_in teacher
-      api_get :show, nil, parameters: { course_id: course.id, id: task_plan.id }
+      controller.sign_in @teacher
+      api_get :show, nil, parameters: { course_id: @course.id, id: @task_plan.id }
       expect(response).to have_http_status(:success)
 
       # Ignore the stats for this test
       expect(response.body_as_hash.except(:stats).to_json).to(
-        eq(Api::V1::TaskPlanRepresenter.new(task_plan.reload).to_json)
+        eq(Api::V1::TaskPlanRepresenter.new(@task_plan.reload).to_json)
       )
     end
 
     it 'does not allow an unauthorized user to view the task_plan' do
-      controller.sign_in user
-      expect { api_get :show, nil, parameters: {course_id: course.id, id: task_plan.id} }
+      controller.sign_in @user
+      expect { api_get :show, nil, parameters: {course_id: @course.id, id: @task_plan.id} }
         .to raise_error(SecurityTransgression)
     end
 
     it 'does not allow an anonymous user to view the task_plan' do
       expect {
-        api_get :show, nil, parameters: {course_id: course.id, id: task_plan.id}
+        api_get :show, nil, parameters: {course_id: @course.id, id: @task_plan.id}
       }.to raise_error(SecurityTransgression)
     end
 
     it 'does not include stats' do
-      controller.sign_in teacher
-      api_get :show, nil, parameters: {id: task_plan.id}
-      body = JSON.parse(response.body)
-      expect(body['stats']).to be_nil
+      controller.sign_in @teacher
+      api_get :show, nil, parameters: {id: @task_plan.id}
+      expect(response.body_as_hash[:stats]).to be_nil
     end
   end
 
   context '#create' do
     it 'allows a teacher to create a task_plan for their course' do
-      controller.sign_in teacher
+      controller.sign_in @teacher
       expect { api_post :create,
                         nil,
-                        parameters: { course_id: course.id },
-                        raw_post_data: Api::V1::TaskPlanRepresenter.new(task_plan).to_json }
+                        parameters: { course_id: @course.id },
+                        raw_post_data: Api::V1::TaskPlanRepresenter.new(@task_plan).to_json }
         .to change{ Tasks::Models::TaskPlan.count }.by(1)
       expect(response).to have_http_status(:success)
 
-      task_plan = Tasks::Models::TaskPlan.last
-      course = task_plan.owner
       expect(response.body).to(
         eq(Api::V1::TaskPlanRepresenter.new(Tasks::Models::TaskPlan.last).to_json)
       )
     end
 
     it 'does not allow an unauthorized user to create a task_plan' do
-      controller.sign_in user
+      controller.sign_in @user
       expect {
         api_post :create,
                  nil,
-                 parameters: { course_id: course.id },
-                 raw_post_data: Api::V1::TaskPlanRepresenter.new(task_plan).to_json
+                 parameters: { course_id: @course.id },
+                 raw_post_data: Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
       }.to raise_error(SecurityTransgression)
     end
 
@@ -277,43 +280,43 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
       expect {
         api_post :create,
                  nil,
-                 parameters: { course_id: course.id },
-                 raw_post_data: Api::V1::TaskPlanRepresenter.new(task_plan).to_json
+                 parameters: { course_id: @course.id },
+                 raw_post_data: Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
       }.to raise_error(SecurityTransgression)
     end
 
     it 'fails if no Assistant found' do
       allow(request).to receive(:remote_ip) { '96.21.0.39' }
 
-      controller.sign_in teacher
+      controller.sign_in @teacher
       result = nil
 
       expect {
         result = api_post :create,
                           nil,
-                          parameters: { course_id: course.id },
+                          parameters: { course_id: @course.id },
                           raw_post_data: Api::V1::TaskPlanRepresenter
-                                           .new(task_plan).to_hash
+                                           .new(@task_plan).to_hash
                                            .except('type').to_json
       }.to raise_error(IllegalState).and change{ Tasks::Models::TaskPlan.count }.by 0
     end
 
     context 'when is_publish_requested is set' do
       let(:valid_json_hash) do
-        Api::V1::TaskPlanRepresenter.new(task_plan).to_hash.merge('is_publish_requested' => true)
+        Api::V1::TaskPlanRepresenter.new(@task_plan).to_hash.merge('is_publish_requested' => true)
       end
 
       it 'allows a teacher to publish a task_plan for their course' do
-        controller.sign_in teacher
+        controller.sign_in @teacher
         start_time = Time.current
         expect { api_post :create,
                           nil,
-                          parameters: { course_id: course.id },
+                          parameters: { course_id: @course.id },
                           raw_post_data: valid_json_hash.to_json }
           .to change{ Tasks::Models::TaskPlan.count }.by(1)
         end_time = Time.current
         expect(response).to have_http_status(:success)
-        new_task_plan = Tasks::Models::TaskPlan.find(JSON.parse(response.body)['id'])
+        new_task_plan = Tasks::Models::TaskPlan.find(response.body_as_hash[:id])
         expect(new_task_plan.publish_last_requested_at).to be > start_time
         expect(new_task_plan.first_published_at).to be > new_task_plan.publish_last_requested_at
         expect(new_task_plan.first_published_at).to be < end_time
@@ -325,8 +328,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         new_task_plan.last_published_at = nil
         expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(new_task_plan).to_json
 
-        response_hash = JSON.parse(response.body)
-        expect(response_hash['publish_job_url']).to include("/api/jobs/")
+        expect(response.body_as_hash[:publish_job_url]).to include('/api/jobs/')
       end
 
       it 'returns an error message if the task_plan settings are invalid' do
@@ -334,10 +336,10 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         invalid_json_hash['settings']['exercise_ids'] = [1, 2, 3]
         invalid_json_hash['settings']['exercises_count_dynamic'] = 3
 
-        controller.sign_in teacher
+        controller.sign_in @teacher
         expect { api_post :create,
                           nil,
-                          parameters: { course_id: course.id },
+                          parameters: { course_id: @course.id },
                           raw_post_data: invalid_json_hash.to_json }
           .not_to change{ Tasks::Models::TaskPlan.count }
         expect(response).to have_http_status(:unprocessable_entity)
@@ -349,122 +351,118 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
 
   context '#update' do
     it 'allows a teacher to update a task_plan for their course' do
-      controller.sign_in teacher
-      api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
-              raw_post_data: Api::V1::TaskPlanRepresenter.new(task_plan).to_json
+      controller.sign_in @teacher
+      api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
+              raw_post_data: Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
       expect(response).to have_http_status(:success)
-      task_plan.reload ## task_plan can be altered on the way in to/out of the database
-      course = task_plan.owner
       expect(response.body).to(
-        eq(Api::V1::TaskPlanRepresenter.new(task_plan).to_json)
+        eq(Api::V1::TaskPlanRepresenter.new(@task_plan.reload).to_json)
       )
     end
 
     it 'does not allow an unauthorized user to update a task_plan' do
-      controller.sign_in user
-      expect { api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
-               raw_post_data: Api::V1::TaskPlanRepresenter.new(task_plan).to_json }
+      controller.sign_in @user
+      expect { api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
+               raw_post_data: Api::V1::TaskPlanRepresenter.new(@task_plan).to_json }
         .to raise_error(SecurityTransgression)
     end
 
     it 'does not allow an anonymous user to update a task_plan' do
-      expect { api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
-               raw_post_data: Api::V1::TaskPlanRepresenter.new(task_plan).to_json }
+      expect { api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
+               raw_post_data: Api::V1::TaskPlanRepresenter.new(@task_plan).to_json }
         .to raise_error(SecurityTransgression)
     end
 
     context 'when is_publish_requested is set' do
       let(:valid_json_hash) do
-        Api::V1::TaskPlanRepresenter.new(task_plan).to_hash.merge('is_publish_requested' => true)
+        Api::V1::TaskPlanRepresenter.new(@task_plan).to_hash.merge('is_publish_requested' => true)
       end
 
       it 'allows a teacher to publish a task_plan for their course' do
-        controller.sign_in teacher
+        controller.sign_in @teacher
         start_time = Time.current
-        api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
+        api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
                               raw_post_data: valid_json_hash.to_json
         end_time = Time.current
         expect(response).to have_http_status(:accepted)
         # Need to reload the task_plan since publishing it will set the
         # publication dates and change the representation
-        task_plan.reload
-        expect(task_plan.publish_last_requested_at).to be > start_time
-        expect(task_plan.first_published_at).to be > task_plan.publish_last_requested_at
-        expect(task_plan.first_published_at).to be < end_time
-        expect(task_plan.last_published_at).to eq task_plan.first_published_at
+        @task_plan.reload
+        expect(@task_plan.publish_last_requested_at).to be > start_time
+        expect(@task_plan.first_published_at).to be > @task_plan.publish_last_requested_at
+        expect(@task_plan.first_published_at).to be < end_time
+        expect(@task_plan.last_published_at).to eq @task_plan.first_published_at
 
         # Revert task_plan to its state when the job was queued
-        task_plan.first_published_at = nil
-        task_plan.last_published_at = nil
-        expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(task_plan).to_json
+        @task_plan.first_published_at = nil
+        @task_plan.last_published_at = nil
+        expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
 
-        response_hash = JSON.parse(response.body)
-        expect(response_hash['publish_job_url']).to include("/api/jobs/")
+        expect(response.body_as_hash[:publish_job_url]).to include('/api/jobs/')
       end
 
       it 'does not update first_published_at for task_plans that are already published' do
-        controller.sign_in teacher
+        controller.sign_in @teacher
 
-        time_zone = task_plan.tasking_plans.first.time_zone.to_tz
+        time_zone = @task_plan.tasking_plans.first.time_zone.to_tz
 
         publish_last_requested_at = Time.current
         published_at = Time.current
         publish_job_uuid = SecureRandom.uuid
 
-        task_plan.publish_last_requested_at = publish_last_requested_at
-        task_plan.first_published_at = published_at
-        task_plan.last_published_at = published_at
-        task_plan.publish_job_uuid = publish_job_uuid
-        task_plan.save!
+        @task_plan.publish_last_requested_at = publish_last_requested_at
+        @task_plan.first_published_at = published_at
+        @task_plan.last_published_at = published_at
+        @task_plan.publish_job_uuid = publish_job_uuid
+        @task_plan.save!
 
         sleep(1)
 
         new_opens_at = time_zone.now.yesterday
         valid_json_hash['tasking_plans'].first['opens_at'] = new_opens_at
 
-        api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
+        api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
                               raw_post_data: valid_json_hash.to_json
 
         expect(response).to have_http_status(:accepted)
         # Need to reload the task_plan since publishing it will set
         # publish_last_requested_at and change the representation
-        expect(task_plan.reload.publish_last_requested_at).not_to(
+        expect(@task_plan.reload.publish_last_requested_at).not_to(
           be_within(1).of(publish_last_requested_at)
         )
-        expect(task_plan.first_published_at).to be_within(1).of(published_at)
-        expect(task_plan.last_published_at).not_to be_within(1).of(published_at)
-        expect(task_plan.publish_job_uuid).not_to eq publish_job_uuid
+        expect(@task_plan.first_published_at).to be_within(1).of(published_at)
+        expect(@task_plan.last_published_at).not_to be_within(1).of(published_at)
+        expect(@task_plan.publish_job_uuid).not_to eq publish_job_uuid
 
-        task_plan.tasks.each do |task|
+        @task_plan.tasks.each do |task|
           expect(task.opens_at).to be_within(1).of(new_opens_at)
         end
 
         # Revert task_plan to its state when the job was queued
-        task_plan.first_published_at = published_at
-        task_plan.last_published_at = published_at
-        expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(task_plan).to_json
+        @task_plan.first_published_at = published_at
+        @task_plan.last_published_at = published_at
+        expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
 
-        response_hash = JSON.parse(response.body)
-        expect(response_hash['publish_job_url']).to include("/api/jobs/")
+        expect(response.body_as_hash[:publish_job_url]).to include('/api/jobs/')
       end
 
       it 'does not republish the task_plan or allow the open date
           to be changed after the assignment is open' do
-        controller.sign_in teacher
+        controller.sign_in @teacher
 
-        time_zone = task_plan.tasking_plans.first.time_zone.to_tz
+        time_zone = @task_plan.tasking_plans.first.time_zone.to_tz
 
         opens_at = time_zone.now
 
         publish_last_requested_at = Time.current
 
-        task_plan.update_attribute :publish_last_requested_at, publish_last_requested_at
-        task_plan.tasking_plans.first.update_attribute :opens_at, opens_at
+        @task_plan.update_attribute :publish_last_requested_at, publish_last_requested_at
+        @task_plan.tasking_plans.first.update_attribute :opens_at, opens_at
 
-        DistributeTasks[task_plan]
+        DistributeTasks[@task_plan]
 
-        published_at = task_plan.reload.last_published_at
-        publish_job_uuid = task_plan.publish_job_uuid
+        published_at = @task_plan.reload.last_published_at
+        publish_job_uuid = @task_plan.publish_job_uuid
 
         valid_json_hash['title'] = 'Canceled'
         valid_json_hash['description'] = 'Canceled Assignment'
@@ -478,28 +476,28 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         # Since the task_plan opens_at is now in the past,
         # further publish requests should be ignored
         expect {
-          api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
+          api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
                                 raw_post_data: valid_json_hash.to_json
-        }.not_to change{ task_plan.reload.tasks }
+        }.not_to change{ @task_plan.reload.tasks }
         expect(response).to have_http_status(:ok)
 
-        expect(task_plan.reload.publish_last_requested_at).to(
+        expect(@task_plan.reload.publish_last_requested_at).to(
           be_within(1).of(publish_last_requested_at)
         )
-        expect(task_plan.last_published_at).to be_within(1).of(published_at)
-        expect(task_plan.publish_job_uuid).to eq publish_job_uuid
-        expect(task_plan.title).to eq 'Canceled'
-        expect(task_plan.description).to eq 'Canceled Assignment'
-        task_plan.tasking_plans.each do |tp|
+        expect(@task_plan.last_published_at).to be_within(1).of(published_at)
+        expect(@task_plan.publish_job_uuid).to eq publish_job_uuid
+        expect(@task_plan.title).to eq 'Canceled'
+        expect(@task_plan.description).to eq 'Canceled Assignment'
+        @task_plan.tasking_plans.each do |tp|
           expect(tp.opens_at).to be_within(1).of(opens_at)
           expect(tp.due_at).to be_within(1).of(new_due_at)
         end
-        task_plan.tasks.each do |task|
+        @task_plan.tasks.each do |task|
           expect(task.opens_at).to be_within(1).of(opens_at)
           expect(task.due_at).to be_within(1).of(new_due_at)
         end
 
-        expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(task_plan).to_json
+        expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
       end
 
       it 'returns an error message if the task_plan settings are invalid' do
@@ -507,8 +505,8 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         invalid_json_hash['settings']['exercise_ids'] = [1, 2, 3]
         invalid_json_hash['settings']['exercises_count_dynamic'] = 3
 
-        controller.sign_in teacher
-        api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
+        controller.sign_in @teacher
+        api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
                               raw_post_data: invalid_json_hash.to_json
         expect(response).to have_http_status(:unprocessable_entity)
         error = response.body_as_hash[:errors].first
@@ -519,8 +517,8 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         invalid_json_hash = valid_json_hash
         invalid_json_hash['tasking_plans'] = [{ target_id: nil, target_type: 'not valid' }]
 
-        controller.sign_in teacher
-        api_put :update, nil, parameters: { course_id: course.id, id: task_plan.id },
+        controller.sign_in @teacher
+        api_put :update, nil, parameters: { course_id: @course.id, id: @task_plan.id },
                               raw_post_data: invalid_json_hash.to_json
         expect(response).to have_http_status(:unprocessable_entity)
         error = response.body_as_hash[:errors].first
@@ -531,62 +529,62 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
 
   context '#destroy' do
     it 'allows a teacher to destroy a task_plan for their course' do
-      controller.sign_in teacher
-      expect{ api_delete :destroy, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      controller.sign_in @teacher
+      expect{ api_delete :destroy, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .to change{ Tasks::Models::TaskPlan.count }.by(-1)
       expect(response).to have_http_status(:success)
-      expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(task_plan.reload).to_json
+      expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(@task_plan).to_json
     end
 
     it 'does not allow a teacher to destroy a task_plan that is already destroyed' do
-      task_plan.destroy!
-      controller.sign_in teacher
-      expect{ api_delete :destroy, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      @task_plan.destroy!
+      controller.sign_in @teacher
+      expect{ api_delete :destroy, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .not_to change{ Tasks::Models::TaskPlan.count }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body_as_hash[:errors].first[:code]).to eq('task_plan_is_already_deleted')
     end
 
     it 'does not allow an unauthorized user to destroy a task_plan' do
-      controller.sign_in user
-      expect { api_delete :destroy, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      controller.sign_in @user
+      expect { api_delete :destroy, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .to raise_error(SecurityTransgression)
     end
 
     it 'does not allow an anonymous user to destroy a task_plan' do
-      expect { api_delete :destroy, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      expect { api_delete :destroy, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .to raise_error(SecurityTransgression)
     end
   end
 
   context '#restore' do
-    before(:each) { task_plan.destroy! }
+    before(:each) { @task_plan.destroy! }
 
     it 'allows a teacher to restore a destroyed task_plan for their course' do
-      controller.sign_in teacher
-      expect{ api_put :restore, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      controller.sign_in @teacher
+      expect{ api_put :restore, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .to change{ Tasks::Models::TaskPlan.count }.by(1)
       expect(response).to have_http_status(:success)
-      expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(task_plan.reload).to_json
+      expect(response.body).to eq Api::V1::TaskPlanRepresenter.new(@task_plan.reload).to_json
     end
 
     it 'does not allow a teacher to restore a task_plan that is not destroyed' do
-      task_plan.restore!(recursive: true)
-      controller.sign_in teacher
-      expect{ api_put :restore, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      @task_plan.restore!(recursive: true)
+      controller.sign_in @teacher
+      expect{ api_put :restore, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .not_to change{ Tasks::Models::TaskPlan.count }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body_as_hash[:errors].first[:code]).to eq('task_plan_is_not_deleted')
     end
 
     it 'does not allow an unauthorized user to restore a task_plan' do
-      controller.sign_in user
-      expect { api_put :restore, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      controller.sign_in @user
+      expect { api_put :restore, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .to raise_error(SecurityTransgression)
     end
 
     it 'does not allow an anonymous user to restore a task_plan' do
-      expect { api_put :restore, nil, parameters: { course_id: course.id, id: task_plan.id } }
+      expect { api_put :restore, nil, parameters: { course_id: @course.id, id: @task_plan.id } }
         .to raise_error(SecurityTransgression)
     end
   end
@@ -594,25 +592,24 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
   context 'stats' do
 
     it 'cannot be requested by unrelated teachers' do
-      controller.sign_in unaffiliated_teacher
+      controller.sign_in @unaffiliated_teacher
       expect {
-        api_get :stats, nil, parameters: { id: published_task_plan.id }
+        api_get :stats, nil, parameters: { id: @published_task_plan.id }
       }.to raise_error(SecurityTransgression)
     end
 
     it "can be requested by the course's teacher" do
-      controller.sign_in teacher
+      controller.sign_in @teacher
       expect {
-        api_get :stats, nil, parameters: { id: published_task_plan.id }
+        api_get :stats, nil, parameters: { id: @published_task_plan.id }
       }.to_not raise_error
     end
 
     it 'includes stats' do
-      controller.sign_in teacher
-      api_get :stats, nil, parameters: { id: published_task_plan.id }
-      body = JSON.parse(response.body)
+      controller.sign_in @teacher
+      api_get :stats, nil, parameters: { id: @published_task_plan.id }
       # The representer spec does validate the json so we'll rely on it and just check presense
-      expect(body['stats']).to be_a(Array)
+      expect(response.body_as_hash[:stats]).to be_a(Array)
     end
 
   end
@@ -620,25 +617,24 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
   context 'review' do
 
     it 'cannot be requested by unrelated teachers' do
-      controller.sign_in unaffiliated_teacher
+      controller.sign_in @unaffiliated_teacher
       expect {
-        api_get :review, nil, parameters: { id: published_task_plan.id }
+        api_get :review, nil, parameters: { id: @published_task_plan.id }
       }.to raise_error(SecurityTransgression)
     end
 
     it "can be requested by the course's teacher" do
-      controller.sign_in teacher
+      controller.sign_in @teacher
       expect {
-        api_get :review, nil, parameters: { id: published_task_plan.id }
+        api_get :review, nil, parameters: { id: @published_task_plan.id }
       }.to_not raise_error
     end
 
     it 'includes stats' do
-      controller.sign_in teacher
-      api_get :review, nil, parameters: { id: published_task_plan.id }
-      body = JSON.parse(response.body)
+      controller.sign_in @teacher
+      api_get :review, nil, parameters: { id: @published_task_plan.id }
       # The representer spec does validate the json so we'll rely on it and just check presense
-      expect(body['stats']).to be_a(Array)
+      expect(response.body_as_hash[:stats]).to be_a(Array)
     end
 
   end

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         @task_plan.update_attribute :publish_last_requested_at, publish_last_requested_at
         @task_plan.tasking_plans.first.update_attribute :opens_at, opens_at
 
-        DistributeTasks[@task_plan]
+        DistributeTasks[task_plan: @task_plan]
 
         published_at = @task_plan.reload.last_published_at
         publish_job_uuid = @task_plan.publish_job_uuid

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         .to change{ @teacher_student_role.taskings.count }.by(1)
       expect(response).to have_http_status(:success)
 
-      expect(@task_plan).not_to be_available_to_students
+      expect(@task_plan).not_to be_out_to_students
     end
 
     it 'does not allow an unauthorized user to create a task_plan' do
@@ -389,7 +389,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
         task.taskings.first.role == @teacher_student_role
       end
       expect(new_preview_task).to be_persisted
-      expect(@task_plan).not_to be_available_to_students
+      expect(@task_plan).not_to be_out_to_students
     end
 
     it 'does not allow an unauthorized user to update a task_plan' do

--- a/spec/factories/tasks/tasked_task_plan.rb
+++ b/spec/factories/tasks/tasked_task_plan.rb
@@ -59,6 +59,6 @@ FactoryGirl.define do
       task_plan.tasking_plans = [build(:tasks_tasking_plan, task_plan: task_plan, target: period)]
     end
 
-    after(:create) { |task_plan, evaluator| DistributeTasks.call(task_plan) }
+    after(:create) { |task_plan, evaluator| DistributeTasks.call(task_plan: task_plan) }
   end
 end

--- a/spec/requests/task_plan_reassignment_works_spec.rb
+++ b/spec/requests/task_plan_reassignment_works_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Task plan reassignment works', type: :request, api: true, versio
 
   scenario 'new students added after assignments published get those assignments' do
     # Publish the assignment, and no one around to get it...
-    DistributeTasks.call(task_plan_1)
+    DistributeTasks.call(task_plan: task_plan_1)
     # TeacherStudent role still gets it
     expect(Tasks::Models::Tasking.count).to eq 1
 
@@ -51,7 +51,7 @@ RSpec.describe 'Task plan reassignment works', type: :request, api: true, versio
     expect(CourseMembership::GetPeriodStudentRoles[periods: period]).to be_empty
 
     # The teacher publishes an assignment, and no one gets it...
-    DistributeTasks.call(task_plan_1)
+    DistributeTasks.call(task_plan: task_plan_1)
     # TeacherStudent role still gets it
     expect(Tasks::Models::Tasking.count).to eq 1
 

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe CalculateTaskStats, type: :routine, speed: :slow, vcr: VCR_OPTS d
         assistant: get_assistant(course: course, task_plan_type: 'reading')
       )
 
-      DistributeTasks.call(task_plan)
+      DistributeTasks.call(task_plan: task_plan)
 
       expect(stats.first.complete_count).to eq 0
     end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
     end
 
     it 'distributes the steps' do
-      results = DistributeTasks.call(homework_plan)
+      results = DistributeTasks.call(task_plan: homework_plan)
       expect(results.errors).to be_empty
       step_types = ["core_group", "core_group", "core_group", "core_group", "core_group",
                     "core_group", "personalized_group", "personalized_group", "personalized_group"]
@@ -76,7 +76,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
       0.upto(5) do
         pids << Tutor.fork_with_connection do
           begin
-            DistributeTasks.call(plan)
+            DistributeTasks.call(task_plan: plan)
             0 # all we care about for this spec is isolation conflicts, anything else is considered passing
           rescue ActiveRecord::TransactionIsolationConflict
             99 # arbitrary exit status to indicate failure
@@ -102,13 +102,13 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
 
       it 'creates tasks for the task_plan' do
         expect(task_plan.tasks).to be_empty
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors).to be_empty
         expect(task_plan.reload.tasks.size).to eq 3
       end
 
       it 'sets the published_at fields' do
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors).to be_empty
         expect(task_plan.reload.first_published_at).to be_within(1.second).of(Time.current)
         expect(task_plan.reload.last_published_at).to be_within(1.second).of(Time.current)
@@ -122,7 +122,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
         end
 
         expect(task_plan.tasks).to be_empty
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors.first.code).to eq :empty_tasks
         expect(task_plan.tasks).to eq [teacher_student_task]
       end
@@ -137,13 +137,13 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
 
       it 'creates tasks for the task_plan' do
         expect(task_plan.tasks).to be_empty
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors).to be_empty
         expect(task_plan.reload.tasks.size).to eq 3
       end
 
       it 'sets the published_at fields' do
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors).to be_empty
         expect(task_plan.reload.first_published_at).to be_within(1.second).of(Time.current)
         expect(task_plan.reload.last_published_at).to be_within(1.second).of(Time.current)
@@ -157,7 +157,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
         end
 
         expect(task_plan.tasks).to be_empty
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors.first.code).to eq :empty_tasks
         expect(task_plan.tasks).to eq [teacher_student_task]
       end
@@ -166,7 +166,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
 
   context 'published task_plan' do
     before(:each) do
-      DistributeTasks.call(task_plan)
+      DistributeTasks.call(task_plan: task_plan)
       new_user.to_model.roles.each do |role|
         role.taskings.each{ |tasking| tasking.task.really_destroy! }
       end
@@ -184,7 +184,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
         expect(task_plan.tasks.size).to eq 2
         old_task = task_plan.tasks.first
 
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors).to be_empty
         expect(task_plan.reload.tasks.size).to eq 3
         expect(task_plan.tasks).not_to include old_task
@@ -193,7 +193,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
       it 'does not set the first_published_at field' do
         old_published_at = task_plan.first_published_at
         publish_time = Time.current
-        result = DistributeTasks.call(task_plan, publish_time)
+        result = DistributeTasks.call(task_plan: task_plan, publish_time: publish_time)
         expect(result.errors).to be_empty
         expect(task_plan.reload.first_published_at).to eq old_published_at
         expect(task_plan.last_published_at).to be_within(1).of(publish_time)
@@ -211,7 +211,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
         expect(task_plan.tasks.size).to eq 2
         old_task = task_plan.tasks.first
 
-        result = DistributeTasks.call(task_plan)
+        result = DistributeTasks.call(task_plan: task_plan)
         expect(result.errors).to be_empty
         expect(task_plan.reload.tasks.size).to eq 3
         expect(task_plan.tasks).to include old_task
@@ -220,7 +220,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
       it 'does not set the first_published_at field' do
         old_published_at = task_plan.first_published_at
         publish_time = Time.current
-        result = DistributeTasks.call(task_plan, publish_time)
+        result = DistributeTasks.call(task_plan: task_plan, publish_time: publish_time)
         expect(result.errors).to be_empty
         expect(task_plan.reload.first_published_at).to eq old_published_at
         expect(task_plan.last_published_at).to be_within(1).of(publish_time)

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
         expect(result.errors).to be_empty
         expect(task_plan.reload.tasks.size).to eq 1
         expect(task_plan.tasks.first.taskings.first.role).to eq period.teacher_student_role
-        expect(task_plan).not_to be_available_to_students
+        expect(task_plan).not_to be_out_to_students
       end
 
       it 'creates tasks for the task_plan' do

--- a/spec/routines/individualize_tasking_plans_spec.rb
+++ b/spec/routines/individualize_tasking_plans_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe IndividualizeTaskingPlans, type: :routine do
   let(:tasking_plan) { task_plan.tasking_plans.first }
 
   let(:result)       { described_class[task_plan: task_plan] }
+  let(:ts_result)    { described_class[task_plan: task_plan, role_type: :teacher_student] }
 
   context 'entity_role' do
     let(:role)  { FactoryGirl.create :entity_role }
@@ -61,9 +62,7 @@ RSpec.describe IndividualizeTaskingPlans, type: :routine do
     let!(:student_role_2)        { AddUserAsPeriodStudent[user: user_2, period: period_1] }
     let!(:student_role_3)        { AddUserAsPeriodStudent[user: user_3, period: period_2] }
 
-    before do
-      tasking_plan.update_attribute(:target, course)
-    end
+    before                       { tasking_plan.update_attribute(:target, course) }
 
     it 'returns tasking plans pointing to the course\'s student and teacher_student roles' do
       expect(result.size).to eq 5
@@ -71,6 +70,18 @@ RSpec.describe IndividualizeTaskingPlans, type: :routine do
                           teacher_student_role_1, teacher_student_role_2]
 
       result.each do |new_tasking_plan|
+        expect(new_tasking_plan.task_plan).to eq task_plan
+        expect(new_tasking_plan.target).to be_in acceptable_roles
+        expect(new_tasking_plan.opens_at).to be_within(1).of tasking_plan.opens_at
+        expect(new_tasking_plan.due_at).to be_within(1).of tasking_plan.due_at
+      end
+    end
+
+    it 'limits results to the specified role_type, if given' do
+      expect(ts_result.size).to eq 2
+      acceptable_roles = [teacher_student_role_1, teacher_student_role_2]
+
+      ts_result.each do |new_tasking_plan|
         expect(new_tasking_plan.task_plan).to eq task_plan
         expect(new_tasking_plan.target).to be_in acceptable_roles
         expect(new_tasking_plan.opens_at).to be_within(1).of tasking_plan.opens_at
@@ -116,6 +127,18 @@ RSpec.describe IndividualizeTaskingPlans, type: :routine do
       acceptable_roles = [student_role_1, student_role_2, teacher_student_role_1]
 
       result.each do |new_tasking_plan|
+        expect(new_tasking_plan.task_plan).to eq task_plan
+        expect(new_tasking_plan.target).to be_in acceptable_roles
+        expect(new_tasking_plan.opens_at).to be_within(1).of tasking_plan.opens_at
+        expect(new_tasking_plan.due_at).to be_within(1).of tasking_plan.due_at
+      end
+    end
+
+    it 'limits results to the specified role_type, if given' do
+      expect(ts_result.size).to eq 1
+      acceptable_roles = [teacher_student_role_1]
+
+      ts_result.each do |new_tasking_plan|
         expect(new_tasking_plan.task_plan).to eq task_plan
         expect(new_tasking_plan.target).to be_in acceptable_roles
         expect(new_tasking_plan.opens_at).to be_within(1).of tasking_plan.opens_at

--- a/spec/routines/individualize_tasking_plans_spec.rb
+++ b/spec/routines/individualize_tasking_plans_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe IndividualizeTaskingPlans, type: :routine do
   let(:task_plan)    { FactoryGirl.create :tasks_task_plan }
   let(:tasking_plan) { task_plan.tasking_plans.first }
 
-  let(:result)       { described_class[task_plan] }
+  let(:result)       { described_class[task_plan: task_plan] }
 
   context 'entity_role' do
     let(:role)  { FactoryGirl.create :entity_role }

--- a/spec/routines/propagate_task_plan_updates_spec.rb
+++ b/spec/routines/propagate_task_plan_updates_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
 
   context 'published task_plan' do
     before(:each) do
-      DistributeTasks.call(task_plan)
+      DistributeTasks.call(task_plan: task_plan)
 
       task_plan.reload
       task_plan.title = new_title

--- a/spec/routines/reassign_published_period_task_plans_spec.rb
+++ b/spec/routines/reassign_published_period_task_plans_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ReassignPublishedPeriodTaskPlans, type: :routine do
 
   before(:each) do
     # Publish task_plan_1
-    DistributeTasks.call(task_plan_1)
+    DistributeTasks.call(task_plan: task_plan_1)
 
     # We are pretending new_user is new to the period, so hard-delete their tasks
     new_user.to_model.roles.each do |role|

--- a/spec/subsystems/tasks/assistants/event_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/event_assistant_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Tasks::Assistants::EventAssistant, type: :assistant do
                                    description: 'No class today, kiddos',
                                    owner: course)
 
-    tasks = DistributeTasks.call(task_plan).outputs.tasks
+    tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
 
     expect(tasks.length).to eq num_taskees + 1
     expect(tasks.flat_map(&:task_type).uniq).to eq(['event'])

--- a/spec/subsystems/tasks/assistants/external_assignment_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/external_assignment_assistant_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Tasks::Assistants::ExternalAssignmentAssistant, type: :assistant 
   end
 
   it 'assigns tasked external urls to students' do
-    tasks = DistributeTasks.call(task_plan_1).outputs.tasks
+    tasks = DistributeTasks.call(task_plan: task_plan_1).outputs.tasks
     expect(tasks.length).to eq num_taskees + 1
 
     tasks.each do |task|
@@ -48,7 +48,7 @@ RSpec.describe Tasks::Assistants::ExternalAssignmentAssistant, type: :assistant 
   end
 
   it 'assigns tasked external urls with templatized urls to students' do
-    tasks = DistributeTasks.call(task_plan_2).outputs.tasks
+    tasks = DistributeTasks.call(task_plan: task_plan_2).outputs.tasks
     expect(tasks.length).to eq num_taskees + 1
 
     tasks.each do |task|

--- a/spec/subsystems/tasks/assistants/extra_assignment_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/extra_assignment_assistant_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Tasks::Assistants::ExtraAssignmentAssistant, type: :assistant, vc
   end
 
   it 'assigns tasked readings and exercises to students' do
-    tasks = DistributeTasks.call(task_plan).outputs.tasks
+    tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
     expect(tasks.length).to eq(num_taskees + 1)
     tasks.each do |task|
       # We added 2 snap lab notes:

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
         receive(:num_personalized_exercises) { personalized_exercise_count }
       )
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
 
       ## it "sets description, task type, and feedback_at"
       tasks.each do |task|
@@ -169,7 +169,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
                                                         exercise_number: exercise.number)
       end
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
 
       tasks.each do |task|
         core_task_steps = task.core_task_steps
@@ -216,7 +216,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant,
                                                         exercise_number: exercise.number)
       end
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
 
       tasks.each do |task|
         core_task_steps = task.core_task_steps

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         receive(:k_ago_map) { [[0, 2]] }
       )
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
@@ -192,7 +192,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
       )
 
       task_plan.update_attribute(:settings, { 'page_ids' => [@content_pages.first.id.to_s] })
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
@@ -234,7 +234,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         end
       end
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
@@ -278,7 +278,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         end
       end
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       expect(tasks.length).to eq num_taskees
 
       tasks.each do |task|
@@ -394,7 +394,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         receive(:k_ago_map) { [[0, 2]] }
       )
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       tasks.each do |task|
         expect(task.taskings.length).to eq 1
         expect(task.feedback_at).to be_nil
@@ -521,7 +521,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         receive(:k_ago_map) { [[0, 2]] }
       )
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       tasks.each do |task|
         expect(task.taskings.length).to eq 1
         expect(task.feedback_at).to be_nil
@@ -685,7 +685,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant,
         ]
       end
 
-      tasks = DistributeTasks.call(task_plan).outputs.tasks
+      tasks = DistributeTasks.call(task_plan: task_plan).outputs.tasks
       expect(tasks.size).to eq 1
       task_steps = tasks.first.task_steps
 

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -132,18 +132,18 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     end
 
     it 'knows if tasks are available to students' do
-      expect(task_plan.available_to_students?).to eq false
+      expect(task_plan.out_to_students?).to eq false
 
       teacher_student_task
-      expect(task_plan.reload.available_to_students?).to eq false
+      expect(task_plan.reload.out_to_students?).to eq false
 
       student_task
-      expect(task_plan.reload.available_to_students?).to eq true
+      expect(task_plan.reload.out_to_students?).to eq true
 
       future_time = Time.now.utc + 1.week
       student_task.update_attribute :opens_at_ntz, future_time
-      expect(task_plan.reload.available_to_students?).to eq false
-      expect(task_plan.reload.available_to_students?(current_time: future_time + 2.days)).to eq true
+      expect(task_plan.reload.out_to_students?).to eq false
+      expect(task_plan.reload.out_to_students?(current_time: future_time + 2.days)).to eq true
     end
 
     it 'will not allow other fields to be updated after tasks are available to students' do

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -77,12 +77,6 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).to be_valid
   end
 
-  it 'will not allow other fields to be updated after a task is open' do
-    task_plan.tasks << new_task
-    task_plan.settings = { due_at: Time.current.tomorrow }
-    expect(task_plan).not_to be_valid
-  end
-
   it 'requires all tasking_plan due_ats to be in the future when publishing' do
     task_plan.is_publish_requested = true
     expect(task_plan).to be_valid
@@ -124,6 +118,43 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     new_task_plan.ecosystem = nil
     expect(new_task_plan.valid?).to eq true
     expect(new_task_plan.ecosystem).to eq ecosystem_model
+  end
+
+  context 'with tasks assigned to students' do
+    let(:teacher_student_role) { FactoryGirl.create :entity_role, role_type: :teacher_student }
+    let(:teacher_student_task) do
+      FactoryGirl.create :tasks_task, task_plan: task_plan, tasked_to: [teacher_student_role]
+    end
+
+    let(:student_role) { FactoryGirl.create :entity_role, role_type: :student }
+    let(:student_task) do
+      FactoryGirl.create :tasks_task, task_plan: task_plan, tasked_to: [student_role]
+    end
+
+    it 'knows if tasks are available to students' do
+      expect(task_plan.available_to_students?).to eq false
+
+      teacher_student_task
+      expect(task_plan.reload.available_to_students?).to eq false
+
+      student_task
+      expect(task_plan.reload.available_to_students?).to eq true
+
+      future_time = Time.now.utc + 1.week
+      student_task.update_attribute :opens_at_ntz, future_time
+      expect(task_plan.reload.available_to_students?).to eq false
+      expect(task_plan.reload.available_to_students?(current_time: future_time + 2.days)).to eq true
+    end
+
+    it 'will not allow other fields to be updated after tasks are available to students' do
+      task_plan.reload.settings = { due_at: Time.current.tomorrow }
+      expect(task_plan).to be_valid
+
+      student_task
+
+      task_plan.reload.settings = { due_at: Time.current.tomorrow }
+      expect(task_plan).not_to be_valid
+    end
   end
 
 end

--- a/spec/support/create_student_history.rb
+++ b/spec/support/create_student_history.rb
@@ -55,10 +55,10 @@ class CreateStudentHistory
 
   def create_assignments(ecosystem, course, periods)
     periods = [periods].flatten.compact
-    run(:distribute_tasks, create_ireading_task_plan(ecosystem, course, periods))
+    run(:distribute_tasks, task_plan: create_ireading_task_plan(ecosystem, course, periods))
 
     task_plan = create_homework_task_plan(ecosystem, course, periods)
-    tasks = run(:distribute_tasks, task_plan).outputs.tasks
+    tasks = run(:distribute_tasks, task_plan: task_plan).outputs.tasks
     tasks.each do |task|
       task = task.reload
       answer_correctly(task.task_steps(true), 2)
@@ -79,8 +79,9 @@ class CreateStudentHistory
   end
 
   def ireading_assistant
-    @ireading_assistant ||= FactoryGirl.create(:tasks_assistant,
-      code_class_name: 'Tasks::Assistants::IReadingAssistant')
+    @ireading_assistant ||= FactoryGirl.create(
+      :tasks_assistant, code_class_name: 'Tasks::Assistants::IReadingAssistant'
+    )
   end
 
   def create_ireading_task_plan(ecosystem, course, periods)

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -100,7 +100,7 @@ class SetupPerformanceReportData
 
     reading_taskplan.save!
 
-    DistributeTasks[reading_taskplan]
+    DistributeTasks[task_plan: reading_taskplan]
 
     homework_taskplan = Tasks::Models::TaskPlan.new(
       title: 'Homework task plan',
@@ -122,7 +122,7 @@ class SetupPerformanceReportData
 
     homework_taskplan.save!
 
-    DistributeTasks[homework_taskplan]
+    DistributeTasks[task_plan: homework_taskplan]
 
     homework2_taskplan = Tasks::Models::TaskPlan.new(
       title: 'Homework 2 task plan',
@@ -144,7 +144,7 @@ class SetupPerformanceReportData
 
     homework2_taskplan.save!
 
-    DistributeTasks[homework2_taskplan]
+    DistributeTasks[task_plan: homework2_taskplan]
 
     future_homework_taskplan = Tasks::Models::TaskPlan.new(
       title: 'Future Homework task plan',
@@ -168,7 +168,7 @@ class SetupPerformanceReportData
 
     future_homework_taskplan.save!
 
-    DistributeTasks[future_homework_taskplan]
+    DistributeTasks[task_plan: future_homework_taskplan]
 
     roles.map{ |role| get_student_tasks(role) }
   end


### PR DESCRIPTION
- Made it so teacher_student tasks don't affect whether or not you can publish or propagate task plan updates
- Automatically create the teacher_student preview task when creating/updating an assignment, even if unpublished