### PR TITLE
Only offer terms that start < 1 year in future

### DIFF
--- a/lib/term_year.rb
+++ b/lib/term_year.rb
@@ -47,7 +47,7 @@ TermYear = Struct.new(:term, :year) do
 
     next_year_visible_term_years = VISIBLE_TERMS.map do |term|
       TermYear.new(term, current_year + 1)
-    end.select{ |term_year| term_year.starts_at <= current_time + 1.year }
+    end.select{ |term_year| term_year.ends_at <= current_time + 1.year }
 
     current_year_visible_term_years + next_year_visible_term_years
   end

--- a/spec/lib/term_year_spec.rb
+++ b/spec/lib/term_year_spec.rb
@@ -119,24 +119,22 @@ RSpec.describe TermYear, type: :lib do
 
     expect(TermYear.visible_term_years(spring_date_time)).to eq [
       TermYear.new(:spring, current_year), TermYear.new(:summer, current_year    ),
-      TermYear.new(:fall,   current_year), TermYear.new(:spring, current_year + 1)
+      TermYear.new(:fall,   current_year)
     ]
 
     expect(TermYear.visible_term_years(spring_summer_date_time)).to eq [
       TermYear.new(:spring, current_year    ), TermYear.new(:summer, current_year    ),
-      TermYear.new(:fall,   current_year    ), TermYear.new(:spring, current_year + 1),
-      TermYear.new(:summer, current_year + 1)
+      TermYear.new(:fall,   current_year    )
     ]
 
     expect(TermYear.visible_term_years(summer_fall_date_time)).to eq [
       TermYear.new(:summer, current_year    ), TermYear.new(:fall,   current_year    ),
-      TermYear.new(:spring, current_year + 1), TermYear.new(:summer, current_year + 1),
-      TermYear.new(:fall,   current_year + 1)
+      TermYear.new(:spring, current_year + 1)
     ]
 
     expect(TermYear.visible_term_years(fall_date_time)).to eq [
       TermYear.new(:fall,   current_year    ), TermYear.new(:spring, current_year + 1),
-      TermYear.new(:summer, current_year + 1), TermYear.new(:fall,   current_year + 1)
+      TermYear.new(:summer, current_year + 1)
     ]
   end
 end


### PR DESCRIPTION
Before it was terms that end 1 year in future, but that was judged too far out into the future.