### PR TITLE
Control task plan creation based on tasking plan dates

### DIFF
--- a/app/access_policies/task_plan_access_policy.rb
+++ b/app/access_policies/task_plan_access_policy.rb
@@ -11,8 +11,6 @@ class TaskPlanAccessPolicy
     owner = task_plan.owner
 
     if owner.is_a?(CourseProfile::Models::Course)
-      return false if action == :create && !owner.active?
-
       UserIsCourseTeacher[user: requestor, course: owner]
     elsif requestor.is_human?
       requestor == owner || requestor.to_model == owner

--- a/spec/access_policies/task_access_policy_spec.rb
+++ b/spec/access_policies/task_access_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe TaskAccessPolicy, type: :access_policy do
-  let(:requestor)         { FactoryGirl.create(:user) }
-  let(:task)              { FactoryGirl.create(:tasks_task) }
+  let(:requestor)          { FactoryGirl.create(:user) }
+  let(:task)               { FactoryGirl.create(:tasks_task) }
 
   subject(:action_allowed) { TaskAccessPolicy.action_allowed?(action, requestor, task) }
 

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -57,7 +57,11 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true, versi
     let!(:orig_task_plan_1) { published_task_plan }
 
     let!(:cloned_course) do
-      CloneCourse[course: course, teacher_user: teacher, copy_question_library: false]
+      CloneCourse[course: course, teacher_user: teacher, copy_question_library: false].tap do |cc|
+        cc.year = course.year
+        cc.starts_at = course.starts_at
+        cc.ends_at = course.ends_at
+      end
     end
 
     let!(:orig_task_plan_2) do

--- a/spec/factories/course_profile/courses.rb
+++ b/spec/factories/course_profile/courses.rb
@@ -8,8 +8,8 @@ FactoryGirl.define do
     term                  { CourseProfile::Models::Course.terms.keys.sample }
     year                  { Time.current.year }
 
-    starts_at             { Time.current }
-    ends_at               { Time.current + 1.week }
+    starts_at             { Time.current - 3.months }
+    ends_at               { Time.current + 3.months }
 
     association :offering, factory: :catalog_offering
 
@@ -18,9 +18,7 @@ FactoryGirl.define do
     end
 
     trait(:process_school_change) do
-      after(:create) do |course|
-        SchoolDistrict::ProcessSchoolChange[course: course]
-      end
+      after(:create) { |course| SchoolDistrict::ProcessSchoolChange[course: course] }
     end
   end
 end

--- a/spec/subsystems/tasks/models/tasking_plan_spec.rb
+++ b/spec/subsystems/tasks/models/tasking_plan_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe Tasks::Models::TaskingPlan, type: :model do
     expect(tasking_plan).not_to be_valid
   end
 
+  it "requires opens_at to be after the course's starts_at, if the owner is a course" do
+    expect(tasking_plan).to be_valid
+    tasking_plan.opens_at = course.starts_at - 1.day
+    expect(tasking_plan).not_to be_valid
+    tasking_plan.opens_at = course.starts_at + 1.day
+    expect(tasking_plan).to be_valid
+  end
+
+  it "requires due_at to be before the course's ends_at, if the owner is a course" do
+    expect(tasking_plan).to be_valid
+    tasking_plan.due_at = course.ends_at + 1.day
+    expect(tasking_plan).not_to be_valid
+    tasking_plan.due_at = course.ends_at - 1.day
+    expect(tasking_plan).to be_valid
+  end
+
   it "requires target to be unique for the task_plan" do
     expect(tasking_plan).to be_valid
 


### PR DESCRIPTION
- Control task plan creation based on tasking plan dates and not on current date
- Improved error message when not allowed to create/update task plan due to course dates