### PR TITLE
TermYear adjustments

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -107,4 +107,12 @@ $(document).ready(function() {
   }
   $('#course_catalog_offering_id').change(updateCourseForm);
   updateCourseForm();
+
+  //========== Clears course start/end dates when a new Term or Year is selected ==========//
+  function clearCourseDates() {
+    $('#course_starts_at').prop('value', '');
+    $('#course_ends_at').prop('value', '');
+  }
+  $('#course_term').change(clearCourseDates);
+  $('#course_year').change(clearCourseDates);
 });

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -88,9 +88,16 @@ class Admin::CoursesController < Admin::BaseController
   def update
     handle_with(Admin::CoursesUpdate,
                 params: course_params,
-                complete: ->(*) {
+                success: ->(*) {
                   flash[:notice] = 'The course has been updated.'
                   redirect_to admin_courses_path
+                },
+                failure: ->(*) {
+                  flash[:error] = @handler_result.errors.full_messages
+                  @course = CourseProfile::Models::Course.find(params[:id])
+                  get_schools
+                  get_catalog_offerings
+                  render :edit
                 })
   end
 

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -41,7 +41,7 @@ class Admin::CoursesController < Admin::BaseController
                   redirect_to admin_courses_path
                 },
                 failure: ->(*) {
-                  flash[:error] = @handler_result.errors.full_messages
+                  flash.now[:error] = @handler_result.errors.full_messages
                   @course = @handler_result.outputs.course || get_new_course
                   get_schools
                   get_catalog_offerings
@@ -93,10 +93,11 @@ class Admin::CoursesController < Admin::BaseController
                   redirect_to admin_courses_path
                 },
                 failure: ->(*) {
-                  flash[:error] = @handler_result.errors.full_messages
+                  flash.now[:error] = @handler_result.errors.full_messages
                   @course = CourseProfile::Models::Course.find(params[:id])
                   get_schools
                   get_catalog_offerings
+                  get_course_details
                   render :edit
                 })
   end

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -43,7 +43,7 @@ class CourseProfile::Models::Course < Tutor::SubSystems::BaseModel
 
   delegate :name, to: :school, prefix: true, allow_nil: true
 
-  before_validation :set_starts_at_and_ends_at, on: :create
+  before_validation :set_starts_at_and_ends_at
 
   def default_due_time
     read_attribute(:default_due_time) || Settings::Db.store[:default_due_time]
@@ -74,6 +74,8 @@ class CourseProfile::Models::Course < Tutor::SubSystems::BaseModel
   protected
 
   def set_starts_at_and_ends_at
+    return if starts_at.present? && ends_at.present?
+
     ty = term_year
     self.starts_at ||= ty.try!(:starts_at)
     self.ends_at   ||= ty.try!(:ends_at)

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -15,16 +15,19 @@
        end
 
        f.select :term, term_select_options, {}, class: 'form-control' %>
+    <small class="form-text text-muted">Changing this will clear the start/end dates</small>
   </div>
 
   <div class="form-group">
     <%= f.label :year %>
     <%= f.number_field :year, class: 'form-control' %>
+    <small class="form-text text-muted">Changing this will clear the start/end dates</small>
   </div>
 
   <div class="form-group">
     <%= f.label :num_sections, 'Number of sections' %>
-    <%= f.number_field :num_sections, min: 0, class: 'form-control' %>
+    <%= f.number_field :num_sections, min: 0, class: 'form-control',
+                                      disabled: !f.object.new_record? %>
   </div>
 
   <div class="form-group">

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -30,11 +30,13 @@
   <div class="form-group">
     <%= f.label :starts_at %>
     <%= f.text_field :starts_at, class: 'form-control datepicker' %>
+    <small class="form-text text-muted">Blank means use default date for the given Term/Year</small>
   </div>
 
   <div class="form-group">
     <%= f.label :ends_at %>
     <%= f.text_field :ends_at, class: 'form-control datepicker' %>
+    <small class="form-text text-muted">Blank means use default date for the given Term/Year</small>
   </div>
 
   <div class="form-group">

--- a/lib/tasks/demo/content.rb
+++ b/lib/tasks/demo/content.rb
@@ -95,8 +95,6 @@ class Demo::Content < Demo::Base
              create_course(name: content.course_name,
                            term: CourseProfile::Models::Course.terms[:demo],
                            year: current_time.year,
-                           starts_at: current_time - 1.month,
-                           ends_at: current_time + 10.years,
                            catalog_offering: offering,
                            appearance_code: content.appearance_code,
                            is_concept_coach: content.is_concept_coach,

--- a/lib/term_year.rb
+++ b/lib/term_year.rb
@@ -1,6 +1,6 @@
 TermYear = Struct.new(:term, :year) do
   LEGACY_TERM_STARTS_AT = DateTime.parse('July 1st, 2015')
-  LEGACY_TERM_ENDS_AT   = DateTime.parse('Feb 1st, 2017' )
+  LEGACY_TERM_ENDS_AT   = DateTime.parse('Jan 1st, 2017' )
 
   TERM_START_DATES = {
     legacy: ->(year) { LEGACY_TERM_STARTS_AT                  },

--- a/lib/term_year.rb
+++ b/lib/term_year.rb
@@ -3,20 +3,19 @@ TermYear = Struct.new(:term, :year) do
   LEGACY_TERM_ENDS_AT   = DateTime.parse('Jan 1st, 2017' )
 
   TERM_START_DATES = {
-    legacy: ->(year) { LEGACY_TERM_STARTS_AT                  },
-    demo:   ->(year) { DateTime.new(Time.current.year - 1, 7) }, # July 1st of last year
-    spring: ->(year) { DateTime.new(             year       ) }, # January 1st of given year
-    summer: ->(year) { DateTime.new(             year    , 5) }, # May 1st of given year
-    fall:   ->(year) { DateTime.new(             year    , 7) }  # July 1st of given year
+    legacy: ->(year) { LEGACY_TERM_STARTS_AT     },
+    demo:   ->(year) { DateTime.new(year - 1, 7) }, # July 1st of the year before given year
+    spring: ->(year) { DateTime.new(year       ) }, # January 1st of given year
+    summer: ->(year) { DateTime.new(year    , 5) }, # May 1st of given year
+    fall:   ->(year) { DateTime.new(year    , 7) }  # July 1st of given year
   }
 
   TERM_END_DATES = {
-    legacy: ->(year) { LEGACY_TERM_ENDS_AT                    },
-    demo:   ->(year) { DateTime.new(Time.current.year + 1, 7) }, # July 1st of next year
-    spring: ->(year) { DateTime.new(             year    , 7) }, # July 1st of given year
-    summer: ->(year) { DateTime.new(             year    , 9) }, # September 1st of given year
-    fall:   ->(year) { DateTime.new(             year + 1   ) }  # January 1st of the year
-                                                                 # after given year
+    legacy: ->(year) { LEGACY_TERM_ENDS_AT       },
+    demo:   ->(year) { DateTime.new(year + 1, 7) }, # July 1st of the year after given year
+    spring: ->(year) { DateTime.new(year    , 7) }, # July 1st of given year
+    summer: ->(year) { DateTime.new(year    , 9) }, # September 1st of given year
+    fall:   ->(year) { DateTime.new(year + 1   ) }  # January 1st of the year after given year
   }
 
   VISIBLE_TERMS = [:spring, :summer, :fall]

--- a/spec/lib/term_year_spec.rb
+++ b/spec/lib/term_year_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TermYear, type: :lib do
 
   CURRENT_YEAR = Time.current.year
-  TESTED_YEARS = 2015..2017
+  TESTED_YEARS = CURRENT_YEAR-1..CURRENT_YEAR+1
 
   subject(:term_year) { described_class.new(term, year) }
 
@@ -19,8 +19,8 @@ RSpec.describe TermYear, type: :lib do
           expect(term_year.starts_at).to eq start_date
         end
 
-        it 'ignores the given year and returns Jan 31st, 2017 11:59:59 PM as the end date' do
-          end_date = DateTime.parse('Jan 31st, 2017 11:59:59 PM')
+        it 'ignores the given year and returns Dec 31st, 2016 11:59:59 PM as the end date' do
+          end_date = DateTime.parse('Dec 31st, 2016 11:59:59 PM')
           expect(term_year.ends_at).to eq end_date
         end
       end

--- a/spec/lib/term_year_spec.rb
+++ b/spec/lib/term_year_spec.rb
@@ -34,15 +34,13 @@ RSpec.describe TermYear, type: :lib do
       context year.to_s do
         let(:year) { year }
 
-        it 'ignores the given year and returns July 1st, ' +
-           '(CURRENT_YEAR - 1) 00:00:00 AM as the start date' do
-          start_date = DateTime.parse("July 1st, #{CURRENT_YEAR - 1} 00:00:00 AM")
+        it "returns July 1st, #{year - 1} 00:00:00 AM as the start date" do
+          start_date = DateTime.parse("July 1st, #{year - 1} 00:00:00 AM")
           expect(term_year.starts_at).to eq start_date
         end
 
-        it 'ignores the given year and returns June 30th, ' +
-           '(CURRENT_YEAR + 1) 11:59:59 PM as the end date' do
-          end_date = DateTime.parse("June 30th, #{CURRENT_YEAR + 1} 11:59:59 PM")
+        it "returns June 30th, #{year + 1} 11:59:59 PM as the end date" do
+          end_date = DateTime.parse("June 30th, #{year + 1} 11:59:59 PM")
           expect(term_year.ends_at).to eq end_date
         end
       end

--- a/spec/subsystems/course_profile/models/course_spec.rb
+++ b/spec/subsystems/course_profile/models/course_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe CourseProfile::Models::Course, type: :model do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:term) }
   it { is_expected.to validate_presence_of(:year) }
-  it { is_expected.to validate_presence_of(:starts_at) }
-  it { is_expected.to validate_presence_of(:ends_at) }
 
   it { is_expected.to validate_uniqueness_of(:time_zone) }
 
@@ -100,5 +98,26 @@ RSpec.describe CourseProfile::Models::Course, type: :model do
 
     course.year = Time.current.year + CourseProfile::Models::Course::MAX_FUTURE_YEARS + 1
     expect(course).not_to be_valid
+  end
+
+  it 'automatically sets starts_at and ends_at based on the term and year' do
+    year = Time.current.year
+    course.term = 'fall'
+    course.year = year
+    course.starts_at = nil
+    course.ends_at = nil
+    expect(course).to be_valid
+    term_year = TermYear.new('fall', year)
+    expect(course.starts_at).to eq term_year.starts_at
+    expect(course.ends_at).to eq term_year.ends_at
+
+    course.term = 'spring'
+    course.year = year + 1
+    course.starts_at = nil
+    course.ends_at = nil
+    expect(course).to be_valid
+    term_year = TermYear.new('spring', year + 1)
+    expect(course.starts_at).to eq term_year.starts_at
+    expect(course.ends_at).to eq term_year.ends_at
   end
 end


### PR DESCRIPTION
- Changed legacy courses to end Dec 31st 2016 at 11:59:59 PM
- Added helper text to admin edit courses screen for editing the term/year and dates
- Added JS to clear dates on admin edit courses screen so the course gets default dates when the term/year are changed
- Changed demo courses to somewhat respect the course year to prevent confusion
- Changed demo rake task courses to use standard demo term dates