### PR TITLE
Update accounts-rails for new accounts (DO NOT MERGE)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'whenever'
 gem 'omniauth-oauth2', '~> 1.3.1'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', git: 'https://github.com/openstax/accounts-rails', ref: '443d902'
+gem 'openstax_accounts', git: 'https://github.com/openstax/accounts-rails', ref: '00817bb30e2'
 
 # OpenStax Exchange integration
 gem 'openstax_exchange', '~> 0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/openstax/accounts-rails
-  revision: 443d9023cf00b131e58da6db07e22153533a136f
-  ref: 443d902
+  revision: 00817bb30e2fe1ae44eaeb236a4276385cc971d4
+  ref: 00817bb30e2
   specs:
     openstax_accounts (7.2.0)
       action_interceptor (>= 1.0)

--- a/db/migrate/20161206181028_change_accounts_username_to_be_nullable.openstax_accounts.rb
+++ b/db/migrate/20161206181028_change_accounts_username_to_be_nullable.openstax_accounts.rb
@@ -1,0 +1,6 @@
+# This migration comes from openstax_accounts (originally 8)
+class ChangeAccountsUsernameToBeNullable < ActiveRecord::Migration
+  def change
+    change_column_null :openstax_accounts_accounts, :username, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161108152717) do
+ActiveRecord::Schema.define(version: 20161206181028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -429,7 +429,7 @@ ActiveRecord::Schema.define(version: 20161108152717) do
 
   create_table "openstax_accounts_accounts", force: :cascade do |t|
     t.integer  "openstax_uid"
-    t.string   "username",                          null: false
+    t.string   "username"
     t.string   "access_token"
     t.string   "first_name"
     t.string   "last_name"


### PR DESCRIPTION
New accounts allows nil usernames, this updates to a version of accounts-rails where usernames aren't required.  DO NOT MERGE until new accounts is blessed.