### PR TITLE
Dont publish task plans if they're "preview" type

### DIFF
--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -62,12 +62,16 @@ class DistributeTasks
 
     save(tasks)
 
-    # Update last_published_at (and first_published_at if this is the first publication)
-    task_plan.first_published_at = publish_time if task_plan.first_published_at.nil?
-    task_plan.last_published_at = publish_time
+    if preview
+      task_plan.touch if task_plan.persisted?
+    else
+      # Update last_published_at (and first_published_at if this is the first publication)
+      task_plan.first_published_at = publish_time if task_plan.first_published_at.nil?
+      task_plan.last_published_at = publish_time
 
-    # We are only changing timestamps here, so no reason to validate the record
-    task_plan.save(validate: false) if task_plan.persisted?
+      # We are only changing timestamps here, so no reason to validate the record
+      task_plan.save(validate: false) if task_plan.persisted?
+    end
 
     outputs[:tasks] = tasks
   end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -108,14 +108,25 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
         task_plan.tasks.each{ |task| task.update_attribute(:opens_at, opens_at) }
       end
 
-      it 'can create a preview task for the task_plan' do
-        expect(task_plan.tasks).to be_empty
-        result = DistributeTasks.call(task_plan: task_plan, preview: true)
+      context 'creating a preview task' do
 
-        expect(result.errors).to be_empty
-        expect(task_plan.reload.tasks.size).to eq 1
-        expect(task_plan.tasks.first.taskings.first.role).to eq period.teacher_student_role
-        expect(task_plan).not_to be_out_to_students
+        it 'can create a preview' do
+          expect(task_plan.tasks).to be_empty
+          result = DistributeTasks.call(task_plan: task_plan, preview: true)
+
+          expect(result.errors).to be_empty
+          expect(task_plan.reload.tasks.size).to eq 1
+          expect(task_plan.tasks.first.taskings.first.role).to eq period.teacher_student_role
+          expect(task_plan).not_to be_out_to_students
+        end
+
+        it 'does not save plan if it is new' do
+          new_plan = task_plan.dup
+          result = DistributeTasks.call(task_plan: new_plan, preview: true)
+          expect(result.errors).to be_empty
+          expect(new_plan).to be_new_record
+        end
+
       end
 
       it 'creates tasks for the task_plan' do


### PR DESCRIPTION
Fixes bug where all task plans were being published even if they were saving as draft