### PR TITLE
pass along "go" param when redirecting

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -105,7 +105,7 @@ class AuthController < ApplicationController
       redirect_to openstax_accounts.dev_accounts_url
       session[:parent] = params[:parent]
     else
-      redirect_to openstax_accounts.login_url
+      redirect_to openstax_accounts.login_url(go: params[:go])
     end
   end
 

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe AuthController, type: :controller do
       }
 
       it 'allows access to popup and redirects to accounts' do
-        get :popup
-        expect(response).to redirect_to(controller.openstax_accounts.login_url)
+        get :popup, go: 'faster'
+        expect(response).to redirect_to(controller.openstax_accounts.login_url(go: 'faster'))
       end
 
     end


### PR DESCRIPTION
Fixes the CC login popup window so it can decide where to go on accounts