### PR TITLE
turn on serving static files in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
                                                                        default: true)
   config.action_controller.perform_caching = false
 
-  config.serve_static_files  = false
+  config.serve_static_files  = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Otherwise requests for `/favicon.ico` (and probably others) are routed
to webview, which returns 404, but they're also stored in the session history.

Then when ConceptCoach logs in it's redirected back to '/favicon.ico`

Note: this was turned off as part of:
https://github.com/openstax/tutor-server/commit/3e4f042de08e88156626de25a928a92ccecc67b9#diff-a2f09e1db7a47eb67c5849478a97f3d7R19

I'm unsure if that was deliberate.