### PR TITLE
Support logging multiple entries at once

### DIFF
--- a/app/representers/api/v1/log_entries_representer.rb
+++ b/app/representers/api/v1/log_entries_representer.rb
@@ -1,0 +1,23 @@
+module Api::V1
+
+  class LogEntriesRepresenter < Roar::Decorator
+
+    include Roar::JSON
+
+    collection :entries,
+               instance: ->(*) { ::Hashie::Mash.new },
+               extend: LogEntryRepresenter,
+               readable: true,
+               writeable: true
+
+    property :level,
+             type: String,
+             readable: false,
+             writeable: true
+
+    property :message,
+             type: String,
+             readable: false,
+             writeable: true
+  end
+end

--- a/spec/controllers/api/v1/log_controller_spec.rb
+++ b/spec/controllers/api/v1/log_controller_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe Api::V1::LogController, type: :controller, api: true, version: :v
       expect(response).to have_http_status(:created)
     end
 
+    it 'can log an array of entries' do
+      expect(Rails.logger).to receive(:log).with(Logger::INFO, '(ext) hi')
+      expect(Rails.logger).to receive(:log).with(Logger::WARN, '(ext) take care!')
+      log(entries: [{level: 'info', message: 'hi'}, {level: 'warn', message: 'take care!'}])
+      expect(response).to have_http_status(:created)
+    end
+
   end
 
   def log(options)


### PR DESCRIPTION
This pattern is more convent for the FE since it needs to wrap it's logging in
a guard so that if something really goes wrong it won't log 1,000
entries in a few milli-seconds.