### PR TITLE
Speedup retrieval of tasking plans

### DIFF
--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -58,8 +58,9 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
         tps
       end
     end
-
-    standard_index(task_plans, Api::V1::TaskPlanSearchRepresenter, exclude_job_info: true)
+    respond_with(Lev::Outputs.new(items: task_plans),
+                 user_options: { exclude_job_info: true },
+                 represent_with: Api::V1::TaskPlanSearchRepresenter)
   end
 
   ###############################################################

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -37,7 +37,7 @@ class Tasks::Models::TaskPlan < Tutor::SubSystems::BaseModel
   before_validation :set_ecosystem
 
   scope :preloaded, -> {
-    preload(:tasking_plans, owner: :time_zone, tasks: [:taskings, task_steps: :tasked])
+    preload(tasking_plans: [:time_zone], tasks: [:taskings, task_steps: :tasked])
   }
 
   def out_to_students?(current_time: Time.current)


### PR DESCRIPTION
This fixes a few N+1 queries.  Neither is that expensive, so not sure it'll speed it up too much.

One is that access was checked for each plan in https://github.com/openstax/tutor-server/blob/master/app/access_policies/task_plan_access_policy.rb#L16 That loaded the the course roles and teacher for each task_plan.

The other is that each tasking_plan was loading the time_zone due to it not being preloaded.
