### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ Berksfile.lock
 # Ignore brakeman reports
 brakeman.html
 
-# Ignore coveralls reports
+# Ignore coverage reports
 coverage/*
 
 # Ignore ERD diagrams and source maps

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,3 @@ before_script:
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-after_script:
-  # Report coverage to codecov
-  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,6 @@ before_script:
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+after_script:
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/Gemfile
+++ b/Gemfile
@@ -252,6 +252,9 @@ group :development, :test do
   # Code Climate integration
   gem "codeclimate-test-reporter", require: false
 
+  # Codecov integration
+  gem 'codecov', :require => false
+
   # Testing excel files
   gem 'roo'
 

--- a/Gemfile
+++ b/Gemfile
@@ -252,9 +252,6 @@ group :development, :test do
   # Code Climate integration
   gem "codeclimate-test-reporter", require: false
 
-  # Coveralls integration
-  gem 'coveralls', require: false
-
   # Testing excel files
   gem 'roo'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,12 +150,6 @@ GEM
       compass (~> 1.0.0)
       sass-rails (<= 5.0.1)
       sprockets (< 2.13)
-    coveralls (0.8.15)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.12.0)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (>= 1.6.0, < 2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     daemons (1.2.2)
@@ -755,7 +749,6 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   coffee-rails-source-maps
   compass-rails
-  coveralls
   daemons
   database_cleaner
   db-query-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,10 @@ GEM
     chunky_png (1.3.4)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
+    codecov (0.1.9)
+      json
+      simplecov
+      url
     coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -659,8 +663,6 @@ GEM
       activerecord (>= 3.0)
       activesupport (>= 3.0)
       polyamorous (~> 1.1.0)
-    term-ansicolor (1.4.0)
-      tins (~> 1.0)
     terminal-table (1.4.5)
     test_xml (0.1.7)
       diffy (~> 3.0)
@@ -677,7 +679,6 @@ GEM
     tilt (1.4.1)
     timecop (0.7.3)
     timeliness (0.3.7)
-    tins (1.12.0)
     transaction_isolation (1.0.3)
       activerecord (>= 3.0.11)
     transaction_retry (1.0.2)
@@ -699,6 +700,7 @@ GEM
       get_process_mem (~> 0)
       unicorn (~> 4)
     uniform_notifier (1.9.0)
+    url (0.3.2)
     validates_timeliness (3.0.14)
       timeliness (~> 0.3.6)
     vcr (2.9.3)
@@ -746,6 +748,7 @@ DEPENDENCIES
   cheat
   chronic
   codeclimate-test-reporter
+  codecov
   coffee-rails (~> 4.0.0)
   coffee-rails-source-maps
   compass-rails

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code Climate](https://codeclimate.com/github/openstax/tutor-server.png)](https://codeclimate.com/github/openstax/tutor-server)
 [![Build Status](https://travis-ci.org/openstax/tutor-server.png?branch=master)](https://travis-ci.org/openstax/tutor-server)
-[![Coverage Status](https://img.shields.io/coveralls/openstax/tutor-server.svg)](https://coveralls.io/r/openstax/tutor-server)
+[![Coverage Status](https://img.shields.io/codecov/c/github/openstax/tutor-server.svg)](https://codecov.io/gh/openstax/tutor-server)
 
 # OpenStax Tutor Backend Server
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,10 +2,7 @@ require 'simplecov'
 require 'codecov'
 require 'parallel_tests'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::Codecov
-]) if ParallelTests.last_process?
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 SimpleCov.at_exit do
   ParallelTests.wait_for_other_processes_to_finish if ParallelTests.last_process?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,10 @@
 require 'simplecov'
+require 'codecov'
 require 'parallel_tests'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::Codecov
 ]) if ParallelTests.last_process?
 
 SimpleCov.at_exit do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,8 @@
 require 'simplecov'
-require 'coveralls'
 require 'parallel_tests'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
+  SimpleCov::Formatter::HTMLFormatter
 ]) if ParallelTests.last_process?
 
 SimpleCov.at_exit do
@@ -179,4 +177,3 @@ def redirect_uri
   expect(response.code).to eq "302"
   uri = URI.parse(response.headers["Location"])
 end
-


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- When should coveralls make comments on the PR and what should be included
- Is the coveralls formatter used for anything (I don't know if there is a corresponding gem for codecov)
- I used this recommendation from codecov.io: https://github.com/codecov/example-ruby but was not sure about whether I needed to change the `SimpleCov`

I didn't run the tests locally because I was hoping Travis would test for me ~but it looks like this repo is configured to only run Travis when a PR is created~ Ah, `tutor-server` takes a long time to run tests.