### PR TITLE
set :go param for student signups to be "student_signup"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   prepend_before_filter :keep_webview_flash
 
   before_filter :block_sign_up, unless: -> { params[:block_sign_up] == false }
-  before_filter :straight_to_sign_up, if: -> { params[:straight_to_sign_up] == true }
+  before_filter :straight_to_student_sign_up, if: -> { params[:straight_to_student_sign_up] == true }
   before_filter :authenticate_user!
 
   protected
@@ -20,9 +20,9 @@ class ApplicationController < ActionController::Base
     login_params[:signup_at] = signup_url
   end
 
-  def straight_to_sign_up
+  def straight_to_student_sign_up
     # Must be called before `authenticate_user!`
-    login_params[:go] = 'signup'
+    login_params[:go] = 'student_signup'
   end
 
   def require_contracts

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -105,7 +105,9 @@ class AuthController < ApplicationController
       redirect_to openstax_accounts.dev_accounts_url
       session[:parent] = params[:parent]
     else
-      redirect_to openstax_accounts.login_url(go: params[:go])
+      redirect_to openstax_accounts.login_url(
+                    go: params[:go] == 'signup' ? 'student_signup' : nil
+                  )
     end
   end
 

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -105,9 +105,7 @@ class AuthController < ApplicationController
       redirect_to openstax_accounts.dev_accounts_url
       session[:parent] = params[:parent]
     else
-      redirect_to openstax_accounts.login_url(
-                    go: params[:go] == 'signup' ? 'student_signup' : nil
-                  )
+      redirect_to openstax_accounts.login_url(go: params[:go])
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       scope :enroll do
         get :':enroll_token(/:ignore)', as: :token_enroll,
                                         block_sign_up: false,
-                                        straight_to_sign_up: true
+                                        straight_to_student_sign_up: true
         post :confirm, as: :confirm_token_enroll
       end
     end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe AuthController, type: :controller do
       }
 
       it 'allows access to popup and redirects to accounts' do
-        get :popup, go: 'faster' # "faster" isn't a valid option
-        expect(response).to redirect_to(controller.openstax_accounts.login_url)
+        get :popup, go: 'faster' # "faster" isn't a valid option, but will still be passed on
+        expect(response).to redirect_to(controller.openstax_accounts.login_url(go: 'faster'))
       end
 
       it 'allows access to popup and redirects to accounts signin' do
-        get :popup, go: 'signup'
+        get :popup, go: 'student_signup'
         expect(response).to redirect_to(controller.openstax_accounts.login_url(go: 'student_signup'))
       end
     end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -23,10 +23,14 @@ RSpec.describe AuthController, type: :controller do
       }
 
       it 'allows access to popup and redirects to accounts' do
-        get :popup, go: 'faster'
-        expect(response).to redirect_to(controller.openstax_accounts.login_url(go: 'faster'))
+        get :popup, go: 'faster' # "faster" isn't a valid option
+        expect(response).to redirect_to(controller.openstax_accounts.login_url)
       end
 
+      it 'allows access to popup and redirects to accounts signin' do
+        get :popup, go: 'signup'
+        expect(response).to redirect_to(controller.openstax_accounts.login_url(go: 'student_signup'))
+      end
     end
 
     context "when using stubbing" do

--- a/spec/requests/webview_spec.rb
+++ b/spec/requests/webview_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Webview", type: :request do
       expect(redirect_query_hash).not_to have_key(:signup_at)
     end
 
-    it 'directs enroll to go straight to signup for student' do
+    it 'directs accounts to go straight to signup for student' do
       get '/enroll/whatever'
       expect(redirect_query_hash[:go]).to eq 'student_signup'
     end

--- a/spec/requests/webview_spec.rb
+++ b/spec/requests/webview_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe "Webview", type: :request do
       expect(redirect_query_hash).not_to have_key(:signup_at)
     end
 
-    it 'directs accounts to go straight to signup' do
+    it 'directs enroll to go straight to signup for student' do
       get '/enroll/whatever'
-      expect(redirect_query_hash[:go]).to eq 'signup'
+      expect(redirect_query_hash[:go]).to eq 'student_signup'
     end
   end
 
 end
-


### PR DESCRIPTION
Originally i was going to add an entirely different param but then realized that we really do want to go to signup, just for a student.  So there's really no need for a different type

Goes along with https://github.com/openstax/accounts/pull/482