### PR TITLE
quick user info page for admins

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -55,6 +55,9 @@ class Admin::UsersController < Admin::BaseController
     redirect_to root_path
   end
 
+  def info
+  end
+
   private
 
   def get_user

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,6 +12,7 @@
               <%= link_to 'Edit', edit_admin_user_path(user.id), class: "btn btn-xs btn-primary" %>
               <%= link_to 'Sign in as', become_admin_user_path(user.id),
                                         method: :post, class: "btn btn-xs btn-primary" %>
+              <%= link_to 'Info', info_admin_users_path(id: user.id), class: "btn btn-xs btn-primary" %>
           </td>
 <% end } %>
 

--- a/app/views/admin/users/info.html.erb
+++ b/app/views/admin/users/info.html.erb
@@ -1,0 +1,49 @@
+<% @page_header = "Misc User Info" %>
+
+<%
+  profile = if params[:openstax_uid]
+    profile = User::Models::Profile.joins{account}.where{account.openstax_uid.eq my{params[:openstax_uid]}}.first
+  elsif params[:id]
+    profile = User::Models::Profile.find(params[:id])
+  else
+    raise "Need 'id' or 'openstax_uid' parameter"
+  end
+
+  user = User::User.find(profile.id)
+%>
+
+<h3>Name</h3>
+
+<div style="float:right">
+<%= link_to "Profile on Accounts",
+             "#{Rails.application.secrets.openstax['accounts']['url']}/admin/users/#{profile.account.openstax_uid}/edit", class: "btn btn-xs btn-primary" %>
+
+              <%= link_to 'Edit in Tutor', edit_admin_user_path(user.id), class: "btn btn-xs btn-primary" %>
+              <%= link_to 'Sign in as in Tutor', become_admin_user_path(user.id),
+                                        method: :post, class: "btn btn-xs btn-primary" %>
+</div>
+
+<%= profile.name %>
+
+<h3>Courses</h3>
+
+<% courses = GetUserCourses[user: user] %>
+
+<% courses.sort_by{|cc| [-cc.year, -CourseProfile::Models::Course.terms[cc.term], cc.name]}.each do |course| %>
+  <ol>
+    <li>
+      <%= link_to course.name, edit_admin_course_path(course) %> //
+      <%= course.term %> <%= course.year %> //
+      <%= course.is_concept_coach ? "Concept Coach" : "Tutor" %> //
+      <%= course.is_college ? "College" : "High School" %> //
+
+      <% roles = GetUserCourseRoles[course: course, user: user] %>
+
+      <% roles.each do |role| %>
+          [ <%= role.role_type %> |
+          <%= role.created_at.in_time_zone('Central Time (US & Canada)').strftime("%m/%d/%Y %H:%M:%S") %> Central |
+          <%= role.research_identifier %> ]
+      <% end %>
+    </li>
+  </ol>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,6 +196,9 @@ Rails.application.routes.draw do
         patch :delete
         patch :undelete
       end
+      collection do
+        get :info
+      end
     end
 
     resources :administrators, only: [:index, :create, :destroy]


### PR DESCRIPTION
Adds a page where admins can get links to edit information in accounts and also see the courses the user is a part of.

![image](https://cloud.githubusercontent.com/assets/1001691/22407430/f83bec0a-e61a-11e6-96b3-7028fdbf01d4.png)
