### PR TITLE
Settings page path helper error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
 
   def block_sign_up
     # Must be called before `authenticate_user!`
-    login_params[:signup_at] = signup_url
+    login_params[:signup_at] = main_app.signup_url
   end
 
   def straight_to_sign_up

--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -44,3 +44,5 @@ OpenStax::RescueFrom.register_exception(
   # only notify when real data involved (only time it really needs admin attention)
   notify: secrets['salesforce']['allow_use_of_real_data']
 )
+
+ExceptionNotifier.ignored_exceptions.reject!{|ee| ee == "ActionController::UrlGenerationError"}

--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -45,4 +45,4 @@ OpenStax::RescueFrom.register_exception(
   notify: secrets['salesforce']['allow_use_of_real_data']
 )
 
-ExceptionNotifier.ignored_exceptions.reject!{|ee| ee == "ActionController::UrlGenerationError"}
+ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -6,16 +6,26 @@ class TestExceptionsController < ApplicationController
   def bad_action
     RaiseUnknownConstantException
   end
+
+  def url_generation_error
+    raise ActionController::UrlGenerationError
+  end
 end
 
 RSpec.describe TestExceptionsController, type: :controller do
   context 'rescuing exceptions' do
-    it 'fires off an email' do
+    before(:each) do
       ActionMailer::Base.deliveries.clear
-
       allow(request).to receive(:remote_ip) { '96.21.0.39' }
+    end
 
+    it 'fires off an email for some error' do
       expect { get :bad_action }.to raise_error(NameError)
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+
+    it 'fires off an email for a UrlGenerationError' do
+      expect { get :url_generation_error }.to raise_error(ActionController::UrlGenerationError)
       expect(ActionMailer::Base.deliveries.size).to eq(1)
     end
   end

--- a/spec/features/admin/visit_admin_dashboard_spec.rb
+++ b/spec/features/admin/visit_admin_dashboard_spec.rb
@@ -10,4 +10,17 @@ RSpec.describe 'Admnistration' do
     expect(page).to have_content('Tutor Admin Console')
     expect(page).to have_link('Courses', href: admin_courses_path)
   end
+
+  context 'pages are reachable via the menu' do
+    before(:each) do
+      admin = FactoryGirl.create(:user, :administrator)
+      stub_current_user(admin)
+      visit admin_root_path
+    end
+
+    scenario 'System Setting/Settings' do
+      click_link 'System Setting'
+      click_link 'Settings'
+    end
+  end
 end

--- a/spec/support/test_routes.rb
+++ b/spec/support/test_routes.rb
@@ -1,11 +1,6 @@
-class TestController < ActionController::Base
-  def bad_action
-    render text: 'Welcome to my application'
-  end
-end
-
 test_routes = Proc.new do
   get 'bad_action' => 'test_exceptions#bad_action'
+  get 'url_generation_error' => 'test_exceptions#url_generation_error'
 end
 
 Rails.application.routes.send(:eval_block, test_routes)


### PR DESCRIPTION
On the admin page, clicking "System Setting" then "Settings" was generating a 500 error because there was a missing `main_app.` prefix on a path helper in the application controller.

Also includes a commit to send out an exception email for this kind of exception.