### PR TITLE
Fixed the constantize error from production

### DIFF
--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -67,11 +67,14 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
   protected
 
   def get_task_step
-    @task_step = ::Tasks::Models::TaskStep.with_deleted.where(id: params[:id]).first
-    if @task_step
-      @tasked = @task_step.tasked
-    else
-      render_api_errors(:no_exercises, :not_found)
+    Tasks::Models::TaskStep.transaction do
+      @task_step = Tasks::Models::TaskStep.with_deleted.lock.find_by(id: params[:id])
+
+      if @task_step.present?
+        @tasked = @task_step.tasked
+      else
+        render_api_errors(:no_exercises, :not_found)
+      end
     end
   end
 


### PR DESCRIPTION
The issue is that even though the record was being properly locked while it was modified, these 2 statements in the controller ran outside of any transaction, so the lock was being ignored. The error happened when the locking transaction committed between the 2 statements.