### PR TITLE
Force term dates to appear on new line

### DIFF
--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -64,9 +64,9 @@
               <span class="ecosystem-created-at" style="white-space: nowrap;">
                 <%= "(#{ecosystem.created_at})" if ecosystem %>
               </span>
-              <span class="course-duration" style="white-space: nowrap;">
+              <div class="course-duration" style="white-space: nowrap;">
                 Term: <%= course_info.starts_at.strftime('%b %d, %Y') %> - <%= course_info.ends_at.strftime('%b %d, %Y') %>
-              </span>
+              </div>
             </div>
             <div class="content-middle">
               <%= ecosystem.try(:comments) %>


### PR DESCRIPTION
Previously they'd wrap after the created-at if it was short.  QA prefers it to always be on it's own line, which makes sense.
