### PR TITLE
Display ecosystem popover on TD tag instead of A

### DIFF
--- a/app/assets/stylesheets/manager.scss
+++ b/app/assets/stylesheets/manager.scss
@@ -34,6 +34,10 @@ nav.navbar.production {
   background-color: #f9f9f9;
 }
 
+[data-toggle="popover"] {
+  cursor: pointer;
+}
+
 /* Courses Stats */
 
 .stats-card {

--- a/app/views/admin/courses/_periods.html.erb
+++ b/app/views/admin/courses/_periods.html.erb
@@ -4,7 +4,7 @@
                      extra_fields_proc: lambda do |period| %>
   <td>
     <%= link_to 'Edit', edit_admin_period_path(period), class: 'btn btn-xs btn-primary' %>
-    <%= link_to 'Delete', admin_period_path(period), method: :delete,
+    <%= link_to 'Archive', admin_period_path(period), method: :delete,
                                                      class: 'btn btn-xs btn-primary' %>
   </td>
 <% end } %>

--- a/app/views/manager/ecosystems/_listing.html.erb
+++ b/app/views/manager/ecosystems/_listing.html.erb
@@ -36,13 +36,13 @@
       <td><%= ecosystem.imported_at %></td>
       <td><%= link_to 'Archive', book.url, target: '_blank',
                                            class: 'btn btn-xs btn-primary' %></td>
-      <td><%= link_to 'Show UUID', '#', role: 'button',
-                                        tabindex: 0,
-                                        data: { toggle: 'popover',
-                                                placement: 'top',
-                                                content: book.uuid,
-                                                container: 'body' },
-                                        class: 'btn btn-xs btn-secondary' %></td>
+      <td data-toggle="popover"
+          data-container="body"
+          data-placement="top"
+          data-content="<%= book.uuid %>"
+      >
+        <%= book.uuid[0...6] %>
+      </td>
       <td><%= link_to 'Download Manifest',
                       manifest_path.call(ecosystem.id),
                       role: 'button',


### PR DESCRIPTION
Otherwise it scrolls to top when the anchor target of '#' is clicked.

We could change the target or call preventDefault on the click, but really
there's no reason to use an A tag since it's not used for navigation

Also fixes a discrepancy QA noted where the admin screens says "delete" for periods archiving, but normal UX says it's "Archive"

![screen shot 2017-02-22 at 2 30 37 pm](https://cloud.githubusercontent.com/assets/79566/23230971/8bf96abe-f90b-11e6-8f90-2c7afe16e6c1.png)
