### PR TITLE
Bump settings size to 1500 chars

### DIFF
--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -28,7 +28,7 @@ module User
       validates :account, presence: true, uniqueness: true
       validates :exchange_read_identifier, presence: true
       validates :exchange_write_identifier, presence: true
-      validates :ui_settings, max_json_length: 1000
+      validates :ui_settings, max_json_length: 1500
       validate  :validate_ui_settings_change_history , on: :update
 
       delegate :username, :first_name, :last_name, :full_name, :title,

--- a/spec/subsystems/user/models/profile_spec.rb
+++ b/spec/subsystems/user/models/profile_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe User::Models::Profile, type: :model do
 
   it 'enforces length of ui_settings' do
     profile = FactoryGirl.build(:user_profile)
-    profile.ui_settings = {test: ('a' * 1000)}
+    profile.ui_settings = {test: ('a' * 1500)}
     expect(profile).to_not be_valid
     expect(profile.errors[:ui_settings].to_s).to include 'too long'
   end


### PR DESCRIPTION
QA is hitting the limit with some test user accounts.

The FE is also making a change to store settings more compactly