### PR TITLE
Add viewed tour ids to bootstrap data 

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -44,8 +44,8 @@ class Api::V1::UsersController < Api::V1::ApiController
     Returns header forbidden (403) if the user is not logged in or api_errors if the update fails.
     If requests succeeds, an empty JSON object is returned
   EOS
-  def tours
-    result = User::RecordTourView.call(user: current_human_user, tour_identifier: params[:id])
+  def record_tour_view
+    result = User::RecordTourView.call(user: current_human_user, tour_identifier: params[:tour_id])
     render_api_errors(result.errors) || head(:no_content)
   end
 

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -22,6 +22,8 @@ module Api::V1
                required: true
              }
 
+    property :viewed_tour_ids
+
     property :profile_url,
              getter: ->(*) {
                Addressable::URI.join(

--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -16,6 +16,7 @@ module User
 
       has_many :enrollment_changes, subsystem: :course_membership
       has_many :tour_views, inverse_of: :profile
+      has_many :tours, through: :tour_views
 
       has_one :administrator, dependent: :destroy, inverse_of: :profile
       has_one :customer_service, dependent: :destroy, inverse_of: :profile

--- a/app/subsystems/user/strategies/direct/anonymous_user.rb
+++ b/app/subsystems/user/strategies/direct/anonymous_user.rb
@@ -44,6 +44,10 @@ module User
           false
         end
 
+        def viewed_tour_ids
+          []
+        end
+
         def to_model
           repository
         end

--- a/app/subsystems/user/strategies/direct/user.rb
+++ b/app/subsystems/user/strategies/direct/user.rb
@@ -85,6 +85,10 @@ module User
           !repository.content_analyst.nil?
         end
 
+        def viewed_tour_ids
+          repository.tours.pluck(:identifier)
+        end
+
         def to_model
           repository
         end

--- a/app/subsystems/user/user.rb
+++ b/app/subsystems/user/user.rb
@@ -142,6 +142,10 @@ module User
       verify_and_return @strategy.ui_settings, klass: Hash, allow_nil: true, error: StrategyError
     end
 
+    def viewed_tour_ids
+      verify_and_return @strategy.viewed_tour_ids, klass: Array, allow_nil: true, error: StrategyError
+    end
+
     # Necessary, at least temporarily, so we can assign users to external polymorphics,
     # like task_plan owner, tasking_plan target and FinePrint signatures
     def to_model

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,9 +66,8 @@ Rails.application.routes.draw do
     resources :users, only: [:index]
     resource :user, only: [:show] do
       get :tasks
-      put :tours
       put :ui_settings
-
+      patch 'tours/:tour_id', action: :record_tour_view
       resources :courses, only: [:index] do
         patch :student, to: 'students#update_self'
       end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
   end
 
 
-  context '#tours' do
-    it 'records tour as viewed' do
+  context '#tour' do
+    it 'records a tour as viewed' do
       expect do
-        api_put :tours, user_1_token, parameters: {id: 'the-grand-tour'}
+        api_patch :record_tour_view, user_1_token, parameters: {tour_id: 'the-grand-tour'}
         expect(response).to have_http_status(:success)
       end.to change { User::Models::TourView.count }.by(1)
     end

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -18,4 +18,9 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
     ).to_s
   end
 
+  it 'includes viewed tour ids' do
+    User::RecordTourView[user: user, tour_identifier: 'chaos-fang']
+    expect(representation['viewed_tour_ids']).to eq ['chaos-fang']
+  end
+
 end

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
     expect(representation['is_customer_service']).to eq user.is_customer_service?
     expect(representation['is_content_analyst']).to eq user.is_content_analyst?
     expect(representation['faculty_status']).to eq user.faculty_status
+    expect(representation['viewed_tour_ids']).to eq []
     expect(representation['profile_url']).to eq Addressable::URI.join(
       OpenStax::Accounts.configuration.openstax_accounts_url, '/profile'
     ).to_s

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Get authentication status', type: :request, version: :v1 do
           is_customer_service: false,
           is_content_analyst: false,
           faculty_status: 'no_faculty_info',
+          viewed_tour_ids: [],
           profile_url: a_string_starting_with('http')
         },
         courses: []

--- a/spec/routines/push_salesforce_course_stats_spec.rb
+++ b/spec/routines/push_salesforce_course_stats_spec.rb
@@ -66,33 +66,6 @@ RSpec.describe PushSalesforceCourseStats, type: :routine do
     end
   end
 
-  context "#salesforce_term_year_for_course" do
-    subject {
-      course = FactoryGirl.create :course_profile_course, term: @term, year: @year
-      instance.salesforce_term_year_for_course(course)
-    }
-
-    it 'works for fall terms' do
-      @term = :fall; @year = 2018
-      expect(subject).to eq "2018 - 19 Fall"
-    end
-
-    it 'works for spring terms' do
-      @term = :spring; @year = 2018
-      expect(subject).to eq "2017 - 18 Spring"
-    end
-
-    it 'errors for legacy terms' do
-      @term = :legacy; @year = 2015
-      expect{subject}.to raise_error(RuntimeError)
-    end
-
-    it 'errors for summer terms b/c SF does not yet support' do
-      @term = :summer; @year = 2015
-      expect{subject}.to raise_error(RuntimeError)
-    end
-  end
-
   context "#notify_errors" do
     it 'does nothing if no errors' do
       expect(Rails.logger).not_to receive(:warn)


### PR DESCRIPTION
The FE needs to know what tour's have been viewed so it won't replay them.