### PR TITLE
return entire task when a step is marked complete

### DIFF
--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -35,15 +35,20 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
 
   api :PUT, '/steps/:step_id/completed',
             'Marks the specified TaskStep as completed (if applicable)'
+  description <<-EOS
+    Marks a task step as complete, which may create or modify other steps.
+    The entire task is returned so the FE can update as needed.
+
+    #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
+  EOS
   def completed
     OSU::AccessPolicy.require_action_allowed!(:mark_completed, current_api_user, @tasked)
 
     result = MarkTaskStepCompleted.call(task_step: @task_step)
-
     render_api_errors(result.errors) || respond_with(
-      @task_step.reload,
+      @task_step.task,
       responder: ResponderWithPutPatchDeleteContent,
-      represent_with: Api::V1::TaskStepRepresenter
+      represent_with: Api::V1::TaskRepresenter
     )
   end
 

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
 
       expect(response).to have_http_status(:success)
 
-      expect(response.body).to eq(Api::V1::Tasks::TaskedReadingRepresenter.new(
-        tasked.reload
+      expect(response.body).to eq(Api::V1::TaskRepresenter.new(
+        tasked.reload.task_step.task
       ).to_json)
 
       expect(tasked.task_step(true).completed?).to be_truthy
@@ -215,7 +215,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       expect(response).to have_http_status(:success)
 
       expect(response.body).to eq(
-        Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked.reload).to_json
+        Api::V1::TaskRepresenter.new(tasked.reload.task_step.task).to_json
       )
 
       expect(tasked.task_step(true).completed?).to be_truthy


### PR DESCRIPTION
Return entire task when a step is marked complete

This is a bit more efficient for the FE since it won't have to re-request the task each time.