### PR TITLE
SF push stats updates

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -208,6 +208,7 @@ class Admin::CoursesController < Admin::BaseController
         :ends_at,
         :is_concept_coach,
         :is_college,
+        :is_test,
         :catalog_offering_id,
         :appearance_code,
         :school_district_school_id,

--- a/app/subsystems/salesforce/remote/individual_adoption.rb
+++ b/app/subsystems/salesforce/remote/individual_adoption.rb
@@ -9,6 +9,8 @@ class Salesforce::Remote::IndividualAdoption < ActiveForce::SObject
   field :summer_start_date,            from: "Summer_Start_Date__c"
   field :winter_start_date,            from: "Winter_Start_Date__c"
   field :spring_start_date,            from: "Spring_Start_Date__c"
+  field :adoption_level,               from: "Adoption_Level__c"
+  field :description,                  from: "Description__c"
 
   # Deprecated
   field :term_year,                    from: "TermYear__c"

--- a/app/subsystems/salesforce/remote/os_ancillary.rb
+++ b/app/subsystems/salesforce/remote/os_ancillary.rb
@@ -17,6 +17,7 @@ class Salesforce::Remote::OsAncillary < ActiveForce::SObject
   field :num_sections,              from: "Sections__c", as: :int
   field :num_students,              from: "Students_Using__c", as: :int
   field :term_year,                 from: "TermYear__c"
+  field :term,                      from: "Term__c"
   field :opportunity_id,            from: 'Opportunity__c'
   field :individual_adoption_id,    from: "Individual_Adoption__c"
   field :contact_id,                from: "Contact__c"

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -92,5 +92,10 @@
     <%= f.check_box :is_college, class: 'form-control' %>
   </div>
 
+  <div class="form-group">
+    <%= f.label :is_test %>
+    <%= f.check_box :is_test, class: 'form-control' %>
+  </div>
+
   <%= f.submit 'Save', class: 'btn btn-primary', id: 'edit-save' %>
 <% end %>

--- a/db/migrate/20170412213150_add_is_test_to_course_profile_courses.rb
+++ b/db/migrate/20170412213150_add_is_test_to_course_profile_courses.rb
@@ -1,0 +1,5 @@
+class AddIsTestToCourseProfileCourses < ActiveRecord::Migration
+  def change
+    add_column :course_profile_courses, :is_test, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170323195331) do
+ActiveRecord::Schema.define(version: 20170412213150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -312,6 +312,7 @@ ActiveRecord::Schema.define(version: 20170323195331) do
     t.integer  "cloned_from_id"
     t.boolean  "is_preview",                                  null: false
     t.boolean  "is_excluded_from_salesforce", default: false, null: false
+    t.boolean  "is_test",                     default: false, null: false
   end
 
   add_index "course_profile_courses", ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id", using: :btree

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/continues_processing_later_courses_when_an_earlier_one_errors.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/continues_processing_later_courses_when_an_earlier_one_errors.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Myrl","LastName":"Hammes","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Aurelie","LastName":"Halvorson","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:41 GMT
+      - Thu, 20 Apr 2017 04:01:42 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FQakg0isRm-4f3Nq4yuoeQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:41 GMT
+      - BrowserId=O3g7pjzjRo6kjgKO2JreVQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/48000
+      - api-usage=265/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3rrQAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvP3QAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3rrQAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvP3QAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:42 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:42 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3rrQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvP3QAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:42 GMT
+      - Thu, 20 Apr 2017 04:01:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ARBZgZ4ZST2nhT8IlwYmpA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:42 GMT
+      - BrowserId=nyzXRM2bSxao9r6jjKRSww;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/48000
+      - api-usage=266/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:42 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:43 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3rrQAB%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvP3QAK%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:43 GMT
+      - Thu, 20 Apr 2017 04:01:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5u8KLGZVSGuZDcn6f94yhA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:43 GMT
+      - BrowserId=MkBjKRHDRNqMUR_CAROwPQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=104/48000
+      - api-usage=266/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,13 +142,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3rrQAB"},"Id":"0034B00000Fg3rrQAB","Name":"Myrl
-        Hammes","FirstName":"Myrl","LastName":"Hammes","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:48:42.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvP3QAK"},"Id":"0030S000004VvP3QAK","Name":"Aurelie
+        Halvorson","FirstName":"Aurelie","LastName":"Halvorson","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:01:42.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:43 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:43 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:43 GMT
+      - Thu, 20 Apr 2017 04:01:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=dknOHosbQ1yj1mF8fewf2Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:43 GMT
+      - BrowserId=5_AVzSyPS8uFpuYaVnDWiw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=110/48000
+      - api-usage=272/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -190,15 +190,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:43 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:43 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3rrQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
+      string: '{"Contact__c":"0030S000004VvP3QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +217,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:43 GMT
+      - Thu, 20 Apr 2017 04:01:44 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs54.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,14 +232,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5q9ezMvMQgSebAXVOzstFA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:43 GMT
+      - BrowserId=ZcwEPD3LQ6GL1wETPUT5NQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=106/48000
+      - api-usage=266/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLAUAY"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065ciUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -241,12 +248,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zLAUAY","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065ciUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:44 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:46 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLAUAY%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065ciUAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +272,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:44 GMT
+      - Thu, 20 Apr 2017 04:01:47 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -274,12 +281,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=JWFuyYedRw-q2GCJBRdfCw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:44 GMT
+      - BrowserId=XziyZ1dCRuO41Ng2buhkpQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=108/48000
+      - api-usage=268/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,13 +297,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:44 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:47 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLAUAY","Contact__c":"0034B00000Fg3rrQAB"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065ciUAA","Contact__c":"0030S000004VvP3QAK"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -314,7 +321,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:45 GMT
+      - Thu, 20 Apr 2017 04:01:47 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -323,14 +330,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nQRTVAv9SQiwcIOB1VEv6Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:45 GMT
+      - BrowserId=oP7EuRA-T7yLauJRL_Gycw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=110/48000
+      - api-usage=267/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207VUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512mUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,12 +346,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207VUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512mUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:46 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:48 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207VUAQ%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512mUAA%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +370,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:46 GMT
+      - Thu, 20 Apr 2017 04:01:48 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +379,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=kA8HgDRcQ96GDRPip0q7qg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:46 GMT
+      - BrowserId=1DhAwEUUR-2huckFBrQjyg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=111/48000
+      - api-usage=275/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,17 +393,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207VUAQ"},"Id":"a1S4B000000207VUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLAUAY","Contact__c":"0034B00000Fg3rrQAB"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512mUAA"},"Id":"a1S0S000000512mUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065ciUAA","Contact__c":"0030S000004VvP3QAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:46 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:48 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207VUAQ
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512mUAA"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":9,"E_Created_Date__c":"2017-04-13T20:48:39Z","Teacher_Join_URL__c":"http://localhost:3001/teach/836fa2b2d4a6c4b44a3b073c91fa0803/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":3,"Students_Using__c":12}'
+      string: '{"Status__c":"Approved","External_ID__c":9,"E_Created_Date__c":"2017-04-20T04:01:40Z","Teacher_Join_URL__c":"http://localhost:3001/teach/3aaeb12ddb1860b209a0c3612e26c8e9/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":3,"Students_Using__c":12}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -414,7 +421,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:47 GMT
+      - Thu, 20 Apr 2017 04:01:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -423,15 +430,15 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=CkyIQdFtTZ-J9c2PWitCUQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:47 GMT
+      - BrowserId=XGs4u212QpGV2yubFE0XAg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=105/48000
+      - api-usage=266/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:47 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/continues_processing_later_courses_when_an_earlier_one_errors.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/continues_processing_later_courses_when_an_earlier_one_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jaycee","LastName":"Becker","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Myrl","LastName":"Hammes","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:43 GMT
+      - Thu, 13 Apr 2017 20:48:41 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ha-mo9cJQzSgN_lGo1GH5Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:43 GMT
+      - BrowserId=FQakg0isRm-4f3Nq4yuoeQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=754/48000
+      - api-usage=103/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxyQAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3rrQAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxyQAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3rrQAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:44 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:42 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxyQAH%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3rrQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:45 GMT
+      - Thu, 13 Apr 2017 20:48:42 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pvEB_Nw_QVqhM1XD6CXbtA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:45 GMT
+      - BrowserId=ARBZgZ4ZST2nhT8IlwYmpA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=758/48000
+      - api-usage=103/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:45 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:42 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000BJSxyQAH%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3rrQAB%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:45 GMT
+      - Thu, 13 Apr 2017 20:48:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=vULOhR0KT9icG0_YlpG9SA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:45 GMT
+      - BrowserId=5u8KLGZVSGuZDcn6f94yhA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=763/48000
+      - api-usage=104/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000BJSxyQAH"},"Id":"0034B00000BJSxyQAH","Name":"Jaycee
-        Becker","FirstName":"Jaycee","LastName":"Becker","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-03-13T22:12:44.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3rrQAB"},"Id":"0034B00000Fg3rrQAB","Name":"Myrl
+        Hammes","FirstName":"Myrl","LastName":"Hammes","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:48:42.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:45 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:43 GMT
 - request:
     method: get
     uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:45 GMT
+      - Thu, 13 Apr 2017 20:48:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-GdutFwRQpiP3DuC15ZJcg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:45 GMT
+      - BrowserId=dknOHosbQ1yj1mF8fewf2Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=760/48000
+      - api-usage=110/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,13 +192,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:45 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:43 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxyQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
+      string: '{"Contact__c":"0034B00000Fg3rrQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +216,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:46 GMT
+      - Thu, 13 Apr 2017 20:48:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,14 +225,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=qfYYLCYWRnO16RNZ1ChwzQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:46 GMT
+      - BrowserId=5q9ezMvMQgSebAXVOzstFA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=767/48000
+      - api-usage=106/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORxUAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLAUAY"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -241,12 +241,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORxUAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zLAUAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:46 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:44 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORxUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLAUAY%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +265,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:46 GMT
+      - Thu, 13 Apr 2017 20:48:44 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -274,12 +274,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=dV1W9boIR421ja6ehRLZIg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:46 GMT
+      - BrowserId=JWFuyYedRw-q2GCJBRdfCw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=764/48000
+      - api-usage=108/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,13 +290,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:46 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:44 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gORxUAM","Contact__c":"0034B00000BJSxyQAH"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLAUAY","Contact__c":"0034B00000Fg3rrQAB"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -314,7 +314,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:47 GMT
+      - Thu, 13 Apr 2017 20:48:45 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -323,14 +323,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=dULS33gTSMeG_F0zx64h9g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:47 GMT
+      - BrowserId=nQRTVAv9SQiwcIOB1VEv6Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=760/48000
+      - api-usage=110/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvL1UAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207VUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,12 +339,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvL1UAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207VUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:48 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:46 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvL1UAK%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207VUAQ%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:48 GMT
+      - Thu, 13 Apr 2017 20:48:46 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +372,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=7cvKAkd1T6Kqnk5KnSGR5w;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:48 GMT
+      - BrowserId=kA8HgDRcQ96GDRPip0q7qg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=761/48000
+      - api-usage=111/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,17 +386,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvL1UAK"},"Id":"a1S4B000000CvL1UAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207VUAQ"},"Id":"a1S4B000000207VUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORxUAM","Contact__c":"0034B00000BJSxyQAH"}]}'
+        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLAUAY","Contact__c":"0034B00000Fg3rrQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:48 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:46 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvL1UAK
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207VUAQ
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":8,"E_Created_Date__c":"2017-03-13T22:12:41Z","Teacher_Join_URL__c":"http://localhost:3001/teach/4ff9346e39784f1642feb65cb1b7ac51/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":3,"Students_Using__c":12}'
+      string: '{"Status__c":"Approved","External_ID__c":9,"E_Created_Date__c":"2017-04-13T20:48:39Z","Teacher_Join_URL__c":"http://localhost:3001/teach/836fa2b2d4a6c4b44a3b073c91fa0803/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":3,"Students_Using__c":12}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -414,7 +414,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:49 GMT
+      - Thu, 13 Apr 2017 20:48:47 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -423,15 +423,15 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ct8D4xdDRReJGnqZeHEZiw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:49 GMT
+      - BrowserId=CkyIQdFtTZ-J9c2PWitCUQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=762/48000
+      - api-usage=105/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:49 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_it_cannot_save_a_new_IA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_it_cannot_save_a_new_IA.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Demond","LastName":"Lemke","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Patsy","LastName":"Considine","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:57 GMT
+      - Thu, 13 Apr 2017 20:48:55 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6Y3OFNitQiKIXfVfcBgnrQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:57 GMT
+      - BrowserId=P4xGoUYQS2WDzCQiV5FUCA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=774/48000
+      - api-usage=119/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSy8QAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pdQAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSy8QAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3pdQAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:58 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:56 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSy8QAH%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pdQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:59 GMT
+      - Thu, 13 Apr 2017 20:48:57 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs51.salesforce.com/services/data/v29.0/query'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +87,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Qdw5Sn90TT2TFLs90q7sgw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:59 GMT
+      - BrowserId=3DeCWs-XS_CeEVd3M1icPg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=773/48000
+      - api-usage=117/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +103,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:59 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:57 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000BJSy8QAH%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3pdQAB%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +125,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:59 GMT
+      - Thu, 13 Apr 2017 20:48:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +134,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hx4dLEhoQGKVWV5PUwL_0A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:59 GMT
+      - BrowserId=-2wpNAUHTP2FI3Eg2cQtew;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=769/48000
+      - api-usage=114/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +148,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000BJSy8QAH"},"Id":"0034B00000BJSy8QAH","Name":"Demond
-        Lemke","FirstName":"Demond","LastName":"Lemke","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-03-13T22:12:58.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3pdQAB"},"Id":"0034B00000Fg3pdQAB","Name":"Patsy
+        Considine","FirstName":"Patsy","LastName":"Considine","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:48:56.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:59 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:57 GMT
 - request:
     method: get
     uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
@@ -167,7 +173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:59 GMT
+      - Thu, 13 Apr 2017 20:48:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +182,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=gdSKhJu7RgajQ7hhvLcHDw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:59 GMT
+      - BrowserId=kSvDNzRXRVeXkbTPOMOXzQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=777/48000
+      - api-usage=116/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,13 +198,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:59 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:57 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSy8QAH","Book__c":"a0Z4B0000002sxQUAQ"}'
+      string: '{"Contact__c":"0034B00000Fg3pdQAB","Book__c":"a0Z4B0000002sxQUAQ"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +222,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:00 GMT
+      - Thu, 13 Apr 2017 20:48:58 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,12 +231,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=s_v32XNITvCgAROB9ZVysg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:00 GMT
+      - BrowserId=urZ9nzA4R5quqAuCDf2XsA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=769/48000
+      - api-usage=118/48000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -239,5 +245,5 @@ http_interactions:
       encoding: UTF-8
       string: '[{"message":"Required fields are missing: [Account__c]","errorCode":"REQUIRED_FIELD_MISSING","fields":["Account__c"]}]'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:00 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_it_cannot_save_a_new_IA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_it_cannot_save_a_new_IA.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Patsy","LastName":"Considine","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Eleonore","LastName":"Schulist","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:55 GMT
+      - Thu, 20 Apr 2017 04:02:01 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=P4xGoUYQS2WDzCQiV5FUCA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:55 GMT
+      - BrowserId=WBNlS9JpRF2NQuQTePzkVg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=119/48000
+      - api-usage=289/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pdQAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPIQA0"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3pdQAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvPIQA0","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:56 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:02 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pdQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPIQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,13 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:57 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
-        http://cs51.salesforce.com/services/data/v29.0/query'
+      - Thu, 20 Apr 2017 04:02:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -87,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=3DeCWs-XS_CeEVd3M1icPg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:57 GMT
+      - BrowserId=j1qwj5hsSI6iKLJUYwJi1w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=117/48000
+      - api-usage=285/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -103,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:57 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:02 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3pdQAB%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvPIQA0%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -125,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:57 GMT
+      - Thu, 20 Apr 2017 04:02:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-2wpNAUHTP2FI3Eg2cQtew;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:57 GMT
+      - BrowserId=hbIS_-0cS7OgUry1dbZUgw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=114/48000
+      - api-usage=291/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -148,13 +142,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3pdQAB"},"Id":"0034B00000Fg3pdQAB","Name":"Patsy
-        Considine","FirstName":"Patsy","LastName":"Considine","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:48:56.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvPIQA0"},"Id":"0030S000004VvPIQA0","Name":"Eleonore
+        Schulist","FirstName":"Eleonore","LastName":"Schulist","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:02:02.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:57 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:02 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:57 GMT
+      - Thu, 20 Apr 2017 04:02:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -182,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=kSvDNzRXRVeXkbTPOMOXzQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:57 GMT
+      - BrowserId=-Vw5pk3SQXe7ccr24ozvjw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=116/48000
+      - api-usage=290/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -196,15 +190,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:57 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:03 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3pdQAB","Book__c":"a0Z4B0000002sxQUAQ"}'
+      string: '{"Contact__c":"0030S000004VvPIQA0","Book__c":"a0Z0S000000FgiCUAS","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -222,7 +217,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:58 GMT
+      - Thu, 20 Apr 2017 04:02:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -231,12 +226,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=urZ9nzA4R5quqAuCDf2XsA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:58 GMT
+      - BrowserId=eGYxSoenTZ6vP4nPC1VFug;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=118/48000
+      - api-usage=288/48000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -245,5 +240,5 @@ http_interactions:
       encoding: UTF-8
       string: '[{"message":"Required fields are missing: [Account__c]","errorCode":"REQUIRED_FIELD_MISSING","fields":["Account__c"]}]'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:58 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_IAs_match.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_IAs_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Bernard","LastName":"Mills","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Pauline","LastName":"Bruen","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:53 GMT
+      - Thu, 13 Apr 2017 20:48:50 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=1_u-ERwTRoqTE9JCvZqOxQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:53 GMT
+      - BrowserId=Go32mpC6Tkm0CuVSvyu5pQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=768/48000
+      - api-usage=113/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxfQAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sGQAR"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxfQAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3sGQAR","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:54 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:51 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxfQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:54 GMT
+      - Thu, 13 Apr 2017 20:48:51 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=BDQYfwgzQe25tfdjUbdFWg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:54 GMT
+      - BrowserId=PGvAuZP2T363N7de0xbLuw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=759/48000
+      - api-usage=115/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOS2UAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLFUAY"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gOS2UAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zLFUAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:54 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:52 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxfQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +125,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:54 GMT
+      - Thu, 13 Apr 2017 20:48:52 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +134,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=eY-0BmiVRROk49jKfBGvzA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:54 GMT
+      - BrowserId=mLRY7oqqTDS6hZ6uSVkXOg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=763/48000
+      - api-usage=116/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOS7UAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLKUAY"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +150,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gOS7UAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zLKUAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:55 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:53 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxfQAH%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sGQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:55 GMT
+      - Thu, 13 Apr 2017 20:48:53 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +183,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=GB75Y9v3SIKtBmMe96vhwQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:55 GMT
+      - BrowserId=RxeHHBtLRr6_SuySb7d-6g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=763/48000
+      - api-usage=114/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,11 +197,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOS2UAM"},"Id":"a1W4B000000gOS2UAM","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxfQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLKUAY"},"Id":"a1W4B0000018zLKUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null},{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOS7UAM"},"Id":"a1W4B000000gOS7UAM","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxfQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+        - 17 Spring","Class_Start_Date__c":null},{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLFUAY"},"Id":"a1W4B0000018zLFUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:55 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_IAs_match.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_IAs_match.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Pauline","LastName":"Bruen","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Jerel","LastName":"Wuckert","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:50 GMT
+      - Thu, 20 Apr 2017 04:01:52 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs54.salesforce.com/services/data/v29.0/sobjects/Contact'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +38,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Go32mpC6Tkm0CuVSvyu5pQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:50 GMT
+      - BrowserId=15vWf6iWTZa5DeB-7WvlmQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=113/48000
+      - api-usage=276/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sGQAR"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvP8QAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +54,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3sGQAR","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvP8QAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:51 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:53 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +81,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:51 GMT
+      - Thu, 20 Apr 2017 04:01:53 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +90,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=PGvAuZP2T363N7de0xbLuw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:51 GMT
+      - BrowserId=SLtMynU6Qier_zKP3GYeeQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=115/48000
+      - api-usage=276/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLFUAY"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cnUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +106,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zLFUAY","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cnUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:52 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:57 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +133,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:52 GMT
+      - Thu, 20 Apr 2017 04:01:58 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +142,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=mLRY7oqqTDS6hZ6uSVkXOg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:52 GMT
+      - BrowserId=QC6d_v_1TdmEgd2yA5AL2A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=116/48000
+      - api-usage=289/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLKUAY"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065csUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +158,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zLKUAY","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065csUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:53 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:59 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sGQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvP8QAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:53 GMT
+      - Thu, 20 Apr 2017 04:01:59 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +191,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=RxeHHBtLRr6_SuySb7d-6g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:53 GMT
+      - BrowserId=M40OxxKFQ7-0iSl__V0-JA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=114/48000
+      - api-usage=290/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,11 +205,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLKUAY"},"Id":"a1W4B0000018zLKUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null},{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLFUAY"},"Id":"a1W4B0000018zLFUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sGQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065csUAA"},"Id":"a1W0S00000065csUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null},{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cnUAA"},"Id":"a1W0S00000065cnUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:53 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_OSAs_match.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_OSAs_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Efrain","LastName":"Dickens","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Velma","LastName":"Zemlak","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:02 GMT
+      - Thu, 13 Apr 2017 20:49:00 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs51.salesforce.com/services/data/v29.0/sobjects/Contact'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +38,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hjtZ3SsyQuGObyCTktKuGA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:02 GMT
+      - BrowserId=BOE1QP4pSZOvysxHG3ep0w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=769/48000
+      - api-usage=116/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSyDQAX"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sQQAR"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +54,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSyDQAX","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3sQQAR","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:03 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:01 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSyDQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3sQQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +80,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:03 GMT
+      - Thu, 13 Apr 2017 20:49:01 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +89,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=GrX-Ju0lTgGrtCiAXsVZog;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:03 GMT
+      - BrowserId=XhHgvnHrR8Wbfz-O8_zD7g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=774/48000
+      - api-usage=119/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOSCUA2"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLLUAY"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +105,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gOSCUA2","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zLLUAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:03 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:01 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gOSCUA2","Contact__c":"0034B00000BJSyDQAX"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +131,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:04 GMT
+      - Thu, 13 Apr 2017 20:49:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +140,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2ssNgkV1SpO6PAQ8PvEPlg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:04 GMT
+      - BrowserId=UuPZFP85QpOWfZrvxINUCA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=770/48000
+      - api-usage=120/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvL6UAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207aUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,15 +156,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvL6UAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207aUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:05 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:03 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gOSCUA2","Contact__c":"0034B00000BJSyDQAX"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -176,7 +182,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:05 GMT
+      - Thu, 13 Apr 2017 20:49:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -185,14 +191,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=7ZNkDd2bTcyqX4FeSjtvKw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:05 GMT
+      - BrowserId=5gZ3qKDGQkGcA3Ih7KWpTQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=774/48000
+      - api-usage=135/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvLBUA0"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207fUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -201,12 +207,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvLBUA0","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207fUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:06 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:05 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSyDQAX%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sQQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -225,7 +231,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:06 GMT
+      - Thu, 13 Apr 2017 20:49:05 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -234,12 +240,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=CU-UN7LsTImjIURSQqplVw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:06 GMT
+      - BrowserId=Ex-lTDvdQt2Qmr1vAAXhkw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=774/48000
+      - api-usage=140/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -248,14 +254,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOSCUA2"},"Id":"a1W4B000000gOSCUA2","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSyDQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLLUAY"},"Id":"a1W4B0000018zLLUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sQQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:06 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:05 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gOSCUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLLUAY%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -274,7 +280,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:07 GMT
+      - Thu, 13 Apr 2017 20:49:05 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -283,12 +289,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ghOINEqNTc2uc_fs5gv_mw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:07 GMT
+      - BrowserId=9fSCYeaJQr-B9kGzeJeurg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=775/48000
+      - api-usage=137/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -297,11 +303,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvL6UAK"},"Id":"a1S4B000000CvL6UAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207fUAA"},"Id":"a1S4B000000207fUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOSCUA2","Contact__c":"0034B00000BJSyDQAX"},{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvLBUA0"},"Id":"a1S4B000000CvLBUA0","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"},{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207aUAA"},"Id":"a1S4B000000207aUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOSCUA2","Contact__c":"0034B00000BJSyDQAX"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:07 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:06 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_OSAs_match.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_OSAs_match.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Velma","LastName":"Zemlak","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Maybelle","LastName":"Lueilwitz","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,13 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:00 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
-        http://cs51.salesforce.com/services/data/v29.0/sobjects/Contact'
+      - Thu, 20 Apr 2017 04:02:05 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -38,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=BOE1QP4pSZOvysxHG3ep0w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:00 GMT
+      - BrowserId=sytJjXkLQ-CzlvpVIu-r9w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=116/48000
+      - api-usage=292/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sQQAR"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPSQA0"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -54,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3sQQAR","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvPSQA0","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:01 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:06 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3sQQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvPSQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -80,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:01 GMT
+      - Thu, 20 Apr 2017 04:02:07 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -89,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=XhHgvnHrR8Wbfz-O8_zD7g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:01 GMT
+      - BrowserId=RnQ8l_37QQONFXohhnE06g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=119/48000
+      - api-usage=289/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLLUAY"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cxUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -105,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zLLUAY","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cxUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:01 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:11 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -131,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:02 GMT
+      - Thu, 20 Apr 2017 04:02:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -140,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=UuPZFP85QpOWfZrvxINUCA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:02 GMT
+      - BrowserId=2nI8KXqTSTSjBTz_3724NQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=120/48000
+      - api-usage=291/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207aUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512wUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -156,15 +151,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207aUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512wUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:03 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:18 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -182,7 +177,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:03 GMT
+      - Thu, 20 Apr 2017 04:02:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -191,14 +186,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5gZ3qKDGQkGcA3Ih7KWpTQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:03 GMT
+      - BrowserId=MhJFoQKwTUmA7R9wkFchwA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=135/48000
+      - api-usage=308/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207fUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005131UAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -207,12 +202,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207fUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005131UAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:05 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:19 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sQQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPSQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -231,7 +226,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:05 GMT
+      - Thu, 20 Apr 2017 04:02:19 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -240,12 +235,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Ex-lTDvdQt2Qmr1vAAXhkw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:05 GMT
+      - BrowserId=NTQUw2yNSg2BDjli0w2Dew;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=140/48000
+      - api-usage=304/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -254,14 +249,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLLUAY"},"Id":"a1W4B0000018zLLUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sQQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cxUAA"},"Id":"a1W0S00000065cxUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvPSQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:05 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:19 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLLUAY%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cxUAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -280,7 +275,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:05 GMT
+      - Thu, 20 Apr 2017 04:02:19 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -289,12 +284,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=9fSCYeaJQr-B9kGzeJeurg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:05 GMT
+      - BrowserId=FPnPnGW0TKCC2oEZUTDtww;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=137/48000
+      - api-usage=309/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -303,11 +298,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207fUAA"},"Id":"a1S4B000000207fUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512wUAA"},"Id":"a1S0S000000512wUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"},{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207aUAA"},"Id":"a1S4B000000207aUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"},{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005131UAA"},"Id":"a1S0S0000005131UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLLUAY","Contact__c":"0034B00000Fg3sQQAR"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:06 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_no_offering.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_no_offering.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Joanie","LastName":"Abbott","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Camryn","LastName":"Huels","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:07 GMT
+      - Thu, 20 Apr 2017 04:02:21 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=DBuMNkPJSTiI21lmHGb97A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:07 GMT
+      - BrowserId=nBmJ85GnT8uSVnx-aUtjaA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=134/48000
+      - api-usage=303/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sVQAR"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPXQA0"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,7 +48,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3sVQAR","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvPXQA0","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:08 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:26 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_no_offering.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_no_offering.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Ronaldo","LastName":"Fisher","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Joanie","LastName":"Abbott","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:09 GMT
+      - Thu, 13 Apr 2017 20:49:07 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=MJK_Q22KQ5yS5oxOFI9_Yg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:09 GMT
+      - BrowserId=DBuMNkPJSTiI21lmHGb97A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=775/48000
+      - api-usage=134/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSyIQAX"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sVQAR"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,7 +48,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSyIQAX","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3sVQAR","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:10 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/when_there_is_an_error_in_writing_stats/writes_the_error_to_the_OSA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/when_there_is_an_error_in_writing_stats/writes_the_error_to_the_OSA.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Freida","LastName":"Stokes","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Destini","LastName":"Casper","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:16 GMT
+      - Thu, 13 Apr 2017 20:49:14 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=DOeU0mxGTFes_ipwSFJuoQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:16 GMT
+      - BrowserId=UjPu_UXuQOCifgctC3SsTg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=782/48000
+      - api-usage=130/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSyNQAX"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sfQAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSyNQAX","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3sfQAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:16 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:15 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSyNQAX%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sfQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:17 GMT
+      - Thu, 13 Apr 2017 20:49:16 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jSmj-ZAxR-CeC5OEn1SCwQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:17 GMT
+      - BrowserId=ZRYlxnsSSQ2eUp-frkRU3w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=776/48000
+      - api-usage=136/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:17 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:16 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000BJSyNQAX%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3sfQAB%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:17 GMT
+      - Thu, 13 Apr 2017 20:49:16 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=C7CMWXG5T6iSmuRyTyULHw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:17 GMT
+      - BrowserId=FQs8lRhBQCapkJfzWG8v-g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=781/48000
+      - api-usage=131/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000BJSyNQAX"},"Id":"0034B00000BJSyNQAX","Name":"Freida
-        Stokes","FirstName":"Freida","LastName":"Stokes","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-03-13T22:13:16.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3sfQAB"},"Id":"0034B00000Fg3sfQAB","Name":"Destini
+        Casper","FirstName":"Destini","LastName":"Casper","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:49:15.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:17 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:16 GMT
 - request:
     method: get
     uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:18 GMT
+      - Thu, 13 Apr 2017 20:49:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Rdal0VqJTe6NDw3bzBSxUw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:18 GMT
+      - BrowserId=bC5YQxzGRKG8TGDEDDOB4Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=775/48000
+      - api-usage=132/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,13 +192,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:18 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:17 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSyNQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
+      string: '{"Contact__c":"0034B00000Fg3sfQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +216,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:18 GMT
+      - Thu, 13 Apr 2017 20:49:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,14 +225,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pvTHxB-fSHyj1CXxn7uB5w;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:18 GMT
+      - BrowserId=eZKNmcQZQaWxtZQgThEwjg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=774/48000
+      - api-usage=130/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOSHUA2"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLPUAY"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -241,12 +241,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gOSHUA2","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zLPUAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:18 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:17 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gOSHUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLPUAY%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +265,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:19 GMT
+      - Thu, 13 Apr 2017 20:49:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -274,12 +274,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=1tD9423JTn2o87FgNesGcA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:19 GMT
+      - BrowserId=r1mjewQXTkedp6NYlw_tJw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=782/48000
+      - api-usage=141/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,13 +290,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:19 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:18 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gOSHUA2","Contact__c":"0034B00000BJSyNQAX"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLPUAY","Contact__c":"0034B00000Fg3sfQAB"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -314,7 +314,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:19 GMT
+      - Thu, 13 Apr 2017 20:49:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -323,14 +323,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=cIg_jWoVToutNgy0vPnsVg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:19 GMT
+      - BrowserId=H0T8SoS8TMWzTYNZRIfayQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=779/48000
+      - api-usage=131/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvLGUA0"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,12 +339,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvLGUA0","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207kUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:20 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:19 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvLGUA0%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207kUAA%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:20 GMT
+      - Thu, 13 Apr 2017 20:49:19 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +372,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=v72tklKIRxy6s14tAAEdOA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:20 GMT
+      - BrowserId=nKmBwCyoQR2H6-ku-AwbhA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=782/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,17 +386,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvLGUA0"},"Id":"a1S4B000000CvLGUA0","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA"},"Id":"a1S4B000000207kUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOSHUA2","Contact__c":"0034B00000BJSyNQAX"}]}'
+        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLPUAY","Contact__c":"0034B00000Fg3sfQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:20 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:19 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvLGUA0
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA
     body:
       encoding: UTF-8
-      string: '{"External_ID__c":16,"E_Created_Date__c":"2017-03-13T22:13:14Z","Error__c":"Unable
+      string: '{"External_ID__c":17,"E_Created_Date__c":"2017-04-13T20:49:12Z","Error__c":"Unable
         to update stats: kaboom"}'
     headers:
       User-Agent:
@@ -415,7 +415,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:21 GMT
+      - Thu, 13 Apr 2017 20:49:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -424,20 +424,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=0if3lav0QtaURdSt7ededw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:21 GMT
+      - BrowserId=r894rbDURmqqUU7AZiiZ1g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=777/48000
+      - api-usage=136/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:21 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:20 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSyNQAX%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sfQAB%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -456,7 +456,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:21 GMT
+      - Thu, 13 Apr 2017 20:49:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -465,12 +465,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=426OcC3aSl6Uoh_UHya1Gg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:21 GMT
+      - BrowserId=NDOGoQXgQLOi_DCsIj5Taw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=788/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -479,14 +479,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOSHUA2"},"Id":"a1W4B000000gOSHUA2","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSyNQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"fix
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLPUAY"},"Id":"a1W4B0000018zLPUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sfQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"fix
         formula","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"TermYear__c":"fix
         formula Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:21 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:21 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gOSHUA2%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLPUAY%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -505,7 +505,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:13:22 GMT
+      - Thu, 13 Apr 2017 20:49:21 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -514,12 +514,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8QQJj0cpQHua0LClnZjSJg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:13:22 GMT
+      - BrowserId=kuQDLld7QraEMN_7LiVHug;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:49:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=786/48000
+      - api-usage=147/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -528,10 +528,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvLGUA0"},"Id":"a1S4B000000CvLGUA0","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"16","E_Created_Date__c":"2017-03-13T22:13:14.000+0000","Error__c":"Unable
-        to update stats: kaboom","General_Access_URL__c":"https://tutor.openstax.org/courses/16/dashboard","Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA"},"Id":"a1S4B000000207kUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"17","E_Created_Date__c":"2017-04-13T20:49:12.000+0000","Error__c":"Unable
+        to update stats: kaboom","General_Access_URL__c":"https://tutor.openstax.org/courses/17/dashboard","Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOSHUA2","Contact__c":"0034B00000BJSyNQAX"}]}'
+        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLPUAY","Contact__c":"0034B00000Fg3sfQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:13:22 GMT
+  recorded_at: Thu, 13 Apr 2017 20:49:21 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/when_there_is_an_error_in_writing_stats/writes_the_error_to_the_OSA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/when_there_is_an_error_in_writing_stats/writes_the_error_to_the_OSA.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Destini","LastName":"Casper","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Jodie","LastName":"Runolfsson","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:14 GMT
+      - Thu, 20 Apr 2017 04:02:32 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=UjPu_UXuQOCifgctC3SsTg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:14 GMT
+      - BrowserId=sPqiyz4MQb6gwUSoNB4J8w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=130/48000
+      - api-usage=317/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3sfQAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPcQAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3sfQAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvPcQAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:15 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:33 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sfQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPcQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:16 GMT
+      - Thu, 20 Apr 2017 04:02:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ZRYlxnsSSQ2eUp-frkRU3w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:16 GMT
+      - BrowserId=pkF-FS52TbKs6-0YOeZALg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=136/48000
+      - api-usage=317/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:16 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:34 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3sfQAB%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvPcQAK%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:16 GMT
+      - Thu, 20 Apr 2017 04:02:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FQs8lRhBQCapkJfzWG8v-g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:16 GMT
+      - BrowserId=Epb2X_3kQ6a-TDrqydlpfw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=131/48000
+      - api-usage=317/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,13 +142,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3sfQAB"},"Id":"0034B00000Fg3sfQAB","Name":"Destini
-        Casper","FirstName":"Destini","LastName":"Casper","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:49:15.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvPcQAK"},"Id":"0030S000004VvPcQAK","Name":"Jodie
+        Runolfsson","FirstName":"Jodie","LastName":"Runolfsson","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:02:33.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:16 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:34 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:17 GMT
+      - Thu, 20 Apr 2017 04:02:35 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=bC5YQxzGRKG8TGDEDDOB4Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:17 GMT
+      - BrowserId=isNe12z4QRaTOcOznbcJqA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=132/48000
+      - api-usage=323/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -190,15 +190,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:17 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:35 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3sfQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
+      string: '{"Contact__c":"0030S000004VvPcQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +217,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:17 GMT
+      - Thu, 20 Apr 2017 04:02:35 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,14 +226,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=eZKNmcQZQaWxtZQgThEwjg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:17 GMT
+      - BrowserId=NC2DAIjdRkuuOHdlyRgbYQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=130/48000
+      - api-usage=324/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLPUAY"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065d2UAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -241,12 +242,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zLPUAY","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065d2UAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:17 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:39 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLPUAY%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065d2UAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:18 GMT
+      - Thu, 20 Apr 2017 04:02:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -274,12 +275,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=r1mjewQXTkedp6NYlw_tJw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:18 GMT
+      - BrowserId=FPayB-RHSj22N4njMFo8KA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=141/48000
+      - api-usage=327/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,13 +291,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:18 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:39 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zLPUAY","Contact__c":"0034B00000Fg3sfQAB"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065d2UAA","Contact__c":"0030S000004VvPcQAK"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -314,7 +315,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:18 GMT
+      - Thu, 20 Apr 2017 04:02:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -323,14 +324,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=H0T8SoS8TMWzTYNZRIfayQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:18 GMT
+      - BrowserId=jYxwjy8SRE-vUtsy0jdAKA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=131/48000
+      - api-usage=326/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,12 +340,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207kUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005136UAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:19 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:40 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207kUAA%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005136UAA%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:19 GMT
+      - Thu, 20 Apr 2017 04:02:41 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +373,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nKmBwCyoQR2H6-ku-AwbhA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:19 GMT
+      - BrowserId=LHIxKuqGQ1yzCyV2znMuUQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=135/48000
+      - api-usage=326/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,17 +387,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA"},"Id":"a1S4B000000207kUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLPUAY","Contact__c":"0034B00000Fg3sfQAB"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"},"Id":"a1S0S0000005136UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065d2UAA","Contact__c":"0030S000004VvPcQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:19 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:41 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"
     body:
       encoding: UTF-8
-      string: '{"External_ID__c":17,"E_Created_Date__c":"2017-04-13T20:49:12Z","Error__c":"Unable
+      string: '{"External_ID__c":17,"E_Created_Date__c":"2017-04-20T04:02:30Z","Error__c":"Unable
         to update stats: kaboom"}'
     headers:
       User-Agent:
@@ -415,7 +416,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:20 GMT
+      - Thu, 20 Apr 2017 04:02:41 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -424,20 +425,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=r894rbDURmqqUU7AZiiZ1g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:20 GMT
+      - BrowserId=Z0hFngYORiiP8TX82Xw5wg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=136/48000
+      - api-usage=327/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:20 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:41 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3sfQAB%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPcQAK%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -456,7 +457,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:20 GMT
+      - Thu, 20 Apr 2017 04:02:41 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -465,12 +466,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=NDOGoQXgQLOi_DCsIj5Taw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:20 GMT
+      - BrowserId=qgEIpxJHQO69h6Ti9lA3aw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=135/48000
+      - api-usage=326/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -479,14 +480,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zLPUAY"},"Id":"a1W4B0000018zLPUAY","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3sfQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"fix
-        formula","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"TermYear__c":"fix
-        formula Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065d2UAA"},"Id":"a1W0S00000065d2UAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvPcQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor","TermYear__c":"2016
+        - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:21 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:41 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zLPUAY%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065d2UAA%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -505,7 +507,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:49:21 GMT
+      - Thu, 20 Apr 2017 04:02:42 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -514,12 +516,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=kuQDLld7QraEMN_7LiVHug;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:49:21 GMT
+      - BrowserId=zB5QbhElSGWztGZqy-Y3dw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:02:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=147/48000
+      - api-usage=332/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -528,10 +530,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207kUAA"},"Id":"a1S4B000000207kUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"17","E_Created_Date__c":"2017-04-13T20:49:12.000+0000","Error__c":"Unable
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"},"Id":"a1S0S0000005136UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"17","E_Created_Date__c":"2017-04-20T04:02:30.000+0000","Error__c":"Unable
         to update stats: kaboom","General_Access_URL__c":"https://tutor.openstax.org/courses/17/dashboard","Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zLPUAY","Contact__c":"0034B00000Fg3sfQAB"}]}'
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065d2UAA","Contact__c":"0030S000004VvPcQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:49:21 GMT
+  recorded_at: Thu, 20 Apr 2017 04:02:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/sf_setup.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/sf_setup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:48 GMT
+      - Thu, 20 Apr 2017 04:00:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -30,12 +30,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=KKwt1gJpS9mTJ_XD-vQuHg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:48 GMT
+      - BrowserId=5TawHbF3S26bt79fTIndWQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=94/48000
+      - api-usage=258/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -44,12 +44,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:48 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:34 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Account
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Account"
     body:
       encoding: US-ASCII
       string: ''
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:49 GMT
+      - Thu, 20 Apr 2017 04:00:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -77,12 +77,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=OoY6jnaLQCC1JRkqXSsR1A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:49 GMT
+      - BrowserId=eajb6ODDTieNz0LnI0D35A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=94/48000
+      - api-usage=258/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -91,8 +91,8 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v29.0/sobjects/Account/0014B00000DaY04QAF"},"Id":"0014B00000DaY04QAF","Name":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v29.0/sobjects/Account/0010S0000057qMUQAY"},"Id":"0010S0000057qMUQAY","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:49 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/sf_setup.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/sf_setup.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:51 GMT
+      - Thu, 13 Apr 2017 20:47:48 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -30,12 +30,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=1ReInnfWS8CWiNqcn2FoMg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:51 GMT
+      - BrowserId=KKwt1gJpS9mTJ_XD-vQuHg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=94/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:52 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:48 GMT
 - request:
     method: get
     uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Account
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:52 GMT
+      - Thu, 13 Apr 2017 20:47:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -77,12 +77,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=cROHLOrUTTeytLKkH7qoMQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:52 GMT
+      - BrowserId=OoY6jnaLQCC1JRkqXSsR1A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=745/48000
+      - api-usage=94/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -94,5 +94,5 @@ http_interactions:
       string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v29.0/sobjects/Account/0014B00000DaY04QAF"},"Id":"0014B00000DaY04QAF","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:52 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handle_exceptions_around_saving_final_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handle_exceptions_around_saving_final_stats.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Flossie","LastName":"Bailey","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Jerrold","LastName":"Miller","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:31 GMT
+      - Thu, 13 Apr 2017 20:48:26 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=dWgDyTLtRViJ4kE2FVg55g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:31 GMT
+      - BrowserId=-MEZqwlcT06z6M10uWgc8Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=756/48000
+      - api-usage=102/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxtQAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3r3QAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxtQAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3r3QAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:32 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:27 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxtQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3r3QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:33 GMT
+      - Thu, 13 Apr 2017 20:48:28 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4Nk77rngQxSUcgXi6AzgFQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:33 GMT
+      - BrowserId=KXbxMUpXTRWJNoNnj88kDA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=749/48000
+      - api-usage=103/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORnUAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL0UAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORnUAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zL0UAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:33 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:28 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gORnUAM","Contact__c":"0034B00000BJSxtQAH"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zL0UAI","Contact__c":"0034B00000Fg3r3QAB"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +125,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:33 GMT
+      - Thu, 13 Apr 2017 20:48:28 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +140,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=sGtdSQxXRP-oBYNGlJh4ug;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:33 GMT
+      - BrowserId=NZFM8lPhSlGoY30EkBMMxQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=757/48000
+      - api-usage=99/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKrUAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207LUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +156,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvKrUAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207LUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:34 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:30 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxtQAH%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3r3QAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +180,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:35 GMT
+      - Thu, 13 Apr 2017 20:48:30 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +189,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=iYDXqdPoRnyyj7rjDGmi3Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:35 GMT
+      - BrowserId=DD1s9BdFQ2-MGcOKjX5maA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=752/48000
+      - api-usage=100/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,14 +203,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORnUAM"},"Id":"a1W4B000000gORnUAM","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxtQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL0UAI"},"Id":"a1W4B0000018zL0UAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3r3QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:35 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:30 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORnUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zL0UAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +229,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:35 GMT
+      - Thu, 13 Apr 2017 20:48:30 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -232,12 +238,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=s6LVsRC7Sre2ZgCHr5euqQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:35 GMT
+      - BrowserId=8DvK2tBSSQOC6mCr84p1ng;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=101/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,9 +252,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKrUAK"},"Id":"a1S4B000000CvKrUAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207LUAQ"},"Id":"a1S4B000000207LUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORnUAM","Contact__c":"0034B00000BJSxtQAH"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zL0UAI","Contact__c":"0034B00000Fg3r3QAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:35 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handle_exceptions_around_saving_final_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handle_exceptions_around_saving_final_stats.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jerrold","LastName":"Miller","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Aylin","LastName":"Haley","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:26 GMT
+      - Thu, 20 Apr 2017 04:01:22 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-MEZqwlcT06z6M10uWgc8Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:26 GMT
+      - BrowserId=-mw6fkMaQ2ukude3iOUAQA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=102/48000
+      - api-usage=266/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3r3QAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOtQAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3r3QAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOtQAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:27 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:23 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3r3QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvOtQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:28 GMT
+      - Thu, 20 Apr 2017 04:01:23 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=KXbxMUpXTRWJNoNnj88kDA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:28 GMT
+      - BrowserId=dWLroYfLTjaGBjjaBnOB1Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/48000
+      - api-usage=261/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL0UAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cYUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zL0UAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cYUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:28 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:26 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zL0UAI","Contact__c":"0034B00000Fg3r3QAB"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cYUAQ","Contact__c":"0030S000004VvOtQAK"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,13 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:28 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
-        http://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c'
+      - Thu, 20 Apr 2017 04:01:27 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -140,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=NZFM8lPhSlGoY30EkBMMxQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:28 GMT
+      - BrowserId=WDjWPirMQ1WydjMtuWCHTQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=267/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207LUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512cUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -156,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207LUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512cUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:30 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:28 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3r3QAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOtQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -180,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:30 GMT
+      - Thu, 20 Apr 2017 04:01:29 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -189,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=DD1s9BdFQ2-MGcOKjX5maA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:30 GMT
+      - BrowserId=C5NZ0iBSTbSN2dgx0aoi1A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=264/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -203,14 +198,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL0UAI"},"Id":"a1W4B0000018zL0UAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3r3QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cYUAQ"},"Id":"a1W0S00000065cYUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOtQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:30 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:29 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zL0UAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cYUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -229,7 +224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:30 GMT
+      - Thu, 20 Apr 2017 04:01:29 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -238,12 +233,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8DvK2tBSSQOC6mCr84p1ng;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:30 GMT
+      - BrowserId=cnlX0awXSk-PWHhGeZpUVw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=101/48000
+      - api-usage=263/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -252,9 +247,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207LUAQ"},"Id":"a1S4B000000207LUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512cUAA"},"Id":"a1S0S000000512cUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zL0UAI","Contact__c":"0034B00000Fg3r3QAB"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cYUAQ","Contact__c":"0030S000004VvOtQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:30 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:29 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handles_final_OSA_save_errors.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handles_final_OSA_save_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Winona","LastName":"Mitchell","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Ivah","LastName":"Cole","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:37 GMT
+      - Thu, 13 Apr 2017 20:48:32 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=tXFN_krYSYelgHn4MhyRwA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:37 GMT
+      - BrowserId=Sne9JAhvSXGDpOv7Qaf7IA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=100/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSvyQAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3qbQAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSvyQAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3qbQAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:38 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:33 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSvyQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3qbQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:38 GMT
+      - Thu, 13 Apr 2017 20:48:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=DSBQVCWqSHyr1_hvmUAzgA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:38 GMT
+      - BrowserId=ymrWQu-xSJiBQbBZllA3Sg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=101/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORsUAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL5UAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORsUAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zL5UAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:39 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:34 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gORsUAM","Contact__c":"0034B00000BJSvyQAH"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zL5UAI","Contact__c":"0034B00000Fg3qbQAB"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +125,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:39 GMT
+      - Thu, 13 Apr 2017 20:48:35 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +134,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=1Xz-4ed6SPihZXn_GGFEkw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:39 GMT
+      - BrowserId=h5poBmZkRnC1n_xsjMSs2g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=752/48000
+      - api-usage=102/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKwUAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207QUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +150,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvKwUAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207QUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:40 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:36 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSvyQAH%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3qbQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:40 GMT
+      - Thu, 13 Apr 2017 20:48:36 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +183,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=YYIAl5sPQsS0mAT8mdihAA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:40 GMT
+      - BrowserId=XTTLrfOCQhm_nvMDX3n1bw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=753/48000
+      - api-usage=100/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,14 +197,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORsUAM"},"Id":"a1W4B000000gORsUAM","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSvyQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL5UAI"},"Id":"a1W4B0000018zL5UAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3qbQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:40 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:36 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORsUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zL5UAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +223,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:41 GMT
+      - Thu, 13 Apr 2017 20:48:37 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -232,12 +232,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=aKcjsxMPT3S7qVryd0f-XQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:41 GMT
+      - BrowserId=i492WDFcRvW4iqvGkKU03Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=751/48000
+      - api-usage=102/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,17 +246,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKwUAK"},"Id":"a1S4B000000CvKwUAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207QUAQ"},"Id":"a1S4B000000207QUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORsUAM","Contact__c":"0034B00000BJSvyQAH"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zL5UAI","Contact__c":"0034B00000Fg3qbQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:41 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:37 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKwUAK
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207QUAQ
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":7,"E_Created_Date__c":"2017-03-13T22:12:35Z","Teacher_Join_URL__c":"http://localhost:3001/teach/714f8a1f084e2d4100f7aa62f53fcd19/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":7,"E_Created_Date__c":"2017-04-13T20:48:31Z","Teacher_Join_URL__c":"http://localhost:3001/teach/12c2a8bf61cfb6b16d38a111f43a79dd/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -274,7 +274,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:41 GMT
+      - Thu, 13 Apr 2017 20:48:37 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -283,15 +283,15 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=kwsmk79yTYOcv2fBYAfl3A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:41 GMT
+      - BrowserId=NMqVbQRbS-qw8qEhto29OQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=101/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:41 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handles_final_OSA_save_errors.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handles_final_OSA_save_errors.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Ivah","LastName":"Cole","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Ansley","LastName":"Schoen","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:32 GMT
+      - Thu, 20 Apr 2017 04:01:31 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Sne9JAhvSXGDpOv7Qaf7IA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:32 GMT
+      - BrowserId=hxHTGYV5QrSDaXdzhMB9mQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=274/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3qbQAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOyQAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3qbQAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOyQAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:33 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:32 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3qbQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvOyQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:34 GMT
+      - Thu, 20 Apr 2017 04:01:32 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ymrWQu-xSJiBQbBZllA3Sg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:34 GMT
+      - BrowserId=pD4GSXVuT3yyWByI4nzw-Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=101/48000
+      - api-usage=269/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL5UAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cdUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zL5UAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cdUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:34 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:36 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zL5UAI","Contact__c":"0034B00000Fg3qbQAB"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cdUAA","Contact__c":"0030S000004VvOyQAK"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:35 GMT
+      - Thu, 20 Apr 2017 04:01:36 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=h5poBmZkRnC1n_xsjMSs2g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:35 GMT
+      - BrowserId=DuTT646rQ4O-BS3Y792aCg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=102/48000
+      - api-usage=264/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207QUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512hUAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207QUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512hUAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:36 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:37 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3qbQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOyQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:36 GMT
+      - Thu, 20 Apr 2017 04:01:37 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=XTTLrfOCQhm_nvMDX3n1bw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:36 GMT
+      - BrowserId=0O1oRSfgQbCcXfLK8cOy2Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=267/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,14 +198,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zL5UAI"},"Id":"a1W4B0000018zL5UAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3qbQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cdUAA"},"Id":"a1W0S00000065cdUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOyQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:36 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:37 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zL5UAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cdUAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:37 GMT
+      - Thu, 20 Apr 2017 04:01:38 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -232,12 +233,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=i492WDFcRvW4iqvGkKU03Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:37 GMT
+      - BrowserId=mjGpZ9O8SDuxfYcHsYbvQQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=102/48000
+      - api-usage=268/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,17 +247,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207QUAQ"},"Id":"a1S4B000000207QUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512hUAA"},"Id":"a1S0S000000512hUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zL5UAI","Contact__c":"0034B00000Fg3qbQAB"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cdUAA","Contact__c":"0030S000004VvOyQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:37 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:38 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207QUAQ
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512hUAA"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":7,"E_Created_Date__c":"2017-04-13T20:48:31Z","Teacher_Join_URL__c":"http://localhost:3001/teach/12c2a8bf61cfb6b16d38a111f43a79dd/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":7,"E_Created_Date__c":"2017-04-20T04:01:29Z","Teacher_Join_URL__c":"http://localhost:3001/teach/30cccbb994da8f8f0bf82e8e3128036f/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -274,7 +275,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:37 GMT
+      - Thu, 20 Apr 2017 04:01:38 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -283,15 +284,15 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=NMqVbQRbS-qw8qEhto29OQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:37 GMT
+      - BrowserId=l_0rDbwITQiwK11KqsTaSQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=101/48000
+      - api-usage=271/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:37 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_already_attached.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_already_attached.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Rosemarie","LastName":"Torphy","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Jany","LastName":"Schulist","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:25 GMT
+      - Thu, 13 Apr 2017 20:48:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=TaHfR7rBTQiJaCCC3ssx8g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:25 GMT
+      - BrowserId=wMPuxDFUTneGRSB-BauBXw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=749/48000
+      - api-usage=102/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxjQAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3qeQAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxjQAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3qeQAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:26 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:21 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxjQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3qeQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:26 GMT
+      - Thu, 13 Apr 2017 20:48:21 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=0I6txInWTKOqSvqqiSdINw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:26 GMT
+      - BrowserId=WDzY20rmT6iiYQMdoA_Q3w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=749/48000
+      - api-usage=99/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORiUAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKvUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORiUAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zKvUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:27 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:22 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gORiUAM","Contact__c":"0034B00000BJSxjQAH"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKvUAI","Contact__c":"0034B00000Fg3qeQAB"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +125,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:27 GMT
+      - Thu, 13 Apr 2017 20:48:22 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +134,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Y1GvHyuwRemjKO6UVwUy_w;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:27 GMT
+      - BrowserId=UEg-2626RI6gZ5IL7WHaAg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=99/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKmUAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +150,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvKmUAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207GUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:28 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:23 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20IN%20(%27a1S4B000000CvKmUAK%27))
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20IN%20(%27a1S4B000000207GUAQ%27))
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:28 GMT
+      - Thu, 13 Apr 2017 20:48:23 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +183,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pqsKcEcWRNaTztkaYm6wOQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:28 GMT
+      - BrowserId=FSXUcDasQHWO7DSmTe390g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=103/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,17 +197,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKmUAK"},"Id":"a1S4B000000CvKmUAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ"},"Id":"a1S4B000000207GUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORiUAM","Contact__c":"0034B00000BJSxjQAH"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKvUAI","Contact__c":"0034B00000Fg3qeQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:28 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:23 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKmUAK
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":5,"E_Created_Date__c":"2017-03-13T22:12:23Z","Teacher_Join_URL__c":"http://localhost:3001/teach/810a67701de54bc695dd02a85b1eb2e7/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":5,"E_Created_Date__c":"2017-04-13T20:48:18Z","Teacher_Join_URL__c":"http://localhost:3001/teach/29f185ad1c4d02d39e3f6d47413673bc/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -225,7 +225,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:29 GMT
+      - Thu, 13 Apr 2017 20:48:24 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -234,20 +234,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=GGdHR5ehTqyOOzU9bflhfw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:29 GMT
+      - BrowserId=IIu6iZK8Taalq5M0a_WZbw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=755/48000
+      - api-usage=101/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:29 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:24 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvKmUAK%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207GUAQ%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -266,7 +266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:29 GMT
+      - Thu, 13 Apr 2017 20:48:24 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -275,12 +275,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=OiFAH6MHToe3CWOMXI30rw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:29 GMT
+      - BrowserId=60WU8czMRWKkxjGlU3VJiA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=751/48000
+      - api-usage=100/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -289,9 +289,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKmUAK"},"Id":"a1S4B000000CvKmUAK","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"5","E_Created_Date__c":"2017-03-13T22:12:23.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/5/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/810a67701de54bc695dd02a85b1eb2e7/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ"},"Id":"a1S4B000000207GUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"5","E_Created_Date__c":"2017-04-13T20:48:18.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/5/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/29f185ad1c4d02d39e3f6d47413673bc/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORiUAM","Contact__c":"0034B00000BJSxjQAH"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKvUAI","Contact__c":"0034B00000Fg3qeQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:29 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_already_attached.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_already_attached.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jany","LastName":"Schulist","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Veda","LastName":"Bauch","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:20 GMT
+      - Thu, 20 Apr 2017 04:01:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=wMPuxDFUTneGRSB-BauBXw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:20 GMT
+      - BrowserId=26ldQfr_Qua7moM8LJ9Zng;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=102/48000
+      - api-usage=259/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3qeQAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOoQAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3qeQAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOoQAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:21 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:14 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3qeQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvOoQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:21 GMT
+      - Thu, 20 Apr 2017 04:01:14 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=WDzY20rmT6iiYQMdoA_Q3w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:21 GMT
+      - BrowserId=6O9npzuPRfmxbqIwAp8_hQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=260/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKvUAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cTUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zKvUAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cTUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:22 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:18 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKvUAI","Contact__c":"0034B00000Fg3qeQAB"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cTUAQ","Contact__c":"0030S000004VvOoQAK"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:22 GMT
+      - Thu, 20 Apr 2017 04:01:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=UEg-2626RI6gZ5IL7WHaAg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:22 GMT
+      - BrowserId=YpZYpgIAQW6fQUzMP-hq7Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=263/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207GUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512XUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:23 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:19 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20IN%20(%27a1S4B000000207GUAQ%27))
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20IN%20(%27a1S0S000000512XUAQ%27))"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:23 GMT
+      - Thu, 20 Apr 2017 04:01:19 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FSXUcDasQHWO7DSmTe390g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:23 GMT
+      - BrowserId=upSOPTslS5W-SRzA5Pkwew;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/48000
+      - api-usage=262/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,17 +198,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ"},"Id":"a1S4B000000207GUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"},"Id":"a1S0S000000512XUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKvUAI","Contact__c":"0034B00000Fg3qeQAB"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cTUAQ","Contact__c":"0030S000004VvOoQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:23 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:19 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":5,"E_Created_Date__c":"2017-04-13T20:48:18Z","Teacher_Join_URL__c":"http://localhost:3001/teach/29f185ad1c4d02d39e3f6d47413673bc/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":5,"E_Created_Date__c":"2017-04-20T04:01:11Z","Teacher_Join_URL__c":"http://localhost:3001/teach/3d78109cbf1a745a677dba7aed8d2a45/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -225,7 +226,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:24 GMT
+      - Thu, 20 Apr 2017 04:01:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -234,20 +235,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=IIu6iZK8Taalq5M0a_WZbw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:24 GMT
+      - BrowserId=huXwM6SaQlCHkxzGVA8itA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=101/48000
+      - api-usage=262/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:24 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:20 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207GUAQ%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512XUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -266,7 +267,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:24 GMT
+      - Thu, 20 Apr 2017 04:01:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -275,12 +276,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=60WU8czMRWKkxjGlU3VJiA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:24 GMT
+      - BrowserId=CftrLomtTmW0QtyR7Blx-A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=261/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -289,9 +290,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207GUAQ"},"Id":"a1S4B000000207GUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"5","E_Created_Date__c":"2017-04-13T20:48:18.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/5/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/29f185ad1c4d02d39e3f6d47413673bc/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"},"Id":"a1S0S000000512XUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"5","E_Created_Date__c":"2017-04-20T04:01:11.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/5/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/3d78109cbf1a745a677dba7aed8d2a45/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKvUAI","Contact__c":"0034B00000Fg3qeQAB"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cTUAQ","Contact__c":"0030S000004VvOoQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:24 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_not_yet_attached.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_not_yet_attached.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jerrell","LastName":"Brakus","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Amparo","LastName":"Schroeder","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:18 GMT
+      - Thu, 13 Apr 2017 20:48:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=yIVgMiuDRCSE65c_kQOaNg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:18 GMT
+      - BrowserId=_KKzXD1uSUGpR84ApSesIQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=753/48000
+      - api-usage=99/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxeQAH"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pcQAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxeQAH","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3pcQAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:19 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:14 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxeQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3pcQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:19 GMT
+      - Thu, 13 Apr 2017 20:48:14 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=mhrFVDduTra2txYB86OIYg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:19 GMT
+      - BrowserId=XO197RuFQvWgRCXWunQm2A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=754/48000
+      - api-usage=100/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORdUAM"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKqUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORdUAM","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zKqUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:20 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:15 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gORdUAM","Contact__c":"0034B00000BJSxeQAH"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKqUAI","Contact__c":"0034B00000Fg3pcQAB"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +125,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:20 GMT
+      - Thu, 13 Apr 2017 20:48:15 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +134,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=IflHOMMfTpqusayGAhn4Kw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:20 GMT
+      - BrowserId=qpCxUyAHRTeRzQ4V7V8ngg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=749/48000
+      - api-usage=101/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKhUAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +150,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvKhUAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B000000207BUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:21 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:16 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxeQAH%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pcQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:21 GMT
+      - Thu, 13 Apr 2017 20:48:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +183,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4rnwKWOsRuyfN_fTkDnz3A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:21 GMT
+      - BrowserId=KmWjHoyDSt6M00CZyGKjSg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=748/48000
+      - api-usage=99/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,14 +197,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORdUAM"},"Id":"a1W4B000000gORdUAM","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxeQAH","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKqUAI"},"Id":"a1W4B0000018zKqUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3pcQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:22 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:17 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORdUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKqUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +223,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:22 GMT
+      - Thu, 13 Apr 2017 20:48:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -232,12 +232,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=GiycnzpYSF-xy47bK-90BA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:22 GMT
+      - BrowserId=z4VWR1lXQFKX0WdTfGkbYA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=747/48000
+      - api-usage=100/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,17 +246,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKhUAK"},"Id":"a1S4B000000CvKhUAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ"},"Id":"a1S4B000000207BUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORdUAM","Contact__c":"0034B00000BJSxeQAH"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKqUAI","Contact__c":"0034B00000Fg3pcQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:22 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:17 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKhUAK
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":4,"E_Created_Date__c":"2017-03-13T22:12:16Z","Teacher_Join_URL__c":"http://localhost:3001/teach/8bc4421d79fc2d651bc390cd847d8798/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":4,"E_Created_Date__c":"2017-04-13T20:48:11Z","Teacher_Join_URL__c":"http://localhost:3001/teach/1f43d80e749d435fd1f88246dd5c0fbe/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -274,7 +274,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:22 GMT
+      - Thu, 13 Apr 2017 20:48:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -283,20 +283,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=epMOWVAaTvWOpgSb0AoSbg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:22 GMT
+      - BrowserId=hFNkdZqYQemSUdCRhVpK_Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=748/48000
+      - api-usage=100/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:23 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:18 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvKhUAK%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207BUAQ%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -315,7 +315,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:23 GMT
+      - Thu, 13 Apr 2017 20:48:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -324,12 +324,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4eYCTiK-S2iN9FitbOHOwA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:23 GMT
+      - BrowserId=nhoZpP0oRzGtIPV8OQNSZw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=748/48000
+      - api-usage=101/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -338,9 +338,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKhUAK"},"Id":"a1S4B000000CvKhUAK","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"4","E_Created_Date__c":"2017-03-13T22:12:16.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/4/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/8bc4421d79fc2d651bc390cd847d8798/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ"},"Id":"a1S4B000000207BUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"4","E_Created_Date__c":"2017-04-13T20:48:11.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/4/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/1f43d80e749d435fd1f88246dd5c0fbe/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORdUAM","Contact__c":"0034B00000BJSxeQAH"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKqUAI","Contact__c":"0034B00000Fg3pcQAB"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:23 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_not_yet_attached.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_not_yet_attached.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Amparo","LastName":"Schroeder","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Jerod","LastName":"Bashirian","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:13 GMT
+      - Thu, 20 Apr 2017 04:01:05 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=_KKzXD1uSUGpR84ApSesIQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:13 GMT
+      - BrowserId=6uYQD32SR-GMdeU7W6QbuA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=261/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pcQAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOjQAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3pcQAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOjQAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:14 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:06 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3pcQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvOjQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:14 GMT
+      - Thu, 20 Apr 2017 04:01:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=XO197RuFQvWgRCXWunQm2A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:14 GMT
+      - BrowserId=yvMEyGN1RriTObOPynj9hQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=259/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKqUAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cOUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zKqUAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cOUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:15 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:09 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKqUAI","Contact__c":"0034B00000Fg3pcQAB"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cOUAQ","Contact__c":"0030S000004VvOjQAK"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -125,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:15 GMT
+      - Thu, 20 Apr 2017 04:01:09 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -134,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=qpCxUyAHRTeRzQ4V7V8ngg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:15 GMT
+      - BrowserId=jB80DfFZSFuYCijwYvwiPg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=101/48000
+      - api-usage=259/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000207BUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512SUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:16 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:10 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pcQAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOjQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:17 GMT
+      - Thu, 20 Apr 2017 04:01:10 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -183,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=KmWjHoyDSt6M00CZyGKjSg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:17 GMT
+      - BrowserId=VEPgrggCT6CIO7qz3jriYA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=260/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,14 +198,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKqUAI"},"Id":"a1W4B0000018zKqUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3pcQAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cOUAQ"},"Id":"a1W0S00000065cOUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOjQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:17 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:10 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKqUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cOUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:17 GMT
+      - Thu, 20 Apr 2017 04:01:10 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -232,12 +233,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=z4VWR1lXQFKX0WdTfGkbYA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:17 GMT
+      - BrowserId=1NKXxwmhSriaoe9jDAcjmA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=261/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,17 +247,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ"},"Id":"a1S4B000000207BUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"},"Id":"a1S0S000000512SUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKqUAI","Contact__c":"0034B00000Fg3pcQAB"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cOUAQ","Contact__c":"0030S000004VvOjQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:17 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:10 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":4,"E_Created_Date__c":"2017-04-13T20:48:11Z","Teacher_Join_URL__c":"http://localhost:3001/teach/1f43d80e749d435fd1f88246dd5c0fbe/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":4,"E_Created_Date__c":"2017-04-20T04:01:03Z","Teacher_Join_URL__c":"http://localhost:3001/teach/1a90ca697100d67b28772dd59ed806ee/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -274,7 +275,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:17 GMT
+      - Thu, 20 Apr 2017 04:01:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -283,20 +284,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hFNkdZqYQemSUdCRhVpK_Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:17 GMT
+      - BrowserId=6JMm6HDPTG2GjA0IRdTmFw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=260/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:18 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:11 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000207BUAQ%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512SUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -315,7 +316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:18 GMT
+      - Thu, 20 Apr 2017 04:01:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -324,12 +325,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nhoZpP0oRzGtIPV8OQNSZw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:18 GMT
+      - BrowserId=Z3NctbRrSDaCwuat5AnOYA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=101/48000
+      - api-usage=262/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -338,9 +339,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000207BUAQ"},"Id":"a1S4B000000207BUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"4","E_Created_Date__c":"2017-04-13T20:48:11.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/4/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/1f43d80e749d435fd1f88246dd5c0fbe/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"},"Id":"a1S0S000000512SUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"4","E_Created_Date__c":"2017-04-20T04:01:03.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/4/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/1a90ca697100d67b28772dd59ed806ee/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKqUAI","Contact__c":"0034B00000Fg3pcQAB"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cOUAQ","Contact__c":"0030S000004VvOjQAK"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:18 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/errors_when_cannot_make_an_OSA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/errors_when_cannot_make_an_OSA.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Kenyon","LastName":"Rosenbaum","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Alberta","LastName":"Klocko","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:13 GMT
+      - Thu, 13 Apr 2017 20:48:09 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=T3poRvfPTCOMLs_SFzZBlw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:13 GMT
+      - BrowserId=IPsUxS21T82Hs2WRN95cyw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=752/48000
+      - api-usage=98/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxZQAX"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3q0QAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxZQAX","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3q0QAB","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:14 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:10 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxZQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3q0QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:15 GMT
+      - Thu, 13 Apr 2017 20:48:10 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=R3HafEEwQ9SMlVnk0Jp2Xw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:15 GMT
+      - BrowserId=6z1qxBkkRT-qiF-iMiOKtw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=750/48000
+      - api-usage=99/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORYUA2"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKlUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,12 +99,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORYUA2","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zKlUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:15 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:10 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxZQAX%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3q0QAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -123,7 +123,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:16 GMT
+      - Thu, 13 Apr 2017 20:48:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -132,12 +132,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=X7gQWTw3QpaSKG6ymhPLyA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:16 GMT
+      - BrowserId=GIuuk-s-TyenoLSstkFkBg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=751/48000
+      - api-usage=99/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,14 +146,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORYUA2"},"Id":"a1W4B000000gORYUA2","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxZQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKlUAI"},"Id":"a1W4B0000018zKlUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3q0QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:16 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:11 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORYUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKlUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:16 GMT
+      - Thu, 13 Apr 2017 20:48:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -181,12 +181,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=BPlXEEFrRqKRagHZhMV5JA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:16 GMT
+      - BrowserId=YYDdAn3iSYm--F8fr0uHhg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=748/48000
+      - api-usage=98/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,5 +197,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:16 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/errors_when_cannot_make_an_OSA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/errors_when_cannot_make_an_OSA.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Alberta","LastName":"Klocko","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Michael","LastName":"Gutmann","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:09 GMT
+      - Thu, 20 Apr 2017 04:00:59 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=IPsUxS21T82Hs2WRN95cyw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:09 GMT
+      - BrowserId=sEgiN3rISnOdcb2iGjhNqA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=265/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3q0QAB"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOeQAK"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3q0QAB","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOeQAK","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:10 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:00 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3q0QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvOeQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:10 GMT
+      - Thu, 20 Apr 2017 04:01:00 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6z1qxBkkRT-qiF-iMiOKtw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:10 GMT
+      - BrowserId=44j2rd8GSmCLpR-RhfXD-Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=260/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKlUAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cJUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,12 +100,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zKlUAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cJUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:10 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:02 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3q0QAB%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOeQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -123,7 +124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:11 GMT
+      - Thu, 20 Apr 2017 04:01:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -132,12 +133,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=GIuuk-s-TyenoLSstkFkBg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:11 GMT
+      - BrowserId=oGTY-SAmTSqKN8Fq8EVqnw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=258/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,14 +147,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKlUAI"},"Id":"a1W4B0000018zKlUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3q0QAB","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cJUAQ"},"Id":"a1W0S00000065cJUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOeQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:11 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:03 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKlUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cJUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:11 GMT
+      - Thu, 20 Apr 2017 04:01:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -181,12 +182,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=YYDdAn3iSYm--F8fr0uHhg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:11 GMT
+      - BrowserId=iwuSd9ftQC2LfUntIySXdQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:01:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=259/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,5 +198,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:11 GMT
+  recorded_at: Thu, 20 Apr 2017 04:01:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/makes_an_OSA_and_pushes_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/makes_an_OSA_and_pushes_stats.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Tony","LastName":"Davis","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Hunter","LastName":"Goodwin","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:01 GMT
+      - Thu, 20 Apr 2017 04:00:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=oHL8xyoZSGetkgNpedcrJA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:01 GMT
+      - BrowserId=6vYX9iE-T-u0S5s3WzZj5g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=97/48000
+      - api-usage=263/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pRQAR"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOUQA0"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3pRQAR","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOUQA0","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:02 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:50 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3pRQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0030S000004VvOUQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:02 GMT
+      - Thu, 20 Apr 2017 04:00:50 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=f4quqnUqRumZ-XuMUYsAPA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:02 GMT
+      - BrowserId=evbUvK6ORUChnEXwv4B7Ww;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=97/48000
+      - api-usage=258/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKgUAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cEUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,12 +100,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zKgUAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065cEUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:02 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:53 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pRQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOUQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -123,7 +124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:03 GMT
+      - Thu, 20 Apr 2017 04:00:54 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -132,12 +133,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8yPQLHmbQ96-rkwQMAXecw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:03 GMT
+      - BrowserId=so0YXhdNSyCU4j3JGxBGzg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=99/48000
+      - api-usage=258/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,14 +147,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKgUAI"},"Id":"a1W4B0000018zKgUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3pRQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
-        - 17 Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cEUAQ"},"Id":"a1W0S00000065cEUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOUQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:03 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:54 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKgUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cEUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:03 GMT
+      - Thu, 20 Apr 2017 04:00:54 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -181,12 +182,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=DvmSQDrOTqulwNGF9hXrIw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:03 GMT
+      - BrowserId=oZqWWoM6TbCFqeGJr7xO2Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=259/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,13 +198,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:03 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:54 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -221,7 +222,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:04 GMT
+      - Thu, 20 Apr 2017 04:00:55 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -230,14 +231,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FGTQy7YYTDSiEuxyTCCWWQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:04 GMT
+      - BrowserId=gmAqiig7Szme-Lsx4ZzYRw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=97/48000
+      - api-usage=259/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,12 +247,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B0000002076UAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512NUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:05 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:55 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002076UAA%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512NUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -270,7 +271,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:05 GMT
+      - Thu, 20 Apr 2017 04:00:56 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -279,12 +280,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=LqzfEmFCQVmxsj72JlM9gA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:05 GMT
+      - BrowserId=viE3WjbNSFCsBLyjqq7Yzg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=264/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -293,17 +294,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"},"Id":"a1S4B0000002076UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"},"Id":"a1S0S000000512NUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:05 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:56 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":2,"E_Created_Date__c":"2017-04-13T20:47:59Z","Teacher_Join_URL__c":"http://localhost:3001/teach/f5b54ac3598845a9d37a0f21c38ddb2c/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":2,"E_Created_Date__c":"2017-04-20T04:00:47Z","Teacher_Join_URL__c":"http://localhost:3001/teach/5cea9c3fead3ee5fb0cdd283b908d5e2/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -321,7 +322,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:06 GMT
+      - Thu, 20 Apr 2017 04:00:56 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -330,20 +331,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Be66eOi5QYKlpgAjcDIDwA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:06 GMT
+      - BrowserId=8UxYF2OdQKSBsfwK2Jot1g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=260/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:06 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:56 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKgUAI%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cEUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -362,7 +363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:06 GMT
+      - Thu, 20 Apr 2017 04:00:56 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -371,12 +372,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=E0Dtc94ZReeO0qLHqwGvwA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:06 GMT
+      - BrowserId=fbRPxpibSnGGSXxk9WrN3Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=261/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -385,14 +386,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"},"Id":"a1S4B0000002076UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-13T20:47:59.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/f5b54ac3598845a9d37a0f21c38ddb2c/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"},"Id":"a1S0S000000512NUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-20T04:00:47.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/5cea9c3fead3ee5fb0cdd283b908d5e2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:06 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:57 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002076UAA%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512NUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -411,7 +412,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:48:07 GMT
+      - Thu, 20 Apr 2017 04:00:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -420,12 +421,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=w720XjCjR--XUcRaL3_5jg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:48:07 GMT
+      - BrowserId=xfi4KF0MSSSazoV76oaT4w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/48000
+      - api-usage=259/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -434,9 +435,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"},"Id":"a1S4B0000002076UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-13T20:47:59.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/f5b54ac3598845a9d37a0f21c38ddb2c/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"},"Id":"a1S0S000000512NUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-20T04:00:47.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/5cea9c3fead3ee5fb0cdd283b908d5e2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:48:07 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/makes_an_OSA_and_pushes_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/makes_an_OSA_and_pushes_stats.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jerome","LastName":"Moore","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Tony","LastName":"Davis","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:05 GMT
+      - Thu, 13 Apr 2017 20:48:01 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5Fk0AlJQSa-3Xbt8ujS_Ew;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:05 GMT
+      - BrowserId=oHL8xyoZSGetkgNpedcrJA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=746/48000
+      - api-usage=97/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxUQAX"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pRQAR"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxUQAX","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3pRQAR","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:06 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:02 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxUQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
+      string: '{"Contact__c":"0034B00000Fg3pRQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,7 +74,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:06 GMT
+      - Thu, 13 Apr 2017 20:48:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -83,14 +83,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=vsy6hlafTcaXu_IhawqQpQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:06 GMT
+      - BrowserId=f4quqnUqRumZ-XuMUYsAPA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=97/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORTUA2"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKgUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -99,12 +99,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gORTUA2","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zKgUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:07 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:02 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxUQAX%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pRQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -123,7 +123,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:07 GMT
+      - Thu, 13 Apr 2017 20:48:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -132,12 +132,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jPQtR3GQTTKr2RqOi8Wyhg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:07 GMT
+      - BrowserId=8yPQLHmbQ96-rkwQMAXecw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=747/48000
+      - api-usage=99/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,14 +146,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gORTUA2"},"Id":"a1W4B000000gORTUA2","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxUQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKgUAI"},"Id":"a1W4B0000018zKgUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3pRQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:07 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:03 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORTUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKgUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:07 GMT
+      - Thu, 13 Apr 2017 20:48:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -181,12 +181,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hxvsqogyRAC-JsiWmPkshw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:07 GMT
+      - BrowserId=DvmSQDrOTqulwNGF9hXrIw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=746/48000
+      - api-usage=98/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -197,13 +197,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:07 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:03 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gORTUA2","Contact__c":"0034B00000BJSxUQAX"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -221,7 +221,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:08 GMT
+      - Thu, 13 Apr 2017 20:48:04 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -230,14 +230,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=lbf1YnGaRkyc9eTluODFiA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:08 GMT
+      - BrowserId=FGTQy7YYTDSiEuxyTCCWWQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=748/48000
+      - api-usage=97/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKcUAK"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -246,12 +246,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvKcUAK","success":true,"errors":[]}'
+      string: '{"id":"a1S4B0000002076UAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:09 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:05 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvKcUAK%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002076UAA%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -270,7 +270,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:09 GMT
+      - Thu, 13 Apr 2017 20:48:05 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -279,12 +279,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=gduj_mocQjmV64YDeeDQ3A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:09 GMT
+      - BrowserId=LqzfEmFCQVmxsj72JlM9gA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=747/48000
+      - api-usage=98/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -293,17 +293,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKcUAK"},"Id":"a1S4B000000CvKcUAK","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"},"Id":"a1S4B0000002076UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORTUA2","Contact__c":"0034B00000BJSxUQAX"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:09 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:05 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKcUAK
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":2,"E_Created_Date__c":"2017-03-13T22:12:03Z","Teacher_Join_URL__c":"http://localhost:3001/teach/b6aba804ed0e258581656ba6e35d3ac5/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":2,"E_Created_Date__c":"2017-04-13T20:47:59Z","Teacher_Join_URL__c":"http://localhost:3001/teach/f5b54ac3598845a9d37a0f21c38ddb2c/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -321,7 +321,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:10 GMT
+      - Thu, 13 Apr 2017 20:48:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -330,20 +330,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-knHnir9Rt2AW_a1EgKXUQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:10 GMT
+      - BrowserId=Be66eOi5QYKlpgAjcDIDwA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=749/48000
+      - api-usage=98/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:10 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:06 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gORTUA2%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKgUAI%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -362,7 +362,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:10 GMT
+      - Thu, 13 Apr 2017 20:48:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -371,12 +371,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=yfQBA9LyQz-CqaV8asQ6oQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:10 GMT
+      - BrowserId=E0Dtc94ZReeO0qLHqwGvwA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=749/48000
+      - api-usage=98/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -385,14 +385,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKcUAK"},"Id":"a1S4B000000CvKcUAK","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-03-13T22:12:03.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/b6aba804ed0e258581656ba6e35d3ac5/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"},"Id":"a1S4B0000002076UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-13T20:47:59.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/f5b54ac3598845a9d37a0f21c38ddb2c/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORTUA2","Contact__c":"0034B00000BJSxUQAX"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:10 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:06 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvKcUAK%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002076UAA%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -411,7 +411,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:11 GMT
+      - Thu, 13 Apr 2017 20:48:07 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -420,12 +420,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=czcc5S9JQQaRTHy53eyBpw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:11 GMT
+      - BrowserId=w720XjCjR--XUcRaL3_5jg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:48:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=751/48000
+      - api-usage=100/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -434,9 +434,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKcUAK"},"Id":"a1S4B000000CvKcUAK","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-03-13T22:12:03.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/b6aba804ed0e258581656ba6e35d3ac5/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002076UAA"},"Id":"a1S4B0000002076UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-13T20:47:59.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/f5b54ac3598845a9d37a0f21c38ddb2c/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gORTUA2","Contact__c":"0034B00000BJSxUQAX"}]}'
+        - 17 Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKgUAI","Contact__c":"0034B00000Fg3pRQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:11 GMT
+  recorded_at: Thu, 13 Apr 2017 20:48:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_no_existing_IA/makes_both_and_pushes_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_no_existing_IA/makes_both_and_pushes_stats.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Evan","LastName":"Gibson","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Derick","LastName":"Nienow","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:51 GMT
+      - Thu, 20 Apr 2017 04:00:37 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=sMF-in5VRRm-UH_v3o9IuA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:51 GMT
+      - BrowserId=QxDPc9UwR6-SfRRrBy0cRw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=94/48000
+      - api-usage=258/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pMQAR"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOPQA0"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000Fg3pMQAR","success":true,"errors":[]}'
+      string: '{"id":"0030S000004VvOPQA0","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:52 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:38 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pMQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOPQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:53 GMT
+      - Thu, 20 Apr 2017 04:00:38 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Va4oI_rzS0Wrcof2g8tPBQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:53 GMT
+      - BrowserId=nkKKyQLwSc6-qDAOvVMppw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=94/48000
+      - api-usage=259/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:53 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:38 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3pMQAR%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvOPQA0%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:53 GMT
+      - Thu, 20 Apr 2017 04:00:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=h01o0yhTQCu_unIsTT9H-g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:53 GMT
+      - BrowserId=4wWvEhMcTl-vYRVicq9FNw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=95/48000
+      - api-usage=259/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,13 +142,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3pMQAR"},"Id":"0034B00000Fg3pMQAR","Name":"Evan
-        Gibson","FirstName":"Evan","LastName":"Gibson","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:47:52.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvOPQA0"},"Id":"0030S000004VvOPQA0","Name":"Derick
+        Nienow","FirstName":"Derick","LastName":"Nienow","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:00:38.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:53 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:39 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:54 GMT
+      - Thu, 20 Apr 2017 04:00:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=p1g7y7eKQiGvXDMNcnhIVA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:54 GMT
+      - BrowserId=D0OvrR3NSSWxgDADElgCfQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=94/48000
+      - api-usage=258/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -190,15 +190,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:54 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:39 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000Fg3pMQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
+      string: '{"Contact__c":"0030S000004VvOPQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +217,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:54 GMT
+      - Thu, 20 Apr 2017 04:00:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,14 +226,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=a4gGctXhShOy95UhlZSZtw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:54 GMT
+      - BrowserId=v85iRBc8SPGE_XeDVDf4nA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=94/48000
+      - api-usage=258/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKbUAI"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065c9UAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -241,12 +242,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B0000018zKbUAI","success":true,"errors":[]}'
+      string: '{"id":"a1W0S00000065c9UAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:55 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:43 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKbUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065c9UAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:55 GMT
+      - Thu, 20 Apr 2017 04:00:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -274,12 +275,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4jfNfSF7Qg2LtrGBbWvWwQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:55 GMT
+      - BrowserId=-BGLzcFfTMGfpugrpcCm9g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=95/48000
+      - api-usage=260/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,13 +291,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:55 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:43 GMT
 - request:
     method: post
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -314,7 +315,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:55 GMT
+      - Thu, 20 Apr 2017 04:00:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -323,14 +324,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=UTAxbg-JQoao7g-2Lq-2iA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:55 GMT
+      - BrowserId=cJXZIbZQQGW1xDHxzMtdew;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=95/48000
+      - api-usage=260/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,12 +340,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B0000002071UAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S000000512IUAQ","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:56 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:44 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002071UAA%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512IUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:57 GMT
+      - Thu, 20 Apr 2017 04:00:45 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +373,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=C8eM7ijhQxaK3iAnMndDbA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:57 GMT
+      - BrowserId=mVZcpT_jTW2I-HQLt75Jxw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=96/48000
+      - api-usage=261/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,17 +387,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"},"Id":"a1S4B0000002071UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"},"Id":"a1S0S000000512IUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:57 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:45 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":1,"E_Created_Date__c":"2017-04-13T20:47:49Z","Teacher_Join_URL__c":"http://localhost:3001/teach/3a285fc98e54fd0162ffa45a3de41804/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":1,"E_Created_Date__c":"2017-04-20T04:00:35Z","Teacher_Join_URL__c":"http://localhost:3001/teach/537dd3c5b7e5ee1fd9f6edfde62e10c2/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -414,7 +415,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:57 GMT
+      - Thu, 20 Apr 2017 04:00:45 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -423,20 +424,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=KYG6hzadRJ2PIyaO3DAJxA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:57 GMT
+      - BrowserId=uDEzLs7nQ0GW3IGCQAsa5A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=96/48000
+      - api-usage=258/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:57 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:45 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pMQAR%27)
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOPQA0%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -455,7 +456,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:58 GMT
+      - Thu, 20 Apr 2017 04:00:46 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -464,12 +465,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=7y5oGYT1QLGeypft0cUnCw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:58 GMT
+      - BrowserId=SmugBcdCQN-Ke_C1OIvBhA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=97/48000
+      - api-usage=259/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -478,14 +479,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKbUAI"},"Id":"a1W4B0000018zKbUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3pMQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"fix
-        formula","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"TermYear__c":"fix
-        formula Spring","Class_Start_Date__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065c9UAA"},"Id":"a1W0S00000065c9UAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOPQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor","TermYear__c":"2016
+        - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:58 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:46 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKbUAI%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065c9UAA%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -504,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:58 GMT
+      - Thu, 20 Apr 2017 04:00:46 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -513,12 +515,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=NkARMHgvQ7mii59orQ8qQg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:58 GMT
+      - BrowserId=-gf6D_D6QBS62lNTl-ADqg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=98/48000
+      - api-usage=262/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -527,14 +529,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"},"Id":"a1S4B0000002071UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-13T20:47:49.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/3a285fc98e54fd0162ffa45a3de41804/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
-        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"},"Id":"a1S0S000000512IUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-20T04:00:35.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/537dd3c5b7e5ee1fd9f6edfde62e10c2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:58 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:46 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002071UAA%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512IUAQ%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -553,7 +555,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 13 Apr 2017 20:47:59 GMT
+      - Thu, 20 Apr 2017 04:00:47 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -562,12 +564,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=_W8CBcZgTE-uCJGvn_wPtQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        12-Jun-2017 20:47:59 GMT
+      - BrowserId=_pvXuH0_SaWjDj-G64IFHQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Jun-2017 04:00:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=96/48000
+      - api-usage=258/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -576,9 +578,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"},"Id":"a1S4B0000002071UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-13T20:47:49.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/3a285fc98e54fd0162ffa45a3de41804/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
-        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"},"Id":"a1S0S000000512IUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-20T04:00:35.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/537dd3c5b7e5ee1fd9f6edfde62e10c2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}]}'
     http_version: 
-  recorded_at: Thu, 13 Apr 2017 20:47:59 GMT
+  recorded_at: Thu, 20 Apr 2017 04:00:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_no_existing_IA/makes_both_and_pushes_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_no_existing_IA/makes_both_and_pushes_stats.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Contact
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Joelle","LastName":"Schroeder","AccountId":"0014B00000DaY04QAF"}'
+      string: '{"FirstName":"Evan","LastName":"Gibson","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:55 GMT
+      - Thu, 13 Apr 2017 20:47:51 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=y1sre47CTxyNNTWXXZ5Tog;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:55 GMT
+      - BrowserId=sMF-in5VRRm-UH_v3o9IuA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=94/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0034B00000BJSxPQAX"
+      - "/services/data/v29.0/sobjects/Contact/0034B00000Fg3pMQAR"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0034B00000BJSxPQAX","success":true,"errors":[]}'
+      string: '{"id":"0034B00000Fg3pMQAR","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:56 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:52 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxPQAX%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pMQAR%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:57 GMT
+      - Thu, 13 Apr 2017 20:47:53 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=3tEGFE1pR2qJOdH6sVESzg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:57 GMT
+      - BrowserId=Va4oI_rzS0Wrcof2g8tPBQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=94/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:57 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:53 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000BJSxPQAX%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000Fg3pMQAR%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:57 GMT
+      - Thu, 13 Apr 2017 20:47:53 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=iGeeldwBSuexkx5Lg4MyOA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:57 GMT
+      - BrowserId=h01o0yhTQCu_unIsTT9H-g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=95/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000BJSxPQAX"},"Id":"0034B00000BJSxPQAX","Name":"Joelle
-        Schroeder","FirstName":"Joelle","LastName":"Schroeder","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-03-13T22:11:56.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0034B00000Fg3pMQAR"},"Id":"0034B00000Fg3pMQAR","Name":"Evan
+        Gibson","FirstName":"Evan","LastName":"Gibson","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-13T20:47:52.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:57 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:53 GMT
 - request:
     method: get
     uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:57 GMT
+      - Thu, 13 Apr 2017 20:47:54 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=slNhCacURL-zFvp_KcgPhg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:57 GMT
+      - BrowserId=p1g7y7eKQiGvXDMNcnhIVA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=745/48000
+      - api-usage=94/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,13 +192,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxQUAQ"},"Id":"a0Z4B0000002sxQUAQ","Name":"Chemistry"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z4B0000002sxVUAQ"},"Id":"a0Z4B0000002sxVUAQ","Name":"Physics"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:57 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:54 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034B00000BJSxPQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
+      string: '{"Contact__c":"0034B00000Fg3pMQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -216,7 +216,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:58 GMT
+      - Thu, 13 Apr 2017 20:47:54 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -225,14 +225,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=kzMuTtnITWWMRKcCK5FN6A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:58 GMT
+      - BrowserId=a4gGctXhShOy95UhlZSZtw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=745/48000
+      - api-usage=94/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOROUA2"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKbUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -241,12 +241,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W4B000000gOROUA2","success":true,"errors":[]}'
+      string: '{"id":"a1W4B0000018zKbUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:58 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:55 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gOROUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKbUAI%27)%20AND%20(Product__c%20=%20%27Tutor%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +265,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:58 GMT
+      - Thu, 13 Apr 2017 20:47:55 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -274,12 +274,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Pa5R51oqR3iwmkac-l4AjA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:58 GMT
+      - BrowserId=4jfNfSF7Qg2LtrGBbWvWwQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=95/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,13 +290,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:11:59 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:55 GMT
 - request:
     method: post
     uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B000000gOROUA2","Contact__c":"0034B00000BJSxPQAX"}'
+      string: '{"Product__c":"Tutor","Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -314,7 +314,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:11:59 GMT
+      - Thu, 13 Apr 2017 20:47:55 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -323,14 +323,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ptQcbFzMSNqWr_asAeiW1Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:11:59 GMT
+      - BrowserId=UTAxbg-JQoao7g-2Lq-2iA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=95/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKXUA0"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,12 +339,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S4B000000CvKXUA0","success":true,"errors":[]}'
+      string: '{"id":"a1S4B0000002071UAA","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:00 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:56 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvKXUA0%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002071UAA%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:01 GMT
+      - Thu, 13 Apr 2017 20:47:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +372,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=znJLrhbKSB-Y--M8pZlprw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:01 GMT
+      - BrowserId=C8eM7ijhQxaK3iAnMndDbA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=96/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,17 +386,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKXUA0"},"Id":"a1S4B000000CvKXUA0","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"},"Id":"a1S4B0000002071UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOROUA2","Contact__c":"0034B00000BJSxPQAX"}]}'
+        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:01 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:57 GMT
 - request:
     method: patch
-    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKXUA0
+    uri: https://cs51.salesforce.com/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":1,"E_Created_Date__c":"2017-03-13T22:11:53Z","Teacher_Join_URL__c":"http://localhost:3001/teach/f649a72b3eb1127a9d0142aaa4cbc290/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":1,"E_Created_Date__c":"2017-04-13T20:47:49Z","Teacher_Join_URL__c":"http://localhost:3001/teach/3a285fc98e54fd0162ffa45a3de41804/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -414,7 +414,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:01 GMT
+      - Thu, 13 Apr 2017 20:47:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -423,20 +423,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=WI2TOZBEQ6SAs4N-3VryPg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:01 GMT
+      - BrowserId=KYG6hzadRJ2PIyaO3DAJxA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=744/48000
+      - api-usage=96/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:02 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:57 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000BJSxPQAX%27)
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270034B00000Fg3pMQAR%27)
     body:
       encoding: US-ASCII
       string: ''
@@ -455,7 +455,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:02 GMT
+      - Thu, 13 Apr 2017 20:47:58 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -464,12 +464,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=IC76sDOwQh-eX769AMuICw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:02 GMT
+      - BrowserId=7y5oGYT1QLGeypft0cUnCw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=745/48000
+      - api-usage=97/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -478,14 +478,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B000000gOROUA2"},"Id":"a1W4B000000gOROUA2","Book_Text__c":"Chemistry","Contact__c":"0034B00000BJSxPQAX","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"fix
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W4B0000018zKbUAI"},"Id":"a1W4B0000018zKbUAI","Book_Text__c":"Chemistry","Contact__c":"0034B00000Fg3pMQAR","Book__c":"a0Z4B0000002sxQUAQ","Account__c":"0014B00000DaY04QAF","School_Year__c":"fix
         formula","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"TermYear__c":"fix
         formula Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:02 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:58 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B000000gOROUA2%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W4B0000018zKbUAI%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -504,7 +504,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:02 GMT
+      - Thu, 13 Apr 2017 20:47:58 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -513,12 +513,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=LdyIImfJS6qhTRUm8H9Bng;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:02 GMT
+      - BrowserId=NkARMHgvQ7mii59orQ8qQg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=745/48000
+      - api-usage=98/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -527,14 +527,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKXUA0"},"Id":"a1S4B000000CvKXUA0","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-03-13T22:11:53.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/f649a72b3eb1127a9d0142aaa4cbc290/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"},"Id":"a1S4B0000002071UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-13T20:47:49.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/3a285fc98e54fd0162ffa45a3de41804/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOROUA2","Contact__c":"0034B00000BJSxPQAX"}]}'
+        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:02 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:58 GMT
 - request:
     method: get
-    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B000000CvKXUA0%27)%20LIMIT%201
+    uri: https://cs51.salesforce.com/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S4B0000002071UAA%27)%20LIMIT%201
     body:
       encoding: US-ASCII
       string: ''
@@ -553,7 +553,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 22:12:03 GMT
+      - Thu, 13 Apr 2017 20:47:59 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -562,12 +562,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=yQsV3AplS0CQq5SBbiQwwQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        12-May-2017 22:12:03 GMT
+      - BrowserId=_W8CBcZgTE-uCJGvn_wPtQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        12-Jun-2017 20:47:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=746/48000
+      - api-usage=96/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -576,9 +576,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B000000CvKXUA0"},"Id":"a1S4B000000CvKXUA0","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-03-13T22:11:53.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/f649a72b3eb1127a9d0142aaa4cbc290/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S4B0000002071UAA"},"Id":"a1S4B0000002071UAA","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-13T20:47:49.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/3a285fc98e54fd0162ffa45a3de41804/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"fix
-        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B000000gOROUA2","Contact__c":"0034B00000BJSxPQAX"}]}'
+        formula Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W4B0000018zKbUAI","Contact__c":"0034B00000Fg3pMQAR"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 22:12:03 GMT
+  recorded_at: Thu, 13 Apr 2017 20:47:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -62,6 +62,19 @@ RSpec.feature 'Admin editing a course' do
     expect(CourseProfile::Models::Course.first.is_college).to be_truthy
   end
 
+  scenario 'Changing "Is Test"' do
+    visit admin_courses_path
+    click_link 'Edit'
+
+    expect(page).to have_content('Edit Course')
+    check 'course_is_test'
+    click_button 'edit-save'
+
+    expect(current_path).to eq(admin_courses_path)
+    expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
+    expect(CourseProfile::Models::Course.first.is_test).to be_truthy
+  end
+
   scenario 'Assigning a school' do
     FactoryGirl.create(:school_district_school, name: 'High high hi school')
     visit admin_courses_path

--- a/spec/features/salesforce/push_salesforce_course_stats_spec.rb
+++ b/spec/features/salesforce/push_salesforce_course_stats_spec.rb
@@ -62,6 +62,9 @@ RSpec.describe "PushSalesforceCourseStats", vcr: VCR_OPTS do
         expect(ias.size).to eq 1
         ia = ias.first
 
+        expect(ia.id).not_to be_blank
+        expect(ia.spring_start_date).to eq "2017-01-01"
+
         osa = Salesforce::Remote::OsAncillary.where(individual_adoption_id: ia.id).first
 
         expect_osa_stats(osa)
@@ -220,7 +223,9 @@ RSpec.describe "PushSalesforceCourseStats", vcr: VCR_OPTS do
       contact_id: sf_contact_a.id,
       spring_start_date: "2017-01-01",
       book_id: @sfh.book_id("Chemistry"),
-      school_id: @sfh.school_id("JP University")
+      school_id: @sfh.school_id("JP University"),
+      adoption_level: "Confirmed Adoption Won",
+      description: "blah"
     ).tap do |ia|
       if !ia.save
         raise "didn't save IA"
@@ -232,7 +237,8 @@ RSpec.describe "PushSalesforceCourseStats", vcr: VCR_OPTS do
     Salesforce::Remote::OsAncillary.new(
       individual_adoption_id: ia.id,
       product: course.is_concept_coach ? "Concept Coach" : "Tutor",
-      contact_id: contact.id
+      contact_id: contact.id,
+      term: "Spring"
     ).tap do |osa|
       if !osa.save
         raise "didn't save OSA"
@@ -282,6 +288,7 @@ RSpec.describe "PushSalesforceCourseStats", vcr: VCR_OPTS do
     expect(osa.status).to be_a(String)
     expect(osa.product).to eq "Tutor"
     expect(osa.error).to be nil
+    expect(osa.term).to be_a(String)
   end
 
   def expect_osa_attachment(osa, course)

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -10,6 +10,7 @@ VCR.configure do |c|
   %w(
     tutor_specs_oauth_token
     tutor_specs_refresh_token
+    tutor_specs_instance_url
   ).each do |salesforce_secret_name|
     Rails.application.secrets['salesforce'][salesforce_secret_name].tap do |value|
       c.filter_sensitive_data("<#{salesforce_secret_name}>") { value } if value.present?


### PR DESCRIPTION
* Make courses be "test" courses (somewhat duplicative with `exclude_from_salesforce` flag but more general)
* Account for changes to Salesforce that make certain fields effectively required
* Skip courses without any teachers