### PR TITLE
Fix setting of term start date and term on IA and OSA SF objects

### DIFF
--- a/app/routines/push_salesforce_course_stats.rb
+++ b/app/routines/push_salesforce_course_stats.rb
@@ -84,28 +84,31 @@ class PushSalesforceCourseStats
                  course: course)
         end
 
-        individual_adoption =
-          candidate_individual_adoptions.first ||
-          begin
-            start_date = course.term_year.starts_at.iso8601.gsub(/T.*/,'')
-            sf_contact = Salesforce::Remote::Contact.where(id: sf_contact_id).first
+        individual_adoption = candidate_individual_adoptions.first
 
-            individual_adoption_options = {
-              contact_id: sf_contact_id,
-              book_id: book_names_to_sf_ids[book_name],
-              school_id: sf_contact.school_id
-            }
+        # already excluded legacy and demo terms
+        start_date_key = "#{course.term}_start_date".to_sym
+        start_date_value = course.starts_at.iso8601.gsub(/T.*/,'')
 
-            # already excluded legacy and demo terms
-            start_date_key = "#{course.term}_start_date".to_sym
+        if individual_adoption.nil?
+          start_date = course.term_year.starts_at.iso8601.gsub(/T.*/,'')
+          sf_contact = Salesforce::Remote::Contact.where(id: sf_contact_id).first
 
-            individual_adoption_options.merge!({
-              start_date_key => course.starts_at.iso8601.gsub(/T.*/,''),
-              adoption_level: "Confirmed Adoption Won",
-              description: Time.now.in_time_zone('Central Time (US & Canada)').iso8601.gsub(/T.*/,'') + ", " +
-                           (Salesforce::Models::User.first.try(:name) || 'Unknown') + ", Created by Tutor"
-            })
+          individual_adoption_options = {
+            contact_id: sf_contact_id,
+            book_id: book_names_to_sf_ids[book_name],
+            school_id: sf_contact.school_id
+          }
 
+
+          individual_adoption_options.merge!({
+            start_date_key => start_date_value,
+            adoption_level: "Confirmed Adoption Won",
+            description: Time.now.in_time_zone('Central Time (US & Canada)').iso8601.gsub(/T.*/,'') + ", " +
+                         (Salesforce::Models::User.first.try(:name) || 'Unknown') + ", Created by Tutor"
+          })
+
+          individual_adoption =
             Salesforce::Remote::IndividualAdoption.new(individual_adoption_options).tap do |ia|
               if !ia.save
                 error!(message: "Could not make new IndividualAdoption for inputs " \
@@ -114,7 +117,12 @@ class PushSalesforceCourseStats
                        course: course)
               end
             end
+        else
+          # Set the term start date if it is blank or has the wrong value
+          if individual_adoption.send(start_date_key) != start_date_value
+            individual_adoption.update_attributes!({start_date_key => start_date_value})
           end
+        end
 
         # Now see if there's an appropriate OSA on the IA; if not, make one.
         # Attach the OSA to the course so we can just use it next time.

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/continues_processing_later_courses_when_an_earlier_one_errors.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/continues_processing_later_courses_when_an_earlier_one_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Aurelie","LastName":"Halvorson","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Myrtle","LastName":"Glover","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:42 GMT
+      - Thu, 27 Apr 2017 22:58:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=O3g7pjzjRo6kjgKO2JreVQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:42 GMT
+      - BrowserId=dLsZyPhITFaS1boVQPLxrw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=265/48000
+      - api-usage=484/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvP3QAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBrQAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvP3QAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSBrQAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:42 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:13 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvP3QAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBrQAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:43 GMT
+      - Thu, 27 Apr 2017 22:58:14 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nyzXRM2bSxao9r6jjKRSww;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:43 GMT
+      - BrowserId=FbPwOj4TTh-m97q1ivAFSg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=266/48000
+      - api-usage=485/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:43 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:13 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvP3QAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004mSBrQAM%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:43 GMT
+      - Thu, 27 Apr 2017 22:58:14 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=MkBjKRHDRNqMUR_CAROwPQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:43 GMT
+      - BrowserId=uQWYjGAbRZCHjdo_CKV4Tg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=266/48000
+      - api-usage=484/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvP3QAK"},"Id":"0030S000004VvP3QAK","Name":"Aurelie
-        Halvorson","FirstName":"Aurelie","LastName":"Halvorson","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:01:42.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004mSBrQAM"},"Id":"0030S000004mSBrQAM","Name":"Myrtle
+        Glover","FirstName":"Myrtle","LastName":"Glover","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-27T22:58:13.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:43 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:14 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:43 GMT
+      - Thu, 27 Apr 2017 22:58:15 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5_AVzSyPS8uFpuYaVnDWiw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:43 GMT
+      - BrowserId=7PhOJl3VQ4aBzuG0wbsltg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=272/48000
+      - api-usage=483/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,14 +192,14 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:43 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:14 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvP3QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
+      string: '{"Contact__c":"0030S000004mSBrQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-27, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -217,13 +217,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:44 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
-        http://cs54.salesforce.com/services/data/v29.0/sobjects/Individual_Adoption__c'
+      - Thu, 27 Apr 2017 22:58:15 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -232,14 +226,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ZcwEPD3LQ6GL1wETPUT5NQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:44 GMT
+      - BrowserId=ZpKqI8iLS3qrn-iAokKxJw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=266/48000
+      - api-usage=487/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065ciUAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEtUAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -248,12 +242,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065ciUAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEtUAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:46 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:17 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065ciUAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEtUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -272,7 +266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:47 GMT
+      - Thu, 27 Apr 2017 22:58:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -281,12 +275,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=XziyZ1dCRuO41Ng2buhkpQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:47 GMT
+      - BrowserId=Cp9f7UHWQqKPHVOj_4HNvg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=268/48000
+      - api-usage=486/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -297,13 +291,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:47 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:18 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065ciUAA","Contact__c":"0030S000004VvP3QAK"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEtUAM","Contact__c":"0030S000004mSBrQAM"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -321,7 +315,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:47 GMT
+      - Thu, 27 Apr 2017 22:58:19 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -330,14 +324,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=oP7EuRA-T7yLauJRL_Gycw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:47 GMT
+      - BrowserId=loJML1XwTL2PKqKOncntVA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=267/48000
+      - api-usage=488/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512mUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1KUAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -346,12 +340,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512mUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G1KUAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:48 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:19 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512mUAA%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G1KUAU%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -370,7 +364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:48 GMT
+      - Thu, 27 Apr 2017 22:58:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -379,12 +373,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=1DhAwEUUR-2huckFBrQjyg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:48 GMT
+      - BrowserId=c05eN4l4QW2m9yLqjKb3xQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=275/48000
+      - api-usage=487/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -393,17 +387,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512mUAA"},"Id":"a1S0S000000512mUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1KUAU"},"Id":"a1S0S0000005G1KUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065ciUAA","Contact__c":"0030S000004VvP3QAK"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEtUAM","Contact__c":"0030S000004mSBrQAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:48 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:20 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512mUAA"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1KUAU"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":9,"E_Created_Date__c":"2017-04-20T04:01:40Z","Teacher_Join_URL__c":"http://localhost:3001/teach/3aaeb12ddb1860b209a0c3612e26c8e9/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":3,"Students_Using__c":12}'
+      string: '{"Status__c":"Approved","External_ID__c":11,"E_Created_Date__c":"2017-04-27T22:58:10Z","Teacher_Join_URL__c":"http://localhost:3001/teach/03ddc54031c3a4ae15aadcb9e56bf3ac/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":3,"Students_Using__c":12}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -421,7 +415,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:49 GMT
+      - Thu, 27 Apr 2017 22:58:21 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -430,15 +424,15 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=XGs4u212QpGV2yubFE0XAg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:49 GMT
+      - BrowserId=OmhZF1vzTqypoLuo36LCMQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=266/48000
+      - api-usage=488/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:49 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_it_cannot_save_a_new_IA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_it_cannot_save_a_new_IA.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Eleonore","LastName":"Schulist","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Janiya","LastName":"Cummerata","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:01 GMT
+      - Thu, 27 Apr 2017 22:58:33 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=WBNlS9JpRF2NQuQTePzkVg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:01 GMT
+      - BrowserId=_L8c-0fiQs2tbWNyoSQVJA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=289/48000
+      - api-usage=490/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPIQA0"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSC6QAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvPIQA0","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSC6QAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:02 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:33 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPIQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSC6QAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:02 GMT
+      - Thu, 27 Apr 2017 22:58:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=j1qwj5hsSI6iKLJUYwJi1w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:02 GMT
+      - BrowserId=LPkJGpqpTRSQ6VWEGS48Ng;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=285/48000
+      - api-usage=499/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:02 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:34 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvPIQA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004mSC6QAM%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:02 GMT
+      - Thu, 27 Apr 2017 22:58:35 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hbIS_-0cS7OgUry1dbZUgw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:02 GMT
+      - BrowserId=SU47znx-S5GRCqAXrG5dTA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=291/48000
+      - api-usage=491/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvPIQA0"},"Id":"0030S000004VvPIQA0","Name":"Eleonore
-        Schulist","FirstName":"Eleonore","LastName":"Schulist","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:02:02.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004mSC6QAM"},"Id":"0030S000004mSC6QAM","Name":"Janiya
+        Cummerata","FirstName":"Janiya","LastName":"Cummerata","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-27T22:58:33.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:02 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:34 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:03 GMT
+      - Thu, 27 Apr 2017 22:58:35 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-Vw5pk3SQXe7ccr24ozvjw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:03 GMT
+      - BrowserId=dI0cl2pFSU-Gco6AIIwaGQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=290/48000
+      - api-usage=494/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,14 +192,14 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:03 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:35 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvPIQA0","Book__c":"a0Z0S000000FgiCUAS","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
+      string: '{"Contact__c":"0030S000004mSC6QAM","Book__c":"a0Z0S000000FgiCUAS","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-27, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -217,7 +217,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:03 GMT
+      - Thu, 27 Apr 2017 22:58:36 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -226,12 +226,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=eGYxSoenTZ6vP4nPC1VFug;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:03 GMT
+      - BrowserId=KBKWO5imRoK_OX8aECHExA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=288/48000
+      - api-usage=500/48000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -240,5 +240,5 @@ http_interactions:
       encoding: UTF-8
       string: '[{"message":"Required fields are missing: [Account__c]","errorCode":"REQUIRED_FIELD_MISSING","fields":["Account__c"]}]'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:03 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_IAs_match.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_IAs_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jerel","LastName":"Wuckert","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Xavier","LastName":"Grady","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,13 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:52 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
-        http://cs54.salesforce.com/services/data/v29.0/sobjects/Contact'
+      - Thu, 27 Apr 2017 22:58:25 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -38,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=15vWf6iWTZa5DeB-7WvlmQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:52 GMT
+      - BrowserId=Ow9ASYmTTYW6fiEdI0l7eQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=276/48000
+      - api-usage=487/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvP8QAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSC1QAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -54,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvP8QAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSC1QAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:53 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:25 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSC1QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -81,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:53 GMT
+      - Thu, 27 Apr 2017 22:58:26 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -90,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=SLtMynU6Qier_zKP3GYeeQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:53 GMT
+      - BrowserId=57pyPJ2QSrmAFpWnBsdkdA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=276/48000
+      - api-usage=489/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cnUAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEyUAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -106,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cnUAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEyUAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:57 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:28 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSC1QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -133,7 +127,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:58 GMT
+      - Thu, 27 Apr 2017 22:58:29 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -142,14 +136,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=QC6d_v_1TdmEgd2yA5AL2A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:58 GMT
+      - BrowserId=uaeFMJuvTUq1CS08ZDjt9A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=289/48000
+      - api-usage=490/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065csUAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SF3UAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -158,12 +152,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065csUAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SF3UAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:59 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:29 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvP8QAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSC1QAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -182,7 +176,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:59 GMT
+      - Thu, 27 Apr 2017 22:58:30 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -191,12 +185,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=M40OxxKFQ7-0iSl__V0-JA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:59 GMT
+      - BrowserId=wnHQuY6mSJqnujW3bPi1jw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=290/48000
+      - api-usage=485/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -205,11 +199,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065csUAA"},"Id":"a1W0S00000065csUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null},{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cnUAA"},"Id":"a1W0S00000065cnUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvP8QAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEyUAM"},"Id":"a1W0S0000006SEyUAM","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSC1QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null},{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SF3UAM"},"Id":"a1W0S0000006SF3UAM","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSC1QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:59 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_OSAs_match.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_multiple_OSAs_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Maybelle","LastName":"Lueilwitz","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Anibal","LastName":"Fritsch","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:05 GMT
+      - Thu, 27 Apr 2017 22:58:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=sytJjXkLQ-CzlvpVIu-r9w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:05 GMT
+      - BrowserId=hqlZ9PucRXi35n5KkFHdFQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=292/48000
+      - api-usage=507/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPSQA0"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSCBQA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvPSQA0","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSCBQA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:06 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:39 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvPSQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSCBQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:07 GMT
+      - Thu, 27 Apr 2017 22:58:40 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=RnQ8l_37QQONFXohhnE06g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:07 GMT
+      - BrowserId=0Pn1Cf9ESq-7v6LP2FogAw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=289/48000
+      - api-usage=504/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cxUAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SF8UAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cxUAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SF8UAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:11 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:43 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SF8UAM","Contact__c":"0030S000004mSCBQA2"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -126,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:11 GMT
+      - Thu, 27 Apr 2017 22:58:45 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -135,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2nI8KXqTSTSjBTz_3724NQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:11 GMT
+      - BrowserId=fim0a_UISIq5AJ5IScF7lA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=291/48000
+      - api-usage=506/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512wUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1PUAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -151,15 +151,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512wUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G1PUAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:18 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:45 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SF8UAM","Contact__c":"0030S000004mSCBQA2"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -177,7 +177,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:18 GMT
+      - Thu, 27 Apr 2017 22:58:47 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -186,14 +186,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=MhJFoQKwTUmA7R9wkFchwA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:18 GMT
+      - BrowserId=4_H2Y91KRAKqzIyq3AMfDw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=308/48000
+      - api-usage=508/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005131UAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1UUAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -202,12 +202,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S0000005131UAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G1UUAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:19 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:48 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPSQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSCBQA2%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -226,7 +226,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:19 GMT
+      - Thu, 27 Apr 2017 22:58:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -235,12 +235,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=NTQUw2yNSg2BDjli0w2Dew;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:19 GMT
+      - BrowserId=Uhj6IYkmSFOR-iCbhw-txw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=304/48000
+      - api-usage=504/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -249,14 +249,57 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cxUAA"},"Id":"a1W0S00000065cxUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvPSQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SF8UAM"},"Id":"a1W0S0000006SF8UAM","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSCBQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:19 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:49 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SF8UAM"
+    body:
+      encoding: UTF-8
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:50 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=GCkLKRLzRlKr9FFWECJIfA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:50 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=502/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:49 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cxUAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SF8UAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -275,7 +318,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:19 GMT
+      - Thu, 27 Apr 2017 22:58:50 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -284,12 +327,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FPnPnGW0TKCC2oEZUTDtww;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:19 GMT
+      - BrowserId=ii-a-yL5SjeO9ljuTtEtyg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=309/48000
+      - api-usage=505/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -298,11 +341,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512wUAA"},"Id":"a1S0S000000512wUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1UUAU"},"Id":"a1S0S0000005G1UUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"},{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005131UAA"},"Id":"a1S0S0000005131UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SF8UAM","Contact__c":"0030S000004mSCBQA2"},{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1PUAU"},"Id":"a1S0S0000005G1PUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cxUAA","Contact__c":"0030S000004VvPSQA0"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SF8UAM","Contact__c":"0030S000004mSCBQA2"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:19 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_no_offering.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/errors_when_no_offering.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Camryn","LastName":"Huels","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Kari","LastName":"Sauer","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:21 GMT
+      - Thu, 27 Apr 2017 22:58:52 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nBmJ85GnT8uSVnx-aUtjaA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:21 GMT
+      - BrowserId=wYCywj9XRsGS_zZcaDm_Cw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=303/48000
+      - api-usage=506/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPXQA0"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSCVQA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,7 +48,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvPXQA0","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSCVQA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:26 GMT
+  recorded_at: Thu, 27 Apr 2017 22:58:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/errors_happen/when_there_is_an_error_in_writing_stats/writes_the_error_to_the_OSA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/errors_happen/when_there_is_an_error_in_writing_stats/writes_the_error_to_the_OSA.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jodie","LastName":"Runolfsson","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Madaline","LastName":"Ullrich","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:32 GMT
+      - Thu, 27 Apr 2017 22:59:00 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=sPqiyz4MQb6gwUSoNB4J8w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:32 GMT
+      - BrowserId=29E7vLALT_e5YpXVY77slQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=317/48000
+      - api-usage=512/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvPcQAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSCfQAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvPcQAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSCfQAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:33 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:01 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPcQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSCfQAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:34 GMT
+      - Thu, 27 Apr 2017 22:59:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pkF-FS52TbKs6-0YOeZALg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:34 GMT
+      - BrowserId=1bBtQyH0RlaoVgICY-lcQA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=317/48000
+      - api-usage=526/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:34 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:01 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvPcQAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004mSCfQAM%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:34 GMT
+      - Thu, 27 Apr 2017 22:59:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Epb2X_3kQ6a-TDrqydlpfw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:34 GMT
+      - BrowserId=C9zi6eI4SE-boqQJZjIoZw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=317/48000
+      - api-usage=520/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvPcQAK"},"Id":"0030S000004VvPcQAK","Name":"Jodie
-        Runolfsson","FirstName":"Jodie","LastName":"Runolfsson","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:02:33.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004mSCfQAM"},"Id":"0030S000004mSCfQAM","Name":"Madaline
+        Ullrich","FirstName":"Madaline","LastName":"Ullrich","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-27T22:59:00.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:34 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:02 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:35 GMT
+      - Thu, 27 Apr 2017 22:59:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=isNe12z4QRaTOcOznbcJqA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:35 GMT
+      - BrowserId=qdaS7qInQh-S6CLCf_COrQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=323/48000
+      - api-usage=518/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,14 +192,14 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:35 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:02 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvPcQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
+      string: '{"Contact__c":"0030S000004mSCfQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-27, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -217,7 +217,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:35 GMT
+      - Thu, 27 Apr 2017 22:59:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -226,14 +226,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=NC2DAIjdRkuuOHdlyRgbYQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:35 GMT
+      - BrowserId=YhRsLGNWRgSzqLzUXMbHPg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=324/48000
+      - api-usage=519/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065d2UAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SFIUA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -242,12 +242,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065d2UAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SFIUA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:39 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:05 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065d2UAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SFIUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -266,7 +266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:39 GMT
+      - Thu, 27 Apr 2017 22:59:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -275,12 +275,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FPayB-RHSj22N4njMFo8KA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:39 GMT
+      - BrowserId=cSN9foxQTOaepW_pifb0Xw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=327/48000
+      - api-usage=527/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -291,13 +291,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:39 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:05 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065d2UAA","Contact__c":"0030S000004VvPcQAK"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SFIUA2","Contact__c":"0030S000004mSCfQAM"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -315,7 +315,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:39 GMT
+      - Thu, 27 Apr 2017 22:59:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -324,14 +324,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jYxwjy8SRE-vUtsy0jdAKA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:39 GMT
+      - BrowserId=SqdCpoFnQaCdKajfCjbBsA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=326/48000
+      - api-usage=530/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1ZUAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -340,12 +340,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S0000005136UAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G1ZUAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:40 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:08 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005136UAA%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G1ZUAU%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -364,7 +364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:41 GMT
+      - Thu, 27 Apr 2017 22:59:09 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -373,12 +373,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=LHIxKuqGQ1yzCyV2znMuUQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:41 GMT
+      - BrowserId=mctWpUJkS_KRWy4ErL31cA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=326/48000
+      - api-usage=533/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -387,17 +387,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"},"Id":"a1S0S0000005136UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1ZUAU"},"Id":"a1S0S0000005G1ZUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065d2UAA","Contact__c":"0030S000004VvPcQAK"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SFIUA2","Contact__c":"0030S000004mSCfQAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:41 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:08 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1ZUAU"
     body:
       encoding: UTF-8
-      string: '{"External_ID__c":17,"E_Created_Date__c":"2017-04-20T04:02:30Z","Error__c":"Unable
+      string: '{"External_ID__c":19,"E_Created_Date__c":"2017-04-27T22:58:57Z","Error__c":"Unable
         to update stats: kaboom"}'
     headers:
       User-Agent:
@@ -416,7 +416,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:41 GMT
+      - Thu, 27 Apr 2017 22:59:09 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -425,20 +425,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Z0hFngYORiiP8TX82Xw5wg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:41 GMT
+      - BrowserId=cYxixCuYRtKUw6dzfUrn7w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=327/48000
+      - api-usage=527/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:41 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:09 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvPcQAK%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSCfQAM%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -457,7 +457,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:41 GMT
+      - Thu, 27 Apr 2017 22:59:10 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -466,12 +466,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=qgEIpxJHQO69h6Ti9lA3aw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:41 GMT
+      - BrowserId=wqWQzuRFSQS6--7fV1GKxw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=326/48000
+      - api-usage=528/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -480,15 +480,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065d2UAA"},"Id":"a1W0S00000065d2UAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvPcQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SFIUA2"},"Id":"a1W0S0000006SFIUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSCfQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor","TermYear__c":"2016
+        Adoption Won","Description__c":"2017-04-27, some name, Created by Tutor","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:41 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:12 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065d2UAA%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SFIUA2%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -507,7 +507,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:02:42 GMT
+      - Thu, 27 Apr 2017 22:59:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -516,12 +516,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=zB5QbhElSGWztGZqy-Y3dw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:02:42 GMT
+      - BrowserId=aDiNpNPqT_mtHcnJamb9xQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:59:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=332/48000
+      - api-usage=528/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -530,10 +530,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005136UAA"},"Id":"a1S0S0000005136UAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"17","E_Created_Date__c":"2017-04-20T04:02:30.000+0000","Error__c":"Unable
-        to update stats: kaboom","General_Access_URL__c":"https://tutor.openstax.org/courses/17/dashboard","Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1ZUAU"},"Id":"a1S0S0000005G1ZUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"19","E_Created_Date__c":"2017-04-27T22:58:57.000+0000","Error__c":"Unable
+        to update stats: kaboom","General_Access_URL__c":"https://tutor.openstax.org/courses/19/dashboard","Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065d2UAA","Contact__c":"0030S000004VvPcQAK"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SFIUA2","Contact__c":"0030S000004mSCfQAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:02:42 GMT
+  recorded_at: Thu, 27 Apr 2017 22:59:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/sf_setup.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/sf_setup.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:34 GMT
+      - Thu, 27 Apr 2017 22:56:15 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -30,12 +30,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5TawHbF3S26bt79fTIndWQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:34 GMT
+      - BrowserId=feAATHvnRlO2xRgSUlg18g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=434/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:34 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:14 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Account"
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:34 GMT
+      - Thu, 27 Apr 2017 22:56:15 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -77,12 +77,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=eajb6ODDTieNz0LnI0D35A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:34 GMT
+      - BrowserId=BdFhMHXKRkioqHXWO_NZZg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=430/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -94,5 +94,5 @@ http_interactions:
       string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v29.0/sobjects/Account/0010S0000057qMUQAY"},"Id":"0010S0000057qMUQAY","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:34 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handle_exceptions_around_saving_final_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handle_exceptions_around_saving_final_stats.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Aylin","LastName":"Haley","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Oswald","LastName":"Walsh","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:22 GMT
+      - Thu, 27 Apr 2017 22:57:29 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-mw6fkMaQ2ukude3iOUAQA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:22 GMT
+      - BrowserId=id5U80z_TsOac1EUqPQf2A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=266/48000
+      - api-usage=454/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOtQAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBXQA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOtQAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSBXQA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:23 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:30 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOtQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSBXQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:23 GMT
+      - Thu, 27 Apr 2017 22:57:31 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=dWLroYfLTjaGBjjaBnOB1Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:23 GMT
+      - BrowserId=EnuKEBSgSGO_J6lCxKydbg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=261/48000
+      - api-usage=452/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cYUAQ"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEeUAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cYUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEeUAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:26 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:32 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cYUAQ","Contact__c":"0030S000004VvOtQAK"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEeUAM","Contact__c":"0030S000004mSBXQA2"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -126,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:27 GMT
+      - Thu, 27 Apr 2017 22:57:33 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -135,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=WDjWPirMQ1WydjMtuWCHTQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:27 GMT
+      - BrowserId=nyyD8wFgTAO5JStl23u14g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=267/48000
+      - api-usage=458/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512cUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G15UAE"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -151,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512cUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G15UAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:28 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:37 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOtQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBXQA2%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -175,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:29 GMT
+      - Thu, 27 Apr 2017 22:57:38 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -184,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=C5NZ0iBSTbSN2dgx0aoi1A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:29 GMT
+      - BrowserId=RFf1AiyJQS24QwJW_brbdQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=264/48000
+      - api-usage=458/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -198,14 +198,57 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cYUAQ"},"Id":"a1W0S00000065cYUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOtQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEeUAM"},"Id":"a1W0S0000006SEeUAM","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBXQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:29 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:38 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEeUAM"
+    body:
+      encoding: UTF-8
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:39 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=RkV61wgNTJSk6zmUc0i26A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:39 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=459/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:38 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cYUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEeUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -224,7 +267,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:29 GMT
+      - Thu, 27 Apr 2017 22:57:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -233,12 +276,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=cnlX0awXSk-PWHhGeZpUVw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:29 GMT
+      - BrowserId=kbuKSyb8TJGvbPJJ6mHsuQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=263/48000
+      - api-usage=459/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -247,9 +290,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512cUAA"},"Id":"a1S0S000000512cUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G15UAE"},"Id":"a1S0S0000005G15UAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cYUAQ","Contact__c":"0030S000004VvOtQAK"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEeUAM","Contact__c":"0030S000004mSBXQA2"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:29 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handles_final_OSA_save_errors.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/handles_final_OSA_save_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Ansley","LastName":"Schoen","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Demarcus","LastName":"Bogisich","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:31 GMT
+      - Thu, 27 Apr 2017 22:57:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hxHTGYV5QrSDaXdzhMB9mQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:31 GMT
+      - BrowserId=xCeK_4agS4eK1Du6D2B5LA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=274/48000
+      - api-usage=461/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOyQAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBcQAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOyQAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSBcQAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:32 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:44 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOyQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSBcQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:32 GMT
+      - Thu, 27 Apr 2017 22:57:45 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pD4GSXVuT3yyWByI4nzw-Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:32 GMT
+      - BrowserId=aHiR_RXfTG6WOVoHEj7Xpw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=269/48000
+      - api-usage=466/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cdUAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEjUAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cdUAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEjUAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:36 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:48 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cdUAA","Contact__c":"0030S000004VvOyQAK"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEjUAM","Contact__c":"0030S000004mSBcQAM"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -126,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:36 GMT
+      - Thu, 27 Apr 2017 22:57:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -135,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=DuTT646rQ4O-BS3Y792aCg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:36 GMT
+      - BrowserId=MK3byG0yRXqqYH0hu7mwuw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=264/48000
+      - api-usage=457/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512hUAA"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1AUAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -151,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512hUAA","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G1AUAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:37 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:50 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOyQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBcQAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -175,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:37 GMT
+      - Thu, 27 Apr 2017 22:57:51 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -184,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=0O1oRSfgQbCcXfLK8cOy2Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:37 GMT
+      - BrowserId=btcFHUrOQ96F5ATISN070Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=267/48000
+      - api-usage=459/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -198,66 +198,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cdUAA"},"Id":"a1W0S00000065cdUAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOyQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEjUAM"},"Id":"a1W0S0000006SEjUAM","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBcQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:37 GMT
-- request:
-    method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cdUAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Authorization:
-      - OAuth <tutor_specs_oauth_token>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Apr 2017 04:01:38 GMT
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - referrer origin-when-cross-origin
-      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
-      Set-Cookie:
-      - BrowserId=mjGpZ9O8SDuxfYcHsYbvQQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:38 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=268/48000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512hUAA"},"Id":"a1S0S000000512hUAA","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cdUAA","Contact__c":"0030S000004VvOyQAK"}]}'
-    http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:38 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:51 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512hUAA"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEjUAM"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":7,"E_Created_Date__c":"2017-04-20T04:01:29Z","Teacher_Join_URL__c":"http://localhost:3001/teach/30cccbb994da8f8f0bf82e8e3128036f/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -275,7 +226,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:38 GMT
+      - Thu, 27 Apr 2017 22:57:52 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -284,15 +235,107 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=l_0rDbwITQiwK11KqsTaSQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:38 GMT
+      - BrowserId=g3BtKGjDRr2y7-5kB1Yv_g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=271/48000
+      - api-usage=472/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:38 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:51 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEjUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:52 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=Ob7mMKY-Q6y69LhBoLdeyw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:52 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=464/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1AUAU"},"Id":"a1S0S0000005G1AUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEjUAM","Contact__c":"0030S000004mSBcQAM"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:52 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1AUAU"
+    body:
+      encoding: UTF-8
+      string: '{"Status__c":"Approved","External_ID__c":8,"E_Created_Date__c":"2017-04-27T22:57:39Z","Teacher_Join_URL__c":"http://localhost:3001/teach/daca803f2db90101596fc2fe960a690f/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:53 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=jYEkgEFZRgOZ8Mi56Y8yxg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:53 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=467/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/it_makes_a_new_one_if_the_old_one_s_Term_is_blank.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/it_makes_a_new_one_if_the_old_one_s_Term_is_blank.yml
@@ -1,0 +1,578 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
+    body:
+      encoding: UTF-8
+      string: '{"FirstName":"Rachael","LastName":"Torphy","AccountId":"0010S0000057qMUQAY"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:56 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=jhIDVV5-Sw--p9qQUvGkSg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:56 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=467/48000
+      Location:
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBhQAM"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0030S000004mSBhQAM","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:56 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
+    body:
+      encoding: UTF-8
+      string: '{"Contact__c":"0030S000004mSBhQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:57 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=4e6rthtVRlaZT3jfYbPA6A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:57 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=464/48000
+      Location:
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEoUAM"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a1W0S0000006SEoUAM","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:00 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
+    body:
+      encoding: UTF-8
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEoUAM","Contact__c":"0030S000004mSBhQAM"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:01 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=lQXKIryZTWiw4d06feQvng;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:01 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=476/48000
+      Location:
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0wUAE"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a1S0S0000005G0wUAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:01 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0wUAE"
+    body:
+      encoding: UTF-8
+      string: '{"Term__c":null}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:02 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=pJuhHq5gQpO7EsdXqkGBdQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:02 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=477/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:02 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBhQAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:03 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=4z0NPBBbRyWT6aFiKI7Ajg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:03 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=475/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEoUAM"},"Id":"a1W0S0000006SEoUAM","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBhQAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:03 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEoUAM"
+    body:
+      encoding: UTF-8
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:04 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=ovM80yTzSB60fXLPlBwQOg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:04 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=479/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:03 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEoUAM%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:04 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=hLCpykA-SOiFp_ubRYZCag;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:04 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=475/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:04 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
+    body:
+      encoding: UTF-8
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEoUAM","Contact__c":"0030S000004mSBhQAM"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:05 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=DgYWHKTKSiitx8CSDTuVTg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:05 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=476/48000
+      Location:
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1FUAU"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a1S0S0000005G1FUAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:06 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G1FUAU%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:07 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=sKoqF3WDS8e9xppcO_aqCg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:07 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=474/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1FUAU"},"Id":"a1S0S0000005G1FUAU","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEoUAM","Contact__c":"0030S000004mSBhQAM"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:07 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G1FUAU"
+    body:
+      encoding: UTF-8
+      string: '{"Status__c":"Approved","External_ID__c":9,"E_Created_Date__c":"2017-04-27T22:57:53Z","Teacher_Join_URL__c":"http://localhost:3001/teach/20d9c7c45552141889cd4c6cfaa9b6c6/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:08 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=lbhLsLuUToWlwASfsdChiw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:08 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=478/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:07 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0wUAE%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:08 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=1wuqHQuVRlmTme00WEZWPg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:08 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=476/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0wUAE"},"Id":"a1S0S0000005G0wUAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":null,"Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEoUAM","Contact__c":"0030S000004mSBhQAM"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:08 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20count(Id)%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEoUAM%27)"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:58:09 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=2ue7C8YsTKi_O7ifey9b7g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:58:09 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=480/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"AggregateResult"},"expr0":2}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:58:08 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_already_attached.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_already_attached.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Veda","LastName":"Bauch","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Sabryna","LastName":"Haley","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:13 GMT
+      - Thu, 27 Apr 2017 22:57:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=26ldQfr_Qua7moM8LJ9Zng;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:13 GMT
+      - BrowserId=nbgLWXBrTWudk6FiIyIW1A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=457/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOoQAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBSQA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOoQAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSBSQA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:14 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:17 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOoQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSBSQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:14 GMT
+      - Thu, 27 Apr 2017 22:57:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6O9npzuPRfmxbqIwAp8_hQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:14 GMT
+      - BrowserId=_sB-6JM8S6i7lbL14zGnrA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=456/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cTUAQ"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEZUA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cTUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEZUA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:18 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:20 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cTUAQ","Contact__c":"0030S000004VvOoQAK"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEZUA2","Contact__c":"0030S000004mSBSQA2"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -126,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:18 GMT
+      - Thu, 27 Apr 2017 22:57:21 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -135,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=YpZYpgIAQW6fQUzMP-hq7Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:18 GMT
+      - BrowserId=x30clX8LQ5mZKMfkQx1Hmw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=263/48000
+      - api-usage=457/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G10UAE"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -151,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512XUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G10UAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:19 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:25 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20IN%20(%27a1S0S000000512XUAQ%27))"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20IN%20(%27a1S0S0000005G10UAE%27))"
     body:
       encoding: US-ASCII
       string: ''
@@ -175,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:19 GMT
+      - Thu, 27 Apr 2017 22:57:26 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -184,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=upSOPTslS5W-SRzA5Pkwew;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:19 GMT
+      - BrowserId=NUGn-eyISFmqAplWsCMBGQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=262/48000
+      - api-usage=452/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -198,17 +198,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"},"Id":"a1S0S000000512XUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G10UAE"},"Id":"a1S0S0000005G10UAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cTUAQ","Contact__c":"0030S000004VvOoQAK"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEZUA2","Contact__c":"0030S000004mSBSQA2"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:19 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:26 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G10UAE"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":5,"E_Created_Date__c":"2017-04-20T04:01:11Z","Teacher_Join_URL__c":"http://localhost:3001/teach/3d78109cbf1a745a677dba7aed8d2a45/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":6,"E_Created_Date__c":"2017-04-27T22:57:14Z","Teacher_Join_URL__c":"http://localhost:3001/teach/fc1ac3a7803c04fad7091bd019f86539/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -226,7 +226,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:20 GMT
+      - Thu, 27 Apr 2017 22:57:27 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -235,20 +235,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=huXwM6SaQlCHkxzGVA8itA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:20 GMT
+      - BrowserId=nYMHznT-SH-U-oVsRO2NUw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=262/48000
+      - api-usage=456/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:20 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:26 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512XUAQ%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G10UAE%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -267,7 +267,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:20 GMT
+      - Thu, 27 Apr 2017 22:57:27 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -276,12 +276,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=CftrLomtTmW0QtyR7Blx-A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:20 GMT
+      - BrowserId=ONIB_oDFQV-gJJDKSdIuNw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=261/48000
+      - api-usage=457/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -290,9 +290,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512XUAQ"},"Id":"a1S0S000000512XUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"5","E_Created_Date__c":"2017-04-20T04:01:11.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/5/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/3d78109cbf1a745a677dba7aed8d2a45/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G10UAE"},"Id":"a1S0S0000005G10UAE","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"6","E_Created_Date__c":"2017-04-27T22:57:14.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/6/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/fc1ac3a7803c04fad7091bd019f86539/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cTUAQ","Contact__c":"0030S000004VvOoQAK"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEZUA2","Contact__c":"0030S000004mSBSQA2"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:20 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:27 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_not_yet_attached.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_an_existing_OSA/pushes_stats_if_not_yet_attached.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jerod","LastName":"Bashirian","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Isaiah","LastName":"Hahn","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:05 GMT
+      - Thu, 27 Apr 2017 22:57:07 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6uYQD32SR-GMdeU7W6QbuA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:05 GMT
+      - BrowserId=lGgmg7Z4QtuI4-WvUZ3TFg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=261/48000
+      - api-usage=451/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOjQAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBNQA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOjQAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSBNQA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:06 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:07 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOjQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSBNQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:06 GMT
+      - Thu, 27 Apr 2017 22:57:08 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=yvMEyGN1RriTObOPynj9hQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:06 GMT
+      - BrowserId=lSWFaZcaQ1W4fHClTTQPPQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=454/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cOUAQ"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEUUA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,15 +100,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cOUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEUUA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:09 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:10 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cOUAQ","Contact__c":"0030S000004VvOjQAK"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEUUA2","Contact__c":"0030S000004mSBNQA2"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -126,7 +126,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:09 GMT
+      - Thu, 27 Apr 2017 22:57:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -135,14 +135,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jB80DfFZSFuYCijwYvwiPg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:09 GMT
+      - BrowserId=EuGlNsPSS36ipZByTMw9-A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=452/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0vUAE"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -151,12 +151,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512SUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G0vUAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:10 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:11 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOjQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBNQA2%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -175,7 +175,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:10 GMT
+      - Thu, 27 Apr 2017 22:57:12 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -184,12 +184,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=VEPgrggCT6CIO7qz3jriYA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:10 GMT
+      - BrowserId=VR_IOlcaTOy1tYPwmllBUw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=455/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -198,66 +198,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cOUAQ"},"Id":"a1W0S00000065cOUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOjQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEUUA2"},"Id":"a1W0S0000006SEUUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBNQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:10 GMT
-- request:
-    method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cOUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Authorization:
-      - OAuth <tutor_specs_oauth_token>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Apr 2017 04:01:10 GMT
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - referrer origin-when-cross-origin
-      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
-      Set-Cookie:
-      - BrowserId=1NKXxwmhSriaoe9jDAcjmA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:10 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=261/48000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"},"Id":"a1S0S000000512SUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cOUAQ","Contact__c":"0030S000004VvOjQAK"}]}'
-    http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:10 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:12 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEUUA2"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":4,"E_Created_Date__c":"2017-04-20T04:01:03Z","Teacher_Join_URL__c":"http://localhost:3001/teach/1a90ca697100d67b28772dd59ed806ee/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -275,7 +226,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:11 GMT
+      - Thu, 27 Apr 2017 22:57:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -284,20 +235,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6JMm6HDPTG2GjA0IRdTmFw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:11 GMT
+      - BrowserId=4arWFuW8RcyTQZ_2DeCHiw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=451/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:11 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:12 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512SUAQ%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEUUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -316,7 +267,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:11 GMT
+      - Thu, 27 Apr 2017 22:57:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -325,12 +276,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Z3NctbRrSDaCwuat5AnOYA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:11 GMT
+      - BrowserId=i94rO2w1Tby48gyY5pNERA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=262/48000
+      - api-usage=457/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -339,9 +290,101 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512SUAQ"},"Id":"a1S0S000000512SUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"4","E_Created_Date__c":"2017-04-20T04:01:03.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/4/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/1a90ca697100d67b28772dd59ed806ee/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
-        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cOUAQ","Contact__c":"0030S000004VvOjQAK"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0vUAE"},"Id":"a1S0S0000005G0vUAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEUUA2","Contact__c":"0030S000004mSBNQA2"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:11 GMT
+  recorded_at: Thu, 27 Apr 2017 22:57:13 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0vUAE"
+    body:
+      encoding: UTF-8
+      string: '{"Status__c":"Approved","External_ID__c":5,"E_Created_Date__c":"2017-04-27T22:57:04Z","Teacher_Join_URL__c":"http://localhost:3001/teach/7c8626600bafaaa670c3bed8ef6adf94/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:14 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=sWIhQRr9RxOIjQD-_4miKg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:14 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=453/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:14 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0vUAE%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:15 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=vIPN6rWSTOmumC2V7392jQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:15 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=456/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0vUAE"},"Id":"a1S0S0000005G0vUAE","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"5","E_Created_Date__c":"2017-04-27T22:57:04.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/5/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/7c8626600bafaaa670c3bed8ef6adf94/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEUUA2","Contact__c":"0030S000004mSBNQA2"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/corrects_bad_term_start_date.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/corrects_bad_term_start_date.yml
@@ -1,0 +1,480 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
+    body:
+      encoding: UTF-8
+      string: '{"FirstName":"Melany","LastName":"Muller","AccountId":"0010S0000057qMUQAY"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:55 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=x01dKObIT8u3t6_ABDi5bw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:55 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=442/48000
+      Location:
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBIQA2"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0030S000004mSBIQA2","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:55 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
+    body:
+      encoding: UTF-8
+      string: '{"Contact__c":"0030S000004mSBIQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:56 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=1hV19gEJSbielFogLKvqLQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:56 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=443/48000
+      Location:
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEPUA2"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a1W0S0000006SEPUA2","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:58 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEPUA2"
+    body:
+      encoding: UTF-8
+      string: '{"Spring_Start_Date__c":"2017-03-28"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:59 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=Of7DoupnRayTlv40vRXJ6Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:59 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=447/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:59 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBIQA2%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=Zl5vmwV2SJiIGmI-hlcTag;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:00 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=449/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEPUA2"},"Id":"a1W0S0000006SEPUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBIQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-03-28","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:59 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEPUA2"
+    body:
+      encoding: UTF-8
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=td7v20XpRY2dLdwFgZQaIQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:00 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=446/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:00 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEPUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:01 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=0yzXopj7TFumDY2HijrDDg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:01 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=449/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:01 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
+    body:
+      encoding: UTF-8
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEPUA2","Contact__c":"0030S000004mSBIQA2"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:02 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=3Id0WsQuRHWUxbJcPVr1ig;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:02 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=450/48000
+      Location:
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0qUAE"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a1S0S0000005G0qUAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:02 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0qUAE%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:03 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=CHHY3YVnQmajwEqP5MW4Ng;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:03 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=451/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0qUAE"},"Id":"a1S0S0000005G0qUAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEPUA2","Contact__c":"0030S000004mSBIQA2"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:03 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0qUAE"
+    body:
+      encoding: UTF-8
+      string: '{"Status__c":"Approved","External_ID__c":4,"E_Created_Date__c":"2017-04-27T22:56:53Z","Teacher_Join_URL__c":"http://localhost:3001/teach/09d5c6c0ced2bd327cb627d009406391/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:04 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=lsfVpOUyS225tuCSA_uwuA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:04 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=455/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:04 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Id%20=%20%27a1W0S0000006SEPUA2%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:57:05 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=o2-cOLwuQre4oFiBTApylw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:57:05 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=451/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEPUA2"},"Id":"a1W0S0000006SEPUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBIQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:57:04 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/errors_when_cannot_make_an_OSA.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/errors_when_cannot_make_an_OSA.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Michael","LastName":"Gutmann","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Harvey","LastName":"Kirlin","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:59 GMT
+      - Thu, 27 Apr 2017 22:56:48 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=sEgiN3rISnOdcb2iGjhNqA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:59 GMT
+      - BrowserId=mX6YV8G-R9aUEchmxiNrlg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=265/48000
+      - api-usage=439/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOeQAK"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSBDQA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOeQAK","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSBDQA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:00 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:48 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOeQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSBDQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:00 GMT
+      - Thu, 27 Apr 2017 22:56:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=44j2rd8GSmCLpR-RhfXD-Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:00 GMT
+      - BrowserId=XNSgsri5TRCIItsekvRzcQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=438/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cJUAQ"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEKUA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,12 +100,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cJUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEKUA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:02 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:51 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOeQAK%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSBDQA2%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -124,7 +124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:03 GMT
+      - Thu, 27 Apr 2017 22:56:52 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -133,12 +133,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=oGTY-SAmTSqKN8Fq8EVqnw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:03 GMT
+      - BrowserId=dzM32bDlSNmx9AZ1we4qYQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=439/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -147,14 +147,57 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cJUAQ"},"Id":"a1W0S00000065cJUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOeQAK","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEKUA2"},"Id":"a1W0S0000006SEKUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSBDQA2","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:03 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:52 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEKUA2"
+    body:
+      encoding: UTF-8
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:53 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=u41H4GBgTlmt5rITfjY7Tg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:53 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=439/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:52 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cJUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEKUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:01:03 GMT
+      - Thu, 27 Apr 2017 22:56:53 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -182,12 +225,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=iwuSd9ftQC2LfUntIySXdQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:01:03 GMT
+      - BrowserId=atX28uPSTbK08cz_--LltQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=440/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -198,5 +241,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:01:03 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/makes_an_OSA_and_pushes_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_an_existing_IA/makes_an_OSA_and_pushes_stats.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Hunter","LastName":"Goodwin","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Alexandrine","LastName":"Senger","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:49 GMT
+      - Thu, 27 Apr 2017 22:56:33 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6vYX9iE-T-u0S5s3WzZj5g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:49 GMT
+      - BrowserId=KRADXVsYSueMPNZrKOiZJQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=263/48000
+      - api-usage=432/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOUQA0"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSB8QAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOUQA0","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSB8QAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:50 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:33 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOUQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"Contact__c":"0030S000004mSB8QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Fall_Start_Date__c":"2016-08-01","Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah"}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:50 GMT
+      - Thu, 27 Apr 2017 22:56:34 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -84,14 +84,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=evbUvK6ORUChnEXwv4B7Ww;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:50 GMT
+      - BrowserId=bmuuCwADQq217mkc9uviqA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=433/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cEUAQ"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEFUA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,12 +100,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065cEUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEFUA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:53 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:37 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOUQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSB8QAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -124,7 +124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:54 GMT
+      - Thu, 27 Apr 2017 22:56:39 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -133,12 +133,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=so0YXhdNSyCU4j3JGxBGzg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:54 GMT
+      - BrowserId=xSnTEM1MRrubYMkCIz_nSA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=440/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -147,164 +147,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065cEUAQ"},"Id":"a1W0S00000065cEUAQ","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOUQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
-        - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEFUA2"},"Id":"a1W0S0000006SEFUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSB8QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":null,"Adoption_Level__c":"Confirmed
         Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:54 GMT
-- request:
-    method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cEUAQ%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Authorization:
-      - OAuth <tutor_specs_oauth_token>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Apr 2017 04:00:54 GMT
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - referrer origin-when-cross-origin
-      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
-      Set-Cookie:
-      - BrowserId=oZqWWoM6TbCFqeGJr7xO2Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:54 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=259/48000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:54 GMT
-- request:
-    method: post
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
-    body:
-      encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}'
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth <tutor_specs_oauth_token>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 20 Apr 2017 04:00:55 GMT
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - referrer origin-when-cross-origin
-      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
-      Set-Cookie:
-      - BrowserId=gmAqiig7Szme-Lsx4ZzYRw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:55 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=259/48000
-      Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"
-      Content-Type:
-      - application/json;charset=UTF-8
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512NUAQ","success":true,"errors":[]}'
-    http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:55 GMT
-- request:
-    method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512NUAQ%27)%20LIMIT%201"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Authorization:
-      - OAuth <tutor_specs_oauth_token>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Apr 2017 04:00:56 GMT
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - referrer origin-when-cross-origin
-      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
-      Set-Cookie:
-      - BrowserId=viE3WjbNSFCsBLyjqq7Yzg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:56 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=264/48000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"},"Id":"a1S0S000000512NUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
-        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}]}'
-    http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:56 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:39 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEFUA2"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":2,"E_Created_Date__c":"2017-04-20T04:00:47Z","Teacher_Join_URL__c":"http://localhost:3001/teach/5cea9c3fead3ee5fb0cdd283b908d5e2/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Spring_Start_Date__c":"2017-01-01"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -322,7 +175,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:56 GMT
+      - Thu, 27 Apr 2017 22:56:40 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -331,20 +184,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8UxYF2OdQKSBsfwK2Jot1g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:56 GMT
+      - BrowserId=_bCSprrITTCCbLlskxWSrQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=440/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:56 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:40 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065cEUAQ%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEFUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:56 GMT
+      - Thu, 27 Apr 2017 22:56:41 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,12 +225,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=fbRPxpibSnGGSXxk9WrN3Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:56 GMT
+      - BrowserId=0BphiAbDQWig-WwdtuuQlQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=261/48000
+      - api-usage=441/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -386,14 +239,63 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"},"Id":"a1S0S000000512NUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-20T04:00:47.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/5cea9c3fead3ee5fb0cdd283b908d5e2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
-        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}]}'
+      string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:57 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:40 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
+    body:
+      encoding: UTF-8
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEFUA2","Contact__c":"0030S000004mSB8QAM"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:41 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=3pKDwqUUT4y5D17eqj-R5Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=440/48000
+      Location:
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0lUAE"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a1S0S0000005G0lUAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:42 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512NUAQ%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0lUAE%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -412,7 +314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:57 GMT
+      - Thu, 27 Apr 2017 22:56:43 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -421,12 +323,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=xfi4KF0MSSSazoV76oaT4w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:57 GMT
+      - BrowserId=0xeYdI_ETH2eiwjeF1O9wQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=441/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -435,9 +337,199 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512NUAQ"},"Id":"a1S0S000000512NUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-20T04:00:47.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/5cea9c3fead3ee5fb0cdd283b908d5e2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
-        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065cEUAQ","Contact__c":"0030S000004VvOUQA0"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0lUAE"},"Id":"a1S0S0000005G0lUAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+        University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEFUA2","Contact__c":"0030S000004mSB8QAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:57 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:43 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0lUAE"
+    body:
+      encoding: UTF-8
+      string: '{"Status__c":"Approved","External_ID__c":2,"E_Created_Date__c":"2017-04-27T22:56:30Z","Teacher_Join_URL__c":"http://localhost:3001/teach/1e0a68753ce6526611bace1e282c0765/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:44 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=WErDLLqoQJ2CxxLzxV8ANg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:44 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=441/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:43 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Id%20=%20%27a1W0S0000006SEFUA2%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:44 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=cxN_5CjZQpmdepL9keZ0Pw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:44 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=439/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEFUA2"},"Id":"a1W0S0000006SEFUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSB8QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+        - 17","Fall_Start_Date__c":"2016-08-01","Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"blah","TermYear__c":"2016 - 17 Spring","Class_Start_Date__c":null}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:44 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEFUA2%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:45 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=lh4mDU5qTZK2gja8xemtmw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:45 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=442/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0lUAE"},"Id":"a1S0S0000005G0lUAE","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-27T22:56:30.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/1e0a68753ce6526611bace1e282c0765/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEFUA2","Contact__c":"0030S000004mSB8QAM"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:44 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0lUAE%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 27 Apr 2017 22:56:46 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=DMeT7pZQTSSLoFXIMyRtWg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:46 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=441/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0lUAE"},"Id":"a1S0S0000005G0lUAE","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"2","E_Created_Date__c":"2017-04-27T22:56:30.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/2/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/1e0a68753ce6526611bace1e282c0765/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+        University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEFUA2","Contact__c":"0030S000004mSB8QAM"}]}'
+    http_version: 
+  recorded_at: Thu, 27 Apr 2017 22:56:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_no_existing_IA/makes_both_and_pushes_stats.yml
+++ b/spec/cassettes/PushSalesforceCourseStats/when_there_is_no_existing_OSA/when_there_is_no_existing_IA/makes_both_and_pushes_stats.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Derick","LastName":"Nienow","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Kellie","LastName":"Hintz","AccountId":"0010S0000057qMUQAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,7 +23,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:37 GMT
+      - Thu, 27 Apr 2017 22:56:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -32,14 +32,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=QxDPc9UwR6-SfRRrBy0cRw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:37 GMT
+      - BrowserId=cTBnwixNQcqKwHupD2LmFA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=431/48000
       Location:
-      - "/services/data/v29.0/sobjects/Contact/0030S000004VvOPQA0"
+      - "/services/data/v29.0/sobjects/Contact/0030S000004mSB3QAM"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -48,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000004VvOPQA0","success":true,"errors":[]}'
+      string: '{"id":"0030S000004mSB3QAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:38 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:18 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOPQA0%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSB3QAM%27)%20AND%20(Book_Text__c%20=%20%27Chemistry%27)%20AND%20(School_Year__c%20=%20%272016%20-%2017%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:38 GMT
+      - Thu, 27 Apr 2017 22:56:19 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -81,12 +81,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nkKKyQLwSc6-qDAOvVMppw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:38 GMT
+      - BrowserId=cn_LZMwGR5-N6LKiJHgVWA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=430/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,10 +97,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:38 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:19 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004VvOPQA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000004mSB3QAM%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:39 GMT
+      - Thu, 27 Apr 2017 22:56:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -128,12 +128,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4wWvEhMcTl-vYRVicq9FNw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:39 GMT
+      - BrowserId=QNd9BPpaSVSI9xo958oRzw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=431/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -142,10 +142,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004VvOPQA0"},"Id":"0030S000004VvOPQA0","Name":"Derick
-        Nienow","FirstName":"Derick","LastName":"Nienow","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-20T04:00:38.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/0030S000004mSB3QAM"},"Id":"0030S000004mSB3QAM","Name":"Kellie
+        Hintz","FirstName":"Kellie","LastName":"Hintz","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-27T22:56:19.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:39 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:19 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Name%20FROM%20Book__c"
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:39 GMT
+      - Thu, 27 Apr 2017 22:56:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -176,12 +176,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=D0OvrR3NSSWxgDADElgCfQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:39 GMT
+      - BrowserId=8WhC8rCiTJiBbcjmWhBPcQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=430/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -192,14 +192,14 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiHUAS"},"Id":"a0Z0S000000FgiHUAS","Name":"Physics"},{"attributes":{"type":"Book__c","url":"/services/data/v29.0/sobjects/Book__c/a0Z0S000000FgiCUAS"},"Id":"a0Z0S000000FgiCUAS","Name":"Chemistry"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:39 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:20 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/Individual_Adoption__c"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0030S000004VvOPQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor"}'
+      string: '{"Contact__c":"0030S000004mSB3QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
+        Adoption Won","Description__c":"2017-04-27, some name, Created by Tutor"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -217,7 +217,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:39 GMT
+      - Thu, 27 Apr 2017 22:56:21 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -226,14 +226,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=v85iRBc8SPGE_XeDVDf4nA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:39 GMT
+      - BrowserId=3eIOTCjWRyGWWFY3N4YheA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=430/48000
       Location:
-      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065c9UAA"
+      - "/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEAUA2"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -242,12 +242,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1W0S00000065c9UAA","success":true,"errors":[]}'
+      string: '{"id":"a1W0S0000006SEAUA2","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:43 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:24 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065c9UAA%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEAUA2%27)%20AND%20(Product__c%20=%20%27Tutor%27)%20AND%20(Term__c%20=%20%27Spring%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -266,7 +266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:43 GMT
+      - Thu, 27 Apr 2017 22:56:25 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -275,12 +275,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-BGLzcFfTMGfpugrpcCm9g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:43 GMT
+      - BrowserId=s0KGbXJJRrm-8aA9wDxSXw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=432/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -291,13 +291,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:43 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:24 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c"
     body:
       encoding: UTF-8
-      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}'
+      string: '{"Product__c":"Tutor","Term__c":"Spring","Individual_Adoption__c":"a1W0S0000006SEAUA2","Contact__c":"0030S000004mSB3QAM"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -315,7 +315,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:43 GMT
+      - Thu, 27 Apr 2017 22:56:25 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -324,14 +324,14 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=cJXZIbZQQGW1xDHxzMtdew;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:43 GMT
+      - BrowserId=YqqxK1YcTiy7DRCbMBJr_w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=260/48000
+      - api-usage=431/48000
       Location:
-      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"
+      - "/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0gUAE"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -340,12 +340,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a1S0S000000512IUAQ","success":true,"errors":[]}'
+      string: '{"id":"a1S0S0000005G0gUAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:44 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:26 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512IUAQ%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0gUAE%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -364,7 +364,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:45 GMT
+      - Thu, 27 Apr 2017 22:56:28 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs54.salesforce.com/services/data/v29.0/query'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -373,12 +379,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=mVZcpT_jTW2I-HQLt75Jxw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:45 GMT
+      - BrowserId=xJ8XHqjQSiygkff0zXS55w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=261/48000
+      - api-usage=432/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -387,17 +393,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"},"Id":"a1S0S000000512IUAQ","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0gUAE"},"Id":"a1S0S0000005G0gUAE","Status__c":null,"Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":null,"E_Created_Date__c":null,"Error__c":null,"General_Access_URL__c":null,"Teacher_Join_URL__c":null,"School_Name__c":"JP
         University","Active_Teachers__c":null,"Sections__c":null,"Students_Using__c":null,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEAUA2","Contact__c":"0030S000004mSB3QAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:45 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:28 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0gUAE"
     body:
       encoding: UTF-8
-      string: '{"Status__c":"Approved","External_ID__c":1,"E_Created_Date__c":"2017-04-20T04:00:35Z","Teacher_Join_URL__c":"http://localhost:3001/teach/537dd3c5b7e5ee1fd9f6edfde62e10c2/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
+      string: '{"Status__c":"Approved","External_ID__c":1,"E_Created_Date__c":"2017-04-27T22:56:16Z","Teacher_Join_URL__c":"http://localhost:3001/teach/c859b9efd6b449c10201009a2e72ffdb/DO_NOT_GIVE_TO_STUDENTS","Active_Teachers__c":1,"Sections__c":2,"Students_Using__c":6}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -415,7 +421,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:45 GMT
+      - Thu, 27 Apr 2017 22:56:29 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -424,20 +430,20 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=uDEzLs7nQ0GW3IGCQAsa5A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:45 GMT
+      - BrowserId=8Nj_FHKjSSy-GHLVmEKIEQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=430/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:45 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:29 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004VvOPQA0%27)"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Book_Text__c,%20Contact__c,%20Book__c,%20Account__c,%20School_Year__c,%20Fall_Start_Date__c,%20Summer_Start_Date__c,%20Winter_Start_Date__c,%20Spring_Start_Date__c,%20Adoption_Level__c,%20Description__c,%20TermYear__c,%20Class_Start_Date__c%20FROM%20Individual_Adoption__c%20WHERE%20(Contact__c%20=%20%270030S000004mSB3QAM%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -456,7 +462,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:46 GMT
+      - Thu, 27 Apr 2017 22:56:30 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -465,12 +471,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=SmugBcdCQN-Ke_C1OIvBhA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:46 GMT
+      - BrowserId=dHDT2reDSlu2iMygRH6sEg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=259/48000
+      - api-usage=431/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -479,15 +485,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S00000065c9UAA"},"Id":"a1W0S00000065c9UAA","Book_Text__c":"Chemistry","Contact__c":"0030S000004VvOPQA0","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Individual_Adoption__c","url":"/services/data/v29.0/sobjects/Individual_Adoption__c/a1W0S0000006SEAUA2"},"Id":"a1W0S0000006SEAUA2","Book_Text__c":"Chemistry","Contact__c":"0030S000004mSB3QAM","Book__c":"a0Z0S000000FgiCUAS","Account__c":"0010S0000057qMUQAY","School_Year__c":"2016
         - 17","Fall_Start_Date__c":null,"Summer_Start_Date__c":null,"Winter_Start_Date__c":null,"Spring_Start_Date__c":"2017-01-01","Adoption_Level__c":"Confirmed
-        Adoption Won","Description__c":"2017-04-19, some name, Created by Tutor","TermYear__c":"2016
+        Adoption Won","Description__c":"2017-04-27, some name, Created by Tutor","TermYear__c":"2016
         - 17 Spring","Class_Start_Date__c":null}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:46 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:29 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S00000065c9UAA%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Individual_Adoption__c%20=%20%27a1W0S0000006SEAUA2%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -506,7 +512,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:46 GMT
+      - Thu, 27 Apr 2017 22:56:30 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,12 +521,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-gf6D_D6QBS62lNTl-ADqg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:46 GMT
+      - BrowserId=zbc6yQanRkqp6lmDLAA83A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=262/48000
+      - api-usage=431/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -529,14 +535,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"},"Id":"a1S0S000000512IUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-20T04:00:35.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/537dd3c5b7e5ee1fd9f6edfde62e10c2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0gUAE"},"Id":"a1S0S0000005G0gUAE","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-27T22:56:16.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/c859b9efd6b449c10201009a2e72ffdb/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEAUA2","Contact__c":"0030S000004mSB3QAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:46 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:30 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S000000512IUAQ%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v29.0/query?q=SELECT%20Id,%20Status__c,%20Product__c,%20Account_Type__c,%20Book_Name__c,%20Class_Start_Date__c,%20Course_Name__c,%20Course_Code__c,%20External_ID__c,%20E_Created_Date__c,%20Error__c,%20General_Access_URL__c,%20Teacher_Join_URL__c,%20School_Name__c,%20Active_Teachers__c,%20Sections__c,%20Students_Using__c,%20TermYear__c,%20Term__c,%20Opportunity__c,%20Individual_Adoption__c,%20Contact__c%20FROM%20OS_Ancillary__c%20WHERE%20(Id%20=%20%27a1S0S0000005G0gUAE%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -555,7 +561,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Apr 2017 04:00:47 GMT
+      - Thu, 27 Apr 2017 22:56:31 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -564,12 +570,12 @@ http_interactions:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=_pvXuH0_SaWjDj-G64IFHQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        19-Jun-2017 04:00:47 GMT
+      - BrowserId=JE2hDGJ8Rzq2m_tEqCQd9A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        26-Jun-2017 22:56:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=258/48000
+      - api-usage=431/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -578,9 +584,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S000000512IUAQ"},"Id":"a1S0S000000512IUAQ","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-20T04:00:35.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/537dd3c5b7e5ee1fd9f6edfde62e10c2/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"OS_Ancillary__c","url":"/services/data/v29.0/sobjects/OS_Ancillary__c/a1S0S0000005G0gUAE"},"Id":"a1S0S0000005G0gUAE","Status__c":"Approved","Product__c":"Tutor","Account_Type__c":null,"Book_Name__c":"Chemistry","Class_Start_Date__c":null,"Course_Name__c":null,"Course_Code__c":null,"External_ID__c":"1","E_Created_Date__c":"2017-04-27T22:56:16.000+0000","Error__c":null,"General_Access_URL__c":"https://tutor.openstax.org/courses/1/dashboard","Teacher_Join_URL__c":"http://localhost:3001/teach/c859b9efd6b449c10201009a2e72ffdb/DO_NOT_GIVE_TO_STUDENTS","School_Name__c":"JP
         University","Active_Teachers__c":1.0,"Sections__c":2.0,"Students_Using__c":6.0,"TermYear__c":"2016
-        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S00000065c9UAA","Contact__c":"0030S000004VvOPQA0"}]}'
+        - 17 Spring","Term__c":"Spring","Opportunity__c":null,"Individual_Adoption__c":"a1W0S0000006SEAUA2","Contact__c":"0030S000004mSB3QAM"}]}'
     http_version: 
-  recorded_at: Thu, 20 Apr 2017 04:00:47 GMT
+  recorded_at: Thu, 27 Apr 2017 22:56:30 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Corrects the setting of the following fields:

IndividualAdoption
* adoption_level
* description
* <term_here>_start_date

OsAncillary
* term

