### PR TITLE
Set time zone and record # of students when course is created

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -153,7 +153,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
     Creates a copy of the course with the given ID
     All JSON attributes in the schema are optional
     They will default to the given course's attributes if ommitted
-    #{json_schema(Api::V1::CourseRepresenter, include: :writeable)}
+    #{json_schema(Api::V1::CourseCloneRepresenter, include: :writeable)}
   EOS
   def clone
     OSU::AccessPolicy.require_action_allowed!(:clone, current_api_user, @course)

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -160,7 +160,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
 
     attributes = consumed(Api::V1::CourseCloneRepresenter)
       .slice(:copy_question_library, :name, :is_college, :term, :year, :num_sections, :time_zone,
-             :default_open_time, :default_due_time)
+             :default_open_time, :default_due_time, :estimated_student_count)
       .merge(course: @course, teacher_user: current_human_user)
 
     course = CloneCourse[attributes]

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -169,6 +169,11 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :estimated_student_count,
+             type: Integer,
+             readable: false,
+             writeable: true
+
     collection :roles,
                extend: Api::V1::RoleRepresenter,
                readable: true,

--- a/app/routines/clone_course.rb
+++ b/app/routines/clone_course.rb
@@ -14,7 +14,7 @@ class CloneCourse
 
   def exec(course:, teacher_user:, copy_question_library:,
            name: nil, is_college: nil, term: nil, year: nil, num_sections: nil,
-           time_zone: nil, default_open_time: nil, default_due_time: nil)
+           time_zone: nil, default_open_time: nil, default_due_time: nil, estimated_student_count: nil)
 
     attrs = {
       name: name || course.name,
@@ -30,6 +30,7 @@ class CloneCourse
       default_open_time: default_open_time || course.default_open_time,
       default_due_time: default_due_time || course.default_due_time,
       cloned_from: course,
+      estimated_student_count: estimated_student_count,
       is_preview: false
     }
 

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -17,7 +17,7 @@ class CreateCourse
   def exec(name:, term:, year:, is_preview:, is_college:, is_concept_coach: nil, num_sections: 0,
            catalog_offering: nil, appearance_code: nil, starts_at: nil, ends_at: nil,
            school: nil, time_zone: nil, cloned_from: nil, default_open_time: nil,
-           default_due_time: nil, estimated_student_count: 0)
+           default_due_time: nil, estimated_student_count: nil)
     # TODO eventually, making a course part of a school should be done independently
     # with separate admin controller interfaces and all work done in the SchoolDistrict SS
 

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -31,7 +31,11 @@ class CreateCourse
 
     # If the given time_zone already has an associated course,
     # make a copy to avoid linking the 2 courses' time_zones to the same record
-    time_zone = time_zone.dup if time_zone.present? && time_zone.course.try!(:persisted?)
+    if time_zone.is_a?(TimeZone)
+      time_zone.dup if time_zone.present? && time_zone.course.try!(:persisted?)
+    else
+      time_zone = TimeZone.find_by_name(time_zone)
+    end
 
     run(:create_course,
         name: name,

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -31,10 +31,18 @@ class CreateCourse
 
     # If the given time_zone already has an associated course,
     # make a copy to avoid linking the 2 courses' time_zones to the same record
-    if time_zone.is_a?(TimeZone)
-      time_zone.dup if time_zone.present? && time_zone.course.try!(:persisted?)
-    else
-      time_zone = TimeZone.find_by_name(time_zone)
+    # p time_zone
+    # time_zone = time_zone.dup if time_zone.present? && time_zone.course.try!(:persisted?)
+
+    # Convert time_zone to a model
+    # if it already is and has an associated course,
+    #   make a copy to avoid linking the 2 courses' time_zones to the same record
+    if time_zone.present?
+      if time_zone.is_a?(TimeZone)
+        time_zone = time_zone.dup if time_zone.course.try!(:persisted?)
+      else
+        time_zone = TimeZone.new(name: time_zone)
+      end
     end
 
     run(:create_course,

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -16,8 +16,8 @@ class CreateCourse
 
   def exec(name:, term:, year:, is_preview:, is_college:, is_concept_coach: nil, num_sections: 0,
            catalog_offering: nil, appearance_code: nil, starts_at: nil, ends_at: nil,
-           school: nil, time_zone: nil, cloned_from: nil,
-           default_open_time: nil, default_due_time: nil)
+           school: nil, time_zone: nil, cloned_from: nil, default_open_time: nil,
+           default_due_time: nil, estimated_student_count: 0)
     # TODO eventually, making a course part of a school should be done independently
     # with separate admin controller interfaces and all work done in the SchoolDistrict SS
 
@@ -60,7 +60,8 @@ class CreateCourse
         time_zone: time_zone,
         cloned_from: cloned_from,
         default_open_time: default_open_time,
-        default_due_time: default_due_time)
+        default_due_time: default_due_time,
+        estimated_student_count: estimated_student_count)
 
     num_sections.times{ run(:create_period, course: outputs.course) }
 

--- a/db/migrate/20170504174702_add_estimated_students.rb
+++ b/db/migrate/20170504174702_add_estimated_students.rb
@@ -1,0 +1,5 @@
+class AddEstimatedStudents < ActiveRecord::Migration
+  def change
+    add_column :course_profile_courses, :estimated_student_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170425195217) do
+ActiveRecord::Schema.define(version: 20170504174702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -314,6 +314,7 @@ ActiveRecord::Schema.define(version: 20170425195217) do
     t.boolean  "is_preview",                                  null: false
     t.boolean  "is_excluded_from_salesforce", default: false, null: false
     t.boolean  "is_test",                     default: false, null: false
+    t.integer  "estimated_student_count"
   end
 
   add_index "course_profile_courses", ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id", using: :btree

--- a/spec/routines/clone_course_spec.rb
+++ b/spec/routines/clone_course_spec.rb
@@ -7,7 +7,12 @@ RSpec.describe CloneCourse, type: :routine do
 
   it 'creates a copy of a course' do
 
-    result = described_class.call(course: course, teacher_user: user, copy_question_library: false)
+    result = described_class.call(
+      course: course,
+      teacher_user: user,
+      copy_question_library: false,
+      estimated_student_count: 100
+    )
 
     expect(result.errors).to be_empty
 
@@ -15,6 +20,7 @@ RSpec.describe CloneCourse, type: :routine do
 
     expect(clone).to be_a CourseProfile::Models::Course
     expect(clone.cloned_from).to eq course
+    expect(clone.estimated_student_count).to eq 100
     expect(clone.course_assistants.count).to eq 4
     expect(UserIsCourseTeacher[user: user, course: clone]).to eq true
 

--- a/spec/routines/create_course_spec.rb
+++ b/spec/routines/create_course_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CreateCourse, type: :routine do
       name: 'Unnamed',
       term: term,
       year: year,
+      time_zone: 'Indiana (East)',
       is_preview: is_preview,
       is_college: is_college,
       catalog_offering: catalog_offering
@@ -19,7 +20,7 @@ RSpec.describe CreateCourse, type: :routine do
     expect(result.errors).to be_empty
 
     course = result.outputs.course
-
+    expect(course.time_zone.name).to eq 'Indiana (East)'
     expect(course).to be_a CourseProfile::Models::Course
     expect(course.course_assistants.count).to eq 4
   end

--- a/spec/routines/create_course_spec.rb
+++ b/spec/routines/create_course_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe CreateCourse, type: :routine do
       time_zone: 'Indiana (East)',
       is_preview: is_preview,
       is_college: is_college,
-      catalog_offering: catalog_offering
+      catalog_offering: catalog_offering,
+      estimated_student_count: 42
     )
     expect(result.errors).to be_empty
 
@@ -23,6 +24,7 @@ RSpec.describe CreateCourse, type: :routine do
     expect(course.time_zone.name).to eq 'Indiana (East)'
     expect(course).to be_a CourseProfile::Models::Course
     expect(course.course_assistants.count).to eq 4
+    expect(course.estimated_student_count).to eq 42
   end
 
   it 'adds a unique registration code for the teacher' do


### PR DESCRIPTION
Previously the create course only accepted a `TimeZone` model, this supports setting as string as well.

Also adds "estimated_student_count" field for teachers to record what they think the class size will be