### PR TITLE
ecommerce BE infrastructure #1

### DIFF
--- a/app/access_policies/course_access_policy.rb
+++ b/app/access_policies/course_access_policy.rb
@@ -25,4 +25,5 @@ class CourseAccessPolicy
       false
     end
   end
+
 end

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -91,7 +91,7 @@ class Admin::CoursesController < Admin::BaseController
                 params: course_params,
                 success: ->(*) {
                   flash[:notice] = 'The course has been updated.'
-                  redirect_to admin_courses_path
+                  redirect_to edit_admin_course_path(params[:id])
                 },
                 failure: ->(*) {
                   flash.now[:error] = @handler_result.errors.full_messages
@@ -214,6 +214,7 @@ class Admin::CoursesController < Admin::BaseController
         :is_concept_coach,
         :is_college,
         :is_test,
+        :does_cost,
         :catalog_offering_id,
         :appearance_code,
         :school_district_school_id,

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -31,6 +31,7 @@ class Api::V1::ApiController < OpenStax::Api::V1::ApiController
   protected
 
   def payment_overdue?(course, student)
+    return false if !Settings::Payments.payments_enabled
     return false if student.nil?                        # only students need to pay
     return false if course.is_preview                   # preview courses should never cost
     return false if !course.does_cost

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -2,4 +2,43 @@
 # this class could be V7 and still inherit from V1 in the API gem.
 #
 class Api::V1::ApiController < OpenStax::Api::V1::ApiController
+
+  def error_if_student_and_needs_to_pay
+    return true if current_api_user.human_user.is_anonymous?
+
+    if @student.present?
+      student = @student
+      course = @student.course
+    elsif @course.present?
+      course = @course
+      student = UserIsCourseStudent.call(
+        user: current_api_user.human_user, course: @course
+      ).outputs.student
+    elsif @task.present?
+      student = @task.taskings.first.role.student
+      course = student.try!(:course)
+    elsif @task_step.present?
+      # Assumes all tasks are assigned to one student
+      student = @task_step.task.taskings.first.role.student
+      course = student.try!(:course)
+    else
+      raise "Either @student, @course, @task, or @task_step must be set"
+    end
+
+    payment_overdue?(course, student) ? render_api_errors(:payment_overdue) : true
+  end
+
+  protected
+
+  def payment_overdue?(course, student)
+    return false if student.nil?                        # only students need to pay
+    return false if course.is_preview                   # preview courses should never cost
+    return false if !course.does_cost
+    return false if student.payment_due_at.nil?
+    return false if Time.now < student.payment_due_at   # not overdue yet
+    return false if student.is_paid
+    return false if student.is_comped
+    return true
+  end
+
 end

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::CoursesController < Api::V1::ApiController
   ]
 
   before_filter :get_course, only: [:show, :update, :dashboard, :cc_dashboard, :roster, :clone]
+  before_filter :error_if_student_and_needs_to_pay, only: [:dashboard]
 
   resource_description do
     api_versions "v1"

--- a/app/controllers/api/v1/practices_controller.rb
+++ b/app/controllers/api/v1/practices_controller.rb
@@ -1,21 +1,22 @@
 module Api
   module V1
     class PracticesController < ApiController
+      before_filter :get_course_and_practice_role
+      before_filter :error_if_student_and_needs_to_pay, only: [:create, :show]
+
       api :POST, '/courses/:course_id/practice(/role/:role_id)',
                  'Starts a new practice widget for a specific set of page_ids or chapter_ids'
       description <<-EOS
         #{json_schema(Api::V1::PracticeRepresenter, include: :writeable)}
       EOS
       def create_specific
-        course, role = get_practice_course_and_role
-
-        OSU::AccessPolicy.require_action_allowed!(:create_practice, current_human_user, course)
+        OSU::AccessPolicy.require_action_allowed!(:create_practice, current_human_user, @course)
 
         practice = OpenStruct.new
         consume!(practice, represent_with: Api::V1::PracticeRepresenter)
 
         result = CreatePracticeSpecificTopicsTask.call(
-          course: course, role: role, page_ids: practice.page_ids, chapter_ids: practice.chapter_ids
+          course: @course, role: @role, page_ids: practice.page_ids, chapter_ids: practice.chapter_ids
         )
 
         render_api_errors(result.errors) || respond_with(
@@ -28,11 +29,9 @@ module Api
       api :POST, '/courses/:course_id/practice/worst(/role/:role_id)',
                  'Starts a new practice widget for Practice Worst Topics'
       def create_worst
-        course, role = get_practice_course_and_role
+        OSU::AccessPolicy.require_action_allowed!(:create_practice, current_human_user, @course)
 
-        OSU::AccessPolicy.require_action_allowed!(:create_practice, current_human_user, course)
-
-        result = CreatePracticeWorstTopicsTask.call course: course, role: role
+        result = CreatePracticeWorstTopicsTask.call course: @course, role: @role
 
         render_api_errors(result.errors) || respond_with(
           result.outputs.task,
@@ -44,8 +43,7 @@ module Api
       api :GET, '/courses/:course_id/practice(/role/:role_id)',
                 'Gets the most recent practice widget'
       def show
-        course, role = get_practice_course_and_role
-        task = ::Tasks::GetPracticeTask[role: role]
+        task = ::Tasks::GetPracticeTask[role: @role]
 
         return head(:not_found) if task.nil?
 
@@ -54,16 +52,16 @@ module Api
 
       protected
 
-      def get_practice_course_and_role
-        course = CourseProfile::Models::Course.find(params[:id])
+      def get_course_and_practice_role
+        @course = CourseProfile::Models::Course.find(params[:id])
         result = ChooseCourseRole.call(user: current_human_user,
-                                       course: course,
+                                       course: @course,
                                        allowed_role_type: :student,
                                        role_id: params[:role_id])
         if result.errors.any?
           raise(SecurityTransgression, result.errors.map(&:message).to_sentence)
         else
-          [course, result.outputs.role]
+          @role = result.outputs.role
         end
       end
     end

--- a/app/controllers/api/v1/practices_controller.rb
+++ b/app/controllers/api/v1/practices_controller.rb
@@ -2,7 +2,9 @@ module Api
   module V1
     class PracticesController < ApiController
       before_filter :get_course_and_practice_role
-      before_filter :error_if_student_and_needs_to_pay, only: [:create, :show]
+      before_filter :error_if_student_and_needs_to_pay, only: [:create_specific,
+                                                               :create_worst,
+                                                               :show]
 
       api :POST, '/courses/:course_id/practice(/role/:role_id)',
                  'Starts a new practice widget for a specific set of page_ids or chapter_ids'

--- a/app/controllers/api/v1/students_controller.rb
+++ b/app/controllers/api/v1/students_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::StudentsController < Api::V1::ApiController
 
   before_filter :get_student, only: [:update, :destroy, :undrop]
   before_filter :get_course_student, only: [:update_self]
-  before_filter :error_if_student_and_needs_to_pay, only: [:update_self, :update, :destroy, :undrop]
+  before_filter :error_if_student_and_needs_to_pay, only: [:update_self, :update]
 
   resource_description do
     api_versions "v1"

--- a/app/controllers/api/v1/students_controller.rb
+++ b/app/controllers/api/v1/students_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::StudentsController < Api::V1::ApiController
 
   before_filter :get_student, only: [:update, :destroy, :undrop]
+  before_filter :get_course_student, only: [:update_self]
+  before_filter :error_if_student_and_needs_to_pay, only: [:update_self, :update, :destroy, :undrop]
 
   resource_description do
     api_versions "v1"
@@ -18,7 +20,6 @@ class Api::V1::StudentsController < Api::V1::ApiController
     #{json_schema(Api::V1::StudentSelfUpdateRepresenter, include: :writeable)}
   EOS
   def update_self
-    @student = get_course_student
     consume!(@student, represent_with: Api::V1::StudentSelfUpdateRepresenter)
 
     if @student.save
@@ -109,7 +110,7 @@ class Api::V1::StudentsController < Api::V1::ApiController
                                    course: CourseProfile::Models::Course.find(params[:course_id]),
                                    allowed_role_type: :student)
     raise(SecurityTransgression, result.errors.map(&:message).to_sentence) if result.errors.any?
-    result.outputs.role.student
+    @student = result.outputs.role.student
   end
 
 end

--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::TaskStepsController < Api::V1::ApiController
 
   before_filter :get_task_step_and_tasked
+  before_filter :error_if_student_and_needs_to_pay
   before_filter :populate_placeholders_if_needed, only: :show
 
   resource_description do

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::TasksController < Api::V1::ApiController
 
   before_action :get_task
+  before_filter :error_if_student_and_needs_to_pay, only: [:show, :destroy]
   before_action :populate_placeholders, only: :show
 
   resource_description do

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,8 +1,7 @@
 class PurchasesController < ApplicationController
 
   def show
-    student = CourseMembership::Models::Student.find_by(uuid: params[:id])
-    raise ActiveRecord::RecordNotFound if student.nil?
+    student = CourseMembership::Models::Student.find_by!(uuid: params[:id])
     raise SecurityTransgression if student.role.role_user.profile != current_user.to_model
     redirect_to course_dashboard_path(student.course)
   end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,0 +1,10 @@
+class PurchasesController < ApplicationController
+
+  def show
+    student = CourseMembership::Models::Student.find_by(uuid: params[:id])
+    raise ActiveRecord::RecordNotFound if student.nil?
+    raise SecurityTransgression if student.role.role_user.profile != current_user.to_model
+    redirect_to course_dashboard_path(student.course)
+  end
+
+end

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -168,6 +168,15 @@ module Api::V1
              readable: false,
              writeable: true
 
+    property :does_cost,
+             writeable: false,
+             readable: true,
+             schema_info: {
+                required: true,
+                type: 'boolean',
+                description: "True iff this course requires students to pay"
+             }
+
     collection :periods,
                extend: Api::V1::PeriodRepresenter,
                readable: true,

--- a/app/representers/api/v1/offering_representer.rb
+++ b/app/representers/api/v1/offering_representer.rb
@@ -46,6 +46,15 @@ class Api::V1::OfferingRepresenter < Roar::Decorator
            readable: true,
            writeable: false
 
+  property :does_cost,
+           writeable: false,
+           readable: true,
+           schema_info: {
+              required: true,
+              type: 'boolean',
+              description: "If true, courses generated from this offering will require students to pay"
+           }
+
   collection :active_term_years,
              class: TermYear,
              extend: Api::V1::TermYearRepresenter,

--- a/app/representers/api/v1/student_representer.rb
+++ b/app/representers/api/v1/student_representer.rb
@@ -63,7 +63,8 @@ module Api::V1
              writeable: false,
              readable: true,
              getter: ->(*) {
-               course = self.course
+               # Shenanigans b/c sometimes this representer gets an AR, sometimes a hash
+               course = self.course || CourseProfile::Models::Course.find(course_profile_course_id)
 
                Settings::Payments.payments_enabled &&
                course.does_cost &&

--- a/app/representers/api/v1/student_representer.rb
+++ b/app/representers/api/v1/student_representer.rb
@@ -59,6 +59,23 @@ module Api::V1
                 description: "Student is dropped iff false"
              }
 
+    property :prompt_student_to_pay,
+             writeable: false,
+             readable: true,
+             getter: ->(*) {
+               course = self.course
+
+               Settings::Payments.payments_enabled &&
+               course.does_cost &&
+               !course.is_preview &&
+               !(is_paid || is_comped)
+             },
+             schema_info: {
+               required: true,
+               type: 'boolean',
+               description: "True iff payments enabled globally, course costs and not preview, and not paid or comped"
+             }
+
     property :is_paid,
              writeable: false,
              readable: true,

--- a/app/representers/api/v1/student_representer.rb
+++ b/app/representers/api/v1/student_representer.rb
@@ -59,5 +59,40 @@ module Api::V1
                 description: "Student is dropped iff false"
              }
 
+    property :is_paid,
+             writeable: false,
+             readable: true,
+             schema_info: {
+                required: true,
+                type: 'boolean',
+                description: "True iff student has paid"
+             }
+
+    property :is_comped,
+             writeable: false,
+             readable: true,
+             schema_info: {
+                required: true,
+                type: 'boolean',
+                description: "True iff student has been comped"
+             }
+
+    property :first_paid_at,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { DateTimeUtilities.to_api_s(first_paid_at) },
+             schema_info: {
+                description: "First time the student paid, doesn't change after set"
+             }
+
+    property :payment_due_at,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { DateTimeUtilities.to_api_s(payment_due_at) },
+             schema_info: {
+               description: "Payment is due before this date (if the course costs)"
+             }
+
   end
 end

--- a/app/routines/clone_course.rb
+++ b/app/routines/clone_course.rb
@@ -25,6 +25,8 @@ class CloneCourse
       num_sections: num_sections || course.num_sections,
       school: course.school,
       catalog_offering: course.offering,
+      # don't copy `does_cost` from the course, because that course may not have cost but this one should
+      does_cost: course.offering.does_cost,
       appearance_code: course.appearance_code,
       time_zone: time_zone || course.time_zone,
       default_open_time: default_open_time || course.default_open_time,

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -55,6 +55,7 @@ class CollectCourseInfo
         is_concept_coach: course.is_concept_coach,
         is_college: course.is_college,
         is_preview: course.is_preview,
+        does_cost: course.does_cost,
         school_name: course.school_name,
         salesforce_book_name: offering.try!(:salesforce_book_name),
         appearance_code: course.appearance_code.blank? ? offering.try!(:appearance_code) :

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -19,7 +19,7 @@ class CreateCourse
            num_sections: 0, catalog_offering: nil, appearance_code: nil,
            starts_at: nil, ends_at: nil, school: nil, time_zone: nil, cloned_from: nil,
            default_open_time: nil, default_due_time: nil, estimated_student_count: nil,
-           does_cost: false)
+           does_cost: nil)
 
     # TODO eventually, making a course part of a school should be done independently
     # with separate admin controller interfaces and all work done in the SchoolDistrict SS
@@ -35,7 +35,7 @@ class CreateCourse
     end
 
     is_concept_coach = catalog_offering.try!(:is_concept_coach) if is_concept_coach.nil?
-    does_cost = catalog_offering.try!(:does_cost) if does_cost.nil?
+    does_cost = (catalog_offering.try!(:does_cost) || false) if does_cost.nil?
 
     fatal_error(
       code: :is_concept_coach_blank,

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -18,7 +18,9 @@ class CreateCourse
   def exec(name:, is_preview:, is_college:, is_concept_coach: nil, term: nil, year: nil,
            num_sections: 0, catalog_offering: nil, appearance_code: nil,
            starts_at: nil, ends_at: nil, school: nil, time_zone: nil, cloned_from: nil,
-           default_open_time: nil, default_due_time: nil, estimated_student_count: nil)
+           default_open_time: nil, default_due_time: nil, estimated_student_count: nil,
+           does_cost: false)
+
     # TODO eventually, making a course part of a school should be done independently
     # with separate admin controller interfaces and all work done in the SchoolDistrict SS
 
@@ -33,15 +35,13 @@ class CreateCourse
     end
 
     is_concept_coach = catalog_offering.try!(:is_concept_coach) if is_concept_coach.nil?
+    does_cost = catalog_offering.try!(:does_cost) if does_cost.nil?
 
     fatal_error(
       code: :is_concept_coach_blank,
       message: 'You must provide at least one of the following 2 options: ' +
                ':is_concept_coach or :catalog_offering'
     ) if is_concept_coach.nil?
-
-    # If the given time_zone already has an associated course,
-    # make a copy to avoid linking the 2 courses' time_zones to the same record
 
     # Convert time_zone to a model
     # if it already is and has an associated course,
@@ -60,6 +60,7 @@ class CreateCourse
       is_college: is_college,
       is_concept_coach: is_concept_coach,
       is_preview: is_preview,
+      does_cost: does_cost,
       term: term,
       year: year,
       starts_at: starts_at,

--- a/app/routines/get_course_roster.rb
+++ b/app/routines/get_course_roster.rb
@@ -17,11 +17,15 @@ class GetCourseRoster
           first_name: student.first_name,
           last_name: student.last_name,
           name: student.name,
+          course_profile_course_id: student.course_profile_course_id,
           course_membership_period_id: student.course_membership_period_id,
           entity_role_id: student.entity_role_id,
           username: student.username,
           student_identifier: student.student_identifier,
-          deleted?: student.deleted?
+          deleted?: student.deleted?,
+          is_paid: student.is_paid,
+          is_comped: student.is_comped,
+          payment_due_at: student.payment_due_at
         })
       end
     }

--- a/app/subsystems/catalog/offering.rb
+++ b/app/subsystems/catalog/offering.rb
@@ -7,7 +7,8 @@ module Catalog
 
     wrap_attributes ::Catalog::Models::Offering,
       :id, :number, :salesforce_book_name, :appearance_code, :is_tutor, :is_concept_coach,
-      :is_available, :title, :description, :webview_url, :pdf_url, :default_course_name
+      :is_available, :title, :description, :webview_url, :pdf_url, :default_course_name,
+      :does_cost
 
     def ecosystem
       verify_and_return @strategy.ecosystem, klass: ::Content::Ecosystem,

--- a/app/subsystems/catalog/strategies/direct/offering.rb
+++ b/app/subsystems/catalog/strategies/direct/offering.rb
@@ -7,7 +7,8 @@ module Catalog
 
         exposes :id, :number, :salesforce_book_name, :appearance_code,
                 :is_tutor, :is_concept_coach, :is_available, :title, :description,
-                :webview_url, :pdf_url, :ecosystem, :content_ecosystem_id, :default_course_name
+                :webview_url, :pdf_url, :ecosystem, :content_ecosystem_id, :default_course_name,
+                :does_cost
 
         def self.find_by(*args)
           model = ::Catalog::Models::Offering.find_by(*args)

--- a/app/subsystems/course_membership/add_student.rb
+++ b/app/subsystems/course_membership/add_student.rb
@@ -19,7 +19,7 @@ class CourseMembership::AddStudent
     course = period.course
 
     # Give the student til midnight after 14 days from now
-    payment_due_at = course.time_zone.to_tz.tomorrow.midnight - 1.second +
+    payment_due_at = course.time_zone.to_tz.now.midnight + 1.day - 1.second +
                      Settings::Payments.student_grace_period_days.days
 
     student = CourseMembership::Models::Student.create(role: role,

--- a/app/subsystems/course_membership/add_student.rb
+++ b/app/subsystems/course_membership/add_student.rb
@@ -16,7 +16,15 @@ class CourseMembership::AddStudent
       }."
     ) unless student.nil?
 
-    student = CourseMembership::Models::Student.create(role: role, course: period.course,
+    course = period.course
+
+    # Give the student til midnight after 14 days from now
+    payment_due_at = course.time_zone.to_tz.tomorrow.midnight - 1.second +
+                     Settings::Payments.student_grace_period_days.days
+
+    student = CourseMembership::Models::Student.create(role: role,
+                                                       course: course,
+                                                       payment_due_at: payment_due_at,
                                                        student_identifier: student_identifier)
     transfer_errors_from(student, {type: :verbatim}, true)
 

--- a/app/subsystems/course_membership/is_course_student.rb
+++ b/app/subsystems/course_membership/is_course_student.rb
@@ -24,7 +24,8 @@ class CourseMembership::IsCourseStudent
     end
 
     is_course_student = valid_student.present? || outputs.is_dropped || outputs.is_archived
-
     outputs.is_course_student = !!is_course_student
+    
+    outputs[:student] = valid_student
   end
 end

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -17,4 +17,5 @@ class CourseMembership::Models::Student < Tutor::SubSystems::BaseModel
   delegate :username, :first_name, :last_name, :full_name, :name, to: :role
   delegate :period, :course_membership_period_id, to: :latest_enrollment, allow_nil: true
 
+
 end

--- a/app/views/admin/catalog_offerings/_display_row.html.erb
+++ b/app/views/admin/catalog_offerings/_display_row.html.erb
@@ -30,6 +30,12 @@
     <b>Ecosystem:</b> <%= offering.ecosystem ? offering.ecosystem.title : 'not set' %>
   </div>
   <div>
+    <b>Available for teachers to select:</b> <%= tf_to_yn(offering.is_available) %>
+  </div>
+  <div>
+    <b>Costs students:</b> <%= tf_to_yn(offering.does_cost) %>
+  </div>
+  <div>
     <b>PDF URL:</b> <%= link_to offering.pdf_url, offering.pdf_url %>
   </div>
   <div>

--- a/app/views/admin/catalog_offerings/_edit_row.html.erb
+++ b/app/views/admin/catalog_offerings/_edit_row.html.erb
@@ -58,6 +58,12 @@
   </div>
   <div class="checkbox">
     <label>
+      <%= form.check_box :does_cost, class: 'form-control' %>
+      <span class="checkbox-label">Costs students?</span>
+    </label>
+  </div>
+  <div class="checkbox">
+    <label>
       <%= form.check_box :is_tutor, class: 'form-control' %>
       <span class="checkbox-label">Works for full Tutor?</span>
     </label>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -97,5 +97,10 @@
     <%= f.check_box :is_test, class: 'form-control' %>
   </div>
 
+  <div class="form-group">
+    <%= f.label :does_cost %>
+    <%= f.check_box :does_cost, class: 'form-control' %>
+  </div>
+
   <%= f.submit 'Save', class: 'btn btn-primary', id: 'edit-save' %>
 <% end %>

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -80,7 +80,8 @@
               <%= "#{course_info.periods_with_deleted.map do |period|
                        period.latest_enrollments_with_deleted.length
                      end.reduce(0, :+)} students /" %>
-              <%= "#{course_info.periods_with_deleted.length} periods" %>
+              <%= "#{course_info.periods_with_deleted.length} periods" %> /
+              <%= course_info.does_cost ? "Does Cost" : "Does NOT Cost" %>
             </div>
           </div>
           <div class="card-content-right">

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -10,6 +10,7 @@ Settings::Db.store.defaults[:import_real_salesforce_courses] = false
 Settings::Db.store.defaults[:default_open_time] = '00:01'
 Settings::Db.store.defaults[:default_due_time] = '07:00'
 Settings::Db.store.defaults[:term_years_to_import] = ''
+Settings::Db.store.defaults[:student_grace_period_days] = 14
 
 secrets = Rails.application.secrets
 

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -11,6 +11,7 @@ Settings::Db.store.defaults[:default_open_time] = '00:01'
 Settings::Db.store.defaults[:default_due_time] = '07:00'
 Settings::Db.store.defaults[:term_years_to_import] = ''
 Settings::Db.store.defaults[:student_grace_period_days] = 14
+Settings::Db.store.defaults[:payments_enabled] = false
 
 secrets = Rails.application.secrets
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,9 @@ en:
       course_appearance_codes:
         name: 'Valid Course Appearance Codes'
         help_block: 'As a Ruby Hash'
+      student_grace_period_days:
+        name: 'Student payment grace period'
+        help_block: 'In days; changes to this value only apply to students who enroll after the change'
       pardot_toa_redirect:
         name: 'TutorOnboardingA Redirect URL'
         help_block: 'Where an arrival to /pardot/toa is redirected'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :purchases, only: [:show]
+
   mount OpenStax::Accounts::Engine => :accounts
   mount FinePrint::Engine => :fine_print
 

--- a/db/migrate/20170428230057_add_payment_fields.rb
+++ b/db/migrate/20170428230057_add_payment_fields.rb
@@ -1,0 +1,16 @@
+class AddPaymentFields < ActiveRecord::Migration
+  def change
+    add_column :catalog_offerings, :does_cost, :boolean, default: false, null: false
+    add_column :course_profile_courses, :does_cost, :boolean, default: false, null: false
+
+    add_column :course_membership_students, :first_paid_at, :datetime
+    add_column :course_membership_students, :is_paid, :boolean, default: false, null: false
+    add_column :course_membership_students, :is_comped, :boolean, default: false, null: false
+    add_column :course_membership_students, :payment_due_at, :datetime
+
+    # remove on rebase already in BL PR
+    enable_extension 'pgcrypto'
+    add_column :course_membership_students, :uuid, :uuid, null: false, default: 'gen_random_uuid()'
+    add_index :course_membership_students, :uuid, unique: true
+  end
+end

--- a/db/migrate/20170428230057_add_payment_fields.rb
+++ b/db/migrate/20170428230057_add_payment_fields.rb
@@ -7,10 +7,5 @@ class AddPaymentFields < ActiveRecord::Migration
     add_column :course_membership_students, :is_paid, :boolean, default: false, null: false
     add_column :course_membership_students, :is_comped, :boolean, default: false, null: false
     add_column :course_membership_students, :payment_due_at, :datetime
-
-    # remove on rebase already in BL PR
-    enable_extension 'pgcrypto'
-    add_column :course_membership_students, :uuid, :uuid, null: false, default: 'gen_random_uuid()'
-    add_index :course_membership_students, :uuid, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20170518182025) do
     t.boolean  "is_available",                         null: false
     t.string   "title",                                null: false
     t.integer  "number",                               null: false
+    t.boolean  "does_cost",            default: false, null: false
   end
 
   add_index "catalog_offerings", ["content_ecosystem_id"], name: "index_catalog_offerings_on_content_ecosystem_id", using: :btree
@@ -292,6 +293,10 @@ ActiveRecord::Schema.define(version: 20170518182025) do
     t.datetime "updated_at",                                             null: false
     t.string   "student_identifier"
     t.uuid     "uuid",                     default: "gen_random_uuid()"
+    t.datetime "first_paid_at"
+    t.boolean  "is_paid",                  default: false,               null: false
+    t.boolean  "is_comped",                default: false,               null: false
+    t.datetime "payment_due_at"
   end
 
   add_index "course_membership_students", ["course_profile_course_id", "student_identifier"], name: "index_course_membership_students_on_c_p_c_id_and_s_identifier", using: :btree
@@ -337,6 +342,7 @@ ActiveRecord::Schema.define(version: 20170518182025) do
     t.string   "biglearn_assignment_pes_algorithm_name",                                     null: false
     t.string   "biglearn_practice_worst_areas_algorithm_name",                               null: false
     t.boolean  "is_test",                                      default: false,               null: false
+    t.boolean  "does_cost",                   default: false, null: false
     t.integer  "estimated_student_count"
     t.datetime "preview_claimed_at"
   end
@@ -422,6 +428,24 @@ ActiveRecord::Schema.define(version: 20170518182025) do
   end
 
   add_index "legal_targeted_contracts", ["target_gid"], name: "legal_targeted_contracts_target", using: :btree
+
+  create_table "lms_nonces", force: :cascade do |t|
+    t.string   "value",                limit: 128, null: false
+    t.integer  "lms_tool_consumer_id",             null: false
+    t.datetime "created_at"
+  end
+
+  add_index "lms_nonces", ["lms_tool_consumer_id", "value"], name: "nonce_consumer_value", unique: true, using: :btree
+
+  create_table "lms_tool_consumers", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.string   "key",        null: false
+    t.string   "secret",     null: false
+    t.string   "owner_id",   null: false
+    t.text     "notes"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -958,6 +982,7 @@ ActiveRecord::Schema.define(version: 20170518182025) do
   add_foreign_key "course_profile_courses", "course_profile_courses", column: "cloned_from_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "course_profile_courses", "school_district_schools", on_update: :cascade, on_delete: :nullify
   add_foreign_key "course_profile_courses", "time_zones", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "lms_nonces", "lms_tool_consumers", on_update: :cascade, on_delete: :cascade
   add_foreign_key "role_role_users", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "role_role_users", "user_profiles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "school_district_schools", "school_district_districts", on_update: :cascade, on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -342,7 +342,7 @@ ActiveRecord::Schema.define(version: 20170518182025) do
     t.string   "biglearn_assignment_pes_algorithm_name",                                     null: false
     t.string   "biglearn_practice_worst_areas_algorithm_name",                               null: false
     t.boolean  "is_test",                                      default: false,               null: false
-    t.boolean  "does_cost",                   default: false, null: false
+    t.boolean  "does_cost",                                    default: false,               null: false
     t.integer  "estimated_student_count"
     t.datetime "preview_claimed_at"
   end
@@ -428,24 +428,6 @@ ActiveRecord::Schema.define(version: 20170518182025) do
   end
 
   add_index "legal_targeted_contracts", ["target_gid"], name: "legal_targeted_contracts_target", using: :btree
-
-  create_table "lms_nonces", force: :cascade do |t|
-    t.string   "value",                limit: 128, null: false
-    t.integer  "lms_tool_consumer_id",             null: false
-    t.datetime "created_at"
-  end
-
-  add_index "lms_nonces", ["lms_tool_consumer_id", "value"], name: "nonce_consumer_value", unique: true, using: :btree
-
-  create_table "lms_tool_consumers", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "key",        null: false
-    t.string   "secret",     null: false
-    t.string   "owner_id",   null: false
-    t.text     "notes"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -982,7 +964,6 @@ ActiveRecord::Schema.define(version: 20170518182025) do
   add_foreign_key "course_profile_courses", "course_profile_courses", column: "cloned_from_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "course_profile_courses", "school_district_schools", on_update: :cascade, on_delete: :nullify
   add_foreign_key "course_profile_courses", "time_zones", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "lms_nonces", "lms_tool_consumers", on_update: :cascade, on_delete: :cascade
   add_foreign_key "role_role_users", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "role_role_users", "user_profiles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "school_district_schools", "school_district_districts", on_update: :cascade, on_delete: :nullify

--- a/lib/settings/payments.rb
+++ b/lib/settings/payments.rb
@@ -3,6 +3,14 @@ module Settings
 
     class << self
 
+      def payments_enabled
+        Settings::Db.store.payments_enabled
+      end
+
+      def payments_enabled=(value)
+        Settings::Db.store.payments_enabled = value
+      end
+
       def student_grace_period_days
         Settings::Db.store.student_grace_period_days
       end

--- a/lib/settings/payments.rb
+++ b/lib/settings/payments.rb
@@ -1,0 +1,17 @@
+module Settings
+  module Payments
+
+    class << self
+
+      def student_grace_period_days
+        Settings::Db.store.student_grace_period_days
+      end
+
+      def student_grace_period_days=(days)
+        Settings::Db.store.student_grace_period_days = days
+      end
+
+    end
+
+  end
+end

--- a/spec/controllers/admin/catalog_offerings_controller_spec.rb
+++ b/spec/controllers/admin/catalog_offerings_controller_spec.rb
@@ -61,12 +61,14 @@ RSpec.describe Admin::CatalogOfferingsController, type: :controller do
     it 'can update an offering' do
       expect(offering.is_tutor).to be false
       expect(offering.is_concept_coach).to be false
+      expect(offering.does_cost).to be false
       response = put :update, { id: offering.id,
-                       offering: offering.attributes.merge({'is_tutor' => 't', 'is_concept_coach' => 't' }) }
+                       offering: offering.attributes.merge({'is_tutor' => 't', 'is_concept_coach' => 't', 'does_cost' => 't' }) }
       expect(response).to redirect_to action: 'index'
       offering.reload
       expect(offering.is_tutor).to be true
       expect(offering.is_concept_coach).to be true
+      expect(offering.does_cost).to be true
     end
   end
 

--- a/spec/controllers/admin/students_controller_spec.rb
+++ b/spec/controllers/admin/students_controller_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Admin::StudentsController do
     it 'returns all the students in a course' do
       get :index, course_id: course.id
       expect(assigns[:course].name).to eq 'Physics'
-      expect(assigns[:students]).to eq([
-        {
+      expect(assigns[:students]).to match a_collection_containing_exactly(
+        a_hash_including(
           'id' => student_1.id,
           'username' => user_1.username,
           'first_name' => user_1.first_name,
@@ -49,8 +49,8 @@ RSpec.describe Admin::StudentsController do
           'course_membership_period_id' => student_1.period.id,
           'student_identifier' => student_1.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_3.id,
           'username' => user_3.username,
           'first_name' => user_3.first_name,
@@ -60,8 +60,8 @@ RSpec.describe Admin::StudentsController do
           'course_membership_period_id' => student_3.period.id,
           'student_identifier' => student_3.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_2.id,
           'username' => user_2.username,
           'first_name' => user_2.first_name,
@@ -71,8 +71,8 @@ RSpec.describe Admin::StudentsController do
           'course_membership_period_id' => student_2.period.id,
           'student_identifier' => student_2.student_identifier,
           'deleted?' => false
-        }
-      ])
+        )
+      )
     end
 
     it 'works even if a student has a nil username' do
@@ -80,8 +80,8 @@ RSpec.describe Admin::StudentsController do
 
       get :index, course_id: course.id
       expect(assigns[:course].name).to eq 'Physics'
-      expect(assigns[:students]).to eq([
-        {
+      expect(assigns[:students]).to match a_collection_containing_exactly(
+        a_hash_including(
           'id' => student_1.id,
           'username' => user_1.username,
           'first_name' => user_1.first_name,
@@ -91,8 +91,8 @@ RSpec.describe Admin::StudentsController do
           'course_membership_period_id' => student_1.period.id,
           'student_identifier' => student_1.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_3.id,
           'username' => user_3.username,
           'first_name' => user_3.first_name,
@@ -102,8 +102,8 @@ RSpec.describe Admin::StudentsController do
           'course_membership_period_id' => student_3.period.id,
           'student_identifier' => student_3.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_2.id,
           'username' => nil,
           'first_name' => user_2.first_name,
@@ -113,8 +113,8 @@ RSpec.describe Admin::StudentsController do
           'course_membership_period_id' => student_2.period.id,
           'student_identifier' => student_2.student_identifier,
           'deleted?' => false
-        }
-      ])
+        )
+      )
     end
   end
 end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -1163,7 +1163,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 name: student.name,
                 period_id: period.id.to_s,
                 role_id: student_role.id.to_s,
-                is_active: true
+                is_active: true,
+                prompt_student_to_pay: false
               },
               {
                 id: student_2.id.to_s,
@@ -1172,7 +1173,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 name: student_2.name,
                 period_id: period.id.to_s,
                 role_id: student_role_2.id.to_s,
-                is_active: true
+                is_active: true,
+                prompt_student_to_pay: false
               },
               {
                 id: student_3.id.to_s,
@@ -1181,7 +1183,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 name: student_3.name,
                 period_id: period_2.id.to_s,
                 role_id: student_role_3.id.to_s,
-                is_active: true
+                is_active: true,
+                prompt_student_to_pay: false
               }
             )
           })

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -1113,7 +1113,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
   context '#roster' do
     let(:application)        { FactoryGirl.create :doorkeeper_application }
 
-    let(:course)             { FactoryGirl.create :course_profile_course }
+    let(:course)             { FactoryGirl.create :course_profile_course, does_cost: true }
     let!(:period_2)          { FactoryGirl.create :course_membership_period, course: course }
 
     let(:student_user)       { FactoryGirl.create(:user) }
@@ -1142,11 +1142,21 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
     context 'caller has an authorization token' do
       context 'caller is a course teacher' do
         it 'returns the course roster' do
+          allow(Settings::Payments).to receive(:payments_enabled) { true }
+
+          student_2.update_attributes(is_paid: true)
+          student_3.update_attributes(is_comped: true)
+
           api_get :roster, teacher_token, parameters: valid_params
           expect(response).to have_http_status(:ok)
           roster = response.body_as_hash
-          expect(roster).to include({
-            teach_url: a_string_matching(/.*teach\/[a-f0-9]{32}\/DO_NOT.*/),
+
+
+          expect(roster).to include(
+            teach_url: a_string_matching(/.*teach\/[a-f0-9]{32}\/DO_NOT.*/)
+          )
+
+          expect(roster).to include(
             teachers: a_collection_containing_exactly(
               {
                 id: teacher_role.teacher.id.to_s,
@@ -1154,9 +1164,12 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 first_name: teacher_user.first_name,
                 last_name: teacher_user.last_name,
               }
-            ),
+            )
+          )
+
+          expect(roster).to include(
             students: a_collection_containing_exactly(
-              {
+              a_hash_including({
                 id: student.id.to_s,
                 first_name: student.first_name,
                 last_name: student.last_name,
@@ -1164,9 +1177,12 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 period_id: period.id.to_s,
                 role_id: student_role.id.to_s,
                 is_active: true,
-                prompt_student_to_pay: false
-              },
-              {
+                prompt_student_to_pay: true,
+                is_paid: false,
+                is_comped: false,
+                payment_due_at: be_kind_of(String)
+              }),
+              a_hash_including({
                 id: student_2.id.to_s,
                 first_name: student_2.first_name,
                 last_name: student_2.last_name,
@@ -1174,9 +1190,12 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 period_id: period.id.to_s,
                 role_id: student_role_2.id.to_s,
                 is_active: true,
-                prompt_student_to_pay: false
-              },
-              {
+                prompt_student_to_pay: false,
+                is_paid: true,
+                is_comped: false,
+                payment_due_at: be_kind_of(String)
+              }),
+              a_hash_including({
                 id: student_3.id.to_s,
                 first_name: student_3.first_name,
                 last_name: student_3.last_name,
@@ -1184,10 +1203,13 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
                 period_id: period_2.id.to_s,
                 role_id: student_role_3.id.to_s,
                 is_active: true,
-                prompt_student_to_pay: false
-              }
+                prompt_student_to_pay: false,
+                is_paid: false,
+                is_comped: true,
+                payment_due_at: be_kind_of(String)
+              })
             )
-          })
+          )
         end
       end
 

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -570,6 +570,14 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
       end
     end
 
+    context 'not paid' do
+      it "422's if needs to pay" do
+        make_payment_required_and_expect_422(course: course, student: student_role.student) {
+          api_get :dashboard, student_token, parameters: {id: course.id}
+        }
+      end
+    end
+
     context 'student' do
       it 'returns an error if the course is a CC course' do
         course.update_attribute(:is_concept_coach, true)

--- a/spec/controllers/api/v1/error_if_student_and_needs_to_pay_spec.rb
+++ b/spec/controllers/api/v1/error_if_student_and_needs_to_pay_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Api::V1::ApiController#error_if_student_and_needs_to_pay', type:
     end
   end
 
+  before(:each) { allow(Settings::Payments).to receive(:payments_enabled) { true } }
+
   let(:application)       { FactoryGirl.create :doorkeeper_application }
   let(:course)            { FactoryGirl.create :course_profile_course }
   let(:period)            { FactoryGirl.create :course_membership_period, course: course }

--- a/spec/controllers/api/v1/error_if_student_and_needs_to_pay_spec.rb
+++ b/spec/controllers/api/v1/error_if_student_and_needs_to_pay_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::ApiController#error_if_student_and_needs_to_pay', type: :controller, api: true, version: :v1 do
+
+  controller(Api::V1::ApiController) do
+    skip_filter *(_process_action_callbacks.map(&:filter))
+    before_filter :set_course_or_student
+    before_filter :error_if_student_and_needs_to_pay
+
+    def index
+      head :ok
+    end
+
+    def set_course_or_student
+      @course = CourseProfile::Models::Course.find(params[:course_id]) if params[:course_id]
+      @student = CourseMembership::Models::Student.find(params[:student_id]) if params[:student_id]
+    end
+  end
+
+  let(:application)       { FactoryGirl.create :doorkeeper_application }
+  let(:course)            { FactoryGirl.create :course_profile_course }
+  let(:period)            { FactoryGirl.create :course_membership_period, course: course }
+
+  let(:student_user)      { FactoryGirl.create(:user) }
+  let(:student_role)      { AddUserAsPeriodStudent[user: student_user, period: period] }
+  let!(:student)          { student_role.student }
+  let(:student_token)     { FactoryGirl.create :doorkeeper_access_token,
+                                               application: application,
+                                               resource_owner_id: student_user.id }
+
+
+  let(:non_student_user)      { FactoryGirl.create(:user) }
+  let(:non_student_token)     { FactoryGirl.create :doorkeeper_access_token,
+                                                   application: application,
+                                                   resource_owner_id: non_student_user.id }
+
+  context 'error_if_student_and_needs_to_pay' do
+    context 'when the user is a student in the course' do
+      it 'returns true when course is free' do
+        student.update_attribute(:payment_due_at, 40.years.ago)
+        api_get :index, student_token, parameters: { course_id: course.id }
+        expect(response).to have_http_status(:success)
+      end
+
+      context 'when the course costs' do
+        before(:each) { course.update_attributes(does_cost: true) }
+
+        it 'return true when uncomped/unpaid but still in grace period' do
+          student.update_attributes(payment_due_at: 3.days.from_now)
+          api_get :index, student_token, parameters: { course_id: course.id }
+          expect(response).to have_http_status(:success)
+        end
+
+        # TODO spec boundaries of grace period time
+
+        it 'errors when unpaid/uncomped and the grace period has passed' do
+          student.update_attributes(payment_due_at: 1.day.ago)
+          api_get :index, student_token, parameters: { course_id: course.id }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'returns true when paid' do
+          student.update_attributes(payment_due_at: 3.days.ago, is_paid: true)
+          api_get :index, student_token, parameters: { course_id: course.id }
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'returns true when comped' do
+          student.update_attributes(payment_due_at: 3.days.ago, is_comped: true)
+          api_get :index, student_token, parameters: { course_id: course.id }
+          expect(response).to have_http_status(:success)
+        end
+      end
+    end
+
+    context 'when the user is not a student in the course' do
+      it 'returns true' do
+        api_get :index, non_student_token, parameters: { course_id: course.id }
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  it 'still works when just student specified' do
+    course.update_attributes(does_cost: true)
+    student.update_attributes(payment_due_at: 3.days.ago, is_paid: true)
+    api_get :index, student_token, parameters: { student_id: student.id }
+  end
+
+end

--- a/spec/controllers/api/v1/guides_controller_spec.rb
+++ b/spec/controllers/api/v1/guides_controller_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe Api::V1::GuidesController, type: :controller, api: true,
         api_get :student, user_1_token, parameters: { course_id: course.id,
                                                       role_id: student_3_role.id }
       end
+
+      it "422's if needs to pay" do
+        make_payment_required_and_expect_422(course: course, student: student_role.student) {
+          api_get :student, user_2_token, parameters: { course_id: course.id }
+        }
+      end
     end
 
     describe '#teacher' do

--- a/spec/controllers/api/v1/practices_controller_spec.rb
+++ b/spec/controllers/api/v1/practices_controller_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
 
       expect(response).to have_http_status(422)
     end
+    
+    it "422's if needs to pay" do
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_post :create_specific,
+                 user_1_token,
+                 parameters: { id: course.id, role_id: role.id },
+                 raw_post_data: { page_ids: [page.id.to_s] }.to_json
+      }
+    end
   end
 
   context 'POST #create_worst' do
@@ -139,6 +148,15 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
 
       expect(response).to have_http_status(422)
     end
+    
+    
+    it "422's if needs to pay" do
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_post :create_worst,
+                 user_1_token,
+                 parameters: { id: course.id, role_id: role.id }
+      }
+    end
   end
 
   context 'GET #show' do
@@ -163,6 +181,14 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
       expect(response.body_as_hash).to(
         include(id: be_kind_of(String), title: 'Practice', steps: have(5).items)
       )
+    end
+
+    it "422's if needs to pay" do
+      AddUserAsPeriodStudent.call(period: period, user: user_1)
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_get :show, user_1_token, parameters: { id: course.id,
+                                                   role_id: Entity::Role.last.id }
+      }
     end
 
     it 'can be called by a teacher using a student role' do

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -114,6 +114,13 @@ RSpec.describe Api::V1::StudentsController, type: :controller, api: true, versio
             expect(response.body_as_hash[:student_identifier]).to eq new_id
             expect(student.reload.student_identifier).to eq new_id
           end
+
+          it "422's if needs to pay" do
+            make_payment_required_and_expect_422(course: course, student: student) {
+              api_patch :update_self, student_token, parameters: valid_params,
+                                                     raw_post_data: valid_body
+            }
+          end
         end
       end
 
@@ -166,6 +173,12 @@ RSpec.describe Api::V1::StudentsController, type: :controller, api: true, versio
               is_active: true
             })
             expect(student.reload.period).to eq period_2.to_model
+          end
+
+          it "422's if needs to pay" do
+            make_payment_required_and_expect_422(course: course, student: student) {
+              api_patch :update, teacher_token, parameters: valid_params, raw_post_data: valid_body
+            }
           end
 
           context 'and updating the student\'s identifier' do

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Api::V1::StudentsController, type: :controller, api: true, versio
             api_patch :update, teacher_token, parameters: valid_params, raw_post_data: valid_body
             expect(response).to have_http_status(:ok)
             new_student = CourseMembership::Models::Student.find(response.body_as_hash[:id])
-            expect(response.body_as_hash).to eq({
+            expect(response.body_as_hash).to include({
               id: student.id.to_s,
               first_name: student.first_name,
               last_name: student.last_name,

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Api::V1::StudentsController, type: :controller, api: true, versio
   let(:student_user)      { FactoryGirl.create(:user) }
   let(:student_role)      { AddUserAsPeriodStudent[user: student_user, period: period] }
   let!(:student)          { student_role.student }
+  let!(:student_original_payment_due_at) { student.payment_due_at }
   let(:student_token)     { FactoryGirl.create :doorkeeper_access_token,
                                                application: application,
                                                resource_owner_id: student_user.id }
@@ -292,6 +293,7 @@ RSpec.describe Api::V1::StudentsController, type: :controller, api: true, versio
               student.reload
               expect(student.persisted?).to eq true
               expect(student.deleted?).to eq false
+              expect(student.payment_due_at).to eq student_original_payment_due_at
             end
 
             it 'fails if the student\'s identifier is taken by someone else' do

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
     end
   end
 
-  context "practice task update step" do    
+  context "practice task update step" do
     let(:step) do
       page = tasked_exercise.exercise.page
 
@@ -270,13 +270,11 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
 
       AddEcosystemToCourse[course: course, ecosystem: ecosystem]
 
-      role = AddUserAsPeriodStudent[period: period, user: user_1]
-
-      task = CreatePracticeSpecificTopicsTask[course: course, role: role, page_ids: [page.id]]
+      task = CreatePracticeSpecificTopicsTask[course: course, role: user_1_role, page_ids: [page.id]]
 
       task.task_steps.first
     end
-  
+
     it "allows updating of a step" do
 
       api_put :update, user_1_token, parameters: { id: step.id },

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -2,13 +2,16 @@ require "rails_helper"
 
 RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, version: :v1 do
 
+  let(:course)              { FactoryGirl.create :course_profile_course }
+  let(:period)              { FactoryGirl.create :course_membership_period, course: course }
+
   let(:application)        { FactoryGirl.create :doorkeeper_application }
   let(:user_1)             { FactoryGirl.create :user }
   let(:user_1_token)       do
     FactoryGirl.create :doorkeeper_access_token, application: application,
                                                  resource_owner_id: user_1.id
   end
-  let(:user_1_role)        { Role::GetDefaultUserRole[user_1] }
+  let(:user_1_role)        { AddUserAsPeriodStudent[user: user_1, period: period] }
 
   let(:user_2)             { FactoryGirl.create(:user) }
   let(:user_2_token)       do
@@ -33,8 +36,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
     te
   end
 
-  let(:course)              { FactoryGirl.create :course_profile_course }
-  let(:period)              { FactoryGirl.create :course_membership_period, course: course }
+
 
   let(:lo)                  { FactoryGirl.create :content_tag, value: 'ost-tag-lo-test-lo01' }
   let(:pp)                  { FactoryGirl.create :content_tag, value: 'os-practice-problems' }
@@ -70,6 +72,12 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       })
     end
 
+    it "422's if needs to pay" do
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_get :show, user_1_token, parameters: { task_id: task_step.task.id, id: task_step.id }
+      }
+    end
+
     it 'raises SecurityTransgression when user is anonymous or not a teacher' do
       expect {
         api_get :show, nil, parameters: { task_id: task_step.task.id, id: task_step.id }
@@ -97,6 +105,13 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       )
 
       expect(tasked.reload.free_response).to eq "Ipsum lorem"
+    end
+
+    it "422's if needs to pay" do
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_put :update, user_1_token, parameters: id_parameters,
+                raw_post_data: { free_response: "Ipsum lorem" }
+      }
     end
 
     it "updates the selected answer of an exercise" do
@@ -197,6 +212,13 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       expect(tasked.task_step(true).completed?).to be_truthy
     end
 
+    it "422's if needs to pay" do
+      tasked = create_tasked(:tasked_reading, user_1_role)
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_put :completed, user_1_token, parameters: { id: tasked.task_step.id }
+      }
+    end
+
     it "should not allow marking completion of reading steps by random user" do
       tasked = create_tasked(:tasked_reading, user_1_role)
       expect{
@@ -235,8 +257,8 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
     end
   end
 
-  context "practice task update step" do
-    it "allows updating of a step" do
+  context "practice task update step" do    
+    let(:step) do
       page = tasked_exercise.exercise.page
 
       Content::Routines::PopulateExercisePools[book: page.book]
@@ -252,12 +274,21 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
 
       task = CreatePracticeSpecificTopicsTask[course: course, role: role, page_ids: [page.id]]
 
-      step = task.task_steps.first
+      task.task_steps.first
+    end
+  
+    it "allows updating of a step" do
 
       api_put :update, user_1_token, parameters: { id: step.id },
               raw_post_data: { free_response: "Ipsum lorem" }
-
       expect(response).to have_http_status(:success)
+    end
+
+    it "422's if needs to pay" do
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_put :update, user_1_token, parameters: { id: step.id },
+                raw_post_data: { free_response: "Ipsum lorem" }
+      }
     end
   end
 

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -2,13 +2,20 @@ require "rails_helper"
 
 RSpec.describe Api::V1::TasksController, type: :controller, api: true, version: :v1 do
 
+  let(:course)            { FactoryGirl.create :course_profile_course }
+  let(:period)            { FactoryGirl.create :course_membership_period, course: course }
+
+  let(:task_1)             { FactoryGirl.create :tasks_task, title: 'A Task Title',
+                                                step_types: [:tasks_tasked_reading,
+                                                             :tasks_tasked_exercise] }
+
   let(:application)        { FactoryGirl.create :doorkeeper_application }
   let(:user_1)             { FactoryGirl.create(:user) }
   let(:user_1_token)       { FactoryGirl.create :doorkeeper_access_token,
                                                 application: application,
                                                 resource_owner_id: user_1.id }
 
-  let(:user_1_role)        { Role::GetDefaultUserRole[user_1] }
+  let!(:user_1_role)        { AddUserAsPeriodStudent[user: user_1, period: period] }
 
   let(:user_2)             { FactoryGirl.create(:user) }
   let(:user_2_token)       { FactoryGirl.create :doorkeeper_access_token,
@@ -18,13 +25,10 @@ RSpec.describe Api::V1::TasksController, type: :controller, api: true, version: 
   let(:userless_token)     { FactoryGirl.create :doorkeeper_access_token,
                                                 application: application }
 
-  let(:task_1)             { FactoryGirl.create :tasks_task, title: 'A Task Title',
-                                                step_types: [:tasks_tasked_reading,
-                                                             :tasks_tasked_exercise] }
   let!(:tasking_1)         { FactoryGirl.create :tasks_tasking, role: user_1_role, task: task_1 }
 
   let(:teacher_user)       { FactoryGirl.create(:user) }
-  let!(:teacher_role)      { AddUserAsCourseTeacher[course: task_1.task_plan.owner,
+  let!(:teacher_role)      { AddUserAsCourseTeacher[course: course,
                                                     user: teacher_user] }
   let(:teacher_user_token) { FactoryGirl.create :doorkeeper_access_token,
                                                 application: application,
@@ -39,6 +43,12 @@ RSpec.describe Api::V1::TasksController, type: :controller, api: true, version: 
       expect(response.body_as_hash).to have_key(:steps)
       expect(response.body_as_hash[:steps][0]).to include(type: 'reading')
       expect(response.body_as_hash[:steps][1]).to include(type: 'exercise')
+    end
+
+    it "422's if needs to pay" do
+      make_payment_required_and_expect_422(course: course, user: user_1) {
+        api_get :show, user_1_token, parameters: {id: task_1.id}
+      }
     end
 
     it 'raises SecurityTransgression when user is anonymous or not a teacher' do
@@ -123,6 +133,12 @@ RSpec.describe Api::V1::TasksController, type: :controller, api: true, version: 
           api_delete :destroy, token, parameters: {id: task_1.id}
 
           expect(task_1.reload).to be_hidden
+        end
+
+        it "422's if needs to pay" do
+          make_payment_required_and_expect_422(course: course, user: user_1) {
+            api_delete :destroy, token, parameters: {id: task_1.id}
+          }
         end
       end
 

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Api::V1::TasksController, type: :controller, api: true, version: 
   let(:course)            { FactoryGirl.create :course_profile_course }
   let(:period)            { FactoryGirl.create :course_membership_period, course: course }
 
+  let(:task_plan_1)       { FactoryGirl.create :tasks_task_plan, owner: course }
   let(:task_1)             { FactoryGirl.create :tasks_task, title: 'A Task Title',
+                                                task_plan: task_plan_1,
                                                 step_types: [:tasks_tasked_reading,
                                                              :tasks_tasked_exercise] }
 

--- a/spec/controllers/customer_service/students_controller_spec.rb
+++ b/spec/controllers/customer_service/students_controller_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe CustomerService::StudentsController do
     it 'returns all the students in a course' do
       get :index, course_id: course.id
       expect(assigns[:course].name).to eq 'Physics'
-      expect(assigns[:students]).to eq([
-        {
+      expect(assigns[:students]).to match a_collection_containing_exactly(
+        a_hash_including(
           'id' => student_1.id,
           'username' => user_1.username,
           'first_name' => user_1.first_name,
@@ -49,8 +49,8 @@ RSpec.describe CustomerService::StudentsController do
           'course_membership_period_id' => student_1.period.id,
           'student_identifier' => student_1.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_3.id,
           'username' => user_3.username,
           'first_name' => user_3.first_name,
@@ -60,8 +60,8 @@ RSpec.describe CustomerService::StudentsController do
           'course_membership_period_id' => student_3.period.id,
           'student_identifier' => student_3.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_2.id,
           'username' => user_2.username,
           'first_name' => user_2.first_name,
@@ -71,8 +71,8 @@ RSpec.describe CustomerService::StudentsController do
           'course_membership_period_id' => student_2.period.id,
           'student_identifier' => student_2.student_identifier,
           'deleted?' => false
-        }
-      ])
+        )
+      )
     end
 
     it 'works even if a student has a nil username' do
@@ -80,8 +80,8 @@ RSpec.describe CustomerService::StudentsController do
 
       get :index, course_id: course.id
       expect(assigns[:course].name).to eq 'Physics'
-      expect(assigns[:students]).to eq([
-        {
+      expect(assigns[:students]).to match a_collection_containing_exactly(
+        a_hash_including(
           'id' => student_1.id,
           'username' => user_1.username,
           'first_name' => user_1.first_name,
@@ -91,8 +91,8 @@ RSpec.describe CustomerService::StudentsController do
           'course_membership_period_id' => student_1.period.id,
           'student_identifier' => student_1.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_3.id,
           'username' => user_3.username,
           'first_name' => user_3.first_name,
@@ -102,8 +102,8 @@ RSpec.describe CustomerService::StudentsController do
           'course_membership_period_id' => student_3.period.id,
           'student_identifier' => student_3.student_identifier,
           'deleted?' => false
-        },
-        {
+        ),
+        a_hash_including(
           'id' => student_2.id,
           'username' => nil,
           'first_name' => user_2.first_name,
@@ -113,8 +113,8 @@ RSpec.describe CustomerService::StudentsController do
           'course_membership_period_id' => student_2.period.id,
           'student_identifier' => student_2.student_identifier,
           'deleted?' => false
-        }
-      ])
+        )
+      )
     end
   end
 end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe PurchasesController, type: :controller do
+  let(:course) { FactoryGirl.create :course_profile_course }
+  let(:period) { FactoryGirl.create :course_membership_period, course: course }
+
+  let(:student_1_user) { FactoryGirl.create(:user) }
+  let(:student_1) { AddUserAsPeriodStudent[period: period, user: student_1_user].student }
+
+  let(:student_2_user) { FactoryGirl.create(:user) }
+  let(:student_2) { AddUserAsPeriodStudent[period: period, user: student_2_user].student }
+
+  it 'redirects users to sign in before access' do
+    get :show, id: 'whatever'
+    expect(response).to redirect_to(%r{/accounts/login})
+  end
+
+  context 'student purchases' do
+    before(:each) { controller.sign_in(student_1_user) }
+
+    it 'gives not found error for bad ID' do
+      expect{
+        get :show, id: 'badnesshere'
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'gives forbidden error if user does not own that ID' do
+      expect{
+        get :show, id: student_2.uuid
+      }.to raise_error(SecurityTransgression)
+    end
+
+    it 'redirects on the happy path' do
+      get :show, id: student_1.uuid
+      expect(response).to redirect_to(%r{/course/#{student_1.course.id}})
+    end
+  end
+end

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -27,9 +27,9 @@ RSpec.feature 'Admin editing a course' do
     fill_in 'Name', with: 'Changed777888'
     click_button 'edit-save'
 
-    expect(current_path).to eq(admin_courses_path)
+    expect(current_path).to eq(edit_admin_course_path(@course))
     expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
-    expect(page).to have_text('Changed777888')
+    expect(find_field('Name').value).to eq 'Changed777888'
   end
 
 
@@ -43,9 +43,11 @@ RSpec.feature 'Admin editing a course' do
     # capybara fails (only on Travis) with the Ambiguous match, found 2 elements matching button "Save"
     click_button 'Save', match: :first
 
-    expect(current_path).to eq(admin_courses_path)
+    expect(current_path).to eq(edit_admin_course_path(@course))
     expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
-    expect(page).to have_text('Term: Jan 01, 2016 - Feb 01, 2016')
+    starts_at = DateTime.parse("2016-01-01")
+    expect(@course.reload.starts_at).to eq starts_at
+    # expect(page).to have_text('Term: Jan 01, 2016 - Feb 01, 2016')
   end
 
 
@@ -57,7 +59,7 @@ RSpec.feature 'Admin editing a course' do
     check 'course_is_college'
     click_button 'edit-save'
 
-    expect(current_path).to eq(admin_courses_path)
+    expect(current_path).to eq(edit_admin_course_path(@course))
     expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
     expect(CourseProfile::Models::Course.first.is_college).to be_truthy
   end
@@ -70,9 +72,22 @@ RSpec.feature 'Admin editing a course' do
     check 'course_is_test'
     click_button 'edit-save'
 
-    expect(current_path).to eq(admin_courses_path)
+    expect(current_path).to eq(edit_admin_course_path(@course))
     expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
     expect(CourseProfile::Models::Course.first.is_test).to be_truthy
+  end
+
+  scenario 'Changing "Does Cost"' do
+    visit admin_courses_path
+    click_link 'Edit'
+
+    expect(page).to have_content('Edit Course')
+    check 'course_does_cost'
+    click_button 'edit-save'
+
+    expect(current_path).to eq(edit_admin_course_path(@course))
+    expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
+    expect(CourseProfile::Models::Course.first.does_cost).to be_truthy
   end
 
   scenario 'Assigning a school' do
@@ -83,7 +98,7 @@ RSpec.feature 'Admin editing a course' do
     select 'High high hi school', from: 'School'
     click_button 'edit-save'
 
-    expect(current_path).to eq(admin_courses_path)
+    expect(current_path).to eq(edit_admin_course_path(@course))
     expect(page).to have_text('High high hi school')
   end
 

--- a/spec/features/pardot_spec.rb
+++ b/spec/features/pardot_spec.rb
@@ -38,9 +38,17 @@ RSpec.describe "Pardot" do
 
     context "redirect URL is set" do
       let(:redirect_url) { "http://www.rice.edu/" }
-      before(:each) {
-        Settings::Pardot.toa_redirect = redirect_url
-        Settings::Db.store.object('pardot_toa_redirect').try!(:expire_cache)
+      around(:each) { |example|
+        begin
+          original_value = Settings::Pardot.toa_redirect
+          Settings::Pardot.toa_redirect = redirect_url
+          Settings::Db.store.object('pardot_toa_redirect').try!(:expire_cache)
+
+          example.run
+        ensure
+          Settings::Pardot.toa_redirect = original_value
+          Settings::Db.store.object('pardot_toa_redirect').try!(:expire_cache)
+        end
       }
 
       context "anonymous user" do

--- a/spec/lib/settings/pardot_spec.rb
+++ b/spec/lib/settings/pardot_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Settings::Pardot, type: :lib do
   it 'can store the TOA redirect' do
+    Settings::Db.store.object('pardot_toa_redirect').try!(:expire_cache)
     expect(described_class.toa_redirect).to be_blank
 
     described_class.toa_redirect = "http://www.google.com"

--- a/spec/lib/settings/payments_spec.rb
+++ b/spec/lib/settings/payments_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe Settings::Payments, type: :lib do
     Settings::Db.store.object('student_grace_period_days').expire_cache
     expect(described_class.student_grace_period_days).to eq 10
   end
+
+  it 'can store payments_enabled' do
+    expect(described_class.payments_enabled).to eq false
+
+    described_class.payments_enabled = true
+    Settings::Db.store.object('payments_enabled').expire_cache
+    expect(described_class.payments_enabled).to eq true
+  end
 end

--- a/spec/lib/settings/payments_spec.rb
+++ b/spec/lib/settings/payments_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Settings::Payments, type: :lib do
+  it 'can store student_grace_period_days' do
+    expect(described_class.student_grace_period_days).to eq 14
+
+    described_class.student_grace_period_days = 10
+    Settings::Db.store.object('student_grace_period_days').expire_cache
+    expect(described_class.student_grace_period_days).to eq 10
+  end
+end

--- a/spec/representers/api/v1/course_representer_shared_examples.rb
+++ b/spec/representers/api/v1/course_representer_shared_examples.rb
@@ -111,5 +111,9 @@ module Api::V1
 
       expect(represented["num_sections"]).to eq 4
     end
+
+    it 'shows does_cost' do
+      expect(represented['does_cost']).to eq false
+    end
   end
 end

--- a/spec/representers/api/v1/offering_representer_spec.rb
+++ b/spec/representers/api/v1/offering_representer_spec.rb
@@ -109,4 +109,17 @@ RSpec.describe Api::V1::OfferingRepresenter, type: :representer do
       )
     end
   end
+
+  context 'does_cost' do
+    it 'can be read' do
+      expect(representation['does_cost']).to eq offering.does_cost
+    end
+
+    it 'cannot be written (attempts are silently ignored)' do
+      expect(offering).not_to receive(:does_cost=)
+      expect{ described_class.new(offering).from_hash('does_cost' => 'true') }.not_to(
+        change{ offering.does_cost }
+      )
+    end
+  end
 end

--- a/spec/representers/api/v1/student_representer_spec.rb
+++ b/spec/representers/api/v1/student_representer_spec.rb
@@ -3,10 +3,11 @@ require 'rails_helper'
 RSpec.describe Api::V1::StudentRepresenter, type: :representer do
   let(:user)    { FactoryGirl.create(:user) }
   let(:period)  { FactoryGirl.create(:course_membership_period) }
+  let(:course)  { period.course }
   let(:student) { AddUserAsPeriodStudent.call(period: period, user: user).outputs.student }
+  let(:representation) { Api::V1::StudentRepresenter.new(student).as_json }
 
   it 'represents a student' do
-    representation = Api::V1::StudentRepresenter.new(student).as_json
     expect(representation).to include(
       'id' => student.id.to_s,
       'period_id' => period.id.to_s,
@@ -19,5 +20,42 @@ RSpec.describe Api::V1::StudentRepresenter, type: :representer do
       'is_comped' => false,
       'payment_due_at' => be_kind_of(String)
     )
+  end
+
+  context '#prompt_student_to_pay' do
+    it 'needs global setting enabled to return true' do
+      allow(Settings::Payments).to receive(:payments_enabled) { false }
+      student.update_attributes(is_paid: true)
+      course.update_attributes(is_preview: false, does_cost: true)
+      expect(representation).to include('prompt_student_to_pay' => false)
+    end
+
+    it 'needs course to cost to return true' do
+      allow(Settings::Payments).to receive(:payments_enabled) { true }
+      student.update_attributes(is_paid: true)
+      course.update_attributes(is_preview: false, does_cost: false)
+      expect(representation).to include('prompt_student_to_pay' => false)
+    end
+
+    it 'needs course to not be preview to return true' do
+      allow(Settings::Payments).to receive(:payments_enabled) { true }
+      student.update_attributes(is_paid: true)
+      course.update_attributes(is_preview: true, does_cost: true)
+      expect(representation).to include('prompt_student_to_pay' => false)
+    end
+
+    it 'returns false is paid' do
+      allow(Settings::Payments).to receive(:payments_enabled) { true }
+      student.update_attributes(is_paid: true, is_comped: false)
+      course.update_attributes(is_preview: false, does_cost: true)
+      expect(representation).to include('prompt_student_to_pay' => false)
+    end
+
+    it 'returns false is comped' do
+      allow(Settings::Payments).to receive(:payments_enabled) { true }
+      student.update_attributes(is_paid: false, is_comped: true)
+      course.update_attributes(is_preview: false, does_cost: true)
+      expect(representation).to include('prompt_student_to_pay' => false)
+    end
   end
 end

--- a/spec/representers/api/v1/student_representer_spec.rb
+++ b/spec/representers/api/v1/student_representer_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Api::V1::StudentRepresenter, type: :representer do
   let(:representation) { Api::V1::StudentRepresenter.new(student).as_json }
 
   it 'represents a student' do
+    student.update_attributes(first_paid_at: 2.days.ago)
+
     expect(representation).to include(
       'id' => student.id.to_s,
       'period_id' => period.id.to_s,
@@ -18,8 +20,15 @@ RSpec.describe Api::V1::StudentRepresenter, type: :representer do
       'is_active' => !student.deleted?,
       'is_paid' => false,
       'is_comped' => false,
-      'payment_due_at' => be_kind_of(String)
+      'payment_due_at' => be_kind_of(String),
+      'first_paid_at' => be_kind_of(String)
     )
+
+    [:first_paid_at, :payment_due_at].each do |date_method|
+      actual_value = Chronic.parse(representation[date_method.to_s])
+      expected_value = student.send(date_method)
+      expect(actual_value).to be_within(1.seconds).of(expected_value)
+    end
   end
 
   context '#prompt_student_to_pay' do

--- a/spec/representers/api/v1/student_representer_spec.rb
+++ b/spec/representers/api/v1/student_representer_spec.rb
@@ -7,14 +7,17 @@ RSpec.describe Api::V1::StudentRepresenter, type: :representer do
 
   it 'represents a student' do
     representation = Api::V1::StudentRepresenter.new(student).as_json
-    expect(representation).to eq(
+    expect(representation).to include(
       'id' => student.id.to_s,
       'period_id' => period.id.to_s,
       'role_id' => student.role.id.to_s,
       'first_name' => student.first_name,
       'last_name' => student.last_name,
       'name' => student.name,
-      'is_active' => !student.deleted?
+      'is_active' => !student.deleted?,
+      'is_paid' => false,
+      'is_comped' => false,
+      'payment_due_at' => be_kind_of(String)
     )
   end
 end

--- a/spec/routines/collect_course_info_spec.rb
+++ b/spec/routines/collect_course_info_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
           salesforce_book_name: course_1.offering.salesforce_book_name,
           appearance_code: course_1.offering.appearance_code,
           cloned_from_id: course_1.cloned_from_id,
-          is_preview: course_1.is_preview
+          is_preview: course_1.is_preview,
+          does_cost: false
         )
       )
     end
@@ -86,7 +87,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
           appearance_code: course_1.offering.appearance_code,
           ecosystems: course_1.ecosystems,
           cloned_from_id: course_1.cloned_from_id,
-          is_preview: course_1.is_preview
+          is_preview: course_1.is_preview,
+          does_cost: false
         ),
         a_hash_including(
           id: course_2.id,
@@ -109,7 +111,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
           appearance_code: course_2.offering.appearance_code,
           ecosystems: course_2.ecosystems,
           cloned_from_id: course_2.cloned_from_id,
-          is_preview: course_2.is_preview
+          is_preview: course_2.is_preview,
+          does_cost: false
         )
       )
     end
@@ -143,7 +146,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
             salesforce_book_name: course_1.offering.salesforce_book_name,
             appearance_code: course_1.offering.appearance_code,
             cloned_from_id: course_1.cloned_from_id,
-            is_preview: course_1.is_preview
+            is_preview: course_1.is_preview,
+            does_cost: false
           )
         )
       end
@@ -171,7 +175,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
             appearance_code: course_1.offering.appearance_code,
             periods: a_collection_containing_exactly(period_1, period_2),
             cloned_from_id: course_1.cloned_from_id,
-            is_preview: course_1.is_preview
+            is_preview: course_1.is_preview,
+            does_cost: false
           )
         )
       end
@@ -204,7 +209,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
             salesforce_book_name: course_1.offering.salesforce_book_name,
             appearance_code: course_1.offering.appearance_code,
             cloned_from_id: course_1.cloned_from_id,
-            is_preview: course_1.is_preview
+            is_preview: course_1.is_preview,
+            does_cost: false
           )
         )
       end
@@ -232,7 +238,8 @@ RSpec.describe CollectCourseInfo, type: :routine do
             appearance_code: course_1.offering.appearance_code,
             periods: [ period_1 ],
             cloned_from_id: course_1.cloned_from_id,
-            is_preview: course_1.is_preview
+            is_preview: course_1.is_preview,
+            does_cost: false
           )
         )
       end

--- a/spec/routines/get_student_roster_spec.rb
+++ b/spec/routines/get_student_roster_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe GetCourseRoster, type: :routine do
   it 'returns all the students in the course' do
     students = GetCourseRoster.call(course: course).outputs.roster[:students]
     students.sort! { |a, b| a.id <=> b.id }
-    expect(students).to eq([
-      {
+    expect(students).to match a_collection_containing_exactly(
+      a_hash_including(
         'id' => students[0].id,
         'first_name' => student_1.first_name,
         'last_name' => student_1.last_name,
@@ -42,8 +42,8 @@ RSpec.describe GetCourseRoster, type: :routine do
         'username' => student_1.username,
         'student_identifier' => student_1_role.student.student_identifier,
         'deleted?' => false
-      },
-      {
+      ),
+      a_hash_including(
         'id' => students[1].id,
         'first_name' => student_2.first_name,
         'last_name' => student_2.last_name,
@@ -53,8 +53,8 @@ RSpec.describe GetCourseRoster, type: :routine do
         'username' => student_2.username,
         'student_identifier' => student_2_role.student.student_identifier,
         'deleted?' => false
-      },
-      {
+      ),
+      a_hash_including(
         'id' => students[2].id,
         'first_name' => student_3.first_name,
         'last_name' => student_3.last_name,
@@ -64,8 +64,8 @@ RSpec.describe GetCourseRoster, type: :routine do
         'username' => student_3.username,
         'student_identifier' => student_3_role.student.student_identifier,
         'deleted?' => false
-      }
-    ])
+      )
+    )
   end
 
   it 'does not blow up when a period has been deleted' do
@@ -77,8 +77,8 @@ RSpec.describe GetCourseRoster, type: :routine do
     students = GetCourseRoster.call(course: course).outputs.roster[:students]
     students.sort! { |a, b| a.id <=> b.id }
 
-    expect(students).to eq([
-      {
+    expect(students).to match a_collection_containing_exactly(
+      a_hash_including(
         'id' => students[0].id,
         'first_name' => student_1.first_name,
         'last_name' => student_1.last_name,
@@ -88,8 +88,8 @@ RSpec.describe GetCourseRoster, type: :routine do
         'username' => student_1.username,
         'student_identifier' => student_1_role.student.student_identifier,
         'deleted?' => false
-      },
-      {
+      ),
+      a_hash_including(
         'id' => students[1].id,
         'first_name' => student_2.first_name,
         'last_name' => student_2.last_name,
@@ -99,8 +99,8 @@ RSpec.describe GetCourseRoster, type: :routine do
         'username' => student_2.username,
         'student_identifier' => student_2_role.student.student_identifier,
         'deleted?' => false
-      },
-      {
+      ),
+      a_hash_including(
         'id' => students[2].id,
         'first_name' => student_3.first_name,
         'last_name' => student_3.last_name,
@@ -110,7 +110,7 @@ RSpec.describe GetCourseRoster, type: :routine do
         'username' => student_3.username,
         'student_identifier' => student_3_role.student.student_identifier,
         'deleted?' => true
-      }
-    ])
+      )
+    )
   end
 end

--- a/spec/routines/move_student_spec.rb
+++ b/spec/routines/move_student_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe MoveStudent, type: :routine do
       period_2 = FactoryGirl.create :course_membership_period, course: course
       student = CourseMembership::AddStudent[period: period_1, role: role]
 
+      original_payment_due_at = student.payment_due_at
+
       result = nil
       expect {
         result = MoveStudent.call(period: period_2, student: student)
@@ -25,6 +27,7 @@ RSpec.describe MoveStudent, type: :routine do
 
       expect(student.reload.course).to eq course
       expect(student.period.id).to eq period_1.id
+      expect(student.payment_due_at).to eq original_payment_due_at
     end
   end
 

--- a/spec/subsystems/course_membership/add_student_spec.rb
+++ b/spec/subsystems/course_membership/add_student_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe CourseMembership::AddStudent, type: :routine do
   context "when adding a new student role to a period" do
-    it "succeeds" do
-      role   = FactoryGirl.create :entity_role
-      course = FactoryGirl.create :course_profile_course
-      period = FactoryGirl.create :course_membership_period, course: course
+    let(:role) { FactoryGirl.create :entity_role }
+    let(:course) { FactoryGirl.create :course_profile_course }
+    let(:period) { FactoryGirl.create :course_membership_period, course: course }
 
+    it "succeeds" do
       result = nil
       expect {
         result = CourseMembership::AddStudent.call(period: period, role: role)
@@ -14,11 +14,20 @@ RSpec.describe CourseMembership::AddStudent, type: :routine do
       expect(result.errors).to be_empty
     end
 
+    it 'sets the payment_due_at to midnight of appropriate day' do
+      # Freeze at a time where the due date will cross into daylight savings time
+      Timecop.freeze(Chronic.parse("March 9, 2017 5:04pm")) do
+        result = CourseMembership::AddStudent.call(period: period, role: role)
+        student = result.outputs.student
+        grace_days = Settings::Payments.student_grace_period_days
+
+        expect(student.payment_due_at - Time.now).to be_within(1.day).of(Settings::Payments.student_grace_period_days.days)
+        expect(student.payment_due_at.in_time_zone(course.time_zone.to_tz).to_s).to include("23:59:59")
+      end
+    end
+
     it "allows a student_identifier to be specified" do
       sid = 'N0B0DY'
-      role   = FactoryGirl.create :entity_role
-      course = FactoryGirl.create :course_profile_course
-      period = FactoryGirl.create :course_membership_period, course: course
 
       result = nil
       expect {


### PR DESCRIPTION
Rebase after BL PR merged (use its migration for the student UUID)

## TODO

* [x] Add a `prompt_student_to_pay` field on the student JSON that is `payments_site_online && course.does_cost && !course.is_preview && !(student.is_paid || student.is_comped)` so that the FE can look at this one place to know whether or not to prompt a student instead of having to compile the data/logic itself.
* [x] Specs for representer changes (including roster showing paid status)
* [x] Spec payment_due_at 1 second before and after
* [x] Spec correct setting of `payment_due_at` on enroll.  Spec that this value doesn't change if dropped and re-enrolled.
* [x] Admin ability to globally ignore that payments are due (should impact BE code check for "has paid" and should be provided to FE in bootstrap data)
* [x] Feature specs showing unpaid students have all intended actions limited
* [x] Spec needs to pay before_filter when only have `@task_step`