### PR TITLE
Handle incoming /pardot/toa links

### DIFF
--- a/app/controllers/pardot_controller.rb
+++ b/app/controllers/pardot_controller.rb
@@ -1,0 +1,27 @@
+class PardotController < ApplicationController
+
+  skip_before_filter :authenticate_user!
+
+  def toa
+    # Fire off tracking background job and redirect user to the configurable
+    # marketing page
+
+    TrackTutorOnboardingEvent.perform_later(
+      event: "arrived_tutor_marketing_page_from_pardot",
+      user: current_user,
+      data: {
+        pardot_reported_contact_id: params[:sfc],
+        pardot_reported_piaid: params[:piaid],
+        pardot_reported_picid: params[:picid]
+      }
+    )
+
+    if Settings::Pardot.toa_redirect.present?
+      redirect_to Settings::Pardot.toa_redirect
+    else
+      raise "Pardot TOA redirect is not set! (if on prod, this is CRITICAL)"
+    end
+  end
+
+
+end

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -47,3 +47,5 @@ Settings::Db.store.defaults[:course_appearance_codes] = {
     intro_sociology:      'Intro to Sociology',
     anatomy_physiology:   'Anatomy and Physiology'
 }
+
+Settings::Db.store.defaults[:pardot_toa_redirect] = ""

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,4 +77,7 @@ en:
         help_block: 'In the format HH:MM'
       course_appearance_codes:
         name: 'Valid Course Appearance Codes'
-        help_blocK: 'As a Ruby Hash'
+        help_block: 'As a Ruby Hash'
+      pardot_toa_redirect:
+        name: 'TutorOnboardingA Redirect URL'
+        help_block: 'Where an arrival to /pardot/toa is redirected'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do
     get :signup
   end
 
+  resource :pardot, controller: :pardot, only: [] do
+    get :toa
+  end
+
   # User information and remote log in/out
   namespace :auth do
     match :status, action: :cors_preflight_check, via: [:options]

--- a/lib/settings/pardot.rb
+++ b/lib/settings/pardot.rb
@@ -1,0 +1,17 @@
+module Settings
+  module Pardot
+
+    class << self
+
+      def toa_redirect
+        Settings::Db.store.pardot_toa_redirect
+      end
+
+      def toa_redirect=(url)
+        Settings::Db.store.pardot_toa_redirect = url
+      end
+
+    end
+
+  end
+end

--- a/spec/features/pardot_spec.rb
+++ b/spec/features/pardot_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe "Pardot" do
+  # No real SF tests here, lots of those in tracking routine spec
+  before(:each) { disable_sfdc_client }
+
+  let(:user) { FactoryGirl.create :user }
+  let(:anonymous_user) do
+    profile = User::Models::AnonymousProfile.instance
+    strategy = User::Strategies::Direct::AnonymousUser.new(profile)
+    User::User.new(strategy: strategy)
+  end
+
+  def happy_path_test(expected_user)
+    Delayed::Worker.with_delay_jobs(true) do
+      visit '/pardot/toa?' + {sfc: "a", piaid: "b", picid: "c"}.to_query
+      # signed in case goes to .../dashboard but side effect
+      expect(current_url).to match redirect_url
+      expect_any_instance_of(TrackTutorOnboardingEvent).to receive(:exec).with(
+        event: "arrived_tutor_marketing_page_from_pardot",
+        user: expected_user,
+        data: {
+          pardot_reported_contact_id: "a",
+          pardot_reported_piaid: "b",
+          pardot_reported_picid: "c"
+        }
+      )
+      expect(Delayed::Worker.new.work_off).to eq [1,0]
+    end
+  end
+
+  context "TutorOnboardingA arrivals" do
+    scenario "explosion when redirect URL not set" do
+      Delayed::Worker.with_delay_jobs(true) do
+        expect{visit '/pardot/toa'}.to raise_error(/redirect is not set!/)
+      end
+    end
+
+    context "redirect URL is set" do
+      let(:redirect_url) { "http://www.rice.edu/" }
+      before(:each) {
+        Settings::Pardot.toa_redirect = redirect_url
+        Settings::Db.store.object('pardot_toa_redirect').try!(:expire_cache)
+      }
+
+      context "anonymous user" do
+        context "data missing" do
+          scenario "non-fatal exceptions when using real BG jobs" do
+            Delayed::Worker.with_delay_jobs(true) do
+              visit '/pardot/toa'
+              expect(current_url).to eq redirect_url
+              expect(Delayed::Worker.new.work_off).to eq [0,1]
+            end
+          end
+
+          scenario "exceptions are raised during the tracking" do
+            expect{ visit '/pardot/toa' }.to raise_error(TrackTutorOnboardingEvent::MissingArgument)
+          end
+        end
+
+        context "data present" do
+          scenario "happy path" do
+            happy_path_test(anonymous_user)
+          end
+        end
+      end
+
+      context "signed in user" do
+        before(:each) { stub_current_user(user) }
+
+        scenario "happy path with data" do
+          happy_path_test(user)
+        end
+      end
+    end
+
+  end
+end

--- a/spec/handlers/admin/courses_remove_salesforce_spec.rb
+++ b/spec/handlers/admin/courses_remove_salesforce_spec.rb
@@ -85,12 +85,6 @@ RSpec.describe Admin::CoursesRemoveSalesforce, type: :handler do
     end
   end
 
-  def disable_sfdc_client
-    allow(ActiveForce)
-      .to receive(:sfdc_client)
-      .and_return(double('null object').as_null_object)
-  end
-
   def fake_sf_object(klass:, id:, save_outcome: true)
     klass.new(id: id).tap do |fake|
       allow(fake).to receive(:save) { save_outcome }   # stub save

--- a/spec/lib/settings/pardot_spec.rb
+++ b/spec/lib/settings/pardot_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Settings::Pardot, type: :lib do
+  it 'can store the TOA redirect' do
+    expect(described_class.toa_redirect).to be_blank
+
+    described_class.toa_redirect = "http://www.google.com"
+    Settings::Db.store.object('pardot_toa_redirect').try!(:expire_cache)
+    expect(described_class.toa_redirect).to eq "http://www.google.com"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -176,3 +176,9 @@ def redirect_uri
   expect(response.code).to eq "302"
   uri = URI.parse(response.headers["Location"])
 end
+
+def disable_sfdc_client
+  allow(ActiveForce)
+    .to receive(:sfdc_client)
+    .and_return(double('null object').as_null_object)
+end


### PR DESCRIPTION
When pardot marketing campaign emails conclude, they'll send users to `https://tutor.openstax.org/pardot/toa?<params here>`.  This PR implements that route, which has the purpose of initializing a TutorOnboardingA record in SF and redirecting users to a configurable marketing page.