### PR TITLE
Fix Biglearn sequence_number gaps on update_course_ecosystems

### DIFF
--- a/app/jobs/openstax/biglearn/api/job.rb
+++ b/app/jobs/openstax/biglearn/api/job.rb
@@ -1,7 +1,18 @@
 class OpenStax::Biglearn::Api::Job < ApplicationJob
   queue_as :default
 
-  def perform(method:, requests:, **ignored)
-    OpenStax::Biglearn::Api.client.public_send(method, requests)
+  def perform(method:, requests:, response_status_key: nil, accepted_response_status: [], **ignored)
+    OpenStax::Biglearn::Api.client.public_send(method, requests).tap do |response|
+      next if response_status_key.nil?
+
+      response_status_key = response_status_key.to_sym
+      accepted_response_status = [accepted_response_status].flatten
+      responses = [response].flatten
+
+      responses.each do |response|
+        raise OpenStax::Biglearn::Api::JobFailed \
+          if !accepted_response_status.include?(response[response_status_key])
+      end
+    end
   end
 end

--- a/app/jobs/openstax/biglearn/api/job_failed.rb
+++ b/app/jobs/openstax/biglearn/api/job_failed.rb
@@ -1,0 +1,2 @@
+class OpenStax::Biglearn::Api::JobFailed < StandardError
+end

--- a/app/representers/api/v1/task_representer.rb
+++ b/app/representers/api/v1/task_representer.rb
@@ -77,11 +77,6 @@ module Api::V1
              schema_info: { type: 'boolean',
                             description: "If the feedback should be shown for the task" }
 
-    property :spy,
-             type: Object,
-             readable: true,
-             writeable: false
-
     property :deleted?,
              as: :is_deleted,
              readable: true,
@@ -90,6 +85,11 @@ module Api::V1
                type: 'boolean',
                description: "Whether or not this task has been withdrawn by the teacher"
              }
+
+    property :spy,
+             type: Object,
+             readable: true,
+             writeable: false
 
   end
 end

--- a/app/representers/api/v1/tasks/task_step_representer.rb
+++ b/app/representers/api/v1/tasks/task_step_representer.rb
@@ -25,7 +25,7 @@ module Api::V1::Tasks
              type: String,
              writeable: false,
              readable: true,
-             getter: lambda {|*| task_step.tasks_task_id },
+             getter: ->(*) { task_step.tasks_task_id },
              schema_info: {
                  required: true,
                  description: "The id of the Task"
@@ -35,8 +35,7 @@ module Api::V1::Tasks
              type: String,
              writeable: false,
              readable: true,
-             getter: lambda { |*| self.class.name.demodulize.remove("Tasked")
-                                                 .underscore.downcase },
+             getter: ->(*) { self.class.name.demodulize.remove("Tasked").underscore.downcase },
              schema_info: {
                required: true,
                description: "The type of this TaskStep (exercise, reading, video, placeholder, etc.)"
@@ -56,7 +55,7 @@ module Api::V1::Tasks
     property :is_completed,
              writeable: false,
              readable: true,
-             getter: lambda {|*| task_step.completed?},
+             getter: ->(*) { task_step.completed? },
              schema_info: {
                required: true,
                type: 'boolean',
@@ -89,9 +88,7 @@ module Api::V1::Tasks
     collection :related_content,
                writeable: false,
                readable: true,
-               getter: ->(*) {
-                 task_step.related_content.map{ |rc| Hashie::Mash.new(rc) }
-               },
+               getter: ->(*) { task_step.related_content.map{ |rc| Hashie::Mash.new(rc) } },
                extend: ::Api::V1::RelatedContentRepresenter,
                schema_info: {
                  required: true,
@@ -106,6 +103,12 @@ module Api::V1::Tasks
                  required: true,
                  description: "Misc properties related to this step"
                }
+
+    property :spy,
+             type: Object,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { task_step.spy }
 
   end
 end

--- a/app/routines/create_practice_worst_topics_task.rb
+++ b/app/routines/create_practice_worst_topics_task.rb
@@ -13,10 +13,8 @@ class CreatePracticeWorstTopicsTask
   end
 
   def add_task_steps
-    exercises = OpenStax::Biglearn::Api.fetch_practice_worst_areas_exercises(
-      student: @role.student,
-      inline_retry_proc: ->(response) { response[:student_status] != 'student_ready' }
-    ).first(CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES)
+    exercises = OpenStax::Biglearn::Api.fetch_practice_worst_areas_exercises(student: @role.student)
+                                       .first(CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES)
 
     fatal_error(
       code: :no_exercises,

--- a/app/routines/create_practice_worst_topics_task.rb
+++ b/app/routines/create_practice_worst_topics_task.rb
@@ -3,6 +3,8 @@ class CreatePracticeWorstTopicsTask
   include CreatePracticeTaskRoutine
 
   uses_routine GetCourseEcosystem, as: :get_course_ecosystem
+  uses_routine TaskExercise, as: :task_exercise
+  uses_routine TranslateBiglearnSpyInfo, as: :translate_biglearn_spy_info
 
   protected
 
@@ -15,7 +17,7 @@ class CreatePracticeWorstTopicsTask
   def add_task_steps
     result = OpenStax::Biglearn::Api.fetch_practice_worst_areas_exercises(student: @role.student)
     exercises = result[:exercises].first(CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES)
-    spy_info = result[:spy_info]
+    spy_info = run(:translate_biglearn_spy_info, spy_info: result[:spy_info]).outputs.spy_info
 
     fatal_error(
       code: :no_exercises,
@@ -26,9 +28,10 @@ class CreatePracticeWorstTopicsTask
 
     # Add the exercises as task steps
     exercises.each do |exercise|
-      TaskExercise.call(exercise: exercise, task: @task) do |step|
+      run(:task_exercise, exercise: exercise, task: @task) do |step|
         step.group_type = :personalized_group
         step.add_related_content(exercise.page.related_content)
+        step.spy = spy_info.fetch(exercise.uuid, {})
       end
     end.tap { @task.update_attribute :pes_are_assigned, true }
   end

--- a/app/routines/create_practice_worst_topics_task.rb
+++ b/app/routines/create_practice_worst_topics_task.rb
@@ -13,8 +13,9 @@ class CreatePracticeWorstTopicsTask
   end
 
   def add_task_steps
-    exercises = OpenStax::Biglearn::Api.fetch_practice_worst_areas_exercises(student: @role.student)
-                                       .first(CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES)
+    result = OpenStax::Biglearn::Api.fetch_practice_worst_areas_exercises(student: @role.student)
+    exercises = result[:exercises].first(CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES)
+    spy_info = result[:spy_info]
 
     fatal_error(
       code: :no_exercises,

--- a/app/routines/task_exercise.rb
+++ b/app/routines/task_exercise.rb
@@ -26,6 +26,7 @@ class TaskExercise
     page = current_step.page
     related_content = current_step.related_content
     labels = current_step.labels
+    spy = current_step.spy
     questions = exercise.content_as_independent_questions
 
     outputs[:task_steps] = questions.each_with_index.map do |question, ii|
@@ -36,7 +37,8 @@ class TaskExercise
         group_type: group_type,
         page: page,
         related_content: related_content,
-        labels: labels
+        labels: labels,
+        spy: spy
       ) if ii > 0
 
       # Mark the step as incomplete just in case it had been marked as complete before

--- a/app/routines/translate_biglearn_spy_info.rb
+++ b/app/routines/translate_biglearn_spy_info.rb
@@ -5,13 +5,19 @@ class TranslateBiglearnSpyInfo
   protected
 
   def exec(spy_info:)
-    task_uuids = spy_info.values.map { |hash| hash[:assignment_uuid] }
+    task_uuids = spy_info.values.map { |hash| hash['assignment_uuid'] }.compact
 
     task_id_by_uuid = Tasks::Models::Task.where(uuid: task_uuids).pluck(:uuid, :id).to_h
 
     translated_spy_info = {}
     spy_info.each do |key, value|
-      translated_spy_info[key] = value.merge(task_id: task_id_by_uuid[value.assignment_uuid])
+      assignment_uuid = value['assignment_uuid']
+
+      translated_spy_info[key] = assignment_uuid.nil? ? value : value.except('assignment_uuid')
+                                                                     .merge(
+        'task_id' => task_id_by_uuid[assignment_uuid],
+        'task_uuid' => assignment_uuid
+      )
     end
 
     outputs.spy_info = translated_spy_info

--- a/app/routines/translate_biglearn_spy_info.rb
+++ b/app/routines/translate_biglearn_spy_info.rb
@@ -1,0 +1,19 @@
+class TranslateBiglearnSpyInfo
+
+  lev_routine
+
+  protected
+
+  def exec(spy_info:)
+    task_uuids = spy_info.values.map { |hash| hash[:assignment_uuid] }
+
+    task_id_by_uuid = Tasks::Models::Task.where(uuid: task_uuids).pluck(:uuid, :id).to_h
+
+    translated_spy_info = {}
+    spy_info.each do |key, value|
+      translated_spy_info[key] = value.merge(task_id: task_id_by_uuid[value.assignment_uuid])
+    end
+
+    outputs.spy_info = translated_spy_info
+  end
+end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -18,6 +18,7 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
   json_serialize :related_content, Hash, array: true
   json_serialize :related_exercise_ids, Integer, array: true
   json_serialize :labels, String, array: true
+  json_serialize :spy, Hash
 
   validates :task, presence: true
   validates :tasked, presence: true

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -3,6 +3,7 @@ class Tasks::PopulatePlaceholderSteps
   lev_routine express_output: :task
 
   uses_routine TaskExercise, as: :task_exercise
+  uses_routine TranslateBiglearnSpyInfo, as: :translate_biglearn_spy_info
 
   protected
 
@@ -79,7 +80,7 @@ class Tasks::PopulatePlaceholderSteps
       # Biglearn controls how many PEs/SPEs (reading tasks)
       result = OpenStax::Biglearn::Api.public_send biglearn_api_method, task: task
       chosen_exercises = result[:exercises]
-      spy_info = result[:spy_info]
+      spy_info = run(:translate_biglearn_spy_info, spy_info: result[:spy_info]).outputs.spy_info
       chosen_exercise_models = chosen_exercises.map(&:to_model)
 
       # Group steps and exercises by content_page_id; Spaced Practice uses nil content_page_ids
@@ -139,6 +140,8 @@ class Tasks::PopulatePlaceholderSteps
 
               num_added_steps += exercise.number_of_parts - 1
             end
+
+            task_step.spy = spy_info.fetch(exercise.uuid, {})
 
             # Assign the exercise (handles multipart questions, etc)
             run(:task_exercise, task_step: task_step, exercise: exercise)

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -77,7 +77,9 @@ class Tasks::PopulatePlaceholderSteps
                                  biglearn_api_method:, biglearn_controls_slots:)
     if biglearn_controls_slots
       # Biglearn controls how many PEs/SPEs (reading tasks)
-      chosen_exercises = OpenStax::Biglearn::Api.public_send(biglearn_api_method, task: task)
+      result = OpenStax::Biglearn::Api.public_send biglearn_api_method, task: task
+      chosen_exercises = result[:exercises]
+      spy_info = result[:spy_info]
       chosen_exercise_models = chosen_exercises.map(&:to_model)
 
       # Group steps and exercises by content_page_id; Spaced Practice uses nil content_page_ids
@@ -153,11 +155,13 @@ class Tasks::PopulatePlaceholderSteps
       ActiveRecord::Associations::Preloader.new.preload(placeholder_steps, :tasked)
 
       # max_num_exercises ensures we don't get more exercises than the number of placeholders
-      chosen_exercises = OpenStax::Biglearn::Api.public_send(
+      result = OpenStax::Biglearn::Api.public_send(
         biglearn_api_method,
         task: task,
         max_num_exercises: placeholder_steps.size
       )
+      chosen_exercises = result[:exercises]
+      spy_info = result[:spy_info]
 
       # This code is much simpler because it doesn't have to account for steps being added
       placeholder_steps.each_with_index do |task_step, index|

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -77,11 +77,7 @@ class Tasks::PopulatePlaceholderSteps
                                  biglearn_api_method:, biglearn_controls_slots:)
     if biglearn_controls_slots
       # Biglearn controls how many PEs/SPEs (reading tasks)
-      chosen_exercises = OpenStax::Biglearn::Api.public_send(
-        biglearn_api_method,
-        task: task,
-        inline_retry_proc: ->(response) { response[:assignment_status] != 'assignment_ready' }
-      )
+      chosen_exercises = OpenStax::Biglearn::Api.public_send(biglearn_api_method, task: task)
       chosen_exercise_models = chosen_exercises.map(&:to_model)
 
       # Group steps and exercises by content_page_id; Spaced Practice uses nil content_page_ids
@@ -160,8 +156,7 @@ class Tasks::PopulatePlaceholderSteps
       chosen_exercises = OpenStax::Biglearn::Api.public_send(
         biglearn_api_method,
         task: task,
-        max_num_exercises: placeholder_steps.size,
-        inline_retry_proc: ->(response) { response[:assignment_status] != 'assignment_ready' }
+        max_num_exercises: placeholder_steps.size
       )
 
       # This code is much simpler because it doesn't have to account for steps being added

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -18,16 +18,11 @@ secrets = Rails.application.secrets
 biglearn_secrets = secrets['openstax']['biglearn']
 biglearn_stub = biglearn_secrets['stub'].nil? ? true : biglearn_secrets['stub']
 Settings::Db.store.defaults[:biglearn_client] = biglearn_stub ? :fake : :real
-Settings::Db.store.defaults[:biglearn_student_clues_algorithm_name] = \
-  biglearn_stub ? 'local_query' : 'sparfa'
-Settings::Db.store.defaults[:biglearn_teacher_clues_algorithm_name] = \
-  biglearn_stub ? 'local_query' : 'sparfa'
-Settings::Db.store.defaults[:biglearn_assignment_spes_algorithm_name] = \
-  biglearn_stub ? 'local_query_student_driven' : 'tesr_student_driven'
-Settings::Db.store.defaults[:biglearn_assignment_pes_algorithm_name] = \
-  biglearn_stub ? 'local_query' : 'tesr'
-Settings::Db.store.defaults[:biglearn_practice_worst_areas_algorithm_name] = \
-  biglearn_stub ? 'local_query' : 'tesr'
+Settings::Db.store.defaults[:biglearn_student_clues_algorithm_name] = 'local_query'
+Settings::Db.store.defaults[:biglearn_teacher_clues_algorithm_name] = 'local_query'
+Settings::Db.store.defaults[:biglearn_assignment_spes_algorithm_name] = 'student_driven_local_query'
+Settings::Db.store.defaults[:biglearn_assignment_pes_algorithm_name] = 'local_query'
+Settings::Db.store.defaults[:biglearn_practice_worst_areas_algorithm_name] = 'local_query'
 
 redis_secrets = secrets['redis']
 Settings::Redis.store = Redis::Store.new(

--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -45,4 +45,9 @@ OpenStax::RescueFrom.register_exception(
   notify: secrets['salesforce']['allow_use_of_real_data']
 )
 
+OpenStax::RescueFrom.register_exception(
+  'OpenStax::Biglearn::Api::JobFailed',
+  notify: true # Change this to false once we are confident that Biglearn jobs work properly
+)
+
 ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,10 +55,10 @@ en:
       biglearn_assignment_spes_algorithm_name:
         name: 'Biglearn algorithm for choosing Spaced Practice exercises'
         labels:
-          Student-driven TeSR: 'tesr_student_driven'
-          Faculty-driven TeSR: 'tesr_instructor_driven'
-          Student-driven Local Query: 'local_query_student_driven'
-          Faculty-driven Local Query: 'local_query_instructor_driven'
+          Student-driven TeSR: 'student_driven_tesr'
+          Faculty-driven TeSR: 'instructor_driven_tesr'
+          Student-driven Local Query: 'student_driven_local_query'
+          Faculty-driven Local Query: 'instructor_driven_local_query'
         help_block: 'This setting can also be changed on a per-course basis. Changing it here will only affect new courses.'
       biglearn_assignment_pes_algorithm_name:
         name: 'Biglearn algorithm for choosing Personalized exercises'

--- a/db/migrate/20170605144519_add_spy_to_task_steps.rb
+++ b/db/migrate/20170605144519_add_spy_to_task_steps.rb
@@ -1,0 +1,5 @@
+class AddSpyToTaskSteps < ActiveRecord::Migration
+  def change
+    add_column :tasks_task_steps, :spy, :text, null: false, default: '{}'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170526133610) do
+ActiveRecord::Schema.define(version: 20170605144519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -700,6 +700,7 @@ ActiveRecord::Schema.define(version: 20170526133610) do
     t.text     "related_exercise_ids", default: "[]", null: false
     t.text     "labels",               default: "[]", null: false
     t.integer  "content_page_id"
+    t.text     "spy",                  default: "{}", null: false
   end
 
   add_index "tasks_task_steps", ["deleted_at"], name: "index_tasks_task_steps_on_deleted_at", using: :btree

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -296,15 +296,19 @@ module OpenStax::Biglearn::Api
           requests: requests,
           keys: :task,
           optional_keys: :max_num_exercises,
-          result_class: Content::Exercise,
           perform_later: false,
           response_status_key: :assignment_status,
           accepted_response_status: 'assignment_ready'
         )
       ) do |request, response|
-        get_ecosystem_exercises_by_uuids ecosystem: request[:task].ecosystem,
-                                         exercise_uuids: response[:exercise_uuids],
-                                         max_num_exercises: request[:max_num_exercises]
+        {
+          exercises: get_ecosystem_exercises_by_uuids(
+            ecosystem: request[:task].ecosystem,
+            exercise_uuids: response[:exercise_uuids],
+            max_num_exercises: request[:max_num_exercises]
+          ),
+          spy_info: response.fetch(:spy_info, {})
+        }
       end
     end
 
@@ -322,15 +326,19 @@ module OpenStax::Biglearn::Api
           requests: requests,
           keys: :task,
           optional_keys: :max_num_exercises,
-          result_class: Content::Exercise,
           perform_later: false,
           response_status_key: :assignment_status,
           accepted_response_status: 'assignment_ready'
         )
       ) do |request, response|
-        get_ecosystem_exercises_by_uuids ecosystem: request[:task].ecosystem,
-                                         exercise_uuids: response[:exercise_uuids],
-                                         max_num_exercises: request[:max_num_exercises]
+        {
+          exercises: get_ecosystem_exercises_by_uuids(
+            ecosystem: request[:task].ecosystem,
+            exercise_uuids: response[:exercise_uuids],
+            max_num_exercises: request[:max_num_exercises]
+          ),
+          spy_info: response.fetch(:spy_info, {})
+        }
       end
     end
 
@@ -348,15 +356,19 @@ module OpenStax::Biglearn::Api
           requests: requests,
           keys: :student,
           optional_keys: :max_num_exercises,
-          result_class: Content::Exercise,
           perform_later: false,
           response_status_key: :student_status,
           accepted_response_status: 'student_ready'
         )
       ) do |request, response|
-        get_ecosystem_exercises_by_uuids ecosystem: request[:student].course.ecosystems.first,
-                                         exercise_uuids: response[:exercise_uuids],
-                                         max_num_exercises: request[:max_num_exercises]
+        {
+          exercises: get_ecosystem_exercises_by_uuids(
+            ecosystem: request[:student].course.ecosystems.first,
+            exercise_uuids: response[:exercise_uuids],
+            max_num_exercises: request[:max_num_exercises]
+          ),
+          spy_info: response.fetch(:spy_info, {})
+        }
       end
     end
 

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -10,7 +10,12 @@ module OpenStax::Biglearn::Api
   MAX_CONTAINERS_PER_COURSE = 100
   MAX_STUDENTS_PER_COURSE = 1000
 
-  OPTION_KEYS = [ :inline_retry_proc, :inline_max_retries, :inline_sleep_interval ]
+  OPTION_KEYS = [
+    :response_status_key,
+    :accepted_response_status,
+    :inline_max_retries,
+    :inline_sleep_interval
+  ]
 
   extend Configurable
   extend Configurable::ClientMethods
@@ -132,7 +137,9 @@ module OpenStax::Biglearn::Api
         keys: [:course, :preparation_uuid],
         perform_later: true,
         sequence_number_model_key: :course,
-        sequence_number_model_class: CourseProfile::Models::Course
+        sequence_number_model_class: CourseProfile::Models::Course,
+        response_status_key: :update_status,
+        accepted_response_status: [ 'updated_and_ready', 'updated_but_unready' ]
       )
     end
 
@@ -290,7 +297,9 @@ module OpenStax::Biglearn::Api
           keys: :task,
           optional_keys: :max_num_exercises,
           result_class: Content::Exercise,
-          perform_later: false
+          perform_later: false,
+          response_status_key: :assignment_status,
+          accepted_response_status: 'assignment_ready'
         )
       ) do |request, response|
         get_ecosystem_exercises_by_uuids ecosystem: request[:task].ecosystem,
@@ -314,7 +323,9 @@ module OpenStax::Biglearn::Api
           keys: :task,
           optional_keys: :max_num_exercises,
           result_class: Content::Exercise,
-          perform_later: false
+          perform_later: false,
+          response_status_key: :assignment_status,
+          accepted_response_status: 'assignment_ready'
         )
       ) do |request, response|
         get_ecosystem_exercises_by_uuids ecosystem: request[:task].ecosystem,
@@ -338,7 +349,9 @@ module OpenStax::Biglearn::Api
           keys: :student,
           optional_keys: :max_num_exercises,
           result_class: Content::Exercise,
-          perform_later: false
+          perform_later: false,
+          response_status_key: :student_status,
+          accepted_response_status: 'student_ready'
         )
       ) do |request, response|
         get_ecosystem_exercises_by_uuids ecosystem: request[:student].course.ecosystems.first,
@@ -487,7 +500,8 @@ module OpenStax::Biglearn::Api
     def single_api_request(method:, request:, keys:, optional_keys: [],
                            result_class: Hash, uuid_key: :request_uuid,
                            sequence_number_model_key: nil, sequence_number_model_class: nil,
-                           create: false, perform_later: false, inline_retry_proc: nil,
+                           create: false, perform_later: false,
+                           response_status_key: nil, accepted_response_status: [],
                            inline_max_attempts: 30, inline_sleep_interval: 1.second)
       include_sequence_number = sequence_number_model_key.present? &&
                                 sequence_number_model_class.present?
@@ -501,16 +515,19 @@ module OpenStax::Biglearn::Api
                                                   optional_keys: optional_keys
 
       request_with_uuid = verified_request.has_key?(uuid_key) ?
-                            verified_request : verified_request.merge(uuid_key => SecureRandom.uuid)
+                            verified_request :
+                            verified_request.merge(uuid_key => SecureRandom.uuid)
 
       if perform_later
         job_class.perform_later method: method.to_s,
                                 requests: request_with_uuid,
                                 create: create,
                                 sequence_number_model_key: sequence_number_model_key.to_s,
-                                sequence_number_model_class: sequence_number_model_class.name
+                                sequence_number_model_class: sequence_number_model_class.name,
+                                response_status_key: response_status_key.try!(:to_s),
+                                accepted_response_status: accepted_response_status
       else
-        should_retry = false
+        should_retry = true
         for ii in 1..inline_max_attempts do
           response = job_class.perform method: method,
                                        requests: request_with_uuid,
@@ -518,7 +535,11 @@ module OpenStax::Biglearn::Api
                                        sequence_number_model_key: sequence_number_model_key,
                                        sequence_number_model_class: sequence_number_model_class
 
-          should_retry = !inline_retry_proc.nil? && inline_retry_proc.call(response)
+          should_retry = if response_status_key.nil?
+            false
+          else
+            ![accepted_response_status].flatten.include?(response[response_status_key])
+          end
           break unless should_retry
 
           sleep(inline_sleep_interval)
@@ -539,7 +560,8 @@ module OpenStax::Biglearn::Api
     def bulk_api_request(method:, requests:, keys:, optional_keys: [],
                          result_class: Hash, uuid_key: :request_uuid, select_proc: nil,
                          sequence_number_model_key: nil, sequence_number_model_class: nil,
-                         create: false, perform_later: false, inline_retry_proc: nil,
+                         create: false, perform_later: false,
+                         response_status_key: nil, accepted_response_status: [],
                          inline_max_attempts: 30, inline_sleep_interval: 1.second)
       include_sequence_numbers = sequence_number_model_key.present? &&
                                  sequence_number_model_class.present?
@@ -573,7 +595,9 @@ module OpenStax::Biglearn::Api
                                 requests: requests_array,
                                 create: create,
                                 sequence_number_model_key: sequence_number_model_key.to_s,
-                                sequence_number_model_class: sequence_number_model_class.name
+                                sequence_number_model_class: sequence_number_model_class.name,
+                                response_status_key: response_status_key.try!(:to_s),
+                                accepted_response_status: accepted_response_status
       else
         responses_map = {}
         for ii in 1..inline_max_attempts do
@@ -582,6 +606,9 @@ module OpenStax::Biglearn::Api
                                         create: create,
                                         sequence_number_model_key: sequence_number_model_key,
                                         sequence_number_model_class: sequence_number_model_class
+
+          accepted_response_status = [accepted_response_status].flatten \
+            unless response_status_key.nil?
 
           responses.each do |response|
             uuid = response[uuid_key]
@@ -592,8 +619,9 @@ module OpenStax::Biglearn::Api
               result_class: result_class
             )
 
-            requests_with_uuids_map.delete uuid if inline_retry_proc.nil? ||
-                                                   !inline_retry_proc.call(response)
+            requests_with_uuids_map.delete(uuid) \
+              if response_status_key.nil? ||
+                 accepted_response_status.include?(response[response_status_key])
           end
 
           break if requests_with_uuids_map.empty?

--- a/spec/controllers/api/v1/practices_controller_spec.rb
+++ b/spec/controllers/api/v1/practices_controller_spec.rb
@@ -83,7 +83,12 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
     it 'returns error when no exercises can be scrounged' do
       AddUserAsPeriodStudent.call(period: period, user: user_1)
 
-      expect(OpenStax::Biglearn::Api).to receive(:fetch_assignment_pes).and_return([])
+      expect(OpenStax::Biglearn::Api).to receive(:fetch_assignment_pes).and_return(
+        {
+          exercises: [],
+          spy_info: {}
+        }
+      )
 
       api_post :create_specific,
                user_1_token,
@@ -92,7 +97,7 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
 
       expect(response).to have_http_status(422)
     end
-    
+
     it "422's if needs to pay" do
       make_payment_required_and_expect_422(course: course, user: user_1) {
         api_post :create_specific,
@@ -140,16 +145,19 @@ RSpec.describe Api::V1::PracticesController, api: true, version: :v1 do
     it 'returns error when no exercises can be scrounged' do
       AddUserAsPeriodStudent.call(period: period, user: user_1)
 
-      expect(OpenStax::Biglearn::Api).to(
-        receive(:fetch_practice_worst_areas_exercises).and_return([])
+      expect(OpenStax::Biglearn::Api).to receive(:fetch_practice_worst_areas_exercises).and_return(
+        {
+          exercises: [],
+          spy_info: {}
+        }
       )
 
       api_post :create_worst, user_1_token, parameters: { id: course.id, role_id: role.id }
 
       expect(response).to have_http_status(422)
     end
-    
-    
+
+
     it "422's if needs to pay" do
       make_payment_required_and_expect_422(course: course, user: user_1) {
         api_post :create_worst,

--- a/spec/jobs/openstax/biglearn/api/job_spec.rb
+++ b/spec/jobs/openstax/biglearn/api/job_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe OpenStax::Biglearn::Api::Job, type: :job do
   subject(:job)  { described_class.new }
 
-  let(:course)                      { FactoryGirl.create :course_profile_course }
+  let(:course)   { FactoryGirl.create :course_profile_course }
 
-  let(:method)                      { :create_course }
-  let(:requests)                    { [ { course: course } ] }
+  let(:method)   { :create_course }
+  let(:requests) { { course: course } }
 
-  let(:args)                        { { method: method, requests: requests } }
+  let(:args)     { { method: method, requests: requests } }
 
   it 'delegates #perform to a new instance of itself' do
     allow(described_class).to receive(:new).and_return(job)
@@ -21,5 +21,37 @@ RSpec.describe OpenStax::Biglearn::Api::Job, type: :job do
     expect(OpenStax::Biglearn::Api.client).to receive(method).with(requests)
 
     job.perform(args)
+  end
+
+  context 'with response_status_key and accepted_response_status' do
+    it 'raises OpenStax::Biglearn::Api::JobFailed if the status is not accepted' do
+      failing_args = args.merge(
+        response_status_key: :course_status, accepted_response_status: []
+      )
+
+      expect(OpenStax::Biglearn::Api.client).to receive(method).with(requests) do |request|
+        {
+          request_uuid: request[:request_uuid],
+          course_status: 'created'
+        }
+      end
+
+      expect{ job.perform(failing_args) }.to raise_error(OpenStax::Biglearn::Api::JobFailed)
+    end
+
+    it 'does not raise an Exception if the status is accepted' do
+      failing_args = args.merge(
+        response_status_key: :course_status, accepted_response_status: 'created'
+      )
+
+      expect(OpenStax::Biglearn::Api.client).to receive(method).with(requests) do |request|
+        {
+          request_uuid: request[:request_uuid],
+          course_status: 'created'
+        }
+      end
+
+      expect{ job.perform(failing_args) }.not_to raise_error
+    end
   end
 end

--- a/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
+++ b/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
@@ -23,7 +23,12 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
 
   let(:request_with_sequence_numbers)  { request.merge sequence_number: 0 }
   let(:job_args)                       do
-    { method: method.to_s, requests: request_with_sequence_numbers }
+    {
+      method: method.to_s,
+      requests: request_with_sequence_numbers,
+      response_status_key: nil,
+      accepted_response_status: []
+    }
   end
 
   it 'delegates #perform to a new instance of itself' do

--- a/spec/lib/openstax/biglearn/api_spec.rb
+++ b/spec/lib/openstax/biglearn/api_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
         requests.map do |request|
           {
             request_uuid: request[:request_uuid],
-            exercise_uuids: exercises.map(&:uuid)
+            exercise_uuids: exercises.map(&:uuid),
+            assignment_status: 'assignment_ready'
           }
         end
       end
@@ -218,7 +219,8 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
         requests.map do |request|
           {
             request_uuid: request[:request_uuid],
-            exercise_uuids: (max_num_exercises + 1).times.map{ SecureRandom.uuid }
+            exercise_uuids: (max_num_exercises + 1).times.map{ SecureRandom.uuid },
+            assignment_status: 'assignment_ready'
           }
         end
       end
@@ -239,7 +241,8 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
         requests.map do |request|
           {
             request_uuid: request[:request_uuid],
-            exercise_uuids: exercises.map(&:uuid)
+            exercise_uuids: exercises.map(&:uuid),
+            assignment_status: 'assignment_ready'
           }
         end
       end
@@ -259,7 +262,8 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
         requests.map do |request|
           {
             request_uuid: request[:request_uuid],
-            exercise_uuids: max_num_exercises.times.map{ SecureRandom.uuid }
+            exercise_uuids: max_num_exercises.times.map{ SecureRandom.uuid },
+            assignment_status: 'assignment_ready'
           }
         end
       end

--- a/spec/lib/openstax/biglearn/api_spec.rb
+++ b/spec/lib/openstax/biglearn/api_spec.rb
@@ -135,21 +135,21 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
         [
           :fetch_assignment_pes,
           -> { [ { task: @task, max_num_exercises: max_num_exercises } ] },
-          Content::Exercise,
+          Hash,
           -> { @course },
           0
         ],
         [
           :fetch_assignment_spes,
           -> { [ { task: @task, max_num_exercises: max_num_exercises } ] },
-          Content::Exercise,
+          Hash,
           -> { @course },
           0
         ],
         [
           :fetch_practice_worst_areas_exercises,
           -> { [ { student: @student, max_num_exercises: max_num_exercises } ] },
-          Content::Exercise,
+          Hash,
           -> { @course },
           0
         ],
@@ -211,7 +211,7 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
           task: @task, max_num_exercises: max_num_exercises
         )
       end.not_to raise_error
-      expect(result).to match_array(exercises)
+      expect(result.fetch(:exercises)).to match_array(exercises)
     end
 
     it 'errors when client returns more exercises than expected' do
@@ -254,7 +254,7 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
           task: @task, max_num_exercises: max_num_exercises
         )
       end.not_to raise_error
-      expect(result).to match_array(exercises)
+      expect(result.fetch(:exercises)).to match_array(exercises)
     end
 
     it 'errors when client returns exercises not present locally' do

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -1,50 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
-  let(:task_step) {
-    step = instance_double(Tasks::Models::TaskStep)
-    allow(step).to receive(:id).and_return(15)
-    allow(step).to receive(:tasks_task_id).and_return(42)
-    allow(step).to receive(:group_name).and_return('Some group')
-    allow(step).to receive(:completed?).and_return(false)
-    allow(step).to receive(:feedback_available?).and_return(false)
-    allow(step).to receive(:can_be_recovered?).and_return(true)
-    allow(step).to receive(:related_content).and_return([])
-    allow(step).to receive(:labels).and_return([])
-    step
-  }
+  let(:task_step) do
+    instance_double(Tasks::Models::TaskStep).tap do |step|
+      allow(step).to receive(:id).and_return(15)
+      allow(step).to receive(:tasks_task_id).and_return(42)
+      allow(step).to receive(:group_name).and_return('Some group')
+      allow(step).to receive(:completed?).and_return(false)
+      allow(step).to receive(:feedback_available?).and_return(false)
+      allow(step).to receive(:can_be_recovered?).and_return(true)
+      allow(step).to receive(:related_content).and_return([])
+      allow(step).to receive(:labels).and_return([])
+      allow(step).to receive(:spy).and_return({})
+    end
+  end
 
-  let(:tasked_exercise) {
-    exercise = instance_double(Tasks::Models::TaskedExercise)
+  let(:tasked_exercise) do
+    instance_double(Tasks::Models::TaskedExercise).tap do |exercise|
+      ## Avoid rspec double class when figuring out :type
+      allow(exercise).to receive(:class).and_return(Tasks::Models::TaskedExercise)
 
-    ## Avoid rspec double class when figuring out :type
-    allow(exercise).to receive(:class).and_return(Tasks::Models::TaskedExercise)
+      allow(exercise).to receive(:task_step).and_return(task_step)
+      allow(exercise).to receive(:can_be_recovered?).and_return(false)
 
-    allow(exercise).to receive(:task_step).and_return(task_step)
-    allow(exercise).to receive(:can_be_recovered?).and_return(false)
+      ## TaskedExercise-specific properties
+      allow(exercise).to receive(:url).and_return('Some url')
+      allow(exercise).to receive(:title).and_return('Some title')
+      allow(exercise).to receive(:context).and_return('Some context')
+      allow(exercise).to receive(:content_hash_for_students).and_return('Some content')
+      allow(exercise).to receive(:solution).and_return('Some solution')
+      allow(exercise).to receive(:feedback).and_return('Some feedback')
+      allow(exercise).to receive(:correct_answer_id).and_return('456')
+      allow(exercise).to receive(:is_correct?).and_return(false)
+      allow(exercise).to receive(:free_response).and_return(nil)
+      allow(exercise).to receive(:answer_id).and_return(nil)
+      allow(exercise).to receive(:last_completed_at).and_return(Time.current)
+      allow(exercise).to receive(:first_completed_at).and_return(Time.current - 1.week)
+      allow(exercise).to receive(:question_id).and_return("questionID")
+      allow(exercise).to receive(:is_in_multipart).and_return(false)
+    end
+  end
 
-    ## TaskedExercise-specific properties
-    allow(exercise).to receive(:url).and_return('Some url')
-    allow(exercise).to receive(:title).and_return('Some title')
-    allow(exercise).to receive(:context).and_return('Some context')
-    allow(exercise).to receive(:content_hash_for_students).and_return('Some content')
-    allow(exercise).to receive(:solution).and_return('Some solution')
-    allow(exercise).to receive(:feedback).and_return('Some feedback')
-    allow(exercise).to receive(:correct_answer_id).and_return('456')
-    allow(exercise).to receive(:is_correct?).and_return(false)
-    allow(exercise).to receive(:free_response).and_return(nil)
-    allow(exercise).to receive(:answer_id).and_return(nil)
-    allow(exercise).to receive(:last_completed_at).and_return(Time.current)
-    allow(exercise).to receive(:first_completed_at).and_return(Time.current - 1.week)
-    allow(exercise).to receive(:question_id).and_return("questionID")
-    allow(exercise).to receive(:is_in_multipart).and_return(false)
-
-    exercise
-  }
-
-  let(:representation) { ## NOTE: This is lazily-evaluated on purpose!
+  let(:representation) do ## NOTE: This is lazily-evaluated on purpose!
     Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked_exercise).as_json
-  }
+  end
 
   shared_examples "a good exercise representation should" do
     it "'type' == 'exercise'" do
@@ -98,6 +97,10 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
 
     it "has 'is_in_multipart" do
       expect(representation).to include("is_in_multipart" => false)
+    end
+
+    it "has 'spy'" do
+      expect(representation).to include("spy" => {})
     end
 
   end

--- a/spec/representers/api/v1/tasks/tasked_external_url_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_external_url_representer_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Api::V1::Tasks::TaskedExternalUrlRepresenter, type: :representer 
       is_completed: false,
       has_recovery: false,
       labels: [],
-      related_content: []
+      related_content: [],
+      spy: {}
     }.stringify_keys)
   end
 end

--- a/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
@@ -1,39 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, type: :representer do
-  let(:task_step) {
-    step = instance_double(Tasks::Models::TaskStep)
-    allow(step).to receive(:id).and_return(15)
-    allow(step).to receive(:tasks_task_id).and_return(42)
-    allow(step).to receive(:group_name).and_return('Some group')
-    allow(step).to receive(:completed?).and_return(false)
-    allow(step).to receive(:feedback_available?).and_return(false)
-    allow(step).to receive(:can_be_recovered?).and_return(false)
-    allow(step).to receive(:related_content).and_return([])
-    allow(step).to receive(:labels).and_return([])
-    step
-  }
+  let(:task_step) do
+    instance_double(Tasks::Models::TaskStep).tap do |step|
+      allow(step).to receive(:id).and_return(15)
+      allow(step).to receive(:tasks_task_id).and_return(42)
+      allow(step).to receive(:group_name).and_return('Some group')
+      allow(step).to receive(:completed?).and_return(false)
+      allow(step).to receive(:feedback_available?).and_return(false)
+      allow(step).to receive(:can_be_recovered?).and_return(false)
+      allow(step).to receive(:related_content).and_return([])
+      allow(step).to receive(:labels).and_return([])
+      allow(step).to receive(:spy).and_return({})
+    end
+  end
 
-  let(:tasked_placeholder) {
-    placeholder = instance_double(Tasks::Models::TaskedPlaceholder)
+  let(:tasked_placeholder) do
+    instance_double(Tasks::Models::TaskedPlaceholder).tap do |placeholder|
+      ## Avoid rspec double class when figuring out :type
+      allow(placeholder).to receive(:class).and_return(Tasks::Models::TaskedPlaceholder)
 
-    ## Avoid rspec double class when figuring out :type
-    allow(placeholder).to receive(:class).and_return(Tasks::Models::TaskedPlaceholder)
+      allow(placeholder).to receive(:task_step).and_return(task_step)
+      allow(placeholder).to receive(:can_be_recovered?).and_return(false)
 
-    allow(placeholder).to receive(:task_step).and_return(task_step)
-    allow(placeholder).to receive(:can_be_recovered?).and_return(false)
+      ## TaskedPlaceholder-specific properties
+      allow(placeholder).to receive(:placeholder_type).and_return('some_exercise_type')
+      allow(placeholder).to receive(:last_completed_at).and_return(Time.current)
+      allow(placeholder).to receive(:first_completed_at).and_return(Time.current - 1.week)
+    end
+  end
 
-    ## TaskedPlaceholder-specific properties
-    allow(placeholder).to receive(:placeholder_type).and_return('some_exercise_type')
-    allow(placeholder).to receive(:last_completed_at).and_return(Time.current)
-    allow(placeholder).to receive(:first_completed_at).and_return(Time.current - 1.week)
-
-    placeholder
-  }
-
-  let(:representation) { ## NOTE: This is lazily-evaluated on purpose!
+  let(:representation) do ## NOTE: This is lazily-evaluated on purpose!
     Api::V1::Tasks::TaskedPlaceholderRepresenter.new(tasked_placeholder).as_json
-  }
+  end
 
   it "'type' == 'placeholder'" do
     expect(representation).to include("type" => "placeholder")
@@ -64,6 +63,10 @@ RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, type: :representer 
 
   it "has 'related_content'" do
     expect(representation).to include("related_content")
+  end
+
+  it "has 'spy'" do
+    expect(representation).to include("spy" => {})
   end
 
 end

--- a/spec/representers/api/v1/tasks/tasked_reading_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_reading_representer_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Api::V1::Tasks::TaskedReadingRepresenter, type: :representer do
       has_recovery: false,
       content_url: task_step.tasked.url,
       content_html: task_step.tasked.content,
-      related_content: a_kind_of(Array)
+      related_content: a_kind_of(Array),
+      spy: {}
     }.stringify_keys)
   end
 end

--- a/spec/representers/api/v1/tasks/tasked_video_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_video_representer_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Api::V1::Tasks::TaskedVideoRepresenter, type: :representer do
       has_recovery: false,
       content_url: task_step.tasked.url,
       content_html: task_step.tasked.content,
-      related_content: a_kind_of(Array)
+      related_content: a_kind_of(Array),
+      spy: {}
     }.stringify_keys)
   end
 end

--- a/spec/routines/create_practice_worst_topics_task_spec.rb
+++ b/spec/routines/create_practice_worst_topics_task_spec.rb
@@ -7,7 +7,12 @@ RSpec.describe CreatePracticeWorstTopicsTask, type: :routine do
                    -> { described_class.call course: course, role: role }
 
   it 'errors when there are not enough local exercises for the widget' do
-    expect(OpenStax::Biglearn::Api).to receive(:fetch_practice_worst_areas_exercises).and_return([])
+    expect(OpenStax::Biglearn::Api).to receive(:fetch_practice_worst_areas_exercises).and_return(
+      {
+        exercises: [],
+        spy_info: {}
+      }
+    )
     expect { result }
       .to  not_change { Tasks::Models::Task.count }
       .and not_change { Tasks::Models::Tasking.count }

--- a/spec/routines/translate_biglearn_spy_info_spec.rb
+++ b/spec/routines/translate_biglearn_spy_info_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe TranslateBiglearnSpyInfo, type: :routine do
+
+  before(:all) do
+    @current_task = FactoryGirl.create :tasks_task
+    @spaced_task = FactoryGirl.create :tasks_task
+  end
+
+  let(:given_exercise_uuid_1) { SecureRandom.uuid }
+  let(:given_exercise_uuid_2) { SecureRandom.uuid }
+  let(:given_exercise_uuid_3) { SecureRandom.uuid }
+
+  let(:given_book_container_uuid_1) { SecureRandom.uuid }
+  let(:given_book_container_uuid_2) { SecureRandom.uuid }
+  let(:given_book_container_uuid_3) { SecureRandom.uuid }
+
+  let(:spy_info) do
+    {
+      given_exercise_uuid_1 => { book_container_uuid: given_book_container_uuid_1 },
+      given_exercise_uuid_2 => {
+        k_ago: 1,
+        assignment_uuid: @spaced_task.uuid,
+        book_container_uuid: given_book_container_uuid_2
+      },
+      given_exercise_uuid_3 => {
+        k_ago: 0,
+        assignment_uuid: @current_task.uuid,
+        book_container_uuid: given_book_container_uuid_3
+      }
+    }.deep_stringify_keys
+  end
+
+  let(:expected_translated_spy_info) do
+    {
+      given_exercise_uuid_1 => { book_container_uuid: given_book_container_uuid_1 },
+      given_exercise_uuid_2 => {
+        k_ago: 1,
+        task_id: @spaced_task.id,
+        task_uuid: @spaced_task.uuid,
+        book_container_uuid: given_book_container_uuid_2
+      },
+      given_exercise_uuid_3 => {
+        k_ago: 0,
+        task_id: @current_task.id,
+        task_uuid: @current_task.uuid,
+        book_container_uuid: given_book_container_uuid_3
+      }
+    }.deep_stringify_keys
+  end
+
+  let(:translated_spy_info) { described_class.call(spy_info: spy_info).outputs.spy_info }
+
+  it 'translates spy info coming from Biglearn' do
+    expect(translated_spy_info).to eq expected_translated_spy_info
+  end
+
+end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe Tasks::Models::Task, type: :model do
   end
 
   it 'returns core task steps' do
-    core_step1            = instance_double('TaskStep', :core_group? => true)
-    core_step2            = instance_double('TaskStep', :core_group? => true)
-    core_step3            = instance_double('TaskStep', :core_group? => true)
-    spaced_practice_step1 = instance_double('TaskStep', :core_group? => false)
-    spaced_practice_step2 = instance_double('TaskStep', :core_group? => false)
+    core_step1            = instance_double('TaskStep', core_group?: true)
+    core_step2            = instance_double('TaskStep', core_group?: true)
+    core_step3            = instance_double('TaskStep', core_group?: true)
+    spaced_practice_step1 = instance_double('TaskStep', core_group?: false)
+    spaced_practice_step2 = instance_double('TaskStep', core_group?: false)
     task_steps = [core_step1, core_step2, core_step3, spaced_practice_step1, spaced_practice_step2]
     task = Tasks::Models::Task.new
     allow(task).to receive(:task_steps).and_return(task_steps)
@@ -88,11 +88,11 @@ RSpec.describe Tasks::Models::Task, type: :model do
   end
 
   it 'returns spaced_practice task steps' do
-    core_step1            = instance_double('TaskStep', :spaced_practice_group? => false)
-    core_step2            = instance_double('TaskStep', :spaced_practice_group? => false)
-    core_step3            = instance_double('TaskStep', :spaced_practice_group? => false)
-    spaced_practice_step1 = instance_double('TaskStep', :spaced_practice_group? => true)
-    spaced_practice_step2 = instance_double('TaskStep', :spaced_practice_group? => true)
+    core_step1            = instance_double('TaskStep', spaced_practice_group?: false)
+    core_step2            = instance_double('TaskStep', spaced_practice_group?: false)
+    core_step3            = instance_double('TaskStep', spaced_practice_group?: false)
+    spaced_practice_step1 = instance_double('TaskStep', spaced_practice_group?: true)
+    spaced_practice_step2 = instance_double('TaskStep', spaced_practice_group?: true)
     task_steps = [core_step1, core_step2, core_step3, spaced_practice_step1, spaced_practice_step2]
     task = Tasks::Models::Task.new
     allow(task).to receive(:task_steps).and_return(task_steps)
@@ -603,7 +603,12 @@ RSpec.describe Tasks::Models::Task, type: :model do
         expect(task.correct_exercise_steps_count).to eq 2
 
         # The placeholder step is removed due to no available personalized exercises
-        expect(OpenStax::Biglearn::Api).to receive(:fetch_assignment_pes).and_return([]).once
+        expect(OpenStax::Biglearn::Api).to receive(:fetch_assignment_pes).and_return(
+          {
+            exercises: [],
+            spy_info: {}
+          }
+        ).once
 
         MarkTaskStepCompleted[task_step: task.task_steps[3]]
 


### PR DESCRIPTION
- Rework retry_proc parameter so it works with background jobs
- Retry background jobs if the status coming from Biglearn indicates the response is not ready