### PR TITLE
multiple GA tracker support

### DIFF
--- a/app/views/webview/_google_analytics.html.erb
+++ b/app/views/webview/_google_analytics.html.erb
@@ -1,3 +1,6 @@
+<%# The GA tracking code in the secrets can be a comma-separated list of codes,
+    in which case we will create trackers for each code. %>
+
 <% unless Rails.application.secrets['ga_tracking_code'].blank? %>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -5,7 +8,15 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '<%= Rails.application.secrets['ga_tracking_code'] %>', 'auto');
+<% Rails.application.secrets['ga_tracking_code'].split(',').map(&:strip).each_with_index do |code, ii| %>
+  <% if ii == 0 # stick with default tracker, happens to be called 't0' %>
+    ga('create', '<%= code %>', 'auto');
     ga('send', 'pageview');
+  <% else # name the tracker 't1', 't2,', etc %>
+    ga('create', '<%= code %>', 'auto', 't<%= ii %>');
+    ga('t<%= ii %>.send', 'pageview');
+  <% end %>
+<% end %>
+
   </script>
 <% end %>


### PR DESCRIPTION
Adds support for multiple Google Analytics trackers.  To use multiple trackers, set the `ga_tracking_code` in the secrets to a comma-separated list of tracking codes.

The FE PR that uses multiple tracking codes is https://github.com/openstax/tutor-js/pull/1685.  Ideally these PRs would be merged together, but this BE PR can be merged without breaking the FE.