### PR TITLE
Relax ui-settings "previous_settings" requirement

### DIFF
--- a/app/controllers/api/v1/log_controller.rb
+++ b/app/controllers/api/v1/log_controller.rb
@@ -47,13 +47,15 @@ class Api::V1::LogController < Api::V1::ApiController
       Rails.logger.log(level, "(ext) #{message}")
       head :created
     end
-    end
+  end
 
 
   api :POST, '/log/onboarding/<event code>', 'Log that a user onboarding event has occured'
   def onboarding_event
     OSU::AccessPolicy.require_action_allowed!(params[:code], current_human_user, TrackTutorOnboardingEvent)
-    TrackTutorOnboardingEvent.perform_later(event: params[:code], user: current_human_user)
+    TrackTutorOnboardingEvent.perform_later(event: params[:code],
+                                            user: current_human_user,
+                                            data: params[:data])
     head :created
   end
 end

--- a/app/representers/api/v1/ui_settings_representer.rb
+++ b/app/representers/api/v1/ui_settings_representer.rb
@@ -3,12 +3,6 @@ module Api::V1
 
     include Roar::JSON
 
-    property :previous_ui_settings,
-             type: Hash,
-             readable: true,
-             writeable: true,
-             schema_info: { required: true }
-
     property :ui_settings,
              type: Hash,
              readable: true,

--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -22,13 +22,10 @@ module User
       has_one :customer_service, dependent: :destroy, inverse_of: :profile
       has_one :content_analyst, dependent: :destroy, inverse_of: :profile
 
-      attr_accessor :previous_ui_settings
-
       json_serialize :ui_settings, Hash
 
       validates :account, presence: true, uniqueness: true
       validates :ui_settings, max_json_length: 1500
-      validate  :validate_ui_settings_change_history , on: :update
 
       delegate :username, :first_name, :last_name, :full_name, :title, :uuid,
                :name, :casual_name, :salesforce_contact_id, :faculty_status,
@@ -36,15 +33,6 @@ module User
 
       def self.anonymous
         ::User::Models::AnonymousProfile.instance
-      end
-
-      private
-
-      def validate_ui_settings_change_history
-        if ui_settings_changed? && previous_ui_settings != ui_settings_was
-          errors.add(:previous_ui_settings,
-                     'out-of-band update detected. Previous does not match stored value')
-        end
       end
 
     end

--- a/spec/controllers/api/v1/log_controller_spec.rb
+++ b/spec/controllers/api/v1/log_controller_spec.rb
@@ -75,9 +75,14 @@ RSpec.describe Api::V1::LogController, type: :controller, api: true, version: :v
 
       it 'tracks valid codes' do
         user.account.update_attributes!(role: :instructor)
-        expect(TrackTutorOnboardingEvent).to receive(:perform_later)
-                                               .with(event: 'arrived_my_courses', user: anything)
-        api_post :onboarding_event, user_token, parameters: { code: 'arrived_my_courses' }
+        expect(TrackTutorOnboardingEvent).to receive(:perform_later).with(
+                                               data: { decision: "I won't be using it" },
+                                               event: 'made_adoption_decision',
+                                               user: anything,
+                                             )
+        api_post :onboarding_event, user_token, parameters: {
+                   code: 'made_adoption_decision', data: { decision: "I won't be using it" },
+                 }
         expect(response).to have_http_status(:success)
       end
     end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -48,14 +48,6 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
   end
 
   context "#ui-settings" do
-    it 'returns api_error when previous is invalid' do
-      api_put :ui_settings, user_1_token, raw_post_data: {
-                ui_settings: {is_open: false, answer: 42}
-              }.to_json
-      expect(response.code).to eq('422')
-      expect(response.body).to include('out-of-band update detected')
-    end
-
     it "saves to profile" do
       api_put :ui_settings, user_1_token, raw_post_data: {
                 previous_ui_settings: {},

--- a/spec/subsystems/user/models/profile_spec.rb
+++ b/spec/subsystems/user/models/profile_spec.rb
@@ -33,14 +33,4 @@ RSpec.describe User::Models::Profile, type: :model do
     expect(profile.errors[:ui_settings].to_s).to include 'too long'
   end
 
-  it 'requires prevsious settings to be valid when changed' do
-    profile = FactoryGirl.create(:user_profile, ui_settings: {'one' => 1})
-    profile.ui_settings = {test: true}
-    expect(profile.save).to be false
-    expect(profile.errors[:previous_ui_settings].to_s).to include 'out-of-band update detected'
-    profile.previous_ui_settings = {'one' => 1}
-    expect(profile.save).to be true
-    expect(profile.errors[:previous_ui_settings]).to be_empty
-  end
-
 end


### PR DESCRIPTION
This continues to cause 422 errors when QA and others are using multiple copies of Tutor concurrently, either though multiple tabs or qa test script.

Also fixes a bug from the pardot pr #1404 where i'd failed to track the `data`  That's needed for FE https://github.com/openstax/tutor-js/pull/1684/commits