### PR TITLE
related_content/label fixes (Comes from)

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -75,7 +75,9 @@ class Api::V1::TasksController < Api::V1::ApiController
   protected
 
   def get_task
-    @task = Tasks::Models::Task.with_deleted.find(params[:id])
+    @task = Tasks::Models::Task.with_deleted
+                               .preload(task_steps: [ :tasked, :page ])
+                               .find(params[:id])
   end
 
   def populate_placeholders

--- a/app/representers/api/v1/tasks/task_step_representer.rb
+++ b/app/representers/api/v1/tasks/task_step_representer.rb
@@ -46,7 +46,7 @@ module Api::V1::Tasks
              type: String,
              writeable: false,
              readable: true,
-             getter: lambda {|*| task_step.group_name },
+             getter: ->(*) { task_step.group_name },
              schema_info: {
                 required: true,
                 description: "Which group this TaskStep belongs to (default,core,spaced practice,personalized)"
@@ -88,7 +88,7 @@ module Api::V1::Tasks
     collection :related_content,
                writeable: false,
                readable: true,
-               getter: ->(*) { task_step.related_content.map{ |rc| Hashie::Mash.new(rc) } },
+               getter: ->(*) { task_step.related_content.map { |rc| OpenStruct.new(rc) } },
                extend: ::Api::V1::RelatedContentRepresenter,
                schema_info: {
                  required: true,

--- a/app/routines/create_practice_specific_topics_task.rb
+++ b/app/routines/create_practice_specific_topics_task.rb
@@ -31,8 +31,8 @@ class CreatePracticeSpecificTopicsTask
     @pages.each do |page|
       task_step = Tasks::Models::TaskStep.new(
         tasked: Tasks::Models::TaskedPlaceholder.exercise_type.new,
-        content_page_id: page.id,
-        group_type: :personalized_group
+        group_type: :personalized_group,
+        page: page.to_model
       )
 
       @task.task_steps << task_step

--- a/app/routines/create_practice_worst_topics_task.rb
+++ b/app/routines/create_practice_worst_topics_task.rb
@@ -30,7 +30,6 @@ class CreatePracticeWorstTopicsTask
     exercises.each do |exercise|
       run(:task_exercise, exercise: exercise, task: @task) do |step|
         step.group_type = :personalized_group
-        step.add_related_content(exercise.page.related_content)
         step.spy = spy_info.fetch(exercise.uuid, {})
       end
     end.tap { @task.update_attribute :pes_are_assigned, true }

--- a/app/routines/get_concept_coach.rb
+++ b/app/routines/get_concept_coach.rb
@@ -119,11 +119,8 @@ class GetConceptCoach
     exercises = core_exercises + spaced_exercises
     group_types = core_exercises.map{ :core_group } + spaced_exercises.map{ :spaced_practice_group }
 
-    related_content_array = exercises.map{ |ex| ex.page.related_content }
-
     # Create the new concept coach task, and put the exercises into steps
-    run(:create_cc_task, role: role, page: page, exercises: exercises,
-                         group_types: group_types, related_content_array: related_content_array)
+    run(:create_cc_task, role: role, page: page, exercises: exercises, group_types: group_types)
 
     run(:add_spy_info, to: outputs.task,
                        from: [ecosystem, { history: history.core_page_ids,

--- a/app/routines/task_exercise.rb
+++ b/app/routines/task_exercise.rb
@@ -4,7 +4,7 @@ class TaskExercise
 
   protected
 
-  def exec(exercise:, title: nil, task: nil, task_step: nil)
+  def exec(exercise:, task: nil, task_step: nil, title: nil)
     # This routine will make one step per exercise part.
     # If provided, the incoming `task_step` will be used as the first step.
 
@@ -14,20 +14,14 @@ class TaskExercise
     exercise_model = exercise.to_model
     page = exercise_model.page
 
-    if task_step.present?
-      current_step = task_step
-      new_step = !task.task_steps.include?(task_step)
-    else
-      current_step = Tasks::Models::TaskStep.new page: page
-      new_step = true
-    end
+    current_step = task_step || Tasks::Models::TaskStep.new(page: page)
 
     group_type = current_step.group_type
-    page = current_step.page
     labels = current_step.labels
     spy = current_step.spy
-    questions = exercise.content_as_independent_questions
 
+    questions = exercise.content_as_independent_questions
+    is_new_step = !task.task_steps.include?(task_step)
     outputs[:task_steps] = questions.each_with_index.map do |question, ii|
       # Make sure that all steps after the first exercise part get their own new step
       current_step = Tasks::Models::TaskStep.new(
@@ -59,13 +53,13 @@ class TaskExercise
 
       # Add the step to the task's list of steps if it's new
       # Both of these only save the steps if the task or the step are already persisted
-      if new_step
+      if is_new_step
         task.task_steps << current_step
       elsif current_step.persisted?
         current_step.save!
       end
 
-      new_step = true
+      is_new_step = true
 
       current_step
     end

--- a/app/routines/task_exercise.rb
+++ b/app/routines/task_exercise.rb
@@ -18,13 +18,12 @@ class TaskExercise
       current_step = task_step
       new_step = !task.task_steps.include?(task_step)
     else
-      current_step = Tasks::Models::TaskStep.new page: page, related_content: page.related_content
+      current_step = Tasks::Models::TaskStep.new page: page
       new_step = true
     end
 
     group_type = current_step.group_type
     page = current_step.page
-    related_content = current_step.related_content
     labels = current_step.labels
     spy = current_step.spy
     questions = exercise.content_as_independent_questions
@@ -36,7 +35,6 @@ class TaskExercise
         number: current_step.number.nil? ? nil : current_step.number + 1,
         group_type: group_type,
         page: page,
-        related_content: related_content,
         labels: labels,
         spy: spy
       ) if ii > 0

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -8,11 +8,11 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
 
     step_builder = ->(fragment) do
       Tasks::Models::TaskStep.new(
-        task: task, group_type: :core_group, page: page.to_model
-      ).tap do |step|
-        step.add_labels(fragment.labels)
-        task.task_steps << step
-      end
+        task: task,
+        group_type: :core_group,
+        page: page.to_model,
+        labels: fragment.labels
+      ).tap { |step| task.task_steps << step }
     end
 
     fragments.each do |fragment|

--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -3,8 +3,7 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
 
   protected
 
-  def task_fragments(task:, fragments:, page_title:, page:, related_content: nil)
-    related_content ||= page.related_content
+  def task_fragments(task:, fragments:, page_title:, page:)
     title = page_title
 
     step_builder = ->(fragment) do
@@ -12,7 +11,6 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
         task: task, group_type: :core_group, page: page.to_model
       ).tap do |step|
         step.add_labels(fragment.labels)
-        step.add_related_content(related_content)
         task.task_steps << step
       end
     end

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -52,13 +52,10 @@ class Tasks::Assistants::GenericAssistant
   end
 
   def add_exercise_step!(task:, exercise:, group_type:, title: nil, labels: nil)
-    related_content = exercise.page.related_content
-
     @used_exercise_numbers << exercise.number
 
     TaskExercise.call(task: task, exercise: exercise) do |step|
       step.group_type = group_type
-      step.add_related_content(related_content) if related_content.present?
       step.add_labels(labels) if labels.present?
     end.outputs.task_step
   end

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -54,9 +54,9 @@ class Tasks::Assistants::GenericAssistant
   def add_exercise_step!(task:, exercise:, group_type:, title: nil, labels: nil)
     @used_exercise_numbers << exercise.number
 
-    TaskExercise.call(task: task, exercise: exercise) do |step|
+    TaskExercise.call(task: task, exercise: exercise, title: title) do |step|
       step.group_type = group_type
-      step.add_labels(labels) if labels.present?
+      step.labels = labels if labels.present?
     end.outputs.task_step
   end
 

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -64,8 +64,7 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
         task: task,
         fragments: page.fragments,
         page_title: page.tutor_title,
-        page: page,
-        related_content: page.related_content
+        page: page
       )
 
       # Personalized exercises after each page

--- a/app/subsystems/tasks/create_concept_coach_task.rb
+++ b/app/subsystems/tasks/create_concept_coach_task.rb
@@ -13,7 +13,7 @@ module Tasks
 
     protected
 
-    def exec(role:, page:, exercises:, group_types:, related_content_array: [])
+    def exec(role:, page:, exercises:, group_types:)
       course = role.student.course
 
       fatal_error(code: :course_not_started) unless course.started?
@@ -33,7 +33,6 @@ module Tasks
       exercises.each_with_index do |exercise, ii|
         TaskExercise.call(exercise: exercise, task: outputs.task) do |step|
           step.group_type = group_types[ii]
-          step.add_related_content(related_content_array[ii])
         end
       end
 

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -15,7 +15,6 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
     :recovery_group
   ]
 
-  json_serialize :related_content, Hash, array: true
   json_serialize :related_exercise_ids, Integer, array: true
   json_serialize :labels, String, array: true
   json_serialize :spy, Hash
@@ -91,13 +90,12 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
     group_type.sub(/_group\z/, '').gsub('_', ' ')
   end
 
-  def add_related_content(related_content_hash)
-    return if related_content_hash.nil?
-    self.related_content << related_content_hash
-  end
-
   def add_labels(labels)
     self.labels = [self.labels, labels].flatten.compact.uniq
+  end
+
+  def related_content
+    page.nil? ? [] : [ page.related_content ]
   end
 
 end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -90,10 +90,6 @@ class Tasks::Models::TaskStep < Tutor::SubSystems::BaseModel
     group_type.sub(/_group\z/, '').gsub('_', ' ')
   end
 
-  def add_labels(labels)
-    self.labels = [self.labels, labels].flatten.compact.uniq
-  end
-
   def related_content
     page.nil? ? [] : [ page.related_content ]
   end

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -102,7 +102,6 @@ class Tasks::PopulatePlaceholderSteps
 
         last_step = page_task_steps.last
         max_page_step_number = last_step.try!(:number) || 0
-        related_content = last_step.try!(:related_content)
         labels = last_step.try!(:labels)
 
         # Iterate through all the exercises and steps
@@ -125,7 +124,6 @@ class Tasks::PopulatePlaceholderSteps
                 number: next_step_number,
                 group_type: group_type,
                 content_page_id: exercise.content_page_id,
-                related_content: related_content,
                 labels: labels
               )
 

--- a/db/migrate/20170612150156_remove_related_content_from_task_steps.rb
+++ b/db/migrate/20170612150156_remove_related_content_from_task_steps.rb
@@ -1,0 +1,5 @@
+class RemoveRelatedContentFromTaskSteps < ActiveRecord::Migration
+  def change
+    remove_column :tasks_task_steps, :related_content, :text, null: false, default: "[]"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170609150609) do
+ActiveRecord::Schema.define(version: 20170612150156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -696,7 +696,6 @@ ActiveRecord::Schema.define(version: 20170609150609) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.datetime "deleted_at"
-    t.text     "related_content",      default: "[]", null: false
     t.text     "related_exercise_ids", default: "[]", null: false
     t.text     "labels",               default: "[]", null: false
     t.integer  "content_page_id"

--- a/spec/representers/api/v1/tasks/tasked_external_url_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_external_url_representer_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Api::V1::Tasks::TaskedExternalUrlRepresenter, type: :representer 
   it 'should represent a tasked external url' do
     task_step = FactoryGirl.create(:tasks_tasked_external_url).task_step
     json = Api::V1::Tasks::TaskedExternalUrlRepresenter.new(task_step.tasked).to_json
+    related_content = task_step.related_content.map do |rc|
+      Api::V1::RelatedContentRepresenter.new(OpenStruct.new(rc)).to_hash
+    end
 
     expect(JSON.parse(json)).to include({
       id: task_step.id.to_s,
@@ -14,9 +17,9 @@ RSpec.describe Api::V1::Tasks::TaskedExternalUrlRepresenter, type: :representer 
       group: 'unknown',
       is_completed: false,
       has_recovery: false,
-      labels: [],
-      related_content: [],
-      spy: {}
+      labels: task_step.labels,
+      related_content: related_content,
+      spy: task_step.spy
     }.stringify_keys)
   end
 end

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -125,11 +125,12 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
       end
 
       it 'sets the published_at fields' do
-        result = DistributeTasks.call(task_plan: task_plan)
+        publish_time = Time.current
+        result = DistributeTasks.call(task_plan: task_plan, publish_time: publish_time)
         expect(result.errors).to be_empty
         task_plan.reload
-        expect(task_plan.first_published_at).to be_within(1).of(Time.current)
-        expect(task_plan.last_published_at).to be_within(1).of(Time.current)
+        expect(task_plan.first_published_at).to be_within(1).of(publish_time)
+        expect(task_plan.last_published_at).to be_within(1).of(publish_time)
       end
 
       it 'fails to publish the task_plan if one or more non-stepless tasks would be empty' do
@@ -161,11 +162,12 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true do
       end
 
       it 'sets the published_at fields' do
-        result = DistributeTasks.call(task_plan: task_plan)
+        publish_time = Time.current
+        result = DistributeTasks.call(task_plan: task_plan, publish_time: publish_time)
         expect(result.errors).to be_empty
         task_plan.reload
-        expect(task_plan.first_published_at).to be_within(1).of(Time.current)
-        expect(task_plan.last_published_at).to be_within(1).of(Time.current)
+        expect(task_plan.first_published_at).to be_within(1).of(publish_time)
+        expect(task_plan.last_published_at).to be_within(1).of(publish_time)
       end
 
       it 'fails to publish the task_plan if one or more non-stepless tasks would be empty' do

--- a/spec/routines/task_exercise_spec.rb
+++ b/spec/routines/task_exercise_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe TaskExercise, type: :routine do
     exercise_step = task.task_steps.third
 
     placeholder_step.update_attributes(
-      group_type: :personalized_group, related_content: [{test: true}], labels: ['test']
+      group_type: :personalized_group, labels: ['test']
     )
 
     TaskExercise[exercise: multipart_exercise, task_step: placeholder_step, task: task]

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::Models::TaskStep, type: :model do
+
   subject(:task_step) { FactoryGirl.create :tasks_task_step }
 
   it { is_expected.to belong_to(:task) }
@@ -68,31 +69,6 @@ RSpec.describe Tasks::Models::TaskStep, type: :model do
     end
   end
 
-  context "related content" do
-    it "can get related content" do
-      expect(task_step.related_content).to eq([])
-    end
-
-    it "can set related content" do
-      target_related_content = [{'title' => 'blah', 'chapter_section' => 'blah'}]
-      task_step.related_content = target_related_content
-      task_step.save!
-      task_step.reload
-      expect(task_step.related_content).to eq(target_related_content)
-    end
-
-    it "can add new related content" do
-      expect(task_step.related_content).to eq([])
-
-      content = {'title' => 'blah', 'chapter_section' => 'blah'}
-      expect{
-        task_step.add_related_content content
-        task_step.save!
-        task_step.reload
-      }.to change{task_step.related_content}.by [content]
-    end
-  end
-
   context "labels" do
     it "can get labels" do
       expect(task_step.labels).to eq([])
@@ -117,4 +93,13 @@ RSpec.describe Tasks::Models::TaskStep, type: :model do
       }.to change{task_step.labels}.by labels
     end
   end
+
+  context "related content" do
+    it "can get related content" do
+      expect(task_step.related_content).to eq([ task_step.page.related_content ])
+      task_step.page = nil
+      expect(task_step.related_content).to eq([])
+    end
+  end
+
 end

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -81,17 +81,6 @@ RSpec.describe Tasks::Models::TaskStep, type: :model do
       task_step.reload
       expect(task_step.labels).to eq(target_labels)
     end
-
-    it "can add new labels" do
-      expect(task_step.labels).to eq([])
-
-      labels = ['a', 'b']
-      expect{
-        task_step.add_labels labels
-        task_step.save!
-        task_step.reload
-      }.to change{task_step.labels}.by labels
-    end
   end
 
   context "related content" do

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -47,11 +47,8 @@ class SetupPerformanceReportData
 
         group_types = (exercises.size - 2).times.map{ :core_group } + [:spaced_practice_group] * 2
 
-        related_content_array = exercises.map{ page.related_content }
-
         Tasks::CreateConceptCoachTask[
-          role: role, page: page, exercises: exercises,
-          group_types: group_types, related_content_array: related_content_array
+          role: role, page: page, exercises: exercises, group_types: group_types
         ]
       end
     end


### PR DESCRIPTION
- Removed related_content as a step field (load it from the page instead)
- Removed add_labels method (assign directly instead)
- Cleaned up TaskExercise a bit