### PR TITLE
Import speedup

### DIFF
--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -50,6 +50,10 @@ class Content::Models::Exercise < Tutor::SubSystems::BaseModel
     tags.to_a.select(&:cnxfeature?)
   end
 
+  def requires_context?
+    tags.to_a.any?(&:requires_context?)
+  end
+
   def content_hash
     @content_hash ||= JSON.parse(content)
   end
@@ -63,10 +67,6 @@ class Content::Models::Exercise < Tutor::SubSystems::BaseModel
         {id: question['id'], content: content}
       end
     end
-  end
-
-  def requires_context?
-    tags.to_a.any?(&:requires_context?)
   end
 
   def questions_hash

--- a/app/subsystems/content/routines/populate_exercise_pools.rb
+++ b/app/subsystems/content/routines/populate_exercise_pools.rb
@@ -12,7 +12,7 @@ class Content::Routines::PopulateExercisePools
   def exec(book:, save: true)
     ecosystem = book.ecosystem
     # Use preload here instead of eager_load here to avoid a memory usage spike
-    chapters = book.chapters.preload(pages: { exercises: { exercise_tags: :tag } })
+    chapters = book.chapters.preload(pages: { exercises: :tags })
 
     hs_logic = HS_UUIDS.include?(book.uuid)
     college_logic = !hs_logic
@@ -39,7 +39,7 @@ class Content::Routines::PopulateExercisePools
                                                             pool_type: :all_exercises)
 
         page.exercises.each do |exercise|
-          tags = exercise.exercise_tags.map{ |et| et.tag.value }
+          tags = exercise.tags.map(&:value)
 
           # All Exercises
           page.all_exercises_pool.content_exercise_ids << exercise.id

--- a/app/subsystems/content/strategies/direct/ecosystem.rb
+++ b/app/subsystems/content/strategies/direct/ecosystem.rb
@@ -178,13 +178,13 @@ module Content
           end.sort_by{ |ex| number_indices[ex.number] }
         end
 
-        def exercises_with_tags(*tags, pages: nil, match_count: tags.size)
+        def exercises_with_tags(*tags_array, pages: nil, match_count: tags_array.size)
           exercises = entity_exercises.reorder(nil)
-                                      .preload(exercise_tags: :tag)
-                                      .joins(exercise_tags: :tag)
-                                      .where(exercise_tags: {tag: {value: tags.flatten}})
+                                      .preload(:tags)
+                                      .joins(:tags)
+                                      .where(tags: {value: tags_array.flatten})
                                       .group(:id).having do
-            count(distinct(exercise_tags.tag.id)).gteq match_count
+            count(distinct(tags.id)).gteq match_count
           end
           exercises = exercises.where(content_page_id: [pages].flatten.map(&:id)) unless pages.nil?
 

--- a/app/subsystems/content/visitors/exercise.rb
+++ b/app/subsystems/content/visitors/exercise.rb
@@ -6,8 +6,8 @@ class Content::Visitors::Exercise < Content::Visitors::Book
 
   def visit_page(page)
     page_exercises = Content::Models::Exercise
-      .joins{exercise_tags.tag.page_tags}
-      .where{exercise_tags.tag.page_tags.content_page_id == my{page.id}}
+      .joins{tags.page_tags}
+      .where{tags.page_tags.content_page_id == my{page.id}}
 
     page_exercises.each do |page_exercise|
       wrapper = OpenStax::Exercises::V1::Exercise.new(content: page_exercise.content)


### PR DESCRIPTION
When looking at where the imports were timing out on QA, I found the exercise#requires_context method every time (and Rails loading the tags which shouldn't happen at that point or else it's N+1).

This PR fixes the preloading of exercise tags by always using the exercise -> tags association instead of going through the exercise_tags records.