### PR TITLE
Provide a way for teachers to sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,9 @@ class ApplicationController < ActionController::Base
   add_flash_types *WEBVIEW_FLASH_TYPES
   prepend_before_filter :keep_webview_flash
 
-  before_filter :block_sign_up, unless: -> { params[:block_sign_up] == false }
-  before_filter :straight_to_student_sign_up, if: -> { params[:straight_to_student_sign_up] == true }
+  before_filter :block_sign_up, unless: -> { params[:block_sign_up].to_s == "false" }
+  before_filter :straight_to_student_sign_up, if: -> { params[:straight_to_student_sign_up].to_s == "true" }
+  before_filter :straight_to_sign_up, if: -> { params[:straight_to_sign_up].to_s == "true" }
   before_filter :authenticate_user!
 
   protected
@@ -23,6 +24,11 @@ class ApplicationController < ActionController::Base
   def straight_to_student_sign_up
     # Must be called before `authenticate_user!`
     login_params[:go] = 'student_signup'
+  end
+
+  def straight_to_sign_up
+    # Must be called before `authenticate_user!`
+    login_params[:go] = 'signup'
   end
 
   def require_contracts

--- a/app/views/static_pages/signup.html.erb
+++ b/app/views/static_pages/signup.html.erb
@@ -21,9 +21,8 @@
     <div class="teacher">
       <h3>Are you an instructor or administrator?</h3>
       <p>
-        OpenStax Tutor beta is currently in closed pilot.
-        If you're interested in learning how to participate,
-        please <a href="mailto:info@openstax.org">contact us</a>.
+        <%= link_to 'Sign up', main_app.non_student_signup_path %> to join the OpenStax Tutor beta.  After we verify
+        that you are faculty, you'll be able to test out preview courses or create your own course.
       </p>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
     get :signup
   end
 
+  get :non_student_signup,
+      to: redirect('/dashboard?block_sign_up=false&straight_to_sign_up=true')
+
   resource :pardot, controller: :pardot, only: [] do
     get :toa
   end

--- a/spec/requests/signup_waypoint_spec.rb
+++ b/spec/requests/signup_waypoint_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Signup waypoint", type: :request do
+
+  it 'lets teachers signup' do
+    get("/non_student_signup")
+
+    expect(redirect_path).to eq "/dashboard"
+    expect(redirect_query_hash).to include(block_sign_up: "false", straight_to_sign_up: "true")
+
+    get(redirect_path_and_query)
+
+    expect(redirect_path).to eq "/accounts/login"
+    expect(redirect_query_hash).to include(go: "signup")
+  end
+
+  def redirect_path
+    redirect_uri.path
+  end
+
+  def redirect_path_and_query
+    "#{redirect_uri.path}?#{redirect_uri.query}"
+  end
+
+  def redirect_query_hash
+    Rack::Utils.parse_nested_query(redirect_uri.query).symbolize_keys
+  end
+
+  def redirect_uri
+    expect(response.code).to match "302|301"
+    uri = URI.parse(response.headers["Location"])
+  end
+
+end


### PR DESCRIPTION
The sign up link in:

![image](https://user-images.githubusercontent.com/1001691/27247635-47e579dc-52af-11e7-9a24-fbad6782bfc5.png)

goes straight to sign up on Accounts.  Once they finish signing up, they get dropped back to the dashboard (my courses)