### PR TITLE
Upgrade accounts-rails for better role & UUID access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'whenever'
 gem 'omniauth-oauth2', '~> 1.3.1'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', '~> 7.5.0'
+gem 'openstax_accounts', '~> 7.6.0'
 
 # Datetime parsing
 gem 'chronic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,7 +434,7 @@ GEM
     omniauth-salesforce (1.0.5)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.0)
-    openstax_accounts (7.5.0)
+    openstax_accounts (7.6.0)
       action_interceptor (>= 1.0)
       keyword_search (>= 1.0.0)
       lev (>= 2.2.1)
@@ -791,7 +791,7 @@ DEPENDENCIES
   oj
   oj_mimic_json
   omniauth-oauth2 (~> 1.3.1)
-  openstax_accounts (~> 7.5.0)
+  openstax_accounts (~> 7.6.0)
   openstax_api (~> 8.1.0)
   openstax_rescue_from (~> 1.6.0)
   openstax_salesforce (~> 0.19.0)

--- a/app/handlers/admin/users_create.rb
+++ b/app/handlers/admin/users_create.rb
@@ -1,6 +1,6 @@
 class Admin::UsersCreate
   ALLOWED_ATTRIBUTES = ['username', 'password', 'first_name', 'last_name',
-                        'full_name', 'title', 'email']
+                        'full_name', 'title', 'email', 'role']
 
   lev_handler
 
@@ -17,6 +17,7 @@ class Admin::UsersCreate
     attribute :full_name, type: String
     attribute :title, type: String
     attribute :email, type: String
+    attribute :role, type: String
     attribute :administrator, type: boolean
     attribute :customer_service, type: boolean
     attribute :content_analyst, type: boolean

--- a/app/routines/import_roster.rb
+++ b/app/routines/import_roster.rb
@@ -11,6 +11,7 @@ class ImportRoster
 
   def exec(user_hashes:, period:)
     user_hashes.each do |user_hash|
+      user_hash[:role] = 'student'
       user = run(:find_or_create_user, user_hash).outputs.user
 
       run(

--- a/app/routines/populate_preview_course_content.rb
+++ b/app/routines/populate_preview_course_content.rb
@@ -41,6 +41,7 @@ class PopulatePreviewCourseContent
         acc.title = student_info[:title]
         acc.first_name = student_info[:first_name]
         acc.last_name = student_info[:last_name]
+        acc.role = 'student'
       end.tap do |acc|
         raise "Someone took the preview username #{acc.username}!" if acc.valid_openstax_uid?
       end

--- a/app/subsystems/user/create_user.rb
+++ b/app/subsystems/user/create_user.rb
@@ -10,7 +10,7 @@ module User
 
     def exec(account_id: nil, email: nil, username: nil, password: nil,
              first_name: nil, last_name: nil, full_name: nil, title: nil,
-             faculty_status: nil, salesforce_contact_id: nil)
+             faculty_status: nil, salesforce_contact_id: nil, role: nil)
       raise ArgumentError, 'Requires either an email, a username or an account_id' \
         if email.nil? && username.nil? && account_id.nil?
 
@@ -18,7 +18,8 @@ module User
         email: email, username: username, password: password,
         first_name: first_name, last_name: last_name,
         full_name: full_name, title: title,
-        faculty_status: faculty_status, salesforce_contact_id: salesforce_contact_id
+        faculty_status: faculty_status, salesforce_contact_id: salesforce_contact_id,
+        role: role
       )
 
       outputs.user = ::User::User.create account_id: account_id

--- a/app/subsystems/user/find_or_create_user.rb
+++ b/app/subsystems/user/find_or_create_user.rb
@@ -9,7 +9,8 @@ module User
     protected
 
     def exec(email: nil, username: nil, password: nil,
-             first_name: nil, last_name: nil, full_name: nil, title: nil)
+             first_name: nil, last_name: nil, full_name: nil,
+             title: nil, role: nil)
 
       run(:find_or_create_account, email: email,
                                    username: username,
@@ -17,7 +18,8 @@ module User
                                    first_name: first_name,
                                    last_name: last_name,
                                    full_name: full_name,
-                                   title: title )
+                                   title: title,
+                                   role: role )
 
       outputs[:user] = MapUsersAccounts.account_to_user(outputs.account)
     end

--- a/app/subsystems/user/models/anonymous_profile.rb
+++ b/app/subsystems/user/models/anonymous_profile.rb
@@ -24,6 +24,10 @@ module User
         nil
       end
 
+      def role
+        'unknown_role'
+      end
+
       def id
         # convention that anonymous user has an ID of -1, helps with globalID lookup
         -1

--- a/app/subsystems/user/models/profile.rb
+++ b/app/subsystems/user/models/profile.rb
@@ -28,7 +28,7 @@ module User
       validates :ui_settings, max_json_length: 10_000
 
       delegate :username, :first_name, :last_name, :full_name, :title, :uuid,
-               :name, :casual_name, :salesforce_contact_id, :faculty_status,
+               :name, :casual_name, :salesforce_contact_id, :faculty_status, :role,
                :first_name=, :last_name=, :full_name=, :title=, to: :account
 
       def self.anonymous

--- a/app/subsystems/user/strategies/direct/anonymous_user.rb
+++ b/app/subsystems/user/strategies/direct/anonymous_user.rb
@@ -7,7 +7,7 @@ module User
         exposes :instance, :anonymous, from_class: ::User::Models::AnonymousProfile
         exposes :account, :username, :title, :first_name, :last_name,
                 :full_name, :name, :casual_name,
-                :salesforce_contact_id, :uuid
+                :salesforce_contact_id, :uuid, :role
 
         class << self
           alias_method :entity_instance, :instance

--- a/app/subsystems/user/strategies/direct/user.rb
+++ b/app/subsystems/user/strategies/direct/user.rb
@@ -8,7 +8,7 @@ module User
 
         exposes :account, :username, :title, :first_name, :last_name,
                 :full_name, :name, :casual_name, :faculty_status, :ui_settings,
-                :salesforce_contact_id, :uuid
+                :salesforce_contact_id, :uuid, :role
 
         class << self
           alias_method :entity_all, :all

--- a/app/subsystems/user/user.rb
+++ b/app/subsystems/user/user.rb
@@ -85,6 +85,10 @@ module User
       verify_and_return @strategy.title, klass: String, allow_nil: true, error: StrategyError
     end
 
+    def role
+      verify_and_return @strategy.role, klass: String, allow_nil: true, error: StrategyError
+    end
+
     def is_human?
       !!@strategy.is_human?
     end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -41,6 +41,11 @@
   <% end %>
 
   <div class='form-group'>
+    <%= f.label :role, class: 'col-sm-2 control-label' %>
+    <%= f.select :role, OpenStax::Accounts::Account.roles.keys.map{|rr| [rr, rr]} %>
+  </div>
+
+  <div class='form-group'>
     <%= f.label :administrator, class: 'col-sm-2 control-label' %>
     <%= check_box_tag 'user[administrator]', "1", @user.try(:is_admin?) %>
   </div>

--- a/spec/routines/import_roster_spec.rb
+++ b/spec/routines/import_roster_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe ImportRoster, type: :routine do
     end
   end
 
+  it 'sets the new users to have the student role' do
+    result
+    expect(OpenStax::Accounts::Account.find_by(username: user_hashes[0][:username]).role).to eq 'student'
+  end
+
   it 'does not overwrite existing users\' info' do
     existing_users = user_hashes.map do |user_hash|
       FactoryGirl.create :user, username: user_hash[:username]


### PR DESCRIPTION
* Uses new version of accounts-rails to populate `role` and `uuid` on unclaimed users or stubbed users
* Sets `student` role on imported students and on preview course students
* Gets rid of the "UUID missing ... sync to Accounts" message in dev.