### PR TITLE
Don't 500 in dev for TOA tracking if no SF user

### DIFF
--- a/app/routines/track_tutor_onboarding_event.rb
+++ b/app/routines/track_tutor_onboarding_event.rb
@@ -72,6 +72,12 @@ protected
       raise
     rescue MissingArgument => ee
       raise(MissingArgument, "Missing the `#{ee.message}` argument for event #{event}")
+    rescue OpenStax::Salesforce::UserMissing => ee
+      if Rails.env.development?
+        Rails.logger.error { "Cannot track TOA event because Salesforce user not set" }
+      else
+        raise
+      end
     end
 
   end

--- a/spec/routines/track_tutor_onboarding_event_spec.rb
+++ b/spec/routines/track_tutor_onboarding_event_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe TrackTutorOnboardingEvent, type: :routine, vcr: VCR_OPTS do
     end
   end
 
+  context "when there is no SF user" do
+    let(:event) { :like_preview_yes }
+    let(:user) { @user_sf_a }
+
+    it "freaks out in production" do
+      clear_salesforce_user
+      ActiveForce.clear_sfdc_client!
+      expect{call}.to raise_error(OpenStax::Salesforce::UserMissing)
+    end
+  end
+
   context 'when user anonymous and no pardot contact ID supplied' do
     let(:event) { :arrived_my_courses }
     let(:user) { anonymous_user }


### PR DESCRIPTION
Prevents a 500 from popping up all the time in dev when the FE tries to track TOA events but there is no SF user set.