### PR TITLE
Fix timeout when creating courses while preview courses are building

### DIFF
--- a/app/subsystems/course_profile/build_preview_courses.rb
+++ b/app/subsystems/course_profile/build_preview_courses.rb
@@ -48,7 +48,7 @@ class CourseProfile::BuildPreviewCourses
       .where(['coalesce(course_preview_count, 0) < ?', desired_count])
       .select('coalesce(course_preview_count, 0) as course_preview_count, catalog_offerings.*')
       .reorder(1, :number) # Work on offerings with lower course_preview_count first
-      .lock('FOR UPDATE OF catalog_offerings SKIP LOCKED') # Skip offerings being worked on
+      .lock('FOR NO KEY UPDATE OF catalog_offerings SKIP LOCKED') # Skip offerings being worked on
       .first # Only lock 1 offering at a time
   end
 

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe CalculateTaskStats, type: :routine, speed: :slow, vcr: VCR_OPTS d
   end
 
   # Workaround for PostgreSQL bug where the task records
-  # stop existing in SELECT FOR UPDATE queries (but not in regular SELECTs)
-  # after the transaction rollback that happens in between spec examples
+  # stop existing in SELECT ... FOR UPDATE queries (but not in regular SELECTs)
+  # after the transaction rollback that happens in-between spec examples
   before(:each) { @task_plan.tasks.each(&:touch) }
 
   let(:student_tasks) do

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe CalculateTaskStats, type: :routine, speed: :slow, vcr: VCR_OPTS d
   # Workaround for PostgreSQL bug where the task records
   # stop existing in SELECT ... FOR UPDATE queries (but not in regular SELECTs)
   # after the transaction rollback that happens in-between spec examples
-  before(:each) { @task_plan.tasks.each(&:touch) }
+  before(:each)       { @task_plan.tasks.each(&:touch) }
 
-  let(:student_tasks) do
-    @task_plan.tasks.joins(taskings: {role: :student}).to_a
-  end
+  let(:student_tasks) { @task_plan.tasks.joins(taskings: { role: :student }).to_a }
 
   context "with an unworked plan" do
 


### PR DESCRIPTION
Works because `FOR NO KEY UPDATE` tells PostgreSQL that we are not going to modify the offering id which is all the course creation cares about (it seems to obtain a `FOR KEY SHARE` lock on the offering when the course is saved)