### PR TITLE
Light blue link color on signup page

### DIFF
--- a/app/assets/stylesheets/alt_signup.scss
+++ b/app/assets/stylesheets/alt_signup.scss
@@ -8,6 +8,11 @@
  #alt-signup {
    $title-height: 260px;
    position: relative;
+
+   a {
+     color: #0dc0dc;
+   }
+
    .title {
      background: #0dc0de;
      height: $title-height;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1001691/27442934-7d95f1ee-5726-11e7-9af5-a1bfd5d07ec9.png)

Still has underline on hover.  Color on hover is the same light blue.