### PR TITLE
Run sequence_number jobs inline in order after the transaction ends

### DIFF
--- a/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
+++ b/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
@@ -2,7 +2,7 @@
 # then queues up another job to make the Biglearn request itself
 # Then attempts to lock the job and, after the transaction is committed, work it inline
 class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::Job
-  INLINE_JOB_TIMEOUT = 10.minutes
+  INLINE_JOB_TIMEOUT = 30.seconds
 
   queue_as :default
 

--- a/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
+++ b/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
@@ -2,9 +2,19 @@
 # then queues up another job to make the Biglearn request itself
 # Then attempts to lock the job and, after the transaction is committed, work it inline
 class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::Job
-  BIGLEARN_API_TIMEOUT = 10.minutes
+  INLINE_JOB_TIMEOUT = 10.minutes
 
   queue_as :default
+
+  def self.perform_later(*_)
+    super.tap do |job|
+      # Attempt to get the sequence_number as soon as the current transaction (if any) ends
+      # This should guarantee that the intended order of events is preserved unless the server dies
+      # in-between committing the transaction and running the after_commit callbacks
+      # (in that case we'll still get the events eventually but they may be in the wrong order)
+      ActiveJob::AfterCommitRunner.new(job, INLINE_JOB_TIMEOUT).run_after_commit
+    end
+  end
 
   def perform(
     method:, requests:, create:, sequence_number_model_key:, sequence_number_model_class:,
@@ -32,9 +42,7 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
       RETURNING "id", "sequence_number"
     SQL
 
-    can_perform_later = Delayed::Worker.delay_jobs
-    worker = Delayed::Worker.new if can_perform_later
-    delayed_job = sequence_number_model_class.transaction do
+    sequence_number_model_class.transaction do
       # Update and read all sequence_numbers in one statement to minimize time waiting for I/O
       # Requests for records that have not been created
       # on the Biglearn side (sequence_number == 0) are suppressed
@@ -51,31 +59,11 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
       requests_with_sequence_numbers = req.map do |request|
         model = request[sequence_number_model_key].to_model
 
-        # This code is currently unused, but could be used if there was a call to Biglearn that
-        # required a sequence_number and had perform_later: false, although that might be a bad idea
-        if model.new_record?
-          # Special case for unsaved records
-          sequence_number = model.sequence_number || 0
-
-          # Detect a race condition with the create call and potentially retry later
-          raise(
-            OpenStax::Biglearn::Api::JobFailed,
-            "[#{method}] Attempted to get sequence_number 0 (reserved for \"create\" calls) from #{
-            sequence_number_model_class} ID #{model.id}"
-          ) if sequence_number == 0 && !create
-
-          # The condition below should never happen unless we have a bug
-          raise(
-            ArgumentError,
-            "[#{method}] The given #{sequence_number_model_class
-            } with ID #{model.id} has already been created"
-          ) if sequence_number > 0 && create
-
-          can_peform_later = false
-
-          model.sequence_number = sequence_number + 1
-          next request.merge(sequence_number: sequence_number)
-        end
+        # Unsaved sequence_number_models are not supported (ActiveJob cannot serialize them)
+        raise(
+          ArgumentError,
+          "The given #{sequence_number_model_class.name} is unsaved."
+        ) if model.new_record?
 
         sequence_number = sequence_numbers_by_model_id[model.id]
 
@@ -111,42 +99,17 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
       modified_requests = requests.is_a?(Hash) ? requests_with_sequence_numbers.first :
                                                  requests_with_sequence_numbers
 
-      # Create a background job if possible to guarantee the sequence_number will reach Biglearn
-      if can_perform_later
-        job = OpenStax::Biglearn::Api::Job.perform_later(
-          method: method.to_s,
-          requests: modified_requests,
-          response_status_key: response_status_key.try!(:to_s),
-          accepted_response_status: accepted_response_status
-        )
+      # nil can happen if the request was suppressed
+      return {} if modified_requests.nil?
+      return [] if modified_requests.empty?
 
-        # Destroy the current job so it's removed from the queue when this transaction commits
-        # Just in case we encounter an error after the transaction ends,
-        # since we don't want this job to run again
-        Delayed::Job.where(id: provider_job_id).delete_all
-
-        delayed_job_id = job.provider_job_id
-
-        return job if delayed_job_id.nil?
-
-        # Lock the Biglearn request job so we can run it inline to speed up Biglearn responses
-        ready_scope = Delayed::Job.ready_to_run(worker.name, Delayed::Worker.max_run_time)
-                                  .where(id: delayed_job_id)
-        # Pretend the lock is much closer to expiring so we get a shorter timeout
-        now = Delayed::Job.db_time_now - Delayed::Worker.max_run_time + BIGLEARN_API_TIMEOUT
-
-        # We just created the job and are still inside the same transaction,
-        # so the lock should never fail (PostgreSQL doesn't even support Read Uncommitted)
-        Delayed::Job.reserve_with_scope(ready_scope, worker, now)
-      else
-        return super(method: method,
-                     requests: modified_requests,
-                     response_status_key: response_status_key,
-                     accepted_response_status: accepted_response_status)
-      end
+      # Create a background job to guarantee the sequence_number request will reach Biglearn
+      OpenStax::Biglearn::Api::Job.perform_later(
+        method: method.to_s,
+        requests: modified_requests,
+        response_status_key: response_status_key.try!(:to_s),
+        accepted_response_status: accepted_response_status
+      )
     end
-
-    # Run the Biglearn request job inline (must be outside the main transaction)
-    worker.run(delayed_job)
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,6 +2,7 @@
 require File.expand_path('../application', __FILE__)
 
 require 'date_time_utilities'
+require 'active_job/after_commit_runner'
 require 'acts_as_resource'
 require 'acts_as_tasked'
 require 'belongs_to_time_zone'

--- a/lib/active_job/after_commit_runner.rb
+++ b/lib/active_job/after_commit_runner.rb
@@ -1,0 +1,54 @@
+# http://blog.arkency.com/2015/10/run-it-in-background-job-after-commit/
+# This class will attempt to reserve the Delayed::Job associated with the given ActiveJob
+# and run it as soon as the current transaction commits, if it was successfully reserved
+# If this is the same transaction that created the Delayed::Job, the reserve step should never fail
+# If there is no ongoing transaction, the Delayed::Job is run immediately, if reserved successfully
+class ActiveJob::AfterCommitRunner
+  def initialize(active_job, inline_job_timeout = Delayed::Worker.max_run_time)
+    @delayed_job = reserve_and_return_delayed_job(active_job, inline_job_timeout)
+  end
+
+  def has_transactional_callbacks?
+    !@delayed_job.nil?
+  end
+
+  def committed!(*_)
+    delayed_worker.run(@delayed_job) if has_transactional_callbacks?
+  end
+
+  def rolledback!(*_)
+  end
+
+  def set_transaction_state(state)
+  end
+
+  def run_after_commit
+    if ActiveRecord::Base.connection.transaction_open?
+      ActiveRecord::Base.connection.current_transaction.add_record self
+    else
+      committed!
+    end
+  end
+
+  protected
+
+  def delayed_worker
+    Thread.current[:delayed_worker] ||= Delayed::Worker.new
+  end
+
+  def reserve_and_return_delayed_job(active_job, inline_job_timeout)
+    delayed_job_id = active_job.provider_job_id
+
+    return if delayed_job_id.nil?
+
+    # Lock the Biglearn request job so we can run it inline to speed up Biglearn responses
+    ready_scope = Delayed::Job.ready_to_run(delayed_worker.name, Delayed::Worker.max_run_time)
+                              .where(id: delayed_job_id)
+    # Pretend the lock is much closer to expiring so we get a shorter timeout
+    now = Delayed::Job.db_time_now - Delayed::Worker.max_run_time + inline_job_timeout
+
+    # We just created the job and are still inside the same transaction,
+    # so the lock should never fail (PostgreSQL doesn't even support Read Uncommitted)
+    Delayed::Job.reserve_with_scope(ready_scope, delayed_worker, now)
+  end
+end

--- a/spec/lib/active_job/after_commit_runner_spec.rb
+++ b/spec/lib/active_job/after_commit_runner_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+class TestJob < ActiveJob::Base
+  cattr_reader :performed_count
+  @@performed_count = 0
+
+  def perform(count)
+    @@performed_count += count
+  end
+end
+
+RSpec.describe ActiveJob::AfterCommitRunner, type: :lib, truncation: true do
+  before(:all)      { Delayed::Worker.delay_jobs = true      }
+  after(:all)       { Delayed::Worker.delay_jobs = false     }
+
+  let(:increment)   { 42 }
+  let(:job)         { TestJob.perform_later(increment)       }
+  let(:delayed_job) { Delayed::Job.find(job.provider_job_id) }
+  let(:runner)      { described_class.new(job)               }
+
+  context '#initialize' do
+    it 'reserves the Delayed::Job associated with the given ActiveJob' do
+      expect { runner }.to  change     { delayed_job.reload.locked_at }
+                       .and change     { delayed_job.locked_by }
+                       .and not_change { TestJob.performed_count }
+    end
+  end
+
+  context '#run_after_commit' do
+    context 'in a transaction' do
+      it 'runs the given job when the transaction commits' do
+        expect do
+          Delayed::Job.transaction do
+            expect { runner.run_after_commit }.to  change { delayed_job.reload.locked_at }
+                                              .and change { delayed_job.locked_by }
+                                              .and not_change { TestJob.performed_count }
+          end
+        end.to change { TestJob.performed_count }.by(increment)
+
+        expect{ delayed_job.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'does not do anything if the transaction rolls back' do
+        expect do
+          Delayed::Job.transaction do
+            expect { runner.run_after_commit }.to  change { delayed_job.reload.locked_at }
+                                              .and change { delayed_job.locked_by }
+                                              .and not_change { TestJob.performed_count }
+
+            raise ActiveRecord::Rollback
+          end
+        end.to  not_change { delayed_job.reload.locked_at }
+           .and not_change { delayed_job.locked_by }
+           .and not_change { TestJob.performed_count }
+      end
+    end
+
+    context 'not in a transaction' do
+      it 'runs the given job immediately' do
+        expect { runner.run_after_commit }.to change { TestJob.performed_count }.by(increment)
+
+        expect{ delayed_job.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/lib/active_job/base_spec.rb
+++ b/spec/lib/active_job/base_spec.rb
@@ -1,17 +1,15 @@
 require 'rails_helper'
 
-module ActiveJob
-  describe Base, type: :lib do
-    let(:job)            { ::ActiveJob::Base.new }
-    let(:exception_class) { ActiveRecord::RecordNotFound }
+RSpec.describe ActiveJob::Base, type: :lib do
+  let(:job)             { described_class.new }
+  let(:exception_class) { ActiveRecord::RecordNotFound }
 
-    it 'triggers exception notifications on failure' do
-      expect(job).to receive(:perform) { raise exception_class }
-      expect(ExceptionNotifier).to receive(:notify_exception) do |exception, options|
-        expect(exception).to be_a exception_class
-      end
-
-      expect{ job.perform_now }.to raise_error exception_class
+  it 'triggers exception notifications on failure' do
+    expect(job).to receive(:perform) { raise exception_class }
+    expect(ExceptionNotifier).to receive(:notify_exception) do |exception, options|
+      expect(exception).to be_a exception_class
     end
+
+    expect{ job.perform_now }.to raise_error exception_class
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,19 +92,9 @@ RSpec.configure do |config|
   end
 
   config.prepend_before(:all) do
+    metadata = self.class.metadata
+    DatabaseCleaner.strategy = metadata[:js] || metadata[:truncation] ? :truncation : :transaction
     DatabaseCleaner.start
-  end
-
-  config.prepend_before(:all, js: true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.prepend_before(:all, truncation: true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.prepend_before(:all) do
-    DatabaseCleaner.strategy = :transaction
   end
 
   config.prepend_before(:each) do


### PR DESCRIPTION
To prevent sequence_number race conditions
Should also fix those JobFailed emails.