### PR TITLE
When a PE is used to fill an SPE slot, display it as a PE

### DIFF
--- a/app/routines/get_task_core_page_ids.rb
+++ b/app/routines/get_task_core_page_ids.rb
@@ -10,7 +10,7 @@ class GetTaskCorePageIds
 
   # The core page ids exclude spaced practice/personalized pages
   def exec(tasks:)
-    loaded_tasks, unloaded_tasks = tasks.partition { |task| task.task_steps.loaded? }
+    loaded_tasks, unloaded_tasks = [ tasks ].flatten.partition { |task| task.task_steps.loaded? }
 
     unloaded_task_steps = Tasks::Models::TaskStep.where(tasks_task_id: unloaded_tasks.map(&:id),
                                                         group_type: CORE_STEP_GROUP_TYPES)
@@ -20,7 +20,7 @@ class GetTaskCorePageIds
     task_id_to_core_page_ids_map = {}
     loaded_tasks.each do |task|
       task_steps = task.task_steps.select do |task_step|
-        step.core_group? || step.personalized_group?
+        task_step.core_group? || task_step.personalized_group?
       end
 
       task_id_to_core_page_ids_map[task.id] = task_steps.map(&:content_page_id).compact.uniq

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -2,6 +2,7 @@ class Tasks::PopulatePlaceholderSteps
 
   lev_routine express_output: :task
 
+  uses_routine GetTaskCorePageIds, as: :get_task_core_page_ids
   uses_routine TaskExercise, as: :task_exercise
   uses_routine TranslateBiglearnSpyInfo, as: :translate_biglearn_spy_info
 
@@ -76,8 +77,8 @@ class Tasks::PopulatePlaceholderSteps
 
   def populate_placeholder_steps(task:, group_type:, biglearn_api_method:, biglearn_controls_slots:)
     # Get the task core_page_ids (only necessary for spaced_practice_group)
-    core_page_ids = Set.new(task.task_steps.select(&:core_group?).map(&:content_page_id)) \
-      if group_type == :spaced_practice_group
+    core_page_ids = run(:get_task_core_page_ids, tasks: task)
+      .outputs.task_id_to_core_page_ids_map[task.id] if group_type == :spaced_practice_group
 
     if biglearn_controls_slots
       # Biglearn controls how many PEs/SPEs

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -708,7 +708,7 @@ module OpenStax::Biglearn::Api
         course = task.taskings.first.try!(:role).try!(:student).try!(:course)
         return [] if course.nil?
 
-        core_page_ids = task.task_steps.map(&:content_page_id).compact.uniq
+        core_page_ids = GetTaskCorePageIds[tasks: task][task.id]
         pages = ecosystem.pages.where(id: core_page_ids)
         if task.reading?
           pool_method = :reading_dynamic_pool

--- a/spec/lib/openstax/biglearn/api_spec.rb
+++ b/spec/lib/openstax/biglearn/api_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
         end.exactly(3).times
         expect(Rails.logger).to receive(:warn).twice
 
-        core_page_ids = @task.task_steps.pluck(:content_page_id)
+        core_page_ids = GetTaskCorePageIds[tasks: @task][@task.id]
 
         result = nil
         expect do

--- a/spec/subsystems/tasks/populate_placeholder_steps_spec.rb
+++ b/spec/subsystems/tasks/populate_placeholder_steps_spec.rb
@@ -4,10 +4,14 @@ require 'vcr_helper'
 RSpec.describe Tasks::PopulatePlaceholderSteps, type: :routine do
 
   before(:all) do
-    @task_plan = FactoryGirl.create(:tasked_task_plan, number_of_students: 1)
-    @course = @task_plan.owner
-    @page = Content::Models::Page.where(id: @task_plan.settings['page_ids']).take
-    @task = @task_plan.tasks.find do |task|
+    task_plan = FactoryGirl.create(:tasked_task_plan, number_of_students: 1)
+    @course = task_plan.owner
+    page = Content::Models::Page.find_by(id: task_plan.settings['page_ids'])
+    @spaced_page = FactoryGirl.create :content_page, chapter: page.chapter
+    page.exercises.each do |exercise|
+      FactoryGirl.create :content_exercise, page: @spaced_page, group_uuid: exercise.group_uuid
+    end
+    @task = task_plan.tasks.find do |task|
       task.taskings.any? { |tasking| tasking.role.student.present? }
     end
     @role = @task.taskings.take.role
@@ -56,11 +60,56 @@ RSpec.describe Tasks::PopulatePlaceholderSteps, type: :routine do
     end
   end
 
+  context 'with some SPE slots filled by PEs' do
+    before do
+      expect(OpenStax::Biglearn::Api.client).to(
+        receive(:fetch_assignment_spes).and_wrap_original do |method, *args|
+          method.call(*args).map do |response|
+            exercise_uuids = [ @spaced_page.exercises.sample.uuid ] +
+                             response[:exercise_uuids][0..-2]
+
+            response.merge(exercise_uuids: exercise_uuids)
+          end
+        end
+      )
+    end
+
+    it 'populates all the placeholder steps in the task and changes the group_type of SPE steps' do
+      num_spe_steps = @task.spaced_practice_task_steps.size
+
+      expect { subject }.to  change { @task.personalized_task_steps.size    }.by(num_spe_steps - 1)
+                        .and change { @task.spaced_practice_task_steps.size }.to(1)
+                        .and change { @task.pes_are_assigned  }.from(false).to(true)
+                        .and change { @task.spes_are_assigned }.from(false).to(true)
+
+      @task.personalized_task_steps.each do |task_step|
+        expect(task_step).not_to be_placeholder
+        expect(task_step).to be_exercise
+      end
+    end
+  end
+
   context 'with enough dynamic exercises available' do
+    before do
+      allow(OpenStax::Biglearn::Api.client).to receive(:fetch_assignment_spes) do |requests|
+        requests.map do |request|
+          {
+            request_uuid: request[:request_uuid],
+            assignment_uuid: request[:task].uuid,
+            exercise_uuids: @spaced_page.exercises.map(&:uuid).sample(request[:max_num_exercises]),
+            assignment_status: 'assignment_ready',
+            spy_info: {}
+          }
+        end
+      end
+    end
+
     context 'with no other tasks' do
       it 'populates all the placeholder steps in the task' do
         expect { subject }.to  not_change { @task.personalized_task_steps.size    }
                           .and not_change { @task.spaced_practice_task_steps.size }
+                          .and change { @task.pes_are_assigned  }.from(false).to(true)
+                          .and change { @task.spes_are_assigned }.from(false).to(true)
 
         (@task.personalized_task_steps + @task.spaced_practice_task_steps).each do |task_step|
           expect(task_step).not_to be_placeholder

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -45,7 +45,7 @@ class SetupPerformanceReportData
       exercises_arrays.map do |exercises|
         page = exercises.first.page
 
-        group_types = (exercises.size - 2).times.map{ :core_group } + [:spaced_practice_group] * 2
+        group_types = (exercises.size - 2).times.map { :core_group } + [:spaced_practice_group] * 2
 
         Tasks::CreateConceptCoachTask[
           role: role, page: page, exercises: exercises, group_types: group_types
@@ -202,21 +202,15 @@ class SetupPerformanceReportData
     Preview::WorkTask[task: student_1_tasks[1], is_correct: false]
 
     # User 1 answered 2 correct core, 1 correct spaced practice
-    # and 1 incorrect spaced practice exercise in 2nd homework
-    is_completed = ->(task, task_step, index) do
-      task_step.core_group? ||
-      task_step == task.spaced_practice_task_steps.first ||
-      task_step == task.spaced_practice_task_steps.last
-    end
-    is_correct = ->(task, task_step, index) do
-      task_step.core_group? || task_step == task.spaced_practice_task_steps.first
-    end
+    # and 1 incorrect personalized exercise (in an SPE slot) in 2nd homework
+    is_completed = ->(task, task_step, index) { true }
+    is_correct   = ->(task, task_step, index) { index < task.task_steps.size }
     Preview::WorkTask[task: student_1_tasks[2], is_completed: is_completed, is_correct: is_correct]
 
     # User 2 answered 2 questions correctly and 2 incorrectly in homework
     student_2_tasks = student_tasks[1]
     is_completed = ->(task, task_step, index) { index < 2 || index >= task.task_steps.size - 2 }
-    is_correct = ->(task, task_step, index) { index < 2 }
+    is_correct   = ->(task, task_step, index) { index < 2 }
     Preview::WorkTask[task: student_2_tasks[0], is_completed: is_completed, is_correct: is_correct]
 
     # User 2 started the reading


### PR DESCRIPTION
PEs can be used to fill SPE slots if there are not enough assignments in the history or if all assignments available for that slot have been excluded.

In that case, change the step type to personalized_group so it's displayed as a PE.