### PR TITLE
UUIDs needed for payments

### DIFF
--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -10,6 +10,12 @@ module Api::V1
              writeable: false,
              schema_info: { required: true }
 
+    property :uuid,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: { required: true }
+
     property :name,
              type: String,
              readable: true,

--- a/app/representers/api/v1/student_representer.rb
+++ b/app/representers/api/v1/student_representer.rb
@@ -12,6 +12,12 @@ module Api::V1
                required: true
              }
 
+    property :uuid,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: { required: true }
+
     property :course_membership_period_id,
              as: :period_id,
              type: String,

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -40,6 +40,7 @@ class CollectCourseInfo
       #       Maybe create a CourseInfo class that contains the course model + the extra attributes?
       Hashie::Mash.new(
         id: course.id,
+        uuid: course.uuid,
         name: course.name,
         term: course.term,
         year: course.year,

--- a/db/migrate/20170715185155_set_default_uuids.rb
+++ b/db/migrate/20170715185155_set_default_uuids.rb
@@ -1,0 +1,6 @@
+class SetDefaultUuids < ActiveRecord::Migration
+  def up
+    execute 'update course_profile_courses set uuid = gen_random_uuid() where uuid is null'
+    change_column_null :course_profile_courses, :uuid, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170621215721) do
+ActiveRecord::Schema.define(version: 20170715185155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -336,7 +336,7 @@ ActiveRecord::Schema.define(version: 20170621215721) do
     t.integer  "cloned_from_id"
     t.boolean  "is_preview",                                                                 null: false
     t.boolean  "is_excluded_from_salesforce",                  default: false,               null: false
-    t.uuid     "uuid",                                         default: "gen_random_uuid()"
+    t.uuid     "uuid",                                         default: "gen_random_uuid()", null: false
     t.integer  "sequence_number",                              default: 0,                   null: false
     t.string   "biglearn_student_clues_algorithm_name",                                      null: false
     t.string   "biglearn_teacher_clues_algorithm_name",                                      null: false

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -1319,9 +1319,11 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
 
       it 'clones the course for the user' do
         api_post :clone, user_1_token, parameters: valid_params, raw_post_data: valid_body
-
         expect(response).to have_http_status(:success)
-        expect(response.body_as_hash).to match expected_response
+        body = response.body_as_hash
+        expect(body[:uuid]).not_to eq(expected_response[:body])
+        expected_response[:uuid] = body[:uuid]
+        expect(body).to match expected_response
       end
     end
   end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -1320,10 +1320,11 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
       it 'clones the course for the user' do
         api_post :clone, user_1_token, parameters: valid_params, raw_post_data: valid_body
         expect(response).to have_http_status(:success)
-        body = response.body_as_hash
-        expect(body[:uuid]).not_to eq(expected_response[:body])
-        expected_response[:uuid] = body[:uuid]
-        expect(body).to match expected_response
+        new_course = response.body_as_hash
+        # the new course will have a different uuid
+        expect(new_course[:uuid]).not_to eq(expected_response[:uuid])
+        # but will otherwise be the same
+        expect(new_course).to match expected_response.merge(uuid: new_course[:uuid])
       end
     end
   end


### PR DESCRIPTION
Most were in the DB but not included in representers; however all my courses were null.  I was afraid production will be the same, so added the migration to make sure they're set.