### PR TITLE
let admins refund a student

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -19,6 +19,11 @@ class Admin::StudentsController < Admin::BaseController
         format.json { respond_with_bip(student) }
       end
     end
+  end
 
+  def refund
+    student = CourseMembership::Models::Student.find(params[:id])
+    RefundPayment[uuid: student.uuid]
+    redirect_to edit_admin_course_path(student.course, anchor: "roster")
   end
 end

--- a/app/views/admin/courses/_roster.html.erb
+++ b/app/views/admin/courses/_roster.html.erb
@@ -21,7 +21,23 @@
     <tr>
       <td><%= student.name %></td>
       <% if @course.does_cost %>
-        <td><%= student.is_paid ? 'Yes' : 'No' %></td>
+        <td>
+          <% if student.is_paid %>
+            <% if student.is_refund_pending %>
+              Yes (Refund pending)
+            <% else %>
+              Yes
+              (<%= link_to "Refund",
+                          refund_admin_student_path(student),
+                          method: :put,
+                          data: {
+                            confirm: "Are you sure you want to refund for #{student.name}?"
+                          } %>)
+            <% end %>
+          <% else %>
+            No
+          <% end %>
+        </td>
         <td>
           <a href="#">
             <%= best_in_place student,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,7 +264,11 @@ Rails.application.routes.draw do
       resources :teachers, only: [:destroy], shallow: true
     end
 
-    resources :students, only: :update
+    resources :students, only: :update do
+      member do
+        put :refund
+      end
+    end
 
     resources :schools, except: [:show]
 


### PR DESCRIPTION
Adds a "Refund" link in the course roster for admins.  This refund link will request a refund from Payments.  The page will be refreshed and the link will change to "Refund pending".  A later refresh should show that the refund went through.

![image](https://user-images.githubusercontent.com/1001691/28350180-5c0a226e-6c04-11e7-945d-dfb8938e523b.png)
