### PR TITLE
bulk extend payment due at from admin console

### DIFF
--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -1,0 +1,19 @@
+class Admin::PaymentsController < Admin::BaseController
+
+  def index; end
+
+  def extend_payment_due_at
+    CourseMembership::Models::Student
+      .joins(:course)
+      .merge(CourseProfile::Models::Course.not_ended)
+      .find_each do |student|
+
+      # When due date nil, student model resets it before saving
+      student.payment_due_at = nil
+      student.save!
+    end
+
+    redirect_to admin_payments_path, notice: "Extended payment due dates"
+  end
+
+end

--- a/app/representers/api/v1/bootstrap_data_representer.rb
+++ b/app/representers/api/v1/bootstrap_data_representer.rb
@@ -39,27 +39,14 @@ module Api::V1
              writeable: false,
              getter: ->(user_options:, **) { user_options[:tutor_api_url] }
 
-    property :is_payments_enabled,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { Settings::Payments.payments_enabled }
-
-    property :payments_base_url,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { Rails.application.secrets['openstax']['payments']['url'] }
-
-    property :payments_embed_js_url,
-             readable: true,
-             writeable: false,
-             getter: ->(*) {
-               OpenStax::Payments::Api.embed_js_url
-             }
-
-    property :payments_product_uuid,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { Rails.application.secrets['openstax']['payments']['product_uuid'] }
+    property :payments, writeable: false, readable: true, getter: ->(*) {
+      {
+        is_enabled: Settings::Payments.payments_enabled,
+        js_url: OpenStax::Payments::Api.embed_js_url,
+        base_url: Rails.application.secrets['openstax']['payments']['url'],
+        product_uuid: Rails.application.secrets['openstax']['payments']['product_uuid']
+      }
+    }
 
     property :flash,
              readable: true,

--- a/app/representers/api/v1/bootstrap_data_representer.rb
+++ b/app/representers/api/v1/bootstrap_data_representer.rb
@@ -39,6 +39,11 @@ module Api::V1
              writeable: false,
              getter: ->(user_options:, **) { user_options[:tutor_api_url] }
 
+    property :is_payments_enabled,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { Settings::Payments.payments_enabled }
+
     property :payments_base_url,
              readable: true,
              writeable: false,

--- a/app/subsystems/course_membership/add_student.rb
+++ b/app/subsystems/course_membership/add_student.rb
@@ -19,13 +19,8 @@ class CourseMembership::AddStudent
 
     course = period.course
 
-    # Give the student til midnight after 14 days from now
-    payment_due_at = course.time_zone.to_tz.now.midnight + 1.day - 1.second +
-                     Settings::Payments.student_grace_period_days.days
-
     student = CourseMembership::Models::Student.create(role: role,
                                                        course: course,
-                                                       payment_due_at: payment_due_at,
                                                        student_identifier: student_identifier)
     transfer_errors_from(student, {type: :verbatim}, true)
 

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -18,7 +18,7 @@ class CourseMembership::Models::Student < Tutor::SubSystems::BaseModel
   validates :course, presence: true
   validates :role, presence: true, uniqueness: true
 
-  after_validation :init_payment_due_at
+  before_save :init_payment_due_at
 
   delegate :username, :first_name, :last_name, :full_name, :name, to: :role
   delegate :period, :course_membership_period_id, to: :latest_enrollment, allow_nil: true

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -18,11 +18,19 @@ class CourseMembership::Models::Student < Tutor::SubSystems::BaseModel
   validates :course, presence: true
   validates :role, presence: true, uniqueness: true
 
+  after_validation :init_payment_due_at
+
   delegate :username, :first_name, :last_name, :full_name, :name, to: :role
   delegate :period, :course_membership_period_id, to: :latest_enrollment, allow_nil: true
 
   def is_refund_allowed
     is_paid ? first_paid_at + REFUND_PERIOD > Time.now : false
+  end
+
+  def new_payment_due_at
+    # Give the student til midnight after configurable days from now
+    course.time_zone.to_tz.now.midnight + 1.day - 1.second +
+      Settings::Payments.student_grace_period_days.days
   end
 
   protected
@@ -31,6 +39,10 @@ class CourseMembership::Models::Student < Tutor::SubSystems::BaseModel
     # Better for this value to be set using actual payment time from Payments,
     # but this is better than nothing
     self.first_paid_at ||= Time.now if is_paid
+  end
+
+  def init_payment_due_at
+    self.payment_due_at ||= new_payment_due_at
   end
 
 end

--- a/app/views/admin/payments/index.html.erb
+++ b/app/views/admin/payments/index.html.erb
@@ -1,0 +1,14 @@
+<% @page_header = "Payments" %>
+
+<h3>Extend Payment Due Dates</h3>
+
+<p>Use the button below to extend the payment due date for all students in courses that have not
+yet ended.  The payment due date will be as if they joined the class when the button is pressed
+(<%= Settings::Payments.student_grace_period_days %> days from now at 11:59:59pm in the course
+time zone).</p>
+
+<%= form_tag(extend_payment_due_at_admin_payments_path, method: :put, style: 'margin: 30px 0') do %>
+  <%= submit_tag 'Extend Payment Due Dates',
+                 class: 'btn btn-primary',
+                 data: { confirm: "Are you sure you want to extend a whole bunch of due dates?"} %>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -74,6 +74,7 @@
 
             <li><%= link_to 'Users', main_app.admin_users_path %></li>
             <li><%= link_to 'Jobs', main_app.admin_jobs_path %></li>
+            <li><%= link_to 'Payments', main_app.admin_payments_path %></li>
 
             <li><%= link_to 'Research Data', main_app.admin_research_data_path %></li>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,12 @@ Rails.application.routes.draw do
       post :freeze_time
       post :time_travel
     end
+
+    resources :payments, only: [:index] do
+      collection do
+        put :extend_payment_due_at
+      end
+    end
   end
 
   # match '/auth/salesforce/callback', to: 'admin/salesforce#callback', via: [:get, :post]

--- a/spec/controllers/admin/payments_controller_spec.rb
+++ b/spec/controllers/admin/payments_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PaymentsController do
+  let(:admin)  { FactoryGirl.create(:user, :administrator) }
+  before       { controller.sign_in(admin) }
+
+  context 'extend payment due dates' do
+    it 'only applies to students in unended courses' do
+      old_student = nil
+      Timecop.travel(1.year.ago) do
+        old_course = FactoryGirl.create :course_profile_course
+        old_period = FactoryGirl.create :course_membership_period, course: old_course
+        old_student = AddUserAsPeriodStudent[user: FactoryGirl.create(:user), period: old_period].student
+      end
+
+      current_course = FactoryGirl.create :course_profile_course
+      current_period = FactoryGirl.create :course_membership_period, course: current_course
+      current_student = AddUserAsPeriodStudent[user: FactoryGirl.create(:user), period: current_period].student
+
+      Timecop.travel(1.month.from_now) do
+        original_old_student_payment_due_at = old_student.payment_due_at
+        original_current_student_payment_due_at = current_student.payment_due_at
+
+        put :extend_payment_due_at
+
+        old_student.reload
+        current_student.reload
+
+        expect(old_student.payment_due_at).to eq original_old_student_payment_due_at
+        expect(current_student.payment_due_at).not_to eq original_current_student_payment_due_at
+        expect(current_student.payment_due_at - Time.now).to be_within(1.day).of(Settings::Payments.student_grace_period_days.days)
+      end
+    end
+  end
+
+end

--- a/spec/features/admin/visit_admin_dashboard_spec.rb
+++ b/spec/features/admin/visit_admin_dashboard_spec.rb
@@ -31,5 +31,14 @@ RSpec.feature 'Admnistration' do
       click_link 'Setup'
       expect(page).to have_content "Salesforce Setup"
     end
+
+    scenario 'Payments' do
+      admin = FactoryGirl.create(:user, :administrator)
+      stub_current_user(admin)
+      visit admin_root_path
+
+      click_link 'Payments'
+      expect(page).to have_content "Extend Payment"
+    end
   end
 end

--- a/spec/representers/api/v1/bootstrap_data_representer_spec.rb
+++ b/spec/representers/api/v1/bootstrap_data_representer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
       "accounts_profile_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'profile',
       "errata_form_url" => 'https://oscms.openstax.org/errata/form',
       "tutor_api_url" => 'https://example.com/api',
+      "is_payments_enabled" => false,
       "payments_base_url" => a_string_starting_with('http'),
       "payments_embed_js_url" => a_string_starting_with('http'),
       "payments_product_uuid" => '6d60ab29-3b3d-575a-93ef-57d62e30984c',

--- a/spec/representers/api/v1/bootstrap_data_representer_spec.rb
+++ b/spec/representers/api/v1/bootstrap_data_representer_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
       "accounts_profile_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'profile',
       "errata_form_url" => 'https://oscms.openstax.org/errata/form',
       "tutor_api_url" => 'https://example.com/api',
-      "is_payments_enabled" => be_falsy,
-      "payments_base_url" => a_string_starting_with('http'),
-      "payments_embed_js_url" => a_string_starting_with('http'),
-      "payments_product_uuid" => '6d60ab29-3b3d-575a-93ef-57d62e30984c',
+      "payments" => a_hash_including(
+        "is_enabled" => be_falsy,
+        "js_url" => a_string_starting_with('http'),
+        "base_url" => a_string_starting_with('http'),
+        "product_uuid" => Rails.application.secrets['openstax']['payments']['product_uuid']
+      ),
       "ui_settings" => {},
       "flash" => { "alert" => 'Nothing!' }
     )

--- a/spec/representers/api/v1/bootstrap_data_representer_spec.rb
+++ b/spec/representers/api/v1/bootstrap_data_representer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
       "accounts_profile_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'profile',
       "errata_form_url" => 'https://oscms.openstax.org/errata/form',
       "tutor_api_url" => 'https://example.com/api',
-      "is_payments_enabled" => false,
+      "is_payments_enabled" => be_falsy,
       "payments_base_url" => a_string_starting_with('http'),
       "payments_embed_js_url" => a_string_starting_with('http'),
       "payments_product_uuid" => '6d60ab29-3b3d-575a-93ef-57d62e30984c',

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -23,10 +23,12 @@ RSpec.describe 'Get authentication status', type: :request, version: :v1 do
         access_token: token,
         errata_form_url: 'https://oscms.openstax.org/errata/form',
         tutor_api_url: a_string_starting_with('http'),
-        is_payments_enabled: false,
-        payments_base_url: a_string_starting_with('http'),
-        payments_embed_js_url: a_string_starting_with('http'),
-        payments_product_uuid: '6d60ab29-3b3d-575a-93ef-57d62e30984c',
+        payments: a_hash_including(
+          is_enabled: be_falsy,
+          js_url: a_string_starting_with('http'),
+          base_url: a_string_starting_with('http'),
+          product_uuid: Rails.application.secrets['openstax']['payments']['product_uuid']
+        ),
         accounts_profile_url: a_string_starting_with('http'),
         accounts_api_url: a_string_starting_with('http'),
         ui_settings: {},

--- a/spec/requests/get_auth_status_spec.rb
+++ b/spec/requests/get_auth_status_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Get authentication status', type: :request, version: :v1 do
         access_token: token,
         errata_form_url: 'https://oscms.openstax.org/errata/form',
         tutor_api_url: a_string_starting_with('http'),
+        is_payments_enabled: false,
         payments_base_url: a_string_starting_with('http'),
         payments_embed_js_url: a_string_starting_with('http'),
         payments_product_uuid: '6d60ab29-3b3d-575a-93ef-57d62e30984c',


### PR DESCRIPTION
Adds a button to a new Payments screen in the admin console to extend the payment due date for all students in a course that has not yet ended.  This button should be used if we enact the ecommerce backup plan or if we need to give extra time to students because of an issue with the payments system.  The due dates are extended just as if a student joined the class when the button is pressed.  If we want to extend a different number of days, we'll have to change the default grace period length, then hit this button, then change the default grace period back.

![image](https://user-images.githubusercontent.com/1001691/28496862-c089ed3c-6f33-11e7-820e-49c9068dde72.png)
