### PR TITLE
Try to prevent cross-spec issues with `Settings::Payments`

### DIFF
--- a/lib/settings/payments.rb
+++ b/lib/settings/payments.rb
@@ -9,6 +9,7 @@ module Settings
 
       def payments_enabled=(value)
         Settings::Db.store.payments_enabled = value
+        Settings::Db.store.object('payments_enabled').expire_cache
       end
 
       def student_grace_period_days
@@ -17,6 +18,7 @@ module Settings
 
       def student_grace_period_days=(days)
         Settings::Db.store.student_grace_period_days = days
+        Settings::Db.store.object('student_grace_period_days').expire_cache
       end
 
     end

--- a/spec/lib/settings/payments_spec.rb
+++ b/spec/lib/settings/payments_spec.rb
@@ -4,16 +4,22 @@ RSpec.describe Settings::Payments, type: :lib do
   it 'can store student_grace_period_days' do
     expect(described_class.student_grace_period_days).to eq 14
 
-    described_class.student_grace_period_days = 10
-    Settings::Db.store.object('student_grace_period_days').expire_cache
-    expect(described_class.student_grace_period_days).to eq 10
+    begin
+      described_class.student_grace_period_days = 10
+      expect(described_class.student_grace_period_days).to eq 10
+    ensure
+      described_class.student_grace_period_days = 14
+    end
   end
 
   it 'can store payments_enabled' do
     expect(described_class.payments_enabled).to eq false
 
-    described_class.payments_enabled = true
-    Settings::Db.store.object('payments_enabled').expire_cache
-    expect(described_class.payments_enabled).to eq true
+    begin
+      described_class.payments_enabled = true
+      expect(described_class.payments_enabled).to eq true
+    ensure
+      described_class.payments_enabled = false
+    end
   end
 end


### PR DESCRIPTION
Sometimes specs would fail on `Settings::Payments` values.  Could be because the spec for that object changed the values of the settings but didn't reset them at the end (and our settings object uses some sort of other cache which doesn't always rollback when a spec transaction rolls back).  

Also put the manual expiry of the cache in the method that sets the value instead of in the spec so that the benefits are seen in normal code too.