### PR TITLE
Pry reconfiguration

### DIFF
--- a/config/initializers/00-pry.rb
+++ b/config/initializers/00-pry.rb
@@ -1,6 +1,1 @@
-if defined? Pry
-  Pry.commands.alias_command 'c', 'continue'
-  Pry.commands.alias_command 's', 'step'
-  Pry.commands.alias_command 'n', 'next'
-  Pry.commands.alias_command 'w', 'whereami'
-end
+Pry.commands.delete('.<shell command>') if defined? Pry


### PR DESCRIPTION
- Remove pry command aliases so we can use single letter variable names in the console
- Remove pry shell commands so pasting leading . does not cause errors