### PR TITLE
Attempt to fix code coverage calculation

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::Codecov
 ]) if ENV['CI'] == 'true'
 
-SimpleCov.start 'rails'
+SimpleCov.start('rails') { merge_timeout 3600 }
 
 ENV['RAILS_ENV'] ||= 'test'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,9 +2,7 @@ require 'simplecov'
 require 'codecov'
 require 'parallel_tests'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::Codecov
-]) if ENV['CI'] == 'true'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CI'] == 'true'
 
 SimpleCov.start('rails') { merge_timeout 3600 }
 


### PR DESCRIPTION
The default timeout (10 minutes) could be a problem if the Travis workers finish running more than 10 minutes apart. So this PR increases it to 1 hour.