### PR TITLE
Fix 403 error loop if a student account becomes verified faculty

### DIFF
--- a/app/access_policies/track_tutor_onboarding_event_policy.rb
+++ b/app/access_policies/track_tutor_onboarding_event_policy.rb
@@ -5,7 +5,7 @@ class TrackTutorOnboardingEventPolicy
     like_preview_ask_later like_preview_yes made_adoption_decision
   }
   def self.action_allowed?(event, requestor, policy)
-    return false if requestor.is_anonymous? || requestor.account.student?
+    return false if requestor.is_anonymous? || !requestor.account.confirmed_faculty?
 
     TEACHER_EVENTS.include?(event)
   end

--- a/spec/access_policies/track_tutor_onboarding_event_policy_spec.rb
+++ b/spec/access_policies/track_tutor_onboarding_event_policy_spec.rb
@@ -6,19 +6,13 @@ RSpec.describe TrackTutorOnboardingEventPolicy, type: :access_policy do
   let(:user) { FactoryGirl.create(:user) }
 
 
-  it 'cannot be accessed by anonymous users' do
+  it 'cannot be accessed by non-confirmed-faculty' do
     expect(TrackTutorOnboardingEventPolicy.action_allowed?('created_real_course', anon,
                                                            TrackTutorOnboardingEvent)).to eq false
   end
 
-  it 'cannot be accessed by student users' do
-    user.account.role = :student
-    expect(TrackTutorOnboardingEventPolicy.action_allowed?('created_real_course', user,
-                                                           TrackTutorOnboardingEvent)).to eq false
-  end
-
-  context 'accessed by a teacher' do
-    before(:each) { user.account.role = :instructor }
+  context 'accessed by confirmed faculty' do
+    before(:each) { user.account.faculty_status = :confirmed_faculty }
 
     it 'rejects invalid events' do
       expect(TrackTutorOnboardingEventPolicy.action_allowed?('wrong_bad_incorrect', user,

--- a/spec/controllers/api/v1/log_controller_spec.rb
+++ b/spec/controllers/api/v1/log_controller_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Api::V1::LogController, type: :controller, api: true, version: :v
                                                                   message: "Bad level"}]})
     end
 
-
     it 'requires a message' do
       expect(Rails.logger).not_to receive(:log)
       log(level: 'info', message: '')
@@ -51,20 +50,18 @@ RSpec.describe Api::V1::LogController, type: :controller, api: true, version: :v
 
 
   describe '#track' do
-    let(:user) { FactoryGirl.create(:user) }
-    let(:user_token)   { FactoryGirl.create :doorkeeper_access_token,
-                                            resource_owner_id: user.id }
+    let(:user)       { FactoryGirl.create(:user) }
+    let(:user_token) { FactoryGirl.create :doorkeeper_access_token, resource_owner_id: user.id }
 
-    it 'rejects student access' do
-      user.account.update_attributes(role: :student)
+    it 'rejects non-confirmed-faculty access' do
       expect(TrackTutorOnboardingEvent).not_to receive(:perform_later)
       expect {
         api_post :onboarding_event, user_token, parameters: { code: 'arrived_my_courses' }
       }.to raise_error(SecurityTransgression)
     end
 
-    describe 'as an instructor' do
-      before(:each) { user.account.role = :instructor }
+    describe 'as confirmed faculty' do
+      before(:each) { user.account.update_attribute :faculty_status, :confirmed_faculty }
 
       it 'rejects invalid codes' do
         expect(TrackTutorOnboardingEvent).not_to receive(:perform_later)
@@ -74,7 +71,6 @@ RSpec.describe Api::V1::LogController, type: :controller, api: true, version: :v
       end
 
       it 'tracks valid codes' do
-        user.account.update_attributes!(role: :instructor)
         expect(TrackTutorOnboardingEvent).to receive(:perform_later).with(
                                                data: { decision: "I won't be using it" },
                                                event: 'made_adoption_decision',


### PR DESCRIPTION
FE checks that the account is verified faculty for the onboarding event logs.
BE should make the same check, since the current check looks at the self-reported role which is set by the client and cannot be trusted.