### PR TITLE
content item prototype

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,9 @@ gem 'openstax_api', '~> 8.1.0'
 gem 'apipie-rails'
 gem 'maruku'
 
-gem 'ims-lti'
+# Fixes unreleased CotentItemSelectionRequest validation error
+# https://github.com/instructure/ims-lti/issues/128
+gem 'ims-lti', git: 'https://github.com/instructure/ims-lti.git', ref: '5134532d4043ee9a3e110dc5b9b41300f6c13a07'
 
 # API JSON rendering/parsing
 # Do not use Roar 1.0.4
@@ -108,7 +110,7 @@ gem 'newrelic_rpm'
 gem 'validates_timeliness'
 
 # JSON schema validation
-gem 'json-schema'
+gem 'json-schema', '~> 2.8.0'
 
 # Cooler hashes
 gem 'hashie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,17 @@
 GIT
+  remote: https://github.com/instructure/ims-lti.git
+  revision: 5134532d4043ee9a3e110dc5b9b41300f6c13a07
+  ref: 5134532d4043ee9a3e110dc5b9b41300f6c13a07
+  specs:
+    ims-lti (2.1.6)
+      addressable (~> 2.5, >= 2.5.1)
+      builder (~> 3.2)
+      faraday (~> 0.8)
+      faraday_middleware (~> 0.8)
+      json-jwt (~> 1.7)
+      simple_oauth (= 0.2)
+
+GIT
   remote: https://github.com/openstax/active_force
   revision: 7caac1727d92206328e72ac9f7540805653f9d73
   ref: 7caac17
@@ -65,7 +78,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.7)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     apipie-rails (0.3.3)
       json
     arel (6.0.4)
@@ -90,6 +104,7 @@ GEM
     best_in_place (3.1.1)
       actionpack (>= 3.2)
       railties (>= 3.2)
+    bindata (2.4.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.2.0.2)
@@ -356,11 +371,6 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.8.1)
     ice_nine (0.11.1)
-    ims-lti (2.1.0)
-      builder (~> 3.2)
-      faraday (~> 0.8)
-      faraday_middleware (~> 0.8)
-      simple_oauth (= 0.2)
     inflecto (0.0.2)
     ipaddress (0.8.0)
     jobba (1.5.0)
@@ -371,8 +381,14 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    json-schema (2.5.1)
-      addressable (~> 2.3.7)
+    json-jwt (1.7.2)
+      activesupport
+      bindata
+      multi_json (>= 1.3)
+      securecompare
+      url_safe_base64
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     jwt (1.5.1)
     keyword_search (1.5.0)
     kgio (2.9.3)
@@ -505,6 +521,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (2.0.5)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.8)
@@ -645,6 +662,7 @@ GEM
     scenic (1.4.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
+    securecompare (1.0.0)
     sexp_processor (4.5.0)
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
@@ -712,6 +730,7 @@ GEM
       unicorn (~> 4)
     uniform_notifier (1.9.0)
     url (0.3.2)
+    url_safe_base64 (0.2.2)
     validates_timeliness (3.0.14)
       timeliness (~> 0.3.6)
     vcr (2.9.3)
@@ -783,10 +802,10 @@ DEPENDENCIES
   guard-rspec
   hashie
   httparty
-  ims-lti
+  ims-lti!
   jobba (~> 1.5.0)
   jquery-rails
-  json-schema
+  json-schema (~> 2.8.0)
   keyword_search
   launchy
   lev (~> 7.1.0)
@@ -855,4 +874,4 @@ DEPENDENCIES
   with_advisory_lock!
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/controllers/lms_controller.rb
+++ b/app/controllers/lms_controller.rb
@@ -1,7 +1,7 @@
 class LmsController < ApplicationController
 
-  skip_before_filter :verify_authenticity_token, only: [:launch]
-  skip_before_filter :authenticate_user!, only: [:configuration, :launch]
+  skip_before_filter :verify_authenticity_token, only: [:launch, :ci_launch]
+  skip_before_filter :authenticate_user!, only: [:configuration, :launch, :ci_launch]
 
   layout false
 
@@ -9,11 +9,12 @@ class LmsController < ApplicationController
   end
 
   def launch
+    response.headers["X-FRAME-OPTIONS"] = 'ALLOWALL'
+
     # Check that the request specifies a valid tool consumer
-    # debugger
     consumer = Lms::Models::ToolConsumer.find_by(key: params[:oauth_consumer_key])
     return redirect_to action: :launch_failed if consumer.nil?
-    # debugger
+
     # Check that the message has the correct OAuth signature
 
     authenticator = ::IMS::LTI::Services::MessageAuthenticator.new(
@@ -22,7 +23,7 @@ class LmsController < ApplicationController
       consumer.secret
     )
     return redirect_to action: :launch_failed if !authenticator.valid_signature?
-    # debugger
+
     @launch_message = authenticator.message
     # Check that we haven't seen this nonce yet
 
@@ -37,6 +38,36 @@ class LmsController < ApplicationController
     respond_to do |format|
       format.html
     end
+  end
+
+  def ci_launch
+    # https://www.imsglobal.org/specs/lticiv1p0/specification-3
+
+    # Allow embedding in Canvas iframe
+    response.headers["X-FRAME-OPTIONS"] = 'ALLOWALL'
+
+    consumer = Lms::Models::ToolConsumer.find_by(key: params[:oauth_consumer_key])
+    return redirect_to action: :launch_failed if consumer.nil?
+
+    authenticator = ::IMS::LTI::Services::MessageAuthenticator.new(
+      request.url,
+      request.request_parameters,
+      consumer.secret
+    )
+    return redirect_to action: :launch_failed if !authenticator.valid_signature?
+
+    @launch_message = authenticator.message
+
+    @cis = IMS::LTI::Models::Messages::ContentItemSelection.new(
+      content_items: [
+        IMS::LTI::Models::ContentItems::LtiLinkItem.new(
+          media_type: 'application/vnd.ims.lti.v1.ltilink',
+          text: 'A URL to click',
+          url: lms_launch_url,
+          thumbnail: IMS::LTI::Models::Image.new(id: 'test', height: 123, width: 456)
+        )
+      ]
+    )
   end
 
   def someplace

--- a/app/views/lms/ci_launch.html.erb
+++ b/app/views/lms/ci_launch.html.erb
@@ -1,0 +1,10 @@
+<form method="post" action="<%= @launch_message.content_item_return_url %>" id="assignment_selection">
+ <input type="hidden" name="data" value="<%= @launch_message.data %>"/>
+ <input type="hidden" name="lti_message_type" value="ContentItemSelection"/>
+ <input type="hidden" name="lti_version" value="LTI-1p0"/>
+ <input type="hidden" name="content_items" value="<%= @cis.parameters['content_items'] %>"/>
+</form>
+
+<script>
+    document.getElementById('assignment_selection').submit();
+</script>

--- a/app/views/lms/configuration.xml.erb
+++ b/app/views/lms/configuration.xml.erb
@@ -20,6 +20,10 @@
          <lticm:property name="enabled">true</lticm:property>
          <lticm:property name="windowTarget">_blank</lticm:property>
       </lticm:options>
+      <lticm:options name="assignment_selection">
+        <lticm:property name="message_type">ContentItemSelectionRequest</lticm:property>
+        <lticm:property name="url">http://localhost:3001/lms/ci_launch</lticm:property>
+      </lticm:options>
     </blti:extensions>
 
 </cartridge_basiclti_link>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,7 @@ Rails.application.routes.draw do
   get 'lms/configuration', to: 'lms#configuration'
   get 'lms/ci_configuration', to: 'lms#ci_configuration'
   post 'lms/launch', to: 'lms#launch'
+  post 'lms/ci_launch', to: 'lms#ci_launch'
   get 'lms/someplace', to: 'lms#someplace'
   get 'lms/launch_failed', to: 'lms#launch_failed'
 


### PR DESCRIPTION
Adds an ability to do content item.  Just immediately returns the launch URL.  The real version will give the user a UI (tutor-generated) where the teacher can choose an assignment to link to.  

I think the teacher can also paste in any valid assignment URL if they want to.  

With content item, since we are going to control the chooser API, we can potentially exclude tasks that have already been worked by some students (because teacher shouldn't want to add those again).