### PR TITLE
Removed the Biglearn sequence number job timeout

### DIFF
--- a/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
+++ b/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
@@ -2,8 +2,6 @@
 # then queues up another job to make the Biglearn request itself
 # Then attempts to lock the job and, after the transaction is committed, work it inline
 class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::Job
-  INLINE_JOB_TIMEOUT = 30.seconds
-
   queue_as :default
 
   def self.perform_later(*_)
@@ -12,7 +10,7 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
       # This should guarantee that the intended order of events is preserved unless the server dies
       # in-between committing the transaction and running the after_commit callbacks
       # (in that case we'll still get the events eventually but they may be in the wrong order)
-      ActiveJob::AfterCommitRunner.new(job, INLINE_JOB_TIMEOUT).run_after_commit
+      ActiveJob::AfterCommitRunner.new(job).run_after_commit
     end
   end
 


### PR DESCRIPTION
It was most likely causing issues with sequence_number gaps during DB backups
DJ timeout implementation is flawed anyway