### PR TITLE
More specific error page for non-enrolled students who click short link

### DIFF
--- a/app/controllers/short_codes_controller.rb
+++ b/app/controllers/short_codes_controller.rb
@@ -26,8 +26,9 @@ class ShortCodesController < ApplicationController
             raise ShortCodeNotFound
           when :authentication_required
             authenticate_user!
-          when :invalid_user
-            raise SecurityTransgression
+          when :user_not_in_course_with_required_role
+            body = "To enroll in this course, please ask your instructor for the course enrollment link."
+            error_page('You are not enrolled in this course.', body, :forbidden, false)
           else
             raise StandardError, "#{@handler_result.errors.map(&:code).join(', ')}"
           end
@@ -36,10 +37,10 @@ class ShortCodesController < ApplicationController
 
   protected
 
-  def error_page(heading, body)
+  def error_page(heading, body, status=:unprocessable_entity, show_apology=true)
     render 'static_pages/generic_error',
-           locals: { heading: heading, body: body },
-           status: :unprocessable_entity
+           locals: { heading: heading, body: body, show_apology: show_apology },
+           status: status
   end
 
 end

--- a/app/routines/choose_course_role.rb
+++ b/app/routines/choose_course_role.rb
@@ -6,7 +6,7 @@
 #   Get the users set of roles for the given course, restricted to
 #   allowed_role_type unless that is set to :any (the default)
 #
-#   If there are no roles, fail with :invalid_user
+#   If there are no roles, fail with :user_not_in_course_with_required_role
 #
 #   If there is one role, return it
 #
@@ -49,7 +49,7 @@ class ChooseCourseRole
       unless find_unique_role(roles: roles, type: :teacher)
         unless find_unique_role(roles: roles, type: :student)
           fatal_error(
-            code:    :invalid_user,
+            code:    :user_not_in_course_with_required_role,
             message: "The user does not have the any role in the course"
           )
         end
@@ -57,14 +57,14 @@ class ChooseCourseRole
     when :teacher
       unless find_unique_role(roles: roles, type: :teacher)
         fatal_error(
-          code:    :invalid_user,
+          code:    :user_not_in_course_with_required_role,
           message: "The user does not have any teacher roles in the course"
         )
       end
     when :student
       unless find_unique_role(roles: roles, type: :student)
         fatal_error(
-          code:    :invalid_user,
+          code:    :user_not_in_course_with_required_role,
           message: "The user does not have any student roles in the course"
         )
       end

--- a/app/views/static_pages/generic_error.html.erb
+++ b/app/views/static_pages/generic_error.html.erb
@@ -5,5 +5,7 @@
   <p><%= body %></p>
   <% end %>
 
+  <% if show_apology %>
   <p>We're sorry this error occurred. If you need help, please contact OpenStax.</p>
+  <% end %>
 </div>

--- a/spec/controllers/short_codes_controller_spec.rb
+++ b/spec/controllers/short_codes_controller_spec.rb
@@ -72,12 +72,10 @@ RSpec.describe ShortCodesController, type: :controller do
     }.to raise_error(ShortCodeNotFound)
   end
 
-  it 'raises SecurityTransgression for users who cannot see the task plan' do
+  it 'gives a 403 for users who cannot see the task plan' do
     controller.sign_in(user)
-
-    expect {
-      get :redirect, short_code: task_plan_code.code
-    }.to raise_error(SecurityTransgression)
+    get :redirect, short_code: task_plan_code.code
+    expect(response).to have_http_status(:forbidden)
   end
 
   it 'returns 404 for short code with a non task plan GID' do

--- a/spec/routines/choose_course_role_spec.rb
+++ b/spec/routines/choose_course_role_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ChooseCourseRole, type: :routine do
       describe "errors" do
         subject { result.errors }
         it { should_not be_empty }
-        it { expect(subject.first.code).to eq(:invalid_user) }
+        it { expect(subject.first.code).to eq(:user_not_in_course_with_required_role) }
       end
 
       describe "output" do

--- a/spec/subsystems/tasks/get_redirect_url_spec.rb
+++ b/spec/subsystems/tasks/get_redirect_url_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Tasks::GetRedirectUrl, type: :routine do
     ).to have_routine_error(:authentication_required)
   end
 
-  it 'returns :invalid_user for users not in the course' do
+  it 'returns :user_not_in_course_with_required_role for users not in the course' do
     expect(
       described_class.call(gid: task_plan_gid, user: user)
-    ).to have_routine_error(:invalid_user)
+    ).to have_routine_error(:user_not_in_course_with_required_role)
   end
 
 end


### PR DESCRIPTION
Instead of a generic "forbidden" error page, students in this situation see:

![image](https://user-images.githubusercontent.com/1001691/29426149-f0db41e8-8342-11e7-9f69-3d7097c68157.png)
