### PR TITLE
LMS feature and enable flags with admin course list setting

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -49,19 +49,28 @@ $(document).ready(function() {
   });
 
   //========== Course select all / deselect all ==========//
-  $('#courses_select_all').change(function(e) {
+  $('#courses_select_all_on_page').change(function(e) {
     if ($(this).is(':checked')) {
       $('.course_id_select').prop('checked', true);
     } else {
       $('.course_id_select').prop('checked', false);
+      $('#courses_select_all_on_all_pages').prop('checked', false);
+    }
+  });
+
+  $('#courses_select_all_on_all_pages').change(function(e) {
+    if ($(this).is(':checked')) {
+      $('#courses_select_all_on_page').prop('checked', true).trigger('change');
+    } else {
+      $('#courses_select_all_on_page').prop('checked', false).trigger('change');
     }
   });
 
   $('.course_id_select').change(function(e) {
     if ($('.course_id_select:checked').length == $('.course_id_select').length) {
-      $('#courses_select_all').prop('checked', true);
+      $('#courses_select_all_on_page').prop('checked', true);
     } else {
-      $('#courses_select_all').prop('checked', false);
+      $('#courses_select_all_on_page').prop('checked', false);
     }
   });
 

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -71,6 +71,7 @@ $(document).ready(function() {
       $('#courses_select_all_on_page').prop('checked', true);
     } else {
       $('#courses_select_all_on_page').prop('checked', false);
+      $('#courses_select_all_on_all_pages').prop('checked', false);
     }
   });
 

--- a/app/assets/stylesheets/manager.scss
+++ b/app/assets/stylesheets/manager.scss
@@ -42,15 +42,16 @@ nav.navbar.production {
 
 .stats-card {
   width: 100%;
-  min-height: 130px;
+  min-height: 110px;
   height: auto;
-  border: #777 3px solid;
+  border: #777 1px solid;
   margin-bottom: 35px;
   overflow-y: auto;
   border-radius: 8px;
 
   .card-header {
-    border-bottom: #777 3px solid;
+    background-color: #eee;
+    border-bottom: #777 1px solid;
     padding: 5px;
 
     .bread-crumb {

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -249,6 +249,7 @@ class Admin::CoursesController < Admin::BaseController
         :appearance_code,
         :school_district_school_id,
         :is_excluded_from_salesforce,
+        :is_lms_enabling_allowed,
         teacher_ids: []
       )
     }

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -167,19 +167,10 @@ class Admin::CoursesController < Admin::BaseController
         course_ids = params[:course_id]
       end
 
-      begin
-        CourseProfile::Models::Course.transaction do
-          CourseProfile::Models::Course
-            .where(id: course_ids)
-            .find_each do |course|
-              course.send("#{params[:flag_name]}=", params[:flag_value].to_s == "true")
-              course.save!
-            end
-        end
-        flash[:notice] = 'Flag values were updated'
-      rescue ActiveRecord::RecordInvalid => invalid
-        flash[:error] = "Could not update flag value for at least one course, rolled back all changes: #{invalid.message}"
-      end
+      CourseProfile::Models::Course.where(id: course_ids).update_all(
+        params[:flag_name] => params[:flag_value].to_s == "true"
+      )
+      flash[:notice] = 'Flag values were updated'
     end
 
     redirect_to admin_courses_path(query: params[:query], order_by: params[:order_by])

--- a/app/controllers/customer_service/courses_controller.rb
+++ b/app/controllers/customer_service/courses_controller.rb
@@ -5,6 +5,7 @@ class CustomerService::CoursesController < CustomerService::BaseController
 
   def index
     @query = params[:query]
+    @order_by = params[:order_by]
     courses = SearchCourses.call(query: params[:query], order_by: params[:order_by]).outputs
     params[:per_page] = courses.total_count if params[:per_page] == "all"
     @total_courses = courses.total_count

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -182,6 +182,25 @@ module Api::V1
                 description: "True iff this course requires students to pay"
              }
 
+    property :is_lms_enabling_allowed,
+             writeable: false,
+             readable: true,
+             schema_info: {
+                required: true,
+                type: 'boolean',
+                description: "Iff true, the teacher can enable LMS integration"
+             }
+
+    property :is_lms_enabled,
+             writeable: true,
+             readable: true,
+             schema_info: {
+                required: false,
+                type: 'boolean',
+                description: "If true, indicates the teacher has chosen to integrate with " \
+                             "an LMS; can be `nil` which indicates no choice yet"
+             }
+
     collection :periods,
                extend: Api::V1::PeriodRepresenter,
                readable: true,

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -57,6 +57,8 @@ class CollectCourseInfo
         is_college: course.is_college,
         is_preview: course.is_preview,
         does_cost: course.does_cost,
+        is_lms_enabling_allowed: course.is_lms_enabling_allowed,
+        is_lms_enabled: course.is_lms_enabled,
         school_name: course.school_name,
         salesforce_book_name: offering.try!(:salesforce_book_name),
         appearance_code: course.appearance_code.blank? ? offering.try!(:appearance_code) :

--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -114,6 +114,42 @@ class SearchCourses
           @items = @items.where(catalog_offering_id: sanitized_queries)
         end
       end
+
+      with.keyword :is_lms_enabled do |queries|
+        queries.each do |query|
+          sanitized_queries = to_boolean_array(query, allow_nil: true)
+          next @items = @items.none if sanitized_queries.empty?
+
+          @items = @items.where(is_lms_enabled: sanitized_queries)
+        end
+      end
+
+      with.keyword :is_lms_enabling_allowed do |queries|
+        queries.each do |query|
+          sanitized_queries = to_boolean_array(query, allow_nil: false)
+          next @items = @items.none if sanitized_queries.empty?
+
+          @items = @items.where(is_lms_enabling_allowed: sanitized_queries)
+        end
+      end
     end
+  end
+end
+
+class OpenStax::Utilities::SearchRelation
+  def to_boolean_array(input, allow_nil: false)
+    array = [input].flatten.map do |ii|
+      ii.downcase!
+      if ii == "false"
+        false
+      elsif ii == "true"
+        true
+      elsif ii == "nil" || ii == "null"
+        nil
+      end
+    end
+
+    array.compact! if !allow_nil
+    array
   end
 end

--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -132,13 +132,40 @@ class SearchCourses
           @items = @items.where(is_lms_enabling_allowed: sanitized_queries)
         end
       end
+
+      with.keyword :term do |terms|
+        terms.each do |term|
+          sanitized_term_values = to_string_array(term).map{|tt| CourseProfile::Models::Course.terms[tt.downcase]}
+          next @items = @items.none if sanitized_term_values.empty?
+
+          @items = @items.where(term: sanitized_term_values)
+        end
+      end
+
+      with.keyword :year do |years|
+        years.each do |year|
+          sanitized_years = to_number_array(year)
+          next @items = @items.none if sanitized_years.empty?
+
+          @items = @items.where(year: sanitized_years)
+        end
+      end
+
+      with.keyword :costs do |queries|
+        queries.each do |query|
+          sanitized_queries = to_boolean_array(query, allow_nil: false)
+          next @items = @items.none if sanitized_queries.empty?
+
+          @items = @items.where(does_cost: sanitized_queries)
+        end
+      end
     end
   end
 end
 
 class OpenStax::Utilities::SearchRelation
   def to_boolean_array(input, allow_nil: false)
-    array = [input].flatten.map do |ii|
+    array = to_string_array(input).map do |ii|
       ii.downcase!
       if ii == "false"
         false

--- a/app/subsystems/course_profile/create_course.rb
+++ b/app/subsystems/course_profile/create_course.rb
@@ -3,6 +3,9 @@ class CourseProfile::CreateCourse
 
   protected
   def exec(attrs = {})
+    attrs[:is_lms_enabling_allowed] = Settings::Db.store.default_is_lms_enabling_allowed
+    attrs[:is_lms_enabled] = nil
+
     outputs.course = CourseProfile::Models::Course.create(attrs)
     transfer_errors_from outputs.course, {type: :verbatim}, true
   end

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -51,6 +51,8 @@ class CourseProfile::Models::Course < Tutor::SubSystems::BaseModel
 
   validate :default_times_have_good_values, :ends_after_it_starts, :valid_year
 
+  validate :lms_enabling_allowed
+
   delegate :name, to: :school, prefix: true, allow_nil: true
 
   before_validation :set_starts_at_and_ends_at
@@ -113,6 +115,12 @@ class CourseProfile::Models::Course < Tutor::SubSystems::BaseModel
     return if valid_year_range.include?(year)
     errors.add :year, 'is outside the valid range'
     false
+  end
+
+  def lms_enabling_allowed
+    errors.add(:is_lms_enabled, "Enabling LMS integration is not allowed for this course") \
+      if is_lms_enabled_changed? && is_lms_enabled && !is_lms_enabling_allowed
+    errors.none?
   end
 
 end

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -102,5 +102,10 @@
     <%= f.check_box :does_cost, class: 'form-control' %>
   </div>
 
+  <div class="form-group">
+    <%= f.label :is_lms_enabling_allowed %>
+    <%= f.check_box :is_lms_enabling_allowed, class: 'form-control' %>
+  </div>
+
   <%= f.submit 'Save', class: 'btn btn-primary', id: 'edit-save' %>
 <% end %>

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -3,15 +3,14 @@
 <%= render partial: 'manager/courses/tabs',
            locals: { incomplete_jobs: @incomplete_jobs, failed_jobs: @failed_jobs } %>
 <br>
-<%= render partial: 'manager/courses/search', locals: { query: @query } %>
+<%= render partial: 'manager/courses/search', locals: {
+             query: @query, order_by: @order_by, total_count: @course_infos.try(:count)
+           } %>
 
-Results per page:
-<%= select_tag "Results per page",
-               options_for_select([25, 50, 100, 200, 400, 'all'], params[:per_page]),
-               id: "search-courses-results-pp" %>
+<%= form_tag bulk_update_admin_courses_path, method: :post do %>
+  <%= hidden_field_tag :query, @query %>
+  <%= hidden_field_tag :order_by, @order_by %>
 
-
-<%= form_tag bulk_update_admin_courses_path, method: :post do |f| %>
   <%= render partial: 'manager/courses/index',
              locals: { course_infos: @course_infos,
                        bulk_actions: true,
@@ -23,16 +22,15 @@ Results per page:
                        job_path_proc: ->(job) { admin_job_path(job.id) },
                        extra_fields_procs: [ lambda do |course_info| %>
     <td>
-      <%= link_to 'List Students', admin_course_students_path(course_info.id),
-                                   class: 'btn btn-sm btn-primary course-stats-button' %>
-      <%= link_to 'Edit', edit_admin_course_path(course_info.id), class: "btn btn-sm btn-primary course-stats-button" %>
+      <%= link_to 'List Students', admin_course_students_path(course_info.id), style: 'display:block' %>
+      <%= link_to 'Edit Course', edit_admin_course_path(course_info.id), style: 'display:block' %>
       <% if course_info.teachers.empty? && course_info.periods.empty? %>
         <%= link_to 'Delete', admin_course_path(course_info.id),
                               method: :delete,
                               data: {
                                 confirm: "Are you sure you want to delete #{course_info.name}?"
                               },
-                              class: 'btn btn-xs btn-primary course-stats-button' %>
+                              style: 'display:block' %>
       <% end %>
     </td>
   <% end ] } %>

--- a/app/views/customer_service/courses/index.html.erb
+++ b/app/views/customer_service/courses/index.html.erb
@@ -3,10 +3,9 @@
 <%= render partial: 'manager/courses/tabs',
            locals: { incomplete_jobs: @incomplete_jobs, failed_jobs: @failed_jobs } %>
 <br>
-<%= render partial: 'manager/courses/search', locals: { query: @query } %>
-
-Results per page:
-<%= select_tag "Results per page", options_for_select([25, 50, 100, 200, 400, "all"], params[:per_page]), id: "search-courses-results-pp" %>
+<%= render partial: 'manager/courses/search', locals: {
+             query: @query, order_by: @order_by, total_count: @course_infos.try(:count)
+           } %>
 
 <%= render partial: 'manager/courses/index',
            locals: { course_infos: @course_infos,
@@ -18,8 +17,7 @@ Results per page:
                      job_path_proc: ->(job) { customer_service_job_path(job.id) },
                      extra_fields_procs: [ lambda do |course_info| %>
   <td>
-    <%= link_to 'List Students', customer_service_course_students_path(course_info.id),
-                                 class: 'btn btn-sm btn-primary course-stats-button' %>
-    <%= link_to 'Show', customer_service_course_path(course_info.id), class: "btn btn-sm btn-primary  course-stats-button" %>
+    <%= link_to 'List Students', customer_service_course_students_path(course_info.id) %>
+    <%= link_to 'Show', customer_service_course_path(course_info.id) %>
   </td>
 <% end ] } %>

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -135,7 +135,16 @@
         <div class="row">
           <div class="form-group col-xs-7">
             <%= select_tag :flag_name,
-                           options_for_select([["Allow teacher to enable LMS?", "is_lms_enabling_allowed"], ["Course costs?", "does_cost"]]),
+                           options_for_select([
+                             #
+                             # *********              ATTENTION                 **********
+                             # only put flags here that are not validated and that do not have
+                             # callbacks use their value.  The flags are set with an `update_all`
+                             # command that skips validations and callbacks.
+                             #
+                             ["Allow teacher to enable LMS?", "is_lms_enabling_allowed"],
+                             ["Course costs?", "does_cost"]
+                            ]),
                            include_blank: '-- Select a flag to modify --',
                            class: 'form-control' %>
           </div>

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -30,7 +30,7 @@
           (This Page)
           &nbsp;
           &nbsp;
-          <%= check_box_tag 'courses_select_all_on_all_pages', nil, checked = true, id: 'courses_select_all_on_all_pages' %>
+          <%= check_box_tag 'courses_select_all_on_all_pages', nil, checked = false, id: 'courses_select_all_on_all_pages' %>
            Select All (All Pages)
           &nbsp;
           &nbsp;
@@ -80,8 +80,10 @@
             </div>
             <div class="content-bottom">
               <div class="course-duration" style="white-space: nowrap;">
-                Term: <%= course_info.starts_at.strftime('%b %d, %Y') %>
-                    - <%= course_info.ends_at.strftime('%b %d, %Y') %>
+                <%= course_info.term.capitalize %>
+                <%= course_info.year %>
+                (<%= course_info.starts_at.strftime('%b %d, %Y') %>
+                - <%= course_info.ends_at.strftime('%b %d, %Y') %>)
               </div>
               <%= "CC /" if course_info.is_concept_coach %>
               <%= course_info.is_college ? "College /" : "High School /" \
@@ -121,7 +123,7 @@
                          options_from_collection_for_select(
                            @ecosystems, :id, :unique_title, params[:ecosystem_id]
                          ),
-                         include_blank: '-- Select an ecosystem --',
+                         include_blank: '-- Select an ecosystem (does not work across pages yet) --',
                          class: 'form-control' %>
           <span class="input-group-btn">
             <%= submit_tag 'Set Ecosystem', class: 'btn btn-primary' %>
@@ -133,7 +135,7 @@
         <div class="row">
           <div class="form-group col-xs-7">
             <%= select_tag :flag_name,
-                           options_for_select([["Allow teacher to enable LMS?", "is_lms_enabling_allowed"]]),
+                           options_for_select([["Allow teacher to enable LMS?", "is_lms_enabling_allowed"], ["Course costs?", "does_cost"]]),
                            include_blank: '-- Select a flag to modify --',
                            class: 'form-control' %>
           </div>

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -5,8 +5,6 @@
 <% failed_jobs ||= [] %>
 <% total_count ||= course_infos.try(:count) %>
 
-<div>Showing <%= total_count %> total</div>
-
 <% page ||= 1 %>
 <% per_page = per_page == 'all' ? total_count : per_page.to_i %>
 <% per_page = 25 if per_page == 0 %>
@@ -26,8 +24,18 @@
 
     <div style="margin-bottom: 10px;">
     <% if bulk_actions %>
-        <%= check_box_tag 'courses_select_all', nil, checked = true, id: 'courses_select_all' %>
+        <%= check_box_tag 'courses_select_all_on_page', nil, checked = true, id: 'courses_select_all_on_page' %>
          Select All
+        <% if pagination.present? %>
+          (This Page)
+          &nbsp;
+          &nbsp;
+          <%= check_box_tag 'courses_select_all_on_all_pages', nil, checked = true, id: 'courses_select_all_on_all_pages' %>
+           Select All (All Pages)
+          &nbsp;
+          &nbsp;
+          Individual selections are not remembered on other pages
+        <% end %>
     <% end %>
     </div>
 
@@ -82,7 +90,15 @@
                        period.latest_enrollments_with_deleted.length
                      end.reduce(0, :+)} students /" %>
               <%= "#{course_info.periods_with_deleted.length} periods" %> /
-              <%= course_info.does_cost ? "Does Cost" : "Does NOT Cost" %>
+              <%= course_info.does_cost ? "Does Cost" : "Does NOT Cost" %> /
+              LMS: <%= course_info.is_lms_enabling_allowed ? "enable allowed" : "enable not allowed" %> -
+              <% if course_info.is_lms_enabled.nil? %>
+                no choice made
+              <% elsif course_info.is_lms_enabled %>
+                enabled
+              <% else %>
+                disabled
+              <% end %>
             </div>
           </div>
           <div class="card-content-right">
@@ -110,6 +126,27 @@
           <span class="input-group-btn">
             <%= submit_tag 'Set Ecosystem', class: 'btn btn-primary' %>
           </span>
+        </div>
+
+        <hr/>
+
+        <div class="row">
+          <div class="form-group col-xs-7">
+            <%= select_tag :flag_name,
+                           options_for_select([["Allow teacher to enable LMS?", "is_lms_enabling_allowed"]]),
+                           include_blank: '-- Select a flag to modify --',
+                           class: 'form-control' %>
+          </div>
+          <div class="form-group col-xs-4">
+            <%= select_tag :flag_value,
+                           options_for_select([["False / No", "false"], ["True / Yes", "true"]]),
+                           class: 'form-control' %>
+          </div>
+          <div class="form-group col-xs-1">
+            <span class="input-group-btn pull-right">
+              <%= submit_tag 'Set Flag', class: 'btn btn-primary pull-right' %>
+            </span>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/manager/courses/_search.html.erb
+++ b/app/views/manager/courses/_search.html.erb
@@ -34,6 +34,9 @@
       <li><b>ecosystem</b> - matches the ecosystem's title</li>
       <li><b>is_lms_enabled</b> - accepts <b>false</b> (disabled), <b>true</b> (enabled), <b>nil</b> (not yet chosen)</li>
       <li><b>is_lms_enabling_allowed</b> - accepts <b>false</b> or <b>true</b></li>
+      <li><b>term</b> - accepts <%= CourseProfile::Models::Course.terms.keys.map{|kk| "<b>#{kk}</b>"}.join(', ').html_safe %></li>
+      <li><b>year</b> - the year of the course, e.g. <b>2017</b></li>
+      <li><b>costs</b> - accepts <b>false</b> (does not cost) or <b>true</b> (does cost)</li>
     </ul>
 
     <p>Examples:</p>

--- a/app/views/manager/courses/_search.html.erb
+++ b/app/views/manager/courses/_search.html.erb
@@ -1,13 +1,61 @@
 <%= form_tag '', id: "search-courses-form", method: :get do %>
 
-  <div class="input-group form-group">
-     <%= text_field_tag :query, query, class: 'form-control', id: "search-courses", placeholder: 'Search here' %>
-     <span class="input-group-btn">
-       <%= submit_tag 'Search', class: "btn btn-primary"  %>
-     </span>
+  <div class="input-group" style="width:100%">
+    <%= text_field_tag :query, query, class: 'form-control', id: "search-courses", placeholder: 'Search here' %>
+  </div>
+  <div class="input-group" style="margin-bottom: 20px" >
+    <%= text_field_tag :order_by, order_by, class: 'form-control', placeholder: "Ordered by" %>
+    <span class="input-group-btn">
+      <%= submit_tag 'Search', class: "btn btn-primary"  %>
+    </span>
   </div>
 
-  <div><b>Use advanced search with keywords like</b> name:physics <b>or </b> teacher:charles</div>
+  <div style="margin-bottom: 10px">
+    Results per page:
+    <%= select_tag "Results per page",
+                   options_for_select([25, 50, 100, 200, 400, 'all'], params[:per_page]),
+                   id: "search-courses-results-pp" %>
 
-  <br>
+    &nbsp; &nbsp; (<%= total_count %> total results)
+  </div>
+
+  <div style="font-size:10px; margin-top: -6px; float:right; margin-bottom: 6px;"><%= link_to "Toggle search help", "#", class: 'search-help' %></div>
+
+
+  <div id="search-help" style="display:none; border: 1px solid #ccc; margin: 20px 0; padding: 20px; clear: right">
+    <p>The search string is made up of a space-separated collection of search conditions on different fields.  Each condition is formatted as “field_name:comma-separated-values”. The resulting list of courses will match all of the conditions. Each condition will produce a list of courses that must match any one of the comma-separated-values. The fields names and their characteristics are given below. All conditions use a wildcard search (so whatever search terms you enter are automatically prepended and appended with wildcards).</p>
+
+    <ul>
+      <li><b>name</b> - matches the course name</li>
+      <li><b>school</b> - matches the school name</li>
+      <li><b>offering</b> - matches the offering title, description, SF book name, or appearance code</li>
+      <li><b>offering_id</b> - matches the offering's integer ID in Tutor</li>
+      <li><b>teacher</b> - matches the teacher's username, first, last, or full name</li>
+      <li><b>ecosystem</b> - matches the ecosystem's title</li>
+      <li><b>is_lms_enabled</b> - accepts <b>false</b> (disabled), <b>true</b> (enabled), <b>nil</b> (not yet chosen)</li>
+      <li><b>is_lms_enabling_allowed</b> - accepts <b>false</b> or <b>true</b></li>
+    </ul>
+
+    <p>Examples:</p>
+
+    <ul>
+      <li><b>school:Rice,Texas</b> - matches courses at Rice University or the University of Texas</li>
+      <li><b>school:Rice teacher:Baran</b> - matches courses at Rice taught by richb.</li>
+    </ul>
+
+    <p>You can also specify the sort field and the sort direction using the "Ordered by" field.  To sort by
+    descending ID, you'd enter <b>id DESC</b>.  The sortable fields are <%=
+      SearchCourses::SORTABLE_FIELDS.keys.map{|kk| "<b>#{kk}</b>"}.join(', ').html_safe
+    %>.</p>
+  </div>
+<% end %>
+
+<% content_for :javascript do %>
+  <script type="text/javascript">
+    $(document).ready(function(){
+      $("a.search-help").on("click", function(e) {
+        $('#search-help').toggle();
+      });
+    });
+  </script>
 <% end %>

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -23,6 +23,8 @@ Settings::Db.store.defaults[:biglearn_assignment_spes_algorithm_name] = 'student
 Settings::Db.store.defaults[:biglearn_assignment_pes_algorithm_name] = 'local_query'
 Settings::Db.store.defaults[:biglearn_practice_worst_areas_algorithm_name] = 'local_query'
 
+Settings::Db.store.defaults[:default_is_lms_enabling_allowed] = false
+
 redis_secrets = secrets['redis']
 Settings::Redis.store = Redis::Store.new(
   url: redis_secrets['url'],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,3 +87,6 @@ en:
       prebuilt_preview_course_count:
         name: '# Prebuilt Preview Courses'
         help_block: 'The number of prebuilt preview courses to keep at the ready'
+      default_is_lms_enabling_allowed:
+        name: 'Default for new course `is_lms_enabling_allowed`'
+        help_block: 'Changing this only changes the default value stored in new courses; to change existing courses, see the courses admin page'

--- a/db/migrate/20170913171643_add_lms_enabled_fields_to_course.rb
+++ b/db/migrate/20170913171643_add_lms_enabled_fields_to_course.rb
@@ -1,0 +1,8 @@
+class AddLmsEnabledFieldsToCourse < ActiveRecord::Migration
+  def change
+    add_column :course_profile_courses, :is_lms_enabled, :boolean, default: nil, null: true
+    add_column :course_profile_courses, :is_lms_enabling_allowed, :boolean, default: false, null: false
+
+    add_index :course_profile_courses, :is_lms_enabling_allowed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -348,15 +348,14 @@ ActiveRecord::Schema.define(version: 20170915024702) do
     t.boolean  "does_cost",                                    default: false,               null: false
     t.integer  "estimated_student_count"
     t.datetime "preview_claimed_at"
-    t.boolean  "is_preview_ready",                             default: false,               null: false
     t.boolean  "is_lms_enabled"
     t.boolean  "is_lms_enabling_allowed",                      default: false,               null: false
   end
 
+  add_index "course_profile_courses", ["catalog_offering_id", "is_preview", "preview_claimed_at"], name: "preview_pending_indx", using: :btree
   add_index "course_profile_courses", ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id", using: :btree
   add_index "course_profile_courses", ["cloned_from_id"], name: "index_course_profile_courses_on_cloned_from_id", using: :btree
   add_index "course_profile_courses", ["is_lms_enabling_allowed"], name: "index_course_profile_courses_on_is_lms_enabling_allowed", using: :btree
-  add_index "course_profile_courses", ["is_preview", "is_preview_ready", "preview_claimed_at", "catalog_offering_id"], name: "preview_pending_index", using: :btree
   add_index "course_profile_courses", ["name"], name: "index_course_profile_courses_on_name", using: :btree
   add_index "course_profile_courses", ["school_district_school_id"], name: "index_course_profile_courses_on_school_district_school_id", using: :btree
   add_index "course_profile_courses", ["teach_token"], name: "index_course_profile_courses_on_teach_token", unique: true, using: :btree
@@ -437,16 +436,15 @@ ActiveRecord::Schema.define(version: 20170915024702) do
   add_index "legal_targeted_contracts", ["target_gid"], name: "legal_targeted_contracts_target", using: :btree
 
   create_table "lms_apps", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "key",        null: false
-    t.string   "secret",     null: false
-    t.text     "notes"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.integer  "owner_id",   null: false
     t.string   "owner_type", null: false
+    t.string   "key",        null: false
+    t.string   "secret",     null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
+  add_index "lms_apps", ["key"], name: "index_lms_apps_on_key", using: :btree
   add_index "lms_apps", ["owner_type", "owner_id"], name: "index_lms_apps_on_owner_type_and_owner_id", using: :btree
 
   create_table "lms_contexts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -348,11 +348,15 @@ ActiveRecord::Schema.define(version: 20170915024702) do
     t.boolean  "does_cost",                                    default: false,               null: false
     t.integer  "estimated_student_count"
     t.datetime "preview_claimed_at"
+    t.boolean  "is_preview_ready",                             default: false,               null: false
+    t.boolean  "is_lms_enabled"
+    t.boolean  "is_lms_enabling_allowed",                      default: false,               null: false
   end
 
-  add_index "course_profile_courses", ["catalog_offering_id", "is_preview", "preview_claimed_at"], name: "preview_pending_indx", using: :btree
   add_index "course_profile_courses", ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id", using: :btree
   add_index "course_profile_courses", ["cloned_from_id"], name: "index_course_profile_courses_on_cloned_from_id", using: :btree
+  add_index "course_profile_courses", ["is_lms_enabling_allowed"], name: "index_course_profile_courses_on_is_lms_enabling_allowed", using: :btree
+  add_index "course_profile_courses", ["is_preview", "is_preview_ready", "preview_claimed_at", "catalog_offering_id"], name: "preview_pending_index", using: :btree
   add_index "course_profile_courses", ["name"], name: "index_course_profile_courses_on_name", using: :btree
   add_index "course_profile_courses", ["school_district_school_id"], name: "index_course_profile_courses_on_school_district_school_id", using: :btree
   add_index "course_profile_courses", ["teach_token"], name: "index_course_profile_courses_on_teach_token", unique: true, using: :btree
@@ -433,15 +437,16 @@ ActiveRecord::Schema.define(version: 20170915024702) do
   add_index "legal_targeted_contracts", ["target_gid"], name: "legal_targeted_contracts_target", using: :btree
 
   create_table "lms_apps", force: :cascade do |t|
-    t.integer  "owner_id",   null: false
-    t.string   "owner_type", null: false
+    t.string   "name",       null: false
     t.string   "key",        null: false
     t.string   "secret",     null: false
+    t.text     "notes"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "owner_id",   null: false
+    t.string   "owner_type", null: false
   end
 
-  add_index "lms_apps", ["key"], name: "index_lms_apps_on_key", using: :btree
   add_index "lms_apps", ["owner_type", "owner_id"], name: "index_lms_apps_on_owner_type_and_owner_id", using: :btree
 
   create_table "lms_contexts", force: :cascade do |t|

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -412,6 +412,22 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(course.time_zone.name).to eq 'Central Time (US & Canada)'
       end
 
+      it 'turns on LMS integration when allowed' do
+        course.update_attribute(:is_lms_enabling_allowed, true)
+        api_patch :update, user_1_token, parameters: { id: course.id },
+                                         raw_post_data: { is_lms_enabled: true }.to_json
+        expect(response.body_as_hash[:is_lms_enabled]).to eq true
+        expect(course.reload.is_lms_enabled).to eq true
+      end
+
+      it 'cannot turn on LMS integration when not allowed' do
+        course.update_attribute(:is_lms_enabling_allowed, false)
+        api_patch :update, user_1_token, parameters: { id: course.id },
+                                         raw_post_data: { is_lms_enabled: true }.to_json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(course.reload.is_lms_enabled).to eq nil
+      end
+
       it 'updates the time_zone' do
         time_zone = course.time_zone.to_tz
         opens_at = time_zone.now - 2.months

--- a/spec/factories/course_profile/courses.rb
+++ b/spec/factories/course_profile/courses.rb
@@ -25,6 +25,8 @@ FactoryGirl.define do
     biglearn_assignment_pes_algorithm_name       { Faker::Hacker.abbreviation }
     biglearn_practice_worst_areas_algorithm_name { Faker::Hacker.abbreviation }
 
+    is_lms_enabling_allowed { is_lms_enabled == true ? true : false }
+
     association :offering, factory: :catalog_offering
 
     trait(:with_assistants) do

--- a/spec/features/admin/bulk_set_flag_spec.rb
+++ b/spec/features/admin/bulk_set_flag_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require 'feature_js_helper'
+
+RSpec.feature 'Bulk set course flag', js: true do
+  before do
+    admin = FactoryGirl.create(:user, :administrator)
+    stub_current_user(admin)
+
+    @course_1 = FactoryGirl.create :course_profile_course, year: 2016
+    @course_2 = FactoryGirl.create :course_profile_course, year: 2017
+    @course_3 = FactoryGirl.create :course_profile_course, year: 2017
+  end
+
+  scenario 'select all on page with no query' do
+    visit admin_courses_path(per_page: 1)
+
+    find('#courses_select_all_on_page').set(true)
+    find('#courses_select_all_on_all_pages').set(false)
+
+    select "Allow teacher to enable LMS", from: 'flag_name'
+    select "True / Yes", from: 'flag_value'
+    click_button 'Set Flag'
+
+    flag_values = [@course_1, @course_2, @course_3].map{|course| course.reload.is_lms_enabling_allowed}
+
+    expect(flag_values).to eq [true, false, false]
+
+    expect(current_path).to eq(admin_courses_path)
+    expect(page).to have_css('.flash_notice', text: 'Flag values were updated')
+    expect(page).to have_text('LMS: enable allowed')
+  end
+
+  scenario 'select all on all pages with no query' do
+    visit admin_courses_path(per_page: 1)
+
+    find('#courses_select_all_on_all_pages').set(true)
+
+    select "Allow teacher to enable LMS", from: 'flag_name'
+    select "True / Yes", from: 'flag_value'
+    click_button 'Set Flag'
+
+    [@course_1, @course_2, @course_3].each do |course|
+      expect(course.reload.is_lms_enabling_allowed).to eq true
+    end
+
+    expect(current_path).to eq(admin_courses_path)
+    expect(page).to have_css('.flash_notice', text: 'Flag values were updated')
+    expect(page).to have_text('LMS: enable allowed')
+  end
+
+  scenario 'select all on all pages with query' do
+    visit admin_courses_path(per_page: 1, query: "year:2017")
+
+    find('#courses_select_all_on_all_pages').set(true)
+
+    select "Allow teacher to enable LMS", from: 'flag_name'
+    select "True / Yes", from: 'flag_value'
+    click_button 'Set Flag'
+
+    flag_values = [@course_1, @course_2, @course_3].map{|course| course.reload.is_lms_enabling_allowed}
+    expect(flag_values).to eq [false, true, true]
+
+
+    expect(current_path).to eq(admin_courses_path)
+    expect(page).to have_css('.flash_notice', text: 'Flag values were updated')
+    expect(page).to have_text('LMS: enable allowed')
+  end
+
+end

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -99,6 +99,26 @@ RSpec.feature 'Admin editing a course' do
     expect(CourseProfile::Models::Course.first.does_cost).to eq true
   end
 
+  scenario 'Changing "Is LMS Enabling Allowed"' do
+    visit admin_courses_path
+    click_link 'Edit'
+
+    expect(page).to have_content('Edit course')
+    check 'course_is_lms_enabling_allowed'
+    click_button 'edit-save'
+
+    expect(current_path).to eq(edit_admin_course_path(@course))
+    expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
+    expect(@course.reload.is_lms_enabling_allowed).to eq true
+
+    uncheck 'course_is_lms_enabling_allowed'
+    click_button 'edit-save'
+
+    expect(current_path).to eq(edit_admin_course_path(@course))
+    expect(page).to have_css('.flash_notice', text: 'The course has been updated.')
+    expect(@course.reload.is_lms_enabling_allowed).to eq false
+  end
+
   scenario 'Assigning a school' do
     FactoryGirl.create(:school_district_school, name: 'High high hi school')
     visit admin_courses_path

--- a/spec/routines/search_courses_spec.rb
+++ b/spec/routines/search_courses_spec.rb
@@ -26,17 +26,20 @@ RSpec.describe SearchCourses, type: :routine do
 
   let!(:course_1) do
     FactoryGirl.create(
-      :course_profile_course, name: 'Physics', school: tutor_school, offering: offering_1
+      :course_profile_course, name: 'Physics', school: tutor_school, offering: offering_1, year: 2016, term: :fall,
+                              is_lms_enabling_allowed: true
     )
   end
   let!(:course_2) do
     FactoryGirl.create(
-      :course_profile_course, name: 'Biology', school: tutor_school, offering: offering_2
+      :course_profile_course, name: 'Biology', school: tutor_school, offering: offering_2, year: 2016, term: :spring,
+                              is_lms_enabled: true
     )
   end
   let!(:course_3) do
     FactoryGirl.create(
-      :course_profile_course, name: 'Concept Coach', school: cc_school, offering: offering_1
+      :course_profile_course, name: 'Concept Coach', school: cc_school, offering: offering_1, year: 2017, term: :fall,
+                              does_cost: true
     )
   end
 
@@ -147,5 +150,31 @@ RSpec.describe SearchCourses, type: :routine do
   it 'returns courses whose catalog offering id matches the given query' do
     courses = described_class[query: "offering_id:#{offering_1.id}"].to_a
     expect(courses).to eq [course_3, course_1]
+  end
+
+  it 'returns courses whose is_lms_enabled matches the given query' do
+    courses = described_class[query: "is_lms_enabled:true"].to_a
+    expect(courses).to eq [course_2]
+  end
+
+  it 'returns courses whose is_lms_enabling_allowed matches the given query' do
+    courses = described_class[query: "is_lms_enabling_allowed:true", order_by: "ID asc"].to_a
+    expect(courses).to eq [course_1, course_2]
+  end
+
+
+  it 'returns courses whose term matches the given query' do
+    courses = described_class[query: "term:SprinG"].to_a
+    expect(courses).to eq [course_2]
+  end
+
+  it 'returns courses whose year matches the given query' do
+    courses = described_class[query: "year:2016", order_by: 'ID asc'].to_a
+    expect(courses).to eq [course_1, course_2]
+  end
+
+  it 'returns courses that cost' do
+    courses = described_class[query: "costs:true", order_by: 'ID asc'].to_a
+    expect(courses).to eq [course_3]
   end
 end


### PR DESCRIPTION
Adds two flags to `CourseProfile::Models::Course` -- `is_lms_enabling_allowed` (an admin-controlled feature flag), and `is_lms_enabled`, a teacher-controlled flag for opting in to LMS integration.  These are reported in course JSON, and `is_lms_enabled` can be set in the patch course API call, if `is_lms_enabling_allowed` is `true`.  

The feature flag can be set via a new bulk flag setting option at the bottom of the course search admin screen, or on the course edit page.  The bulk flag setting option also respects a new "Select all on all pages" toggle.

More search terms were added to the admin course search, including the ability to search by the values of these new LMS booleans (also `costs`, `term`, `year`).  Added a toggleable search help div.

![image](https://user-images.githubusercontent.com/1001691/30503070-0e321fc4-9a26-11e7-8e45-1e3e29ccd583.png)


## TODO

* [ ] ~~Use the `is_lms_enabled` field to allow/block related actions~~ (will do this in another PR)
* [x] Be able to toggle `is_lms_enabling_allowed` and `is_lms_enabled` from the course edit screen (currently can only set via the course search screen)
* [x] specs all around