### PR TITLE
update to mathjax 2.7.2

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -4,7 +4,7 @@
   <title>OpenStax Tutor</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel='stylesheet' href='<%= Rails.application.secrets[:css_url] %>' />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='https://c.la2-c2-dfw.salesforceliveagent.com/content/g/js/39.0/deployment.js'></script>
   <script type='text/javascript' src='<%= Rails.application.secrets[:js_url] %>' async></script>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
The old version (2.7.1) has errors with loading the accessibility extension