### PR TITLE
Global highlighting feature flag

### DIFF
--- a/app/representers/api/v1/bootstrap_data_representer.rb
+++ b/app/representers/api/v1/bootstrap_data_representer.rb
@@ -60,6 +60,13 @@ module Api::V1
       }
     }
 
+    property :feature_flags, writeable: false, readable: true, getter: ->(*) {
+      {
+        is_highlighting_allowed: Settings::Highlighting.is_allowed,
+        is_payments_enabled: Settings::Payments.payments_enabled
+      }
+    }
+
     property :flash,
              readable: true,
              writeable: false,

--- a/config/initializers/02-settings.rb
+++ b/config/initializers/02-settings.rb
@@ -16,6 +16,7 @@ Settings::Db.store.defaults[:student_grace_period_days] = 14
 Settings::Db.store.defaults[:payments_enabled] = false
 Settings::Db.store.defaults[:ga_tracking_codes] = \
     (secrets.environment_name == "prodtutor") ? 'UA-66552106-1' : ''
+Settings::Db.store.defaults[:is_highlighting_allowed] = false
 
 Settings::Db.store.defaults[:biglearn_student_clues_algorithm_name] = 'local_query'
 Settings::Db.store.defaults[:biglearn_teacher_clues_algorithm_name] = 'local_query'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,3 +87,6 @@ en:
       prebuilt_preview_course_count:
         name: '# Prebuilt Preview Courses'
         help_block: 'The number of prebuilt preview courses to keep at the ready'
+      is_highlighting_allowed:
+        name: 'Allow highlighting?'
+        help_block: 'If false (unchecked), disables highlighting; if true (checked), may enable highlighting (other checks used too)'

--- a/lib/settings/highlighting.rb
+++ b/lib/settings/highlighting.rb
@@ -1,0 +1,13 @@
+module Settings
+  module Highlighting
+
+    class << self
+
+      def is_allowed
+        Settings::Db.store.is_highlighting_allowed
+      end
+
+    end
+
+  end
+end

--- a/spec/representers/api/v1/bootstrap_data_representer_spec.rb
+++ b/spec/representers/api/v1/bootstrap_data_representer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
   end
 
   it "generates a JSON representation of data for a user to start work with" do
-    expect(JSON.parse representation).to match(
+    expect(JSON.parse representation).to match a_hash_including(
       "user" =>  Api::V1::UserRepresenter.new(user).as_json,
       "courses" => [], # not testing this since it's too expensive to generate meaningful course data
       "accounts_api_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'api',
@@ -25,6 +25,10 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
         "js_url" => a_string_starting_with('http'),
         "base_url" => a_string_starting_with('http'),
         "product_uuid" => Rails.application.secrets['openstax']['payments']['product_uuid']
+      ),
+      "feature_flags" => a_hash_including(
+        "is_highlighting_allowed" => false,
+        "is_payments_enabled" => Settings::Payments.payments_enabled
       ),
       "ui_settings" => {},
       "flash" => { "alert" => 'Nothing!' }


### PR DESCRIPTION
Adds a `is_highlighting_allowed` feature flag to the admin settings and bootstrap data.