### PR TITLE
Should fix ecosystem updates (needs testing)

### DIFF
--- a/app/jobs/openstax/biglearn/api/job.rb
+++ b/app/jobs/openstax/biglearn/api/job.rb
@@ -12,8 +12,8 @@ class OpenStax::Biglearn::Api::Job < ApplicationJob
       responses.each do |response|
         raise(
           OpenStax::Biglearn::Api::JobFailed,
-          "[#{method}] Expected #{response_status_key} to be in #{
-          accepted_response_status.inspect} but was #{response[response_status_key]} instead"
+          "[#{method}] Expected \"#{response_status_key}\" to be in #{
+          accepted_response_status.inspect} but was \"#{response[response_status_key]}\" instead"
         ) unless accepted_response_status.include?(response[response_status_key])
       end
     end

--- a/app/subsystems/content/models/map.rb
+++ b/app/subsystems/content/models/map.rb
@@ -118,8 +118,8 @@ class Content::Models::Map < Tutor::SubSystems::BaseModel
   end
 
   def before_save_callbacks
-    create_exercise_id_to_page_id_map,
-    create_page_id_to_page_id_map,
+    create_exercise_id_to_page_id_map
+    create_page_id_to_page_id_map
     create_page_id_to_pool_type_exercise_ids_map
     validate_maps
   end

--- a/app/subsystems/content/models/map.rb
+++ b/app/subsystems/content/models/map.rb
@@ -10,8 +10,7 @@ class Content::Models::Map < Tutor::SubSystems::BaseModel
   validates :from_ecosystem, :to_ecosystem, presence: true
   validates :to_ecosystem, uniqueness: { scope: :content_from_ecosystem_id }
 
-  before_save :create_exercise_id_to_page_id_map, :create_page_id_to_page_id_map,
-              :create_page_id_to_pool_type_exercise_ids_map, :validate_maps
+  before_save :before_save_callbacks
 
   def create_exercise_id_to_page_id_map
     return unless exercise_id_to_page_id_map.blank?
@@ -116,6 +115,13 @@ class Content::Models::Map < Tutor::SubSystems::BaseModel
     exercises_map_to_pages
     pages_map_to_pages
     pages_map_to_exercises
+  end
+
+  def before_save_callbacks
+    create_exercise_id_to_page_id_map,
+    create_page_id_to_page_id_map,
+    create_page_id_to_pool_type_exercise_ids_map
+    validate_maps
   end
 
   protected

--- a/lib/openstax/biglearn/api/client.rb
+++ b/lib/openstax/biglearn/api/client.rb
@@ -1,0 +1,15 @@
+class OpenStax::Biglearn::Api::Client
+  # Must be implemented by all clients so that sequentially_prepare_and_update_course_ecosystem
+  # can be successfully called
+  def prepare_course_ecosystem(request)
+    raise NotImplementedError
+  end
+
+  # Executes prepare_course_ecosystem and update_course_ecosystems sequentially
+  def sequentially_prepare_and_update_course_ecosystem(request)
+    prepare_course_ecosystem(request)
+
+    # Call OpenStax::Biglearn::Api to obtain a new sequence_number in a fresh background job
+    OpenStax::Biglearn::Api.update_course_ecosystems request.slice(:course, :preparation_uuid)
+  end
+end

--- a/lib/openstax/biglearn/api/fake_client.rb
+++ b/lib/openstax/biglearn/api/fake_client.rb
@@ -1,4 +1,4 @@
-class OpenStax::Biglearn::Api::FakeClient
+class OpenStax::Biglearn::Api::FakeClient < OpenStax::Biglearn::Api::Client
 
   attr_reader :store
 

--- a/lib/openstax/biglearn/api/real_client.rb
+++ b/lib/openstax/biglearn/api/real_client.rb
@@ -2,7 +2,7 @@
 # or else they will introduce gaps in the sequence_number
 # If aborting a request in here is required in the future,
 # we will need to introduce a NO-OP CourseEvent in biglearn-api
-class OpenStax::Biglearn::Api::RealClient
+class OpenStax::Biglearn::Api::RealClient < OpenStax::Biglearn::Api::Client
 
   HEADER_OPTIONS = { 'Content-Type' => 'application/json' }.freeze
 

--- a/spec/lib/openstax/biglearn/api/client_spec.rb
+++ b/spec/lib/openstax/biglearn/api/client_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'vcr_helper'
+
+RSpec.describe OpenStax::Biglearn::Api::Client, type: :external, vcr: VCR_OPTS do
+  subject(:client)       { OpenStax::Biglearn::Api::Client.new }
+
+  let(:preparation_uuid) { SecureRandom.uuid }
+  let(:course)           { FactoryGirl.create(:course_profile_course) }
+  let(:ecosystem)        { FactoryGirl.create(:content_ecosystem) }
+
+  let(:request)          do
+    { preparation_uuid: preparation_uuid, course: course, ecosystem: ecosystem }
+  end
+
+  it 'can call prepare_course_ecosystem and update_course_ecosystems sequentially' do
+    expect(client).to receive(:prepare_course_ecosystem).with(request)
+    expect(OpenStax::Biglearn::Api).to receive(:update_course_ecosystems).with(
+      request.slice(:course, :preparation_uuid)
+    )
+    client.sequentially_prepare_and_update_course_ecosystem request
+  end
+end

--- a/spec/lib/openstax/biglearn/api_spec.rb
+++ b/spec/lib/openstax/biglearn/api_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe OpenStax::Biglearn::Api, type: :external do
           1
         ],
         [
+          :sequentially_prepare_and_update_course_ecosystem,
+          -> { { course: @course, ecosystem: @ecosystem } },
+          Hash,
+          -> { @course },
+          2
+        ],
+        [
           :update_rosters,
           -> { [ { course: @course } ] },
           OpenStax::Biglearn::Api::JobWithSequenceNumber,


### PR DESCRIPTION
Fix `(NoMethodError) "undefined method 'page_id_to_page_id_map' for nil:NilClass"` when trying to update many course ecosystems at the same time

