### PR TITLE
updated scores export to have 'Course Average' terminology

### DIFF
--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -218,8 +218,7 @@ module Tasks
         @helper.merge_and_style(sheet, "D7:F8",
           style!(
             b: true,
-            bg_color: 'C9F0F8',
-            border: { edges: [:left, :top, :right, :bottom], :color => '000000', :style => :thin},
+            border: { edges: [:left, :top, :right], :color => '000000', :style => :thin},
             alignment: {horizontal: :center, vertical: :center, wrap_text: true}
           )
         )
@@ -228,7 +227,7 @@ module Tasks
 
         top_data_heading_columns =
           3.times.map{["", {style: @normal_T}]} +
-          ["Homework\nScore", "Homework\nProgress", "Reading\nProgress"].map{|text| [text, style: @bold]}
+          ["Course Average*\n(Homework Score)", "Homework\nProgress", "Reading\nProgress"].map{|text| [text, style: @bold]}
 
         center_bold_R_style = style!(
           b: true, border: {edges: [:right], :color => '000000', :style => :thin},
@@ -264,7 +263,7 @@ module Tasks
 
         # Final averages sub headings
         @helper.merge_and_style(sheet, "D9:D10", style!(
-          b: true, border: {edges: [:left], :color => '000000', :style => :thin},
+          b: true, bg_color: 'C9F0F8', border: {edges: [:left], :color => '000000', :style => :thin},
           alignment: {horizontal: :center, vertical: :center, wrap_text: true}))
         @helper.merge_and_style(sheet, "E9:E10", center_bold_style)
         @helper.merge_and_style(sheet, "F9:F10", center_bold_R_style)
@@ -335,7 +334,8 @@ module Tasks
         # then set all numerical columns to have a fixed width.
 
         data_widths = sheet.column_info.map(&:width)
-        data_widths[3..-1] = data_widths[3..-1].length.times.map{15}
+        data_widths[3..5] = data_widths[3..5].map{20}
+        data_widths[6..-1] = data_widths[6..-1].length.times.map{15}
 
         # AVERAGE ROW
 
@@ -412,6 +412,14 @@ module Tasks
         dropped_footer_columns =
           (report[:data_headings].count*5 + 6).times.map {["", {style: dropped_footer_style}]}
         @helper.add_row(sheet, dropped_footer_columns)
+
+        # Course average explanation
+
+        3.times { sheet.add_row }
+
+        @helper.add_row(sheet, [["* Course average is the average of all homework assignment scores. " \
+                                 "Reading scores and progress averages are not included.",
+                                 {style: @italic}]])
 
         # Normalize height
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -154,6 +154,14 @@ RSpec::Matchers.define :be_the_same_time_as do |expected|
   end
 end
 
+# Make the Boxr gem work with Webmock/VCR
+RSpec.configure do |config|
+  config.before(:suite) do
+    Boxr.send :remove_const, 'BOX_CLIENT'
+    Boxr::BOX_CLIENT = HTTPClient.new
+  end
+end
+
 def fake_flash(key, value)
   flash_hash = ActionDispatch::Flash::FlashHash.new
   flash_hash[key] = value

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,11 +91,3 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
-
-# Make the Boxr gem work with Webmock/VCR
-RSpec.configure do |config|
-  config.before(:suite) do
-    Boxr.send :remove_const, 'BOX_CLIENT'
-    Boxr::BOX_CLIENT = HTTPClient.new
-  end
-end

--- a/spec/subsystems/tasks/performance_report/export_xlsx_spec.rb
+++ b/spec/subsystems/tasks/performance_report/export_xlsx_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Tasks::PerformanceReport::ExportXlsx, type: :routine do
         filepath = Timecop.freeze(Chronic.parse("3/18/2016 1:30PM")) do
           described_class.call(course_name: 'Physics 101',
                                report: report_1,
-                               filename: "#{dir}/testfile")
+                               filename: "#{dir}/testfile#{SecureRandom.hex(2)}")
         end
 
         # Uncomment this to open the file for visual inspection


### PR DESCRIPTION
Used to look like:

![image](https://user-images.githubusercontent.com/1001691/31136504-b1dc54de-a825-11e7-9057-fab96632c56b.png)

Now has "Course Average" heading in blue with an asterisk explainer:

![image](https://user-images.githubusercontent.com/1001691/31136527-c654fb28-a825-11e7-8dd0-6e3e170eec87.png)
