### PR TITLE
Add :: to fix missing LMS namespace resolution

### DIFF
--- a/app/controllers/api/v1/lms/courses_controller.rb
+++ b/app/controllers/api/v1/lms/courses_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::Lms::CoursesController < Api::V1::ApiController
   def show
     OSU::AccessPolicy.require_action_allowed!(:lms_connection_info, current_api_user, @course)
 
-    app = Lms::Models::App.find_or_create_by(owner: @course)
+    app = ::Lms::Models::App.find_or_create_by(owner: @course)
 
     render json: app.as_json.merge(
              url: lms_configuration_url(format: :xml),


### PR DESCRIPTION
probably depending on load order or something, but I **sometimes** get a:

`uninitialized constant Api::V1::Lms::CoursesController::Lms"`