### PR TITLE
Course search by is_preview; default is_preview search to false

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'squeel'
 gem 'fine_print', '~> 3.1.0'
 
 # Keyword search
-gem "keyword_search"
+gem "keyword_search", github: 'openstax/keyword_search', ref: '21785cb0f644'
 
 # File uploads
 gem 'remotipart'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,13 @@ GIT
       restforce (~> 2.1.0)
 
 GIT
+  remote: https://github.com/openstax/keyword_search.git
+  revision: 21785cb0f644f16c30886a3fa83213887d0f4cde
+  ref: 21785cb0f644
+  specs:
+    keyword_search (1.5.0)
+
+GIT
   remote: https://github.com/openstax/rescue_from.git
   revision: e0d60e68afc629361d8b0c142c5eb0283e523aaa
   ref: e0d60e68afc629361d8b0c142c5eb0283e523aaa
@@ -402,7 +409,6 @@ GEM
     json-schema (2.8.0)
       addressable (>= 2.4)
     jwt (1.5.1)
-    keyword_search (1.5.0)
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -818,7 +824,7 @@ DEPENDENCIES
   jobba (~> 1.6.0)
   jquery-rails
   json-schema (~> 2.8.0)
-  keyword_search
+  keyword_search!
   launchy
   lev (~> 8.0.0)
   lograge

--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -159,6 +159,15 @@ class SearchCourses
           @items = @items.where(does_cost: sanitized_queries)
         end
       end
+
+      with.keyword :is_preview, nil, "false" do |queries|
+        queries.each do |query|
+          sanitized_queries = to_boolean_array(query, allow_nil: false)
+          next @items = @items.none if sanitized_queries.empty?
+
+          @items = @items.where(is_preview: sanitized_queries)
+        end
+      end
     end
   end
 end

--- a/app/views/manager/courses/_search.html.erb
+++ b/app/views/manager/courses/_search.html.erb
@@ -37,6 +37,7 @@
       <li><b>term</b> - accepts <%= CourseProfile::Models::Course.terms.keys.map{|kk| "<b>#{kk}</b>"}.join(', ').html_safe %></li>
       <li><b>year</b> - the year of the course, e.g. <b>2017</b></li>
       <li><b>costs</b> - accepts <b>false</b> (does not cost) or <b>true</b> (does cost)</li>
+      <li><b>is_preview</b> - accepts <b>false</b> (is not preview) or <b>true</b> (is preview). Defaults to <b>false</b>.</li>
     </ul>
 
     <p>Examples:</p>

--- a/spec/routines/search_courses_spec.rb
+++ b/spec/routines/search_courses_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe SearchCourses, type: :routine do
                               does_cost: true
     )
   end
+  let!(:course_4) do
+    FactoryGirl.create(
+      :course_profile_course, name: 'Howdy', school: tutor_school, offering: offering_1, year: 2017, term: :fall,
+                              does_cost: true, is_preview: true
+    )
+  end
 
   let(:teacher_user) { FactoryGirl.create(:user, first_name: 'Charles') }
 
@@ -176,5 +182,15 @@ RSpec.describe SearchCourses, type: :routine do
   it 'returns courses that cost' do
     courses = described_class[query: "costs:true", order_by: 'ID asc'].to_a
     expect(courses).to eq [course_3]
+  end
+
+  it 'excludes preview courses by default' do
+    courses = described_class[query: "", order_by: 'ID asc'].to_a
+    expect(courses).to eq [course_1, course_2, course_3]
+  end
+
+  it 'can include preview courses' do
+    courses = described_class[query: "is_preview:true", order_by: 'ID asc'].to_a
+    expect(courses).to eq [course_4]
   end
 end


### PR DESCRIPTION
Admin course search can now search by `is_preview`.  Defaults to `is_preview:false` so that previews are hidden most of the time.