### PR TITLE
Added TC scoping to LMS user IDs, changed Tutor description for LMSs

### DIFF
--- a/app/controllers/lms_controller.rb
+++ b/app/controllers/lms_controller.rb
@@ -124,7 +124,7 @@ class LmsController < ApplicationController
     redirect_to openstax_accounts.login_url(
       sp: OpenStax::Api::Params.sign(
         params: {
-          uuid:  launch.lms_user_id,
+          uuid:  launch.lms_tc_scoped_user_id,
           name:  launch.full_name,
           email: launch.email,
           school: launch.school,

--- a/app/subsystems/lms/launch.rb
+++ b/app/subsystems/lms/launch.rb
@@ -61,6 +61,10 @@ class Lms::Launch
     request_parameters[:user_id]
   end
 
+  def lms_tc_scoped_user_id
+    "#{lms_user_id}--#{tool_consumer_instance_guid}"
+  end
+
   def full_name
     request_parameters[:lis_person_name_full]
   end

--- a/app/views/lms/configuration.xml.erb
+++ b/app/views/lms/configuration.xml.erb
@@ -11,7 +11,7 @@
     http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
 
     <blti:title>OpenStax Tutor</blti:title>
-    <blti:description>Improve how your students learn with research-based technology.</blti:description>
+    <blti:description>OpenStax Tutor Beta is a personalized learning tool for College Physics, Biology, and Introduction to Sociology 2e.</blti:description>
     <blti:launch_url><%= lms_launch_url %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="privacy_level">public</lticm:property>

--- a/spec/support/lms/launch_helper.rb
+++ b/spec/support/lms/launch_helper.rb
@@ -38,7 +38,7 @@ class Lms::LaunchHelper
       expect(redirect_path).to eq "/accounts/login"
       expect(redirect_query_hash[:sp]["signature"]).not_to be_blank
 
-      user_identifer = redirect_query_hash[:sp]["uuid"]
+      user_identifer = redirect_query_hash[:sp]["uuid"].split('--')[0]
       user = this.get_user!(user_identifer, default: log_in_as)
 
       stub_current_user(user)


### PR DESCRIPTION
The LTI spec recommends that user IDs given out from an LMS be unique at least within the scope of the LMS.  I hope that is at least the case.  If that is all we get tho, we need to consider the LMS user ID to be scoped within the LMS ID, which this PR does.  

Also changes the Tutor description used by the LMS.