### PR TITLE
prevent launch reuse from interstitial page; disable course nav lms config

### DIFF
--- a/app/views/lms/configuration.xml.erb
+++ b/app/views/lms/configuration.xml.erb
@@ -15,11 +15,15 @@
     <blti:launch_url><%= lms_launch_url %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="privacy_level">public</lticm:property>
+
+      <% if false # we are not doing course navigations links for the moment %>
       <lticm:options name="course_navigation">
          <lticm:property name="url"><%= lms_launch_url %></lticm:property>
          <lticm:property name="enabled">true</lticm:property>
          <lticm:property name="windowTarget">_blank</lticm:property>
       </lticm:options>
+      <% end %>
+
       <lticm:options name="assignment_selection">
         <lticm:property name="message_type">ContentItemSelectionRequest</lticm:property>
         <lticm:property name="url"><%= lms_ci_launch_url %></lticm:property>

--- a/app/views/lms/launch.html.erb
+++ b/app/views/lms/launch.html.erb
@@ -9,8 +9,8 @@
 
     <div id="lms-say-open-in-tab" style="display:none">
       <%= image_tag "openstax-tutor-beta-logo.svg", class: 'logo' %>
-      <div class="text">Continue to OpenStax Tutor in a new browser tab.</div>
-      <%= link_to "Continue", lms_launch_authenticate_path, target: :_blank, class: "btn" %>
+      <div class="text" id="message">Continue to OpenStax Tutor in a new browser tab.</div>
+      <%= link_to "Continue", lms_launch_authenticate_path, target: :_blank, class: "btn", id: 'continue' %>
     </div>
 
     <script>
@@ -30,8 +30,16 @@
       } else {
         window.location.href = '<%= lms_launch_authenticate_path %>';
       }
+
+      document.getElementById('continue').onclick=function() {
+        document.getElementById('message').innerHTML =
+          '<p>OpenStax Tutor was successfully loaded in a new browser tab.</p>' +
+          '<p>Reload the page to access it again.</p>';
+        document.getElementById('continue').style.display = 'none'
+      }
     })();
     </script>
 
   </body>
 </html>
+


### PR DESCRIPTION
For LMS, after a user clicks the link to open Tutor in a new tab, the link gets replaced with text saying the user must reload the page to use the link again (launches are one-time uses).

![image](https://user-images.githubusercontent.com/1001691/31361560-248f3ee8-ad11-11e7-8c61-049dbddd39ee.png)

Disabled the part of the LMS configuration that puts the link to Tutor in the course sidebar (cool, but doesn't give us linkage information to report scores back)