### PR TITLE
give equal weights to column widths

### DIFF
--- a/app/assets/stylesheets/enroll.scss
+++ b/app/assets/stylesheets/enroll.scss
@@ -50,6 +50,7 @@ body#enroll {
       justify-content: space-between;
 
       > div {
+        flex: 1;
         background-size: 100px auto;
         background-repeat: no-repeat;
         background-position: top center;


### PR DESCRIPTION
This way they're all the same width and are centered properly

before:
<img width="940" alt="screen shot 2017-10-11 at 11 57 43 am" src="https://user-images.githubusercontent.com/79566/31454574-7e516fb2-ae7b-11e7-856a-be45e7744f53.png">


after:
<img width="925" alt="screen shot 2017-10-11 at 11 57 50 am" src="https://user-images.githubusercontent.com/79566/31454573-7e3500b6-ae7b-11e7-87a8-dcc1da91f19f.png">