### PR TITLE
Truncate long course names to avoid Errno::ENAMETOOLONG when exportin…

### DIFF
--- a/app/subsystems/tasks/export_performance_report.rb
+++ b/app/subsystems/tasks/export_performance_report.rb
@@ -37,7 +37,7 @@ module Tasks
       is_cc = course.is_concept_coach
       klass = "Tasks::PerformanceReport::Export#{is_cc ? 'Cc' : ''}#{format.to_s.camelize}"
       exporter = klass.constantize
-      filename = [FilenameSanitizer.sanitize(course.name),
+      filename = [FilenameSanitizer.sanitize(course.name.first(200)),
                   'Scores',
                   Time.now.utc.strftime("%Y%m%d-%H%M%S")].join('_')
 

--- a/spec/subsystems/tasks/export_performance_report_spec.rb
+++ b/spec/subsystems/tasks/export_performance_report_spec.rb
@@ -41,4 +41,11 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine, speed: :slow do
     }.not_to raise_error
   end
 
+  it 'does not blow up if the course name is too long' do
+    @course.update_attribute(:name, 'Tro' + (['lo'] * 150).join)
+    expect {
+      @output_filename = described_class[role: @role, course: @course]
+    }.not_to raise_error
+  end
+
 end


### PR DESCRIPTION
…g scores