### PR TITLE
redirect launching dropped students to course, not enrollment

### DIFF
--- a/app/controllers/lms_controller.rb
+++ b/app/controllers/lms_controller.rb
@@ -163,7 +163,7 @@ class LmsController < ApplicationController
       # Note if the user is not yet a student in the course, so they can be sent through the
       # LMS-optimized enrollment flow.
 
-      if !UserIsCourseStudent[course: course, user: current_user]
+      if !UserIsCourseStudent[course: course, user: current_user, include_dropped_students: true]
         is_unenrolled_student = true
       end
     elsif launch.is_instructor?

--- a/spec/requests/lms_launch_spec.rb
+++ b/spec/requests/lms_launch_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe 'LMS Launch', type: :request do
         expect_course_score_callback_count(user: bob_user, count: 1)
       end
     end
+
+    context "dropped" do
+      it 'redirects the student to the course, not enrollment' do
+        simulator.add_student("bob")
+        simulator.launch(user: "bob", assignment: "tutor")
+        bob_user = launch_helper.complete_the_launch_locally
+
+        student = AddUserAsPeriodStudent[period: period, user: bob_user].student
+        CourseMembership::InactivateStudent[student: student]
+
+        simulator.launch(user: "bob", assignment: "tutor")
+        bob_user = launch_helper.complete_the_launch_locally
+
+        expect(response.body).to match("/course/#{course.id}")
+      end
+    end
   end
 
   context "teacher launches" do


### PR DESCRIPTION
For students who have been dropped inside Tutor but not from the LMS, prevents them from relaunching from the LMS and getting re-enrolled.