### PR TITLE
Speedup research export

### DIFF
--- a/app/controllers/admin/research_data_controller.rb
+++ b/app/controllers/admin/research_data_controller.rb
@@ -6,13 +6,13 @@ module Admin
 
     def create
       filename = "export_#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}.csv"
+      concept_coach_values = [ Tasks::Models::Task.task_types[:concept_coach] ]
       mapping = {
-        "tutor" => Tasks::Models::Task.task_types.values_at(:homework, :reading, :chapter_practice,
-                   :page_practice, :mixed_practice, :external, :event, :extra),
-        "concept_coach" => Tasks::Models::Task.task_types.values_at(:concept_coach)
+        "tutor" => Tasks::Models::Task.task_types.values - concept_coach_values,
+        "concept_coach" => concept_coach_values
       }
 
-      task_types_params = params.fetch(:export_research_data).fetch(:task_types).reject{|i|i.blank?}
+      task_types_params = params.fetch(:export_research_data).fetch(:task_types).reject(&:blank?)
 
       if task_types_params.blank?
         flash.now[:alert] = "You must select at least one type of Tasks"
@@ -20,15 +20,15 @@ module Admin
         return
       end
 
-      task_types = task_types_params.inject([]) do |result, task_types_param|
-        result.concat(
-          mapping.fetch(task_types_param) { |key| raise "Don't know about application #{key}" }
-        )
+      task_types = task_types_params.flat_map do |task_types_param|
+        mapping.fetch(task_types_param) { |key| raise "Don't know about application #{key}" }
       end
 
-      from_date = params[:export_research_data][:from] || "1/1/1970"
+      from_date = params[:export_research_data][:from] || Time.at(0).to_s
       to_date = params[:export_research_data][:to] || Time.current.to_s
-      ExportAndUploadResearchData.perform_later(filename: filename, from: from_date, to: to_date, task_types: task_types)
+      ExportAndUploadResearchData.perform_later(
+        filename: filename, from: from_date, to: to_date, task_types: task_types
+      )
       redirect_to admin_research_data_path,
                   notice: "#{filename} is being created and will be uploaded to Box when ready"
     end

--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -46,83 +46,132 @@ class ExportAndUploadResearchData
         "Tags"
       ]
 
-      steps = Tasks::Models::TaskStep.joins(task: :taskings)
-                                     .preload([{task: :taskings}, :tasked])
-
+      steps = Tasks::Models::TaskStep
+        .joins(task: :taskings)
+        .where(task: { task_type: task_types })
+        .where(
+          <<-SQL.strip_heredoc
+            NOT EXISTS (
+              SELECT *
+              FROM "tasks_task_plans"
+              WHERE "tasks_task_plans"."id" = "tasks_tasks"."tasks_task_plan_id"
+                AND "tasks_task_plans"."is_preview" = TRUE
+            )
+          SQL
+        )
       steps = steps.where(task: { created_at: date_range }) if date_range
-      steps = steps.where(task: { task_type: task_types })
 
-      total_count = steps.count
-      current_count = 0
+      # find_in_batches completely ignores any sort of limit or order
+      steps.find_in_batches do |steps|
+        task_ids = steps.map(&:tasks_task_id)
+        tasks_by_task_id = Tasks::Models::Task.where(id: task_ids)
+                                              .preload(:taskings, :time_zone)
+                                              .index_by(&:id)
 
-      # find_each completely ignores any sort of limit or order
-      steps.find_each do |step|
-        begin
-          if current_count % 20 == 0
-            print "\r"
-            print "#{current_count} / #{total_count}"
-          end
-          current_count += 1
-
-          role_id = step.task.taskings.first.entity_role_id
-          r_info = role_info[role_id]
-          next if r_info.nil?
-
-          tasked = step.tasked
-          type = step.tasked_type.match(/Tasked(.+)\z/).try!(:[], 1)
-          course_id = r_info[:course_id]
-          url = tasked.respond_to?(:url) ? tasked.url : nil
-
-          row = [
-            r_info[:research_identifier],
-            course_id,
-            is_cc?(course_id),
-            step.task.taskings.first.course_membership_period_id,
-            step.task.tasks_task_plan_id,
-            step.tasks_task_id,
-            step.task.task_type,
-            step.id,
-            step.number,
-            type,
-            step.group_name,
-            format_time(step.first_completed_at),
-            format_time(step.last_completed_at),
-            format_time(step.task.opens_at),
-            format_time(step.task.due_at),
-            url
-          ]
-
-          row.push(*(
-            case type
-            when 'Exercise'
+        taskeds_by_tasked_type_and_tasked_id = Hash.new { |hash, key| hash[key] = {} }
+        steps.group_by(&:tasked_type).each do |tasked_type, steps|
+          tasked_class = tasked_type.constantize
+          tasked_ids = steps.map(&:tasked_id)
+          taskeds = tasked_class.where(id: tasked_ids).select(
+            case tasked_type
+            when Tasks::Models::TaskedExercise.name
               [
-                url.gsub("org","org/api") + ".json",
-                tasked.correct_answer_id,
-                tasked.answer_id,
-                tasked.is_correct?,
-                # escape so Excel doesn't see as formula
-                tasked.free_response.try(:gsub, /\A=/,"'="),
-                tasked.tags.join(',')
+                :id,
+                :url,
+                :free_response,
+                :answer_id,
+                :correct_answer_id,
+                'COALESCE("answer_id" = "correct_answer_id", FALSE) AS "is_correct"',
+                <<-TAGS_SQL.strip_heredoc
+                  (
+                    SELECT COALESCE(ARRAY_AGG("content_tags"."value"), ARRAY[]::varchar[])
+                    FROM "content_exercises"
+                    INNER JOIN "content_exercise_tags"
+                      ON "content_exercise_tags"."content_exercise_id" = "content_exercises"."id"
+                    INNER JOIN "content_tags"
+                      ON "content_tags"."id" = "content_exercise_tags"."content_tag_id"
+                    WHERE "content_exercises"."id" = "tasks_tasked_exercises"."content_exercise_id"
+                  ) AS "tags_array"
+                TAGS_SQL
               ]
-            when 'Reading'
-              [
-                url + ".json", nil, nil, nil, nil
-              ]
+            when Tasks::Models::TaskedPlaceholder.name
+              [ :id ]
             else
-              5.times.map{nil}
+              [ :id, :url ]
             end
-          ))
+          )
 
-          file << row
-        rescue StandardError => e
-          print "\r"
-          print "Skipped step #{step.id} for #{e.inspect} @ #{e.try(:backtrace).try(:first)}\n"
+          taskeds.each do |tasked|
+            taskeds_by_tasked_type_and_tasked_id[tasked_type][tasked.id] = tasked
+          end
+        end
+
+        steps.each do |step|
+          begin
+            task = tasks_by_task_id[step.tasks_task_id]
+            next if task.nil?
+
+            tasked = taskeds_by_tasked_type_and_tasked_id[step.tasked_type][step.tasked_id]
+            next if tasked.nil?
+
+            role_id = task.taskings.first.entity_role_id
+            r_info = role_info[role_id]
+            next if r_info.nil?
+
+            type = step.tasked_type.match(/Tasked(.+)\z/).try!(:[], 1)
+            course_id = r_info[:course_id]
+            url = tasked.url if tasked.respond_to?(:url)
+
+            row = [
+              r_info[:research_identifier],
+              course_id,
+              is_cc?(course_id),
+              task.taskings.first.course_membership_period_id,
+              task.tasks_task_plan_id,
+              task.id,
+              task.task_type,
+              step.id,
+              step.number,
+              type,
+              step.group_name,
+              format_time(step.first_completed_at),
+              format_time(step.last_completed_at),
+              format_time(task.opens_at),
+              format_time(task.due_at),
+              url
+            ]
+
+            row.push(*(
+              case type
+              when 'Exercise'
+                [
+                  url.gsub("org", "org/api") + ".json",
+                  tasked.correct_answer_id,
+                  tasked.answer_id,
+                  tasked.is_correct,
+                  # escape so Excel doesn't see as formula
+                  tasked.free_response.try!(:gsub, /\A=/, "'="),
+                  tasked.tags_array.join(',')
+                ]
+              when 'Reading'
+                [ "#{url}.json" ] + [ nil ] * 4
+              else
+                [ nil ] * 5
+              end
+            ))
+
+            file << row
+          rescue StandardError => e
+            Rails.logger.error do
+              "Skipped step #{step.id} for #{e.inspect} @ #{e.try(:backtrace).try(:first)}\n"
+            end
+          end
         end
       end
-      puts "\n"
     end
   end
 
+  # TODO: Fix (will OOM with too many students in the system)
   def role_info
     @role_info ||= {}.tap do |role_info|
       CourseMembership::Models::Student

--- a/db/migrate/20171016185328_improve_tasks_tasks_task_type_index_for_research_export.rb
+++ b/db/migrate/20171016185328_improve_tasks_tasks_task_type_index_for_research_export.rb
@@ -1,0 +1,6 @@
+class ImproveTasksTasksTaskTypeIndexForResearchExport < ActiveRecord::Migration
+  def change
+    remove_index :tasks_tasks, :task_type
+    add_index :tasks_tasks, [ :task_type, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 20171025173835) do
     t.integer  "cloned_from_id"
     t.boolean  "is_preview",                                                                 null: false
     t.boolean  "is_excluded_from_salesforce",                  default: false,               null: false
-    t.uuid     "uuid",                                         default: "gen_random_uuid()"
+    t.uuid     "uuid",                                         default: "gen_random_uuid()", null: false
     t.integer  "sequence_number",                              default: 0,                   null: false
     t.string   "biglearn_student_clues_algorithm_name",                                      null: false
     t.string   "biglearn_teacher_clues_algorithm_name",                                      null: false
@@ -346,12 +346,12 @@ ActiveRecord::Schema.define(version: 20171025173835) do
     t.boolean  "does_cost",                                    default: false,               null: false
     t.integer  "estimated_student_count"
     t.datetime "preview_claimed_at"
+    t.boolean  "is_preview_ready",                             default: false,               null: false
+    t.datetime "deleted_at"
     t.boolean  "is_lms_enabled"
     t.boolean  "is_lms_enabling_allowed",                      default: false,               null: false
-    t.boolean  "is_preview_ready",                             default: false,               null: false
     t.boolean  "is_access_switchable",                         default: true,                null: false
     t.string   "last_lms_scores_push_job_id"
-    t.datetime "deleted_at"
   end
 
   add_index "course_profile_courses", ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id", using: :btree
@@ -922,7 +922,7 @@ ActiveRecord::Schema.define(version: 20171025173835) do
   add_index "tasks_tasks", ["hidden_at"], name: "index_tasks_tasks_on_hidden_at", using: :btree
   add_index "tasks_tasks", ["last_worked_at"], name: "index_tasks_tasks_on_last_worked_at", using: :btree
   add_index "tasks_tasks", ["opens_at_ntz"], name: "index_tasks_tasks_on_opens_at_ntz", using: :btree
-  add_index "tasks_tasks", ["task_type"], name: "index_tasks_tasks_on_task_type", using: :btree
+  add_index "tasks_tasks", ["task_type", "created_at"], name: "index_tasks_tasks_on_task_type_and_created_at", using: :btree
   add_index "tasks_tasks", ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id", using: :btree
   add_index "tasks_tasks", ["time_zone_id"], name: "index_tasks_tasks_on_time_zone_id", using: :btree
   add_index "tasks_tasks", ["uuid"], name: "index_tasks_tasks_on_uuid", unique: true, using: :btree

--- a/lib/openstax/exercises/v1/real_client.rb
+++ b/lib/openstax/exercises/v1/real_client.rb
@@ -50,7 +50,7 @@ class OpenStax::Exercises::V1::RealClient
 
       # Don't record access token requests in cassettes
       oauth_token  = oauth_client.client_credentials.get_token \
-        unless Rails.env.test? || @client_id.nil?
+        unless @client_id.nil? || Rails.env.test?
 
       oauth_token || oauth_client
     end

--- a/spec/controllers/admin/research_data_controller_spec.rb
+++ b/spec/controllers/admin/research_data_controller_spec.rb
@@ -21,12 +21,17 @@ RSpec.describe Admin::ResearchDataController, type: :controller do
     end
 
     context "assigns default dates" do
+      let(:task_types) do
+        Tasks::Models::Task.task_types.values - [ Tasks::Models::Task.task_types[:concept_coach] ]
+      end
+
       specify "with invalid 'from' and 'to' parameters" do
         right_now = Time.current
         Timecop.freeze(right_now) do
           filename = "export_#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}.csv"
-          expect(ExportAndUploadResearchData).to receive(:perform_later)
-                                                 .with( filename: filename, from: "1/1/1970", to: right_now.to_s, task_types: [*0..7] )
+          expect(ExportAndUploadResearchData).to receive(:perform_later).with(
+            filename: filename, from: Time.at(0).to_s, to: right_now.to_s, task_types: task_types
+          )
 
           post :create, from: "not-even", to: "valid", export_research_data: {task_types: ["tutor"]}
         end
@@ -36,8 +41,9 @@ RSpec.describe Admin::ResearchDataController, type: :controller do
         right_now = Time.current
         Timecop.freeze(right_now) do
           filename = "export_#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}.csv"
-          expect(ExportAndUploadResearchData).to receive(:perform_later)
-                                                 .with( filename: filename, from: "1/1/1970", to: right_now.to_s, task_types: [*0..7] )
+          expect(ExportAndUploadResearchData).to receive(:perform_later).with(
+            filename: filename, from: Time.at(0).to_s, to: right_now.to_s, task_types: task_types
+          )
 
           post :create, from: "", to: "", export_research_data: {task_types: ["tutor"]}
         end

--- a/spec/controllers/api/v1/pages_controller_spec.rb
+++ b/spec/controllers/api/v1/pages_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
       expect(response.body_as_hash[:content_html]).not_to include(
         '#ost/api/ex/k12phys-ch04-ex001'
       )
+
       exercises_url_base = Rails.application.secrets.openstax['exercises']['url']
       expect(response.body_as_hash[:content_html]).to include(
         "#{exercises_url_base}/api/exercises?q=tag%3A%22k12phys-ch04-ex001%22"

--- a/spec/routines/export_and_upload_research_data_spec.rb
+++ b/spec/routines/export_and_upload_research_data_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ExportAndUploadResearchData, type: :routine do
           answer_id = step.exercise? ? tasked.answer_id : nil
           correct = step.exercise? ? tasked.is_correct?.to_s : nil
           free_response = step.exercise? ? tasked.free_response : nil
-          tags = step.exercise? ? tasked.tags.join(',') : nil
+          tags = step.exercise? ? tasked.tags : []
 
           expect(data['Student']).to eq(task.taskings.first.role.research_identifier)
           expect(data['Course ID']).to eq(course.id.to_s)
@@ -95,7 +95,7 @@ RSpec.describe ExportAndUploadResearchData, type: :routine do
           expect(data['Answer ID']).to eq(answer_id)
           expect(data['Correct?']).to eq(correct)
           expect(data['Free Response']).to eq(free_response)
-          expect(data['Tags']).to eq(tags)
+          expect((data['Tags'] || '').split(',')).to match_array(tags)
         end
       end
     end


### PR DESCRIPTION
- Add missing index
- Preload time_zones
- Don't select the huge fields in TaskedExercises
- Don't parse TaskedExercises to get the tags