### PR TITLE
Keep only one score callback per link / user combo; email devs on error

### DIFF
--- a/app/controllers/lms_controller.rb
+++ b/app/controllers/lms_controller.rb
@@ -158,7 +158,7 @@ class LmsController < ApplicationController
     course = launch.context.course
 
     if launch.is_student?
-      launch.store_score_callback_if_needed(current_user)
+      launch.store_score_callback(current_user)
 
       # Note if the user is not yet a student in the course, so they can be sent through the
       # LMS-optimized enrollment flow.

--- a/db/migrate/20171025173835_add_resource_link_id_to_lms_course_score_callbacks.rb
+++ b/db/migrate/20171025173835_add_resource_link_id_to_lms_course_score_callbacks.rb
@@ -1,0 +1,20 @@
+class AddResourceLinkIdToLmsCourseScoreCallbacks < ActiveRecord::Migration
+  def up
+    # Callbacks should have had a resource_link_id on them, and in the new
+    # way of things it doesn't make sense to have any without them, so blow
+    # away existing (ok since not yet used on prod, and on other systems
+    # will just require students relaunching).
+    Lms::Models::CourseScoreCallback.destroy_all
+
+    add_column :lms_course_score_callbacks, :resource_link_id, :string, null: false
+
+    remove_index :lms_course_score_callbacks, name: "course_score_callbacks_on_course_user_result_outcome"
+    add_index :lms_course_score_callbacks, [:course_profile_course_id, :user_profile_id, :resource_link_id],
+                                           name: "course_score_callbacks_on_course_user_link",
+                                           unique: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171009182057) do
+ActiveRecord::Schema.define(version: 20171025173835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 20171009182057) do
     t.integer  "cloned_from_id"
     t.boolean  "is_preview",                                                                 null: false
     t.boolean  "is_excluded_from_salesforce",                  default: false,               null: false
-    t.uuid     "uuid",                                         default: "gen_random_uuid()", null: false
+    t.uuid     "uuid",                                         default: "gen_random_uuid()"
     t.integer  "sequence_number",                              default: 0,                   null: false
     t.string   "biglearn_student_clues_algorithm_name",                                      null: false
     t.string   "biglearn_teacher_clues_algorithm_name",                                      null: false
@@ -346,12 +346,12 @@ ActiveRecord::Schema.define(version: 20171009182057) do
     t.boolean  "does_cost",                                    default: false,               null: false
     t.integer  "estimated_student_count"
     t.datetime "preview_claimed_at"
-    t.boolean  "is_preview_ready",                             default: false,               null: false
-    t.datetime "deleted_at"
     t.boolean  "is_lms_enabled"
     t.boolean  "is_lms_enabling_allowed",                      default: false,               null: false
+    t.boolean  "is_preview_ready",                             default: false,               null: false
     t.boolean  "is_access_switchable",                         default: true,                null: false
     t.string   "last_lms_scores_push_job_id"
+    t.datetime "deleted_at"
   end
 
   add_index "course_profile_courses", ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id", using: :btree
@@ -469,9 +469,10 @@ ActiveRecord::Schema.define(version: 20171009182057) do
     t.integer  "course_profile_course_id", null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.string   "resource_link_id",         null: false
   end
 
-  add_index "lms_course_score_callbacks", ["course_profile_course_id", "user_profile_id", "result_sourcedid", "outcome_url"], name: "course_score_callbacks_on_course_user_result_outcome", unique: true, using: :btree
+  add_index "lms_course_score_callbacks", ["course_profile_course_id", "user_profile_id", "resource_link_id"], name: "course_score_callbacks_on_course_user_link", unique: true, using: :btree
   add_index "lms_course_score_callbacks", ["result_sourcedid", "outcome_url"], name: "course_score_callback_result_outcome", unique: true, using: :btree
   add_index "lms_course_score_callbacks", ["user_profile_id"], name: "course_score_callbacks_on_user", using: :btree
 

--- a/spec/requests/lms_score_push_spec.rb
+++ b/spec/requests/lms_score_push_spec.rb
@@ -92,11 +92,15 @@ RSpec.describe 'LMS Score Push', type: :request, version: :v1 do
     # Should still get it
     simulator.expect_to_receive_score(user: "bob", assignment: "tutor", score: 0.9111)
 
+    ActionMailer::Base.deliveries.clear
+
     api_put("/api/lms/courses/#{course.id}/push_scores", teacher_token)
     expect(response).to have_http_status :accepted
 
     expect_job_info(errors: [a_hash_including("lms_description" => /User is dropped/)],
                     data: {"num_callbacks" => 1, "num_missing_scores" => 0})
+
+    expect(ActionMailer::Base.deliveries.count).to eq 1
   end
 
   it 'copes with exceptions when sending errors' do


### PR DESCRIPTION
Some LMS's change the sourcedid per launch.  We don't want to accumulate a bunch of callbacks for one user and one LMS link when they are all reporting the same score.  Furthermore, the LTI 1.1 implementation guide even says that we should only keep the latest.

Changes the code...
* to make callback records include the `resource_link_id` which is a required parameter in the launch and which identifies the link that was clicked.  
* to keep only one callback per `resource_link_id` / user combo
* to somewhat unrelatedly email devs when there's an error syncing scores.