### PR TITLE
Expose user info page to support team

### DIFF
--- a/app/views/customer_service/users/index.html.erb
+++ b/app/views/customer_service/users/index.html.erb
@@ -5,4 +5,10 @@
                      items: @user_search.items,
                      total_count: @user_search.total_count,
                      page: params[:page],
-                     per_page: @per_page } %>
+                     per_page: @per_page,
+                     extra_headers: 'Actions',
+                     extra_fields_proc: lambda do |user| %>
+          <td>
+              <%= link_to 'Info', info_customer_service_users_path(id: user.id), class: "btn btn-xs btn-primary" %>
+          </td>
+<% end } %>

--- a/app/views/customer_service/users/info.html.erb
+++ b/app/views/customer_service/users/info.html.erb
@@ -1,4 +1,4 @@
 <% @page_header = "Misc User Info" %>
 
 <%= render partial: 'manager/users/info',
-           locals: { is_admin: true } %>
+           locals: { is_admin: false } %>

--- a/app/views/manager/users/_info.html.erb
+++ b/app/views/manager/users/_info.html.erb
@@ -1,0 +1,56 @@
+<%
+  is_admin ||= false
+%>
+
+<%
+  profile = if params[:openstax_uid]
+    profile = User::Models::Profile.joins{account}.where{account.openstax_uid.eq my{params[:openstax_uid]}}.first
+  elsif params[:id]
+    profile = User::Models::Profile.find(params[:id])
+  else
+    raise "Need 'id' or 'openstax_uid' parameter"
+  end
+
+  user = User::User.find(profile.id)
+%>
+
+<h3>Name</h3>
+
+<div style="float:right">
+<%= link_to "Profile on Accounts",
+             "#{Rails.application.secrets.openstax['accounts']['url']}/admin/users/#{profile.account.openstax_uid}/edit", class: "btn btn-xs btn-primary" %>
+
+             <% if is_admin %>
+              <%= link_to 'Edit in Tutor', edit_admin_user_path(user.id), class: "btn btn-xs btn-primary" %>
+              <%= link_to 'Sign in as in Tutor', become_admin_user_path(user.id),
+                                        method: :post, class: "btn btn-xs btn-primary" %>
+            <% end %>
+</div>
+
+<%= profile.name %>
+
+<h3>Courses</h3>
+
+<% courses = GetUserCourses[user: user] %>
+
+<% courses.sort_by do |cc|
+     [-cc.year, -CourseProfile::Models::Course.terms[cc.term], cc.name]
+   end.each do |course| %>
+  <ol>
+    <li>
+      <%= link_to course.name, (is_admin ? edit_admin_course_path(course) : customer_service_course_path(course)) %> //
+      <%= course.term %> <%= course.year %> //
+      <%= course.is_concept_coach ? "Concept Coach" : "Tutor" %> //
+      <%= course.is_college.nil? ? "" : (course.is_college ? "College" : "High School") %> //
+
+      <% roles = GetUserCourseRoles[courses: course, user: user] %>
+
+      <% roles.each do |role| %>
+          [ <%= role.role_type %> |
+          <%= role.created_at.in_time_zone('Central Time (US & Canada)')
+                             .strftime("%m/%d/%Y %H:%M:%S") %> Central |
+          <%= role.research_identifier %> ]
+      <% end %>
+    </li>
+  </ol>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,7 +345,11 @@ Rails.application.routes.draw do
   namespace :customer_service do
     root 'console#index'
 
-    resources :users, only: [:index]
+    resources :users, only: [:index] do
+      collection do
+        get :info
+      end
+    end
 
     resources :ecosystems, only: [:index] do
       get :manifest, on: :member


### PR DESCRIPTION
Exposes the user info page to the support team.  

Adds an "Info" button next to users in the user search:

![image](https://user-images.githubusercontent.com/1001691/32022568-0bf86f64-b994-11e7-99e8-7ef7d2b93288.png)

When clicked, you see what courses the user is in, along with their role, and their "deidentifier" ("918b8b26" in this case) which can be used to talk about students without exposing sensitive information.

![image](https://user-images.githubusercontent.com/1001691/32022579-143cf762-b994-11e7-867d-bab680c0959a.png)

Also includes a link to the user's admin edit page on Accounts (requires being an admin there).  The Accounts admin page has a link back to this edit page, but for the moment that link only goes to the Tutor admin version of this page (you could always manually change the URL until we add a new support button there).

