### PR TITLE
Fix error handling in the demo script

### DIFF
--- a/lib/demo/base.rb
+++ b/lib/demo/base.rb
@@ -99,14 +99,6 @@ class Demo::Base
     results
   end
 
-  # Same as wait_for_parallel_completion,
-  # but raises an exception if any of the child processes failed
-  def wait_for_parallel_completion!
-    results = wait_for_parallel_completion
-
-    raise('Child process failed') if results.any? { |result| !result.last.success? }
-  end
-
   def sign_contract(user:, name:)
     string_name = name.to_s
     return if FinePrint::Contract.where{name == string_name}.none?

--- a/lib/fork_with_connection.rb
+++ b/lib/fork_with_connection.rb
@@ -29,7 +29,9 @@ module ForkWithConnection
         # Run the closure passed to the fork_with_new_connection method
         exit_status = yield
       rescue Exception => exception
-        Rails.logger.fatal "Forked operation failed with exception: #{e}"
+        Rails.logger.fatal do
+          "Child process failed with exception: #{exception}\n#{exception.backtrace.first}"
+        end
 
         # The op failed, so note it for the Process exit
         exit_status = false
@@ -45,7 +47,7 @@ module ForkWithConnection
           !!exit_status
         end
 
-        # Exit without running any at_exit hooks
+        # Exit without running any at_exit hooks (leave those to the parent process)
         exit! exit_status
       end
     end.tap do |pid|


### PR DESCRIPTION
So forked exceptions properly cause the script to fail and print the first line of the backtrace