### PR TITLE
Reset nil is college and make it default to true in the representer

### DIFF
--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -158,6 +158,7 @@ module Api::V1
     property :is_college,
              readable: true,
              writeable: true,
+             getter: ->(*) { is_college.nil? ? true : is_college },
              schema_info: {
                type: 'boolean'
              }

--- a/db/migrate/20171102155254_reset_is_college.rb
+++ b/db/migrate/20171102155254_reset_is_college.rb
@@ -1,0 +1,12 @@
+class ResetIsCollege < ActiveRecord::Migration
+  def up
+    sanitized_date = CourseProfile::Models::Course.sanitize DateTime.new(2017, 6, 30)
+    CourseProfile::Models::Course
+      .where(is_preview: false, is_college: true)
+      .where("created_at >= #{sanitized_date}")
+      .update_all(is_college: nil)
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171027145335) do
+ActiveRecord::Schema.define(version: 20171102155254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/representers/api/v1/course_representer_shared_examples.rb
+++ b/spec/representers/api/v1/course_representer_shared_examples.rb
@@ -78,8 +78,17 @@ module Api::V1
       expect(represented['is_concept_coach']).to eq true
     end
 
-    it 'shows whether or not it is a college course' do
+    it 'shows whether or not it is a college course, defaulting to true' do
       expect(represented['is_college']).to eq false
+
+      course.update_attribute :is_college, nil
+      expect(described_class.new(course).as_json['is_college']).to eq true
+
+      course.update_attribute :is_college, true
+      expect(described_class.new(course).as_json['is_college']).to eq true
+
+      course.update_attribute :is_college, false
+      expect(described_class.new(course).as_json['is_college']).to eq false
     end
 
     it "shows the id of the source course's catalog offering" do


### PR DESCRIPTION
We recently had an issue where college courses were being marked as high school. This is because we no longer ask instructors if they have a college course, and the FE was defaulting to high school when is_college is NULL. To solve this, I manually marked those courses as is_college: true.

This PR sets them back to is_college: nil (since we never asked the instructors we don't know for sure). It also makes the representer return is_college: true when it is nil so these courses still show up as college courses.