### PR TITLE
allow restoring a student even if the id is in use

### DIFF
--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -5,10 +5,7 @@ module CourseMembership
     def exec(student:)
       fatal_error(code: :already_active,
                   message: 'Student is already active') unless student.dropped?
-      fatal_error(code: :student_identifier_has_already_been_taken,
-                  message: 'Student identifier has already been taken') \
-        if student.student_identifier.present? &&
-           CourseMembership::Models::Student.exists?(student_identifier: student.student_identifier)
+
       student.restore
       student.clear_association_cache
       transfer_errors_from(student, { type: :verbatim }, true)

--- a/spec/controllers/api/v1/students_controller_spec.rb
+++ b/spec/controllers/api/v1/students_controller_spec.rb
@@ -309,25 +309,17 @@ RSpec.describe Api::V1::StudentsController, type: :controller, api: true, versio
               expect(student.payment_due_at).to eq student_original_payment_due_at
             end
 
-            it 'fails if the student\'s identifier is taken by someone else' do
+            it 'succeeds even if the student\'s identifier is taken by someone else' do
               student_id = '123456789'
               student.update_attribute :student_identifier, student_id
               FactoryGirl.create :course_membership_student, course: course,
                                                              student_identifier: student_id
 
               api_put :undrop, teacher_token, parameters: valid_params
-              expect(response).to have_http_status(:unprocessable_entity)
-              expect(response.body_as_hash[:status]).to eq 422
-              expect(response.body_as_hash[:errors].first[:code]).to(
-                eq 'student_identifier_has_already_been_taken'
-              )
-              expect(response.body_as_hash[:errors].first[:message]).to(
-                eq 'Student identifier has already been taken'
-              )
-
+              expect(response).to have_http_status(:ok)
               student.reload
               expect(student.persisted?).to eq true
-              expect(student.dropped?).to eq true
+              expect(student.dropped?).to eq false
             end
           end
         end


### PR DESCRIPTION
Also the code had a bug where it was checking all students, including the current one so it'd always fail this check