### PR TITLE
Add app name and environment to dev mailer subjects

### DIFF
--- a/app/mailers/dev_mailer.rb
+++ b/app/mailers/dev_mailer.rb
@@ -4,7 +4,7 @@ class DevMailer < ApplicationMailer
     @object = object
     mail to: to || Rails.application.secrets.exception['recipients'],
          from: from || Rails.application.secrets.exception['sender'],
-         subject: subject
+         subject: "[Tutor] (#{Rails.application.secrets.environment_name}) #{subject}"
   end
 
 end

--- a/spec/requests/lms_score_push_spec.rb
+++ b/spec/requests/lms_score_push_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe 'LMS Score Push', type: :request, version: :v1 do
                     data: {"num_callbacks" => 1, "num_missing_scores" => 0})
 
     expect(ActionMailer::Base.deliveries.count).to eq 1
+    expect(ActionMailer::Base.deliveries.last.subject).to eq "[Tutor] (test) Lms::SendCourseScores errors"
   end
 
   it 'copes with exceptions when sending errors' do


### PR DESCRIPTION
Adds the  `[Tutor] (prodtutor)` subject prefix to several of our system-generated emails.  