### PR TITLE
Reraise timeout errors on ExportAndUploadResearchData

### DIFF
--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -161,9 +161,11 @@ class ExportAndUploadResearchData
             ))
 
             file << row
-          rescue StandardError => e
+          rescue StandardError => ex
+            raise ex if ex.is_a? Timeout::Error
+
             Rails.logger.error do
-              "Skipped step #{step.id} for #{e.inspect} @ #{e.try(:backtrace).try(:first)}\n"
+              "Skipped step #{step.id} for #{ex.inspect} @ #{ex.try(:backtrace).try(:first)}\n"
             end
           end
         end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -19,7 +19,7 @@ Delayed::Worker.sleep_delay = 1
 Delayed::Worker.default_queue_name = :default
 
 # max_run_time must be longer than the longest-running job
-Delayed::Worker.max_run_time = 4.hours
+Delayed::Worker.max_run_time = 8.hours
 
 # Default queue priorities
 Delayed::Worker.queue_attributes = {


### PR DESCRIPTION
To prevent research report corruption

Also increase the timeout to 8 hours