### PR TITLE
Do not send LMS score error email if no errors

### DIFF
--- a/app/subsystems/lms/send_course_scores.rb
+++ b/app/subsystems/lms/send_course_scores.rb
@@ -119,6 +119,8 @@ class Lms::SendCourseScores
   end
 
   def send_errors_to_devs
+    return if @errors.empty?
+
     DevMailer.inspect_object(
       object: {
         course: @course.id,


### PR DESCRIPTION
Current code sends error emails when there are no errors ... which is annoying.