### PR TITLE
Reduce background job churn due to caching routines

### DIFF
--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -1,6 +1,6 @@
 class DistributeTasks
 
-  lev_routine active_job_enqueue_options: { queue: :low_priority }
+  lev_routine
 
   uses_routine IndividualizeTaskingPlans, as: :individualize_tasking_plans
 

--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -1,6 +1,6 @@
 class ExportAndUploadResearchData
 
-  lev_routine active_job_enqueue_options: { queue: :long_running }, express_output: :filename
+  lev_routine active_job_enqueue_options: { queue: :lowest_priority }, express_output: :filename
 
   def exec(filename: nil, task_types: [], from: nil, to: nil)
     fatal_error(code: :tasks_types_missing, message: "You must specify the types of Tasks") \

--- a/app/routines/export_exercise_exclusions.rb
+++ b/app/routines/export_exercise_exclusions.rb
@@ -1,6 +1,6 @@
 class ExportExerciseExclusions
 
-  lev_routine active_job_enqueue_options: { queue: :long_running }
+  lev_routine active_job_enqueue_options: { queue: :lowest_priority }
 
   protected
 

--- a/app/routines/import_ecosystem_manifest.rb
+++ b/app/routines/import_ecosystem_manifest.rb
@@ -1,6 +1,6 @@
 class ImportEcosystemManifest
 
-  lev_routine express_output: :ecosystem, active_job_enqueue_options: { queue: :long_running }
+  lev_routine express_output: :ecosystem, active_job_enqueue_options: { queue: :lowest_priority }
 
   uses_routine FetchAndImportBookAndCreateEcosystem, as: :fetch_and_import,
                                                      translations: { outputs: { type: :verbatim } }

--- a/app/routines/import_roster.rb
+++ b/app/routines/import_roster.rb
@@ -1,6 +1,6 @@
 class ImportRoster
 
-  lev_routine active_job_enqueue_options: { queue: :long_running }
+  lev_routine active_job_enqueue_options: { queue: :lowest_priority }
 
   uses_routine User::FindOrCreateUser, as: :find_or_create_user,
                                        translations: { outputs: { type: :verbatim } }

--- a/app/routines/populate_preview_course_content.rb
+++ b/app/routines/populate_preview_course_content.rb
@@ -12,7 +12,7 @@ class PopulatePreviewCourseContent
   # Should correspond to the total preview course duration, in weeks
   MAX_NUM_ASSIGNED_CHAPTERS = 10
 
-  lev_routine active_job_enqueue_options: { queue: :long_running }
+  lev_routine active_job_enqueue_options: { queue: :lowest_priority }
 
   uses_routine User::CreateUser, as: :create_user
   uses_routine CourseMembership::CreatePeriod, as: :create_period

--- a/app/routines/reassign_published_period_task_plans.rb
+++ b/app/routines/reassign_published_period_task_plans.rb
@@ -1,6 +1,6 @@
 class ReassignPublishedPeriodTaskPlans
 
-  lev_routine active_job_enqueue_options: { queue: :low_priority }
+  lev_routine
 
   uses_routine DistributeTasks, as: :distribute
 

--- a/app/routines/work_preview_course_tasks.rb
+++ b/app/routines/work_preview_course_tasks.rb
@@ -6,7 +6,7 @@ class WorkPreviewCourseTasks
 
   FREE_RESPONSE = 'This is where you can see each student’s answer in his or her own words.'
 
-  lev_routine active_job_enqueue_options: { queue: :long_running, wait: 30.seconds }
+  lev_routine active_job_enqueue_options: { queue: :lowest_priority, wait: 60.seconds }
 
   uses_routine Preview::WorkTask, as: :work_task
 

--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -15,7 +15,7 @@ module CourseMembership
       period = student.period
       ReassignPublishedPeriodTaskPlans[period: student.period]
 
-      Tasks::UpdatePeriodCaches.perform_later(periods: period)
+      Tasks::UpdatePeriodCaches.perform_later(periods: period, force: true)
 
       outputs.student = student
     end

--- a/app/subsystems/course_membership/inactivate_student.rb
+++ b/app/subsystems/course_membership/inactivate_student.rb
@@ -14,7 +14,7 @@ module CourseMembership
       RefundPayment.perform_later(uuid: student.uuid) if student.is_refund_allowed
 
       period = student.period
-      Tasks::UpdatePeriodCaches.perform_later(periods: period) unless period.nil?
+      Tasks::UpdatePeriodCaches.perform_later(periods: period, force: true)
 
       outputs.student = student
     end

--- a/app/subsystems/tasks/models/task_cache.rb
+++ b/app/subsystems/tasks/models/task_cache.rb
@@ -10,6 +10,7 @@ class Tasks::Models::TaskCache < ApplicationRecord
   validates :ecosystem,        presence: true, uniqueness: { scope: :tasks_task_id }
 
   validates :opens_at, :due_at, :feedback_at, timeliness: { type: :date }, allow_nil: true
+  validates :is_cached_for_period, inclusion: { in: [ true, false ] }
 
   def practice?
     chapter_practice? || page_practice? || mixed_practice? || practice_worst_topics?

--- a/app/subsystems/tasks/update_task_caches.rb
+++ b/app/subsystems/tasks/update_task_caches.rb
@@ -1,7 +1,7 @@
 # Updates the TaskCaches, used by the Quick Look and Student Performance Forecast
 # Tasks not assigned to a student (preview tasks) are ignored
 class Tasks::UpdateTaskCaches
-  lev_routine transaction: :read_committed
+  lev_routine active_job_enqueue_options: { queue: :low_priority }, transaction: :read_committed
 
   uses_routine GetCourseEcosystemsMap, as: :get_course_ecosystems_map
 
@@ -183,7 +183,15 @@ class Tasks::UpdateTaskCaches
     # Update the TaskCaches
     Tasks::Models::TaskCache.import task_caches, validate: false, on_duplicate_key_update: {
       conflict_target: [ :tasks_task_id, :content_ecosystem_id ],
-      columns: [ :opens_at, :due_at, :feedback_at, :student_ids, :student_names, :as_toc ]
+      columns: [
+        :opens_at,
+        :due_at,
+        :feedback_at,
+        :student_ids,
+        :student_names,
+        :as_toc,
+        :is_cached_for_period
+      ]
     }
 
     # Update the PeriodCaches
@@ -330,7 +338,8 @@ class Tasks::UpdateTaskCaches
       feedback_at: task.feedback_at,
       student_ids: student_ids,
       student_names: student_names,
-      as_toc: toc
+      as_toc: toc,
+      is_cached_for_period: false
     )
   end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -23,10 +23,10 @@ Delayed::Worker.max_run_time = 4.hours
 
 # Default queue priorities
 Delayed::Worker.queue_attributes = {
-  high_priority: { priority: -5 },
-  default:       { priority:  0 },
-  low_priority:  { priority:  5 },
-  long_running:  { priority: 10 }
+  high_priority:   { priority: -5 },
+  default:         { priority:  0 },
+  low_priority:    { priority:  5 },
+  lowest_priority: { priority: 10 }
 }
 
 # Allows us to use this gem in tests instead of setting the ActiveJob adapter to :inline

--- a/db/migrate/20171219012010_add_is_cached_for_period_to_tasks_task_caches.rb
+++ b/db/migrate/20171219012010_add_is_cached_for_period_to_tasks_task_caches.rb
@@ -1,0 +1,11 @@
+class AddIsCachedForPeriodToTasksTaskCaches < ActiveRecord::Migration
+  def change
+    add_column :tasks_task_caches, :is_cached_for_period, :boolean
+
+    Tasks::Models::TaskCache.update_all(is_cached_for_period: true)
+
+    change_column_null :tasks_task_caches, :is_cached_for_period, false
+
+    add_index :tasks_task_caches, :is_cached_for_period
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212165309) do
+ActiveRecord::Schema.define(version: 20171219012010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -777,11 +777,13 @@ ActiveRecord::Schema.define(version: 20171212165309) do
     t.text     "as_toc",               default: "{}", null: false
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.boolean  "is_cached_for_period",                null: false
   end
 
   add_index "tasks_task_caches", ["content_ecosystem_id"], name: "index_tasks_task_caches_on_content_ecosystem_id", using: :btree
   add_index "tasks_task_caches", ["due_at"], name: "index_tasks_task_caches_on_due_at", using: :btree
   add_index "tasks_task_caches", ["feedback_at"], name: "index_tasks_task_caches_on_feedback_at", using: :btree
+  add_index "tasks_task_caches", ["is_cached_for_period"], name: "index_tasks_task_caches_on_is_cached_for_period", using: :btree
   add_index "tasks_task_caches", ["opens_at"], name: "index_tasks_task_caches_on_opens_at", using: :btree
   add_index "tasks_task_caches", ["student_ids"], name: "index_tasks_task_caches_on_student_ids", using: :gin
   add_index "tasks_task_caches", ["task_type"], name: "index_tasks_task_caches_on_task_type", using: :btree

--- a/spec/factories/tasks/task_caches.rb
+++ b/spec/factories/tasks/task_caches.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :tasks_task_cache, class: 'Tasks::Models::TaskCache' do
-    association   :task,      factory: :tasks_task
-    association   :ecosystem, factory: :content_ecosystem
-    task_type     { task.task_type }
-    student_ids   { task.taskings.map { |tasking| tasking.role.student.id } }
-    student_names { task.taskings.map { |tasking| tasking.role.student.name } }
-    as_toc        { { books: [] } }
+    association          :task,      factory: :tasks_task
+    association          :ecosystem, factory: :content_ecosystem
+    task_type            { task.task_type }
+    student_ids          { task.taskings.map { |tasking| tasking.role.student.id } }
+    student_names        { task.taskings.map { |tasking| tasking.role.student.name } }
+    as_toc               { { books: [] } }
+    is_cached_for_period { [ true, false ].sample }
   end
 end


### PR DESCRIPTION
Should help with Redis running out of memory on prod

- Reduce duplicate work in UpdatePeriodCache
- Set caching routines to low_priority
- Set assignment publishing back to normal priority
- Rename long_running queue to lowest_priority