### PR TITLE
allow content analysts access to ecosystem

### DIFF
--- a/app/access_policies/ecosystem_access_policy.rb
+++ b/app/access_policies/ecosystem_access_policy.rb
@@ -2,8 +2,8 @@ class EcosystemAccessPolicy
   def self.action_allowed?(action, requestor, ecosystem)
     return false unless requestor.is_human?
 
-    # Admins can do all things content
-    return true if requestor.is_admin?
+    # Admins and content analysts can do all things content
+    return true if requestor.is_admin? or requestor.is_content_analyst?
 
     case action
     when :index

--- a/spec/access_policies/ecosystem_access_policy_spec.rb
+++ b/spec/access_policies/ecosystem_access_policy_spec.rb
@@ -79,30 +79,23 @@ RSpec.describe EcosystemAccessPolicy, type: :access_policy, speed: :medium do
     end
   end
 
-  context 'content analysts' do
-    let(:requestor) { content_analyst }
-
-    context 'index' do
-      let(:action) { :index }
-      it { should eq true }
-    end
-
-    [:create, :update, :destroy, :manifest, :readings, :exercises].each do |test_action|
+  [:index, :create, :update, :destroy, :manifest, :readings, :exercises].each do |test_action|
+    context 'admins' do
+      let(:requestor) { admin }
       context "#{test_action}" do
         let(:action) { test_action }
-        it { should eq false }
+        it { should eq true }
       end
     end
-  end
 
-  context 'admins' do
-    let(:requestor) { admin }
+    context 'content analysts' do
+      let(:requestor) { content_analyst }
 
-    [:index, :create, :update, :destroy, :manifest, :readings, :exercises].each do |test_action|
       context "#{test_action}" do
         let(:action) { test_action }
         it { should eq true }
       end
     end
   end
+
 end


### PR DESCRIPTION
I took a stab at fixing the QA view and discovered that the "content" user couldn't request readings or exercises.