### PR TITLE
assign missing surveys routine

### DIFF
--- a/app/controllers/research/survey_plans_controller.rb
+++ b/app/controllers/research/survey_plans_controller.rb
@@ -7,7 +7,7 @@ class Research::SurveyPlansController < Research::BaseController
   end
 
   def create
-    @survey_plan = Research::Models::SurveyPlan.new(cleared_params)# params[:research_models_survey_plan])
+    @survey_plan = Research::Models::SurveyPlan.new(cleared_params)
 
     respond_to do |format|
       if @survey_plan.save
@@ -39,7 +39,7 @@ class Research::SurveyPlansController < Research::BaseController
   def publish
     respond_to do |format|
       begin
-        Research::PublishSurveyPlan[survey_plan: Research::Models::SurveyPlan.first]
+        Research::PublishSurveyPlan[survey_plan: @survey_plan]
         format.html { redirect_to research_survey_plans_path, notice: "Published survey plan #{@survey_plan.id}"}
       rescue
         format.html { redirect_to research_survey_plans_path, alert: "Could not publish survey plan #{@survey_plan.id}"}

--- a/app/subsystems/course_membership/add_student.rb
+++ b/app/subsystems/course_membership/add_student.rb
@@ -9,6 +9,9 @@ class CourseMembership::AddStudent
   uses_routine CourseProfile::MarkCourseEnrolled,
                as: :mark_course_enrolled, translations: { outputs: { type: :verbatim } }
 
+  uses_routine Research::AssignMissingSurveys, as: :assign_missing_surveys,
+                                               translations: { outputs: { type: :verbatim } }
+
   protected
 
   def exec(period:, role:, student_identifier: nil,
@@ -36,5 +39,7 @@ class CourseMembership::AddStudent
     )
 
     run(:mark_course_enrolled, course: course)
+
+    run(:assign_missing_surveys, student: student)
   end
 end

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -12,6 +12,8 @@ class CourseMembership::Models::Student < ApplicationRecord
   has_many :enrollments, inverse_of: :student
   has_one :latest_enrollment, -> { latest }, class_name: '::CourseMembership::Models::Enrollment'
 
+  has_many :surveys, subsystem: :research, inverse_of: :student
+
   before_validation :init_first_paid_at
 
   validates :role, presence: true, uniqueness: true

--- a/app/subsystems/research/add_course_to_study.rb
+++ b/app/subsystems/research/add_course_to_study.rb
@@ -2,11 +2,14 @@ class Research::AddCourseToStudy
 
   lev_routine
 
+  uses_routine Research::AssignMissingSurveys, as: :assign_missing_surveys,
+                                               translations: { outputs: { type: :verbatim } }
+
   def exec(course:, study:)
     study_course = Research::Models::StudyCourse.create(course: course, study: study)
     transfer_errors_from(study_course, {type: :verbatim}, true)
 
-    # TODO assign surveys that are published
+    run(:assign_missing_surveys, course: course)
   end
 
 end

--- a/app/subsystems/research/assign_missing_surveys.rb
+++ b/app/subsystems/research/assign_missing_surveys.rb
@@ -1,0 +1,101 @@
+class Research::AssignMissingSurveys
+
+  lev_routine
+
+  def exec(survey_plan: nil, course: nil, student: nil)
+    # Only one input should be present, if multiple are set only one
+    # will be used.
+
+    missing_surveys = missing_surveys_for_student(student) ||
+                      missing_surveys_for_course(course) ||
+                      missing_surveys_for_survey_plan(survey_plan)
+
+    return if missing_surveys.empty? # e.g. if only non-published plans
+
+    Research::Models::Survey.import!(missing_surveys)
+  end
+
+  def missing_surveys_for_student(student)
+    return nil if student.nil?
+
+    # Can find multiple surveys missing for this one student
+
+    survey_plan_ids_not_assigned =
+      Research::Models::SurveyPlan
+        .published
+        .joins{study.courses.students}
+        .where{study.courses.students.id == my{student.id}}
+        .where(
+          <<-WHERE_SQL.strip_heredoc
+            NOT EXISTS (
+              SELECT *
+              FROM "research_surveys"
+              WHERE "research_surveys"."course_membership_student_id" = #{student.id}
+              AND "research_surveys"."research_survey_plan_id" = "research_survey_plans"."id"
+            )
+          WHERE_SQL
+        )
+        .pluck(:id)
+
+    survey_plan_ids_not_assigned.map do |survey_plan_id|
+      Research::Models::Survey.new(
+        course_membership_student_id: student.id,
+        research_survey_plan_id: survey_plan_id,
+      )
+    end
+  end
+
+  def missing_surveys_for_survey_plan(survey_plan)
+    return nil if survey_plan.nil? || survey_plan.is_published?
+
+    # Can find multiple students missing this one survey
+
+    student_ids_needing_survey = student_ids_needing_survey_for_plan(survey_plan)
+
+    student_ids_needing_survey.map do |student_id|
+      Research::Models::Survey.new(
+        course_membership_student_id: student_id,
+        research_survey_plan_id: survey_plan.id,
+      )
+    end
+  end
+
+  def missing_surveys_for_course(course)
+    return nil if course.nil?
+
+    # Can find multiple students missing multiple surveys
+
+    survey_plans =
+      Research::Models::SurveyPlan
+        .published
+        .joins{study.courses}
+        .where{study.courses.id == my{course.id}}
+
+    survey_plans.flat_map do |survey_plan|
+      student_ids_needing_survey = student_ids_needing_survey_for_plan(survey_plan)
+
+      student_ids_needing_survey.map do |student_id|
+        Research::Models::Survey.new(
+          course_membership_student_id: student_id,
+          research_survey_plan_id: survey_plan.id,
+        )
+      end
+    end
+  end
+
+  def student_ids_needing_survey_for_plan(survey_plan)
+    CourseMembership::Models::Student
+      .joins{course.studies}
+      .where{course.studies.id == my{survey_plan.research_study_id}}
+      .where(
+        <<-WHERE_SQL.strip_heredoc
+          NOT EXISTS (
+            SELECT *
+            FROM "research_surveys"
+            WHERE "research_surveys"."course_membership_student_id" = "course_membership_students"."id"
+            AND "research_surveys"."research_survey_plan_id" = #{survey_plan.id}
+          )
+        WHERE_SQL
+    ).pluck(:id)
+  end
+end

--- a/app/subsystems/research/models/survey.rb
+++ b/app/subsystems/research/models/survey.rb
@@ -1,5 +1,5 @@
 class Research::Models::Survey < ApplicationRecord
-  belongs_to :survey_plan
+  belongs_to :survey_plan, subsystem: :research
   belongs_to :student, subsystem: :course_membership
 
   validates :student, uniqueness: { scope: :research_survey_plan_id }

--- a/app/subsystems/research/models/survey_plan.rb
+++ b/app/subsystems/research/models/survey_plan.rb
@@ -5,6 +5,8 @@ class Research::Models::SurveyPlan < ApplicationRecord
   validates :title_for_students, presence: true
   validate :changes_allowed
 
+  scope :published, -> { where.not(published_at: nil) }
+
   def destroy
     false
   end

--- a/app/subsystems/research/publish_survey_plan.rb
+++ b/app/subsystems/research/publish_survey_plan.rb
@@ -2,27 +2,13 @@ class Research::PublishSurveyPlan
 
   lev_routine
 
+  uses_routine Research::AssignMissingSurveys, as: :assign_missing_surveys,
+                                               translations: { outputs: { type: :verbatim } }
+
   def exec(survey_plan:)
     raise "Cannot publish an already-published survey plan" if survey_plan.is_published?
 
-    # TODO move most of this into AssignMissingSurveys
-
-    student_ids =
-      CourseMembership::Models::Student
-        .joins{course.studies.survey_plans}
-        .where{course.studies.survey_plans.id == my{survey_plan.id}}
-        .pluck(:id)
-
-    # Add code to not assign surveys that already exist
-
-    surveys = student_ids.map do |student_id|
-      Research::Models::Survey.new(
-        course_membership_student_id: student_id,
-        research_survey_plan_id: survey_plan.id,
-      )
-    end
-
-    Research::Models::Survey.import!(surveys)
+    run(:assign_missing_surveys, survey_plan: survey_plan)
 
     survey_plan.update_attributes(published_at: Time.current)
     transfer_errors_from(survey_plan, {type: :verbatim}, true)

--- a/spec/factories/research/study.rb
+++ b/spec/factories/research/study.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :research_study, class: '::Research::Models::Study' do
+    name { Faker::Name.name }
+  end
+end

--- a/spec/factories/research/study_course.rb
+++ b/spec/factories/research/study_course.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :research_study_course, class: '::Research::Models::ToolConsumer' do
+    association :study, factory: :research_study
+    association :course, factory: :course_profile_course
+  end
+end

--- a/spec/factories/research/survey.rb
+++ b/spec/factories/research/survey.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :research_survey, class: '::Research::Models::ToolConsumer' do
+    association :survey_plan, factory: :research_study
+    association :student, factory: :course_membership_student
+
+    trait :completed do
+      completed_at { Time.now }
+    end
+
+    trait :hidden do
+      permanently_hidden_at { Time.now }
+    end
+  end
+end

--- a/spec/factories/research/survey_plan.rb
+++ b/spec/factories/research/survey_plan.rb
@@ -1,0 +1,44 @@
+FactoryBot.define do
+  factory :research_survey_plan, class: '::Research::Models::SurveyPlan' do
+    association :study, factory: :research_study
+
+    title_for_researchers { Faker::Lorem.sentence }
+    title_for_students { Faker::Lorem.sentence }
+
+    survey_js_model <<-MODEL
+      {
+       pages: [
+        {
+         name: "page1",
+         elements: [
+          {
+           type: "text",
+           name: "question1",
+           title: "How old are you?"
+          }
+         ]
+        },
+        {
+         name: "page2",
+         elements: [
+          {
+           type: "rating",
+           name: "What's your favorite number?"
+          }
+         ]
+        }
+       ]
+      }
+    MODEL
+
+    trait :published do
+      after(:create) do |plan|
+        plan.update_attributes(published_at: Time.now)
+      end
+    end
+
+    trait :hidden do
+      permanently_hidden_at { Time.now }
+    end
+  end
+end

--- a/spec/subsystems/course_membership/add_student_spec.rb
+++ b/spec/subsystems/course_membership/add_student_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe CourseMembership::AddStudent, type: :routine do
       expect(result.errors).to be_empty
       expect(result.outputs.student.student_identifier).to eq sid
     end
+
+    it "assigns any published surveys" do
+      study = FactoryBot.create :research_study
+      Research::AddCourseToStudy[course: course, study: study]
+      survey_plan = FactoryBot.create :research_survey_plan, :published, study: study
+
+      student = described_class[period: period, role: role]
+      expect(student.surveys.map(&:research_survey_plan_id)).to eq [survey_plan.id]
+    end
   end
 
   context "when adding an existing student role to a course" do
@@ -64,4 +73,5 @@ RSpec.describe CourseMembership::AddStudent, type: :routine do
       expect(student.period.id).to eq period_1.id
     end
   end
+
 end

--- a/spec/subsystems/research/add_course_to_study_spec.rb
+++ b/spec/subsystems/research/add_course_to_study_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Research::AddCourseToStudy do
+
+  before(:each) do
+    @course = FactoryBot.create :course_profile_course
+    @period = FactoryBot.create :course_membership_period, course: @course
+
+    @student_1_user = FactoryBot.create(:user)
+    @student_2_user = FactoryBot.create(:user)
+
+    @student_1 = AddUserAsPeriodStudent[period: @period, user: @student_1_user].student
+    @student_2 = AddUserAsPeriodStudent[period: @period, user: @student_2_user].student
+
+    @study = FactoryBot.create :research_study
+  end
+
+  let(:survey_plan) { FactoryBot.create :research_survey_plan, study: @study }
+
+  it "adds the course to the study" do
+    described_class[study: @study, course: @course]
+    expect(@study.courses).to include(@course)
+    expect(@course.studies).to include(@study)
+  end
+
+  it "freaks out if course already in study" do
+    described_class[study: @study, course: @course]
+    expect{
+      described_class[study: @study, course: @course]
+    }.to raise_error(StandardError)
+  end
+
+  it "assigns previously-published surveys to course students" do
+    survey_plan = FactoryBot.create :research_survey_plan, :published, study: @study
+    described_class[study: @study, course: @course]
+
+    [@student_1, @student_2].each do |student|
+      expect(student.surveys.map(&:research_survey_plan_id)).to eq [survey_plan.id]
+    end
+  end
+
+  it "does not assign unpublished surveys to course students" do
+    survey_plan = FactoryBot.create :research_survey_plan, study: @study
+    described_class[study: @study, course: @course]
+
+    [@student_1, @student_2].each do |student|
+      expect(student.surveys).to be_empty
+    end
+  end
+
+  it "does not change assignment for students who already have it" do
+    # Distribute survey to 1st course
+    survey_plan = FactoryBot.create :research_survey_plan, :published, study: @study
+    described_class[study: @study, course: @course]
+
+    # Add a new course to the study...
+    another_course = FactoryBot.create :course_profile_course
+    another_period = FactoryBot.create :course_membership_period, course: another_course
+    student_3_user = FactoryBot.create(:user)
+    student_3 = AddUserAsPeriodStudent[period: another_period, user: student_3_user].student
+
+    # It should not mess with students 1 and 2, but should add survey to student 3
+    expect{
+      described_class[study: @study, course: another_course]
+    }.to change{ Research::Models::Survey.count }.by(1)
+
+    [@student_1, @student_2, student_3].each do |student|
+      expect(student.surveys.map(&:research_survey_plan_id)).to eq [survey_plan.id]
+    end
+  end
+
+end

--- a/spec/subsystems/research/assign_missing_surveys_spec.rb
+++ b/spec/subsystems/research/assign_missing_surveys_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Research::AssignMissingSurveys do
+
+  # The specs for this routine are inside other routine specs (those
+  # that call AssignMissingSurveys).
+  #
+  #
+  # research/publish_survey_plan_spec  - tests AssignMissingSurveys[survey_plan: ...]
+  # research/add_course_to_study_spec  - tests AssignMissingSurveys[course: ...]
+  # course_membership/add_student_spec - test AssignMissingSurveys[student: ...]
+
+end

--- a/spec/subsystems/research/publish_survey_plan_spec.rb
+++ b/spec/subsystems/research/publish_survey_plan_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Research::PublishSurveyPlan do
+
+  before(:each) do
+    @course = FactoryBot.create :course_profile_course
+    @period = FactoryBot.create :course_membership_period, course: @course
+
+    @student_1_user = FactoryBot.create(:user)
+    @student_2_user = FactoryBot.create(:user)
+
+    @student_1 = AddUserAsPeriodStudent[period: @period, user: @student_1_user].student
+    @student_2 = AddUserAsPeriodStudent[period: @period, user: @student_2_user].student
+
+    @study = FactoryBot.create :research_study
+    Research::AddCourseToStudy[course: @course, study: @study]
+  end
+
+  let(:survey_plan) { FactoryBot.create :research_survey_plan, study: @study }
+
+  context "when already published" do
+    it "freaks out" do
+      expect{described_class[survey_plan: survey_plan]}.not_to raise_error
+      expect{described_class[survey_plan: survey_plan]}.to raise_error(/already-published/)
+    end
+  end
+
+  context "when not yet published" do
+    it "becomes marked as published" do
+      described_class[survey_plan: survey_plan]
+      expect(survey_plan.reload).to be_is_published
+    end
+
+    it "assigns to students missing it" do
+      described_class[survey_plan: survey_plan]
+
+      [@student_1, @student_2].each do |student|
+        expect(student.surveys.map(&:research_survey_plan_id)).to eq [survey_plan.id]
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Handles assigning surveys when (1) survey plans are published, (2) courses are added to a study with previously-published survey plans, (3) a student is added to a course in a study with previously-published survey plans.