### PR TITLE
reuse nomad campaign members

### DIFF
--- a/app/routines/track_tutor_onboarding_event.rb
+++ b/app/routines/track_tutor_onboarding_event.rb
@@ -114,7 +114,7 @@ protected
       nomad_onboarding_campaign_id = Settings::Salesforce.active_nomad_onboarding_salesforce_campaign_id
       raise(MissingOnboardingCampaignId, "nomad campaign") if nomad_onboarding_campaign_id.blank?
 
-      cm = CM.new(contact_id: sf_contact_id, campaign_id: nomad_onboarding_campaign_id)
+      cm = CM.find_or_initialize_by(contact_id: sf_contact_id, campaign_id: nomad_onboarding_campaign_id)
     end
 
     cm.first_teacher_contact_id ||= user.salesforce_contact_id

--- a/spec/cassettes/TrackTutorOnboardingEvent/sf_setup.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/sf_setup.yml
@@ -23,7 +23,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:36 GMT
+      - Thu, 18 Jan 2018 20:48:44 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -32,15 +32,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=XrGEQlMYRE-aucAEfUuLfQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:36 GMT;Max-Age=5184000
+      - BrowserId=w2bGah6NQo6MBP1ia5kjoQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:44 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=133/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -50,13 +52,13 @@ http_interactions:
       string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/001W000000cnIFcIAM"},"Id":"001W000000cnIFcIAM","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:36 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:44 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Chester","LastName":"Weissnat","AccountId":"001W000000cnIFcIAM"}'
+      string: '{"FirstName":"Darby","LastName":"Powlowski","AccountId":"001W000000cnIFcIAM"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -76,41 +78,49 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:36 GMT
+      - Thu, 18 Jan 2018 20:48:45 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data: blob: file:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com *.visualforce.com *.documentforce.com;
+        font-src https: data: blob: file:; connect-src ''self'' https:; report-uri
+        /_/ContentDomainCSP?type=appserver'
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=wuFtFHn1R0eELuDQF98z0A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:36 GMT;Max-Age=5184000
+      - BrowserId=kqnmq39dRfq2KWtwkn_rEg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:45 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=128/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/003W000000l8O4wIAE"
+      - "/services/data/v37.0/sobjects/Contact/003W000000ljcV1IAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"003W000000l8O4wIAE","success":true,"errors":[]}'
+      string: '{"id":"003W000000ljcV1IAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:39 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:47 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Campaign"
     body:
       encoding: UTF-8
-      string: '{"Name":"7d7e11f2bc951bb0"}'
+      string: '{"Name":"06564ff441a430cf"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -130,7 +140,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:39 GMT
+      - Thu, 18 Jan 2018 20:48:48 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -139,32 +149,34 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=IhcNug7STri_0grCNl1wLg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:39 GMT;Max-Age=5184000
+      - BrowserId=uxbXz9JuSj6l49x-TgU9yA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:48 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=134/48000
       Location:
-      - "/services/data/v37.0/sobjects/Campaign/701W0000000SlxwIAC"
+      - "/services/data/v37.0/sobjects/Campaign/701W0000000Sr5OIAS"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"701W0000000SlxwIAC","success":true,"errors":[]}'
+      string: '{"id":"701W0000000Sr5OIAS","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:41 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:48 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Campaign"
     body:
       encoding: UTF-8
-      string: '{"Name":"571935b808451e92"}'
+      string: '{"Name":"27667ee684cb4587"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -184,7 +196,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:41 GMT
+      - Thu, 18 Jan 2018 20:48:49 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -193,24 +205,26 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=77gLGdAkT-eOdi92ezneSA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:41 GMT;Max-Age=5184000
+      - BrowserId=c6YQ-849RLajgeGH_QJrgA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:49 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=134/48000
       Location:
-      - "/services/data/v37.0/sobjects/Campaign/701W0000000Sly1IAC"
+      - "/services/data/v37.0/sobjects/Campaign/701W0000000Sr5TIAS"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"701W0000000Sly1IAC","success":true,"errors":[]}'
+      string: '{"id":"701W0000000Sr5TIAS","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:43 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_does_not_exist/say_yes_to_like_preview_arbitrary_event_to_test_nomad_context_/when_the_nomad_campaign_ID_is_NOT_set/errors_when_the_active_campaign_ID_is_not_set.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_does_not_exist/say_yes_to_like_preview_arbitrary_event_to_test_nomad_context_/when_the_nomad_campaign_ID_is_NOT_set/errors_when_the_active_campaign_ID_is_not_set.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:27 GMT
+      - Thu, 18 Jan 2018 20:49:56 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -32,15 +32,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=Uub9nKuAQ_OBwjNZ_HhssQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:27 GMT;Max-Age=5184000
+      - BrowserId=xajxsOeeRUKvQRdbnRcIpQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:56 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=57/48000
+      - api-usage=172/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,5 +51,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:27 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_does_not_exist/say_yes_to_like_preview_arbitrary_event_to_test_nomad_context_/when_the_nomad_campaign_ID_is_set/tracks_on_a_new_campaign_member_on_the_nomad_campaign.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_does_not_exist/say_yes_to_like_preview_arbitrary_event_to_test_nomad_context_/when_the_nomad_campaign_ID_is_set/tracks_on_a_new_campaign_member_on_the_nomad_campaign.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:25 GMT
+      - Thu, 18 Jan 2018 20:49:46 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -32,15 +32,69 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=eUTj39tAQ36eXSFxRgQ8Ag;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:25 GMT;Max-Age=5184000
+      - BrowserId=9Vd1H1RuRO6STMvxPySfQg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:46 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=54/48000
+      - api-usage=162/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5TIAS%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:47 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=SLWsgr7LSsO3gfcLh9oZhg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:47 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=162/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -55,7 +109,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000Sly1IAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","like_preview_yes_at__c":"2017-07-23T23:04:00.000+00:00"}'
+      string: '{"CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","like_preview_yes_at__c":"2017-07-23T23:04:00.000+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -75,7 +129,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:26 GMT
+      - Thu, 18 Jan 2018 20:49:47 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -84,29 +138,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=aZeAbm5NQqW5lRolMZXikA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:26 GMT;Max-Age=5184000
+      - BrowserId=OmKwemypQY-xHMl8tEHeiw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:47 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=52/48000
+      - api-usage=156/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CXIA0"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMauIAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7CXIA0","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMauIAG","success":true,"errors":[]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7CXIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMauIAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -127,7 +183,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:26 GMT
+      - Thu, 18 Jan 2018 20:49:48 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,27 +192,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=iLOhfgRcSOeQfsq0AJJhcQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:26 GMT;Max-Age=5184000
+      - BrowserId=s7cDqG89SZy5MDUQAm12iQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:48 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=56/48000
+      - api-usage=152/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CXIA0"},"Id":"00vW0000003Q7CXIA0","CampaignId":"701W0000000Sly1IAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMauIAG"},"Id":"00vW0000003QMauIAG","CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CXIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMauIAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -175,7 +233,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:27 GMT
+      - Thu, 18 Jan 2018 20:49:49 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -184,18 +242,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=zLO0P2WeRiu0EmHJ7NXvXA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:27 GMT;Max-Age=5184000
+      - BrowserId=eQ7au9fuQkipoB-aS38u2A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:49 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=55/48000
+      - api-usage=159/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:27 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_does_not_exist/say_yes_to_like_preview_arbitrary_event_to_test_nomad_context_/when_the_nomad_campaign_ID_is_set/tracks_on_a_new_campaign_member_on_the_nomad_campaign_and_then_reuses_that_next_time.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_does_not_exist/say_yes_to_like_preview_arbitrary_event_to_test_nomad_context_/when_the_nomad_campaign_ID_is_set/tracks_on_a_new_campaign_member_on_the_nomad_campaign_and_then_reuses_that_next_time.yml
@@ -1,0 +1,466 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:50 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=v77QBbiOTwyDuwW8ACJGZg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:50 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=175/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5TIAS%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:50 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=mMiy8tYLRPWIC2y6NVTIsA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:50 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=179/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
+    body:
+      encoding: UTF-8
+      string: '{"CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","like_preview_yes_at__c":"2017-07-23T23:04:00.000+00:00"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:51 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=Fc9xvWvoQgqLyGjNoYGm4Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:51 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=174/48000
+      Location:
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMazIAG"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"00vW0000003QMazIAG","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMazIAG%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:52 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=C0MhDDPQRuePBxVGC0B5oQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:52 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=180/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMazIAG"},"Id":"00vW0000003QMazIAG","CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+    http_version: 
+  recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:52 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=LVcG8yIYSFq3Vw0SBdg1Ug;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:52 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=185/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 20:49:52 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5TIAS%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:53 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=SBD9z9rZRJKoF3d5kSntMQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:53 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=181/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMazIAG"},"Id":"00vW0000003QMazIAG","CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 20:49:53 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMazIAG"
+    body:
+      encoding: UTF-8
+      string: '{"latest_adoption_decision__c":"For extra credit","latest_adoption_decision_at__c":"2018-01-18T20:49:53.438+00:00"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 18 Jan 2018 20:49:54 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=ivsn_2LPRCGZ99D7jgVxIA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:54 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=172/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 20:49:54 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMazIAG%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:54 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=3Q_2rSIARciXjJcVhaGj1Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:54 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=182/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMazIAG"},"Id":"00vW0000003QMazIAG","CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":"For
+        extra credit","latest_adoption_decision_at__c":"2018-01-18T20:49:53.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 20:49:54 GMT
+- request:
+    method: delete
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMazIAG"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 18 Jan 2018 20:49:55 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=JI-mV8A6SHSiYYoSIhi2ZQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:55 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=183/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 20:49:55 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/errors_if_data_missing.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/errors_if_data_missing.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:09 GMT
+      - Thu, 18 Jan 2018 20:49:25 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=LUYdwgnNT22kDhBhOXPtQg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:09 GMT;Max-Age=5184000
+      - BrowserId=Yzf0L-KDRDyzxdTD7gF4ug;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:25 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/48000
+      - api-usage=150/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C3IAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaQIAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7C3IAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMaQIAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:09 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:26 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C3IAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaQIAW"
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +77,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:09 GMT
+      - Thu, 18 Jan 2018 20:49:26 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -84,18 +86,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=k1vJCkxaRka5oKSe-ulpaQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:09 GMT;Max-Age=5184000
+      - BrowserId=IzzEgSmUTHec3lNdx8PyKg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:26 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=45/48000
+      - api-usage=154/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:10 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:26 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/overwrites_the_first_decision_if_done_again.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/overwrites_the_first_decision_if_done_again.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:20 GMT
+      - Thu, 18 Jan 2018 20:49:39 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=_oCPYEtIQ4qpLy6MByIrwA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:20 GMT;Max-Age=5184000
+      - BrowserId=dQ71o8jQR-SWPHdJF54SMg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:39 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=46/48000
+      - api-usage=155/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7CNIA0","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMakIAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:20 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:40 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:21 GMT
+      - Thu, 18 Jan 2018 20:49:40 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,31 +88,33 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=gGI5V7p0RQC2cZoHPHobUg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:21 GMT;Max-Age=5184000
+      - BrowserId=UJ5RkA23TR65Xo0KQULMOg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:40 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/48000
+      - api-usage=149/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"},"Id":"00vW0000003Q7CNIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"},"Id":"00vW0000003QMakIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:21 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:40 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:21.130+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:40.749+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -128,7 +132,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:21 GMT
+      - Thu, 18 Jan 2018 20:49:41 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -137,23 +141,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=ED7XPKYpTxmONZ4E40y3Gw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:21 GMT;Max-Age=5184000
+      - BrowserId=uV8NdKMtTIOMQBMBlQODxg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:41 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=55/48000
+      - api-usage=151/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:21 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:41 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7CNIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMakIAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +180,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:21 GMT
+      - Thu, 18 Jan 2018 20:49:41 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -183,28 +189,30 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=NIBo9PswTA2GMj0gmiTOdA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:21 GMT;Max-Age=5184000
+      - BrowserId=dY2ApGAnSMmzIE_ZPndv8w;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:41 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/48000
+      - api-usage=150/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"},"Id":"00vW0000003Q7CNIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:21.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"},"Id":"00vW0000003QMakIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:40.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:22 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:41 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -225,7 +233,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:22 GMT
+      - Thu, 18 Jan 2018 20:49:42 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -234,31 +242,33 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=wdRHXDTFTzq9Jxk9pTlSNA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:22 GMT;Max-Age=5184000
+      - BrowserId=j5D8NnijTnq2FgsfvB_Iqw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:42 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=46/48000
+      - api-usage=147/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"},"Id":"00vW0000003Q7CNIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:21.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"},"Id":"00vW0000003QMakIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:40.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:22 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:42 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"
     body:
       encoding: UTF-8
-      string: '{"latest_adoption_decision__c":"For extra credit","latest_adoption_decision_at__c":"2018-01-03T04:16:22.514+00:00"}'
+      string: '{"latest_adoption_decision__c":"For extra credit","latest_adoption_decision_at__c":"2018-01-18T20:49:42.377+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -276,7 +286,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:22 GMT
+      - Thu, 18 Jan 2018 20:49:42 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -285,23 +295,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=A7db_P8hSeeLUWfurvfcAA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:22 GMT;Max-Age=5184000
+      - BrowserId=Rob05c3AR76w-qaoDuiiKA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:42 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=52/48000
+      - api-usage=148/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:23 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:42 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7CNIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMakIAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -322,7 +334,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:23 GMT
+      - Thu, 18 Jan 2018 20:49:43 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -331,28 +343,30 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=IyQQF7sJSXuxz-oqMUJsng;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:23 GMT;Max-Age=5184000
+      - BrowserId=BZSBmK4pQe-Nn6vkeQh4tw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:43 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=52/48000
+      - api-usage=158/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"},"Id":"00vW0000003Q7CNIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        extra credit","latest_adoption_decision_at__c":"2018-01-03T04:16:22.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"},"Id":"00vW0000003QMakIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        extra credit","latest_adoption_decision_at__c":"2018-01-18T20:49:42.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:23 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:43 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CNIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMakIAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -371,7 +385,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:23 GMT
+      - Thu, 18 Jan 2018 20:49:44 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -380,18 +394,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=WQcJroYLR5-HMR9kOvxR-g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:23 GMT;Max-Age=5184000
+      - BrowserId=MOdAuABhTsKAgWLIVHY4ew;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:44 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=47/48000
+      - api-usage=161/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:23 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/overwrites_the_first_timestamp_if_done_again.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/overwrites_the_first_timestamp_if_done_again.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:16 GMT
+      - Thu, 18 Jan 2018 20:49:34 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=MwLBxYPrRmCSUZS2kBkNPQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:16 GMT;Max-Age=5184000
+      - BrowserId=4i9ITYUXQH6aZMnTRl32gg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:34 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=53/48000
+      - api-usage=155/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7CIIA0","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMafIAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:16 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:34 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:16 GMT
+      - Thu, 18 Jan 2018 20:49:35 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,31 +88,33 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=qwEd80-MSZ-RhY-0s2PLUg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:16 GMT;Max-Age=5184000
+      - BrowserId=rUJOm039RWymqJFYhJSjqg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:35 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/48000
+      - api-usage=150/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"},"Id":"00vW0000003Q7CIIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"},"Id":"00vW0000003QMafIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:16 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:35 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:16.765+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:35.419+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -128,7 +132,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:17 GMT
+      - Thu, 18 Jan 2018 20:49:35 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -137,23 +141,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=A4lkPsCsRRWVgdF3ygV2lA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:17 GMT;Max-Age=5184000
+      - BrowserId=BRACs6n2S8SNBdUsOFdGVg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:35 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/48000
+      - api-usage=148/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:17 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:36 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7CIIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMafIAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +180,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:17 GMT
+      - Thu, 18 Jan 2018 20:49:36 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -183,28 +189,30 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=yQFVNgm5TlqFNrHUZ8amiQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:17 GMT;Max-Age=5184000
+      - BrowserId=tPP1qagcQZCSzjVp_eI3wQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:36 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/48000
+      - api-usage=151/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"},"Id":"00vW0000003Q7CIIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:16.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"},"Id":"00vW0000003QMafIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:35.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:17 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:36 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -225,7 +233,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:18 GMT
+      - Thu, 18 Jan 2018 20:49:37 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -234,31 +242,33 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=4kswykIPTKixg8V9WNdXdA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:18 GMT;Max-Age=5184000
+      - BrowserId=_I7E1q9aRZOeQMuXC5cgGw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:37 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=52/48000
+      - api-usage=154/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"},"Id":"00vW0000003Q7CIIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:16.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"},"Id":"00vW0000003QMafIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:35.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:21:17 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:36 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"
     body:
       encoding: UTF-8
-      string: '{"latest_adoption_decision_at__c":"2018-01-03T04:21:17.861+00:00"}'
+      string: '{"latest_adoption_decision_at__c":"2018-01-18T20:54:36.752+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -276,7 +286,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:18 GMT
+      - Thu, 18 Jan 2018 20:49:37 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -285,23 +295,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=gAP7b0MkSsy6EZJ1wCYpBg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:18 GMT;Max-Age=5184000
+      - BrowserId=lzBzMY5NQ0ShKANkddXIfg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:37 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/48000
+      - api-usage=146/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:21:17 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:36 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7CIIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMafIAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -322,7 +334,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:19 GMT
+      - Thu, 18 Jan 2018 20:49:38 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -331,28 +343,30 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=lYpoxRs6Td6Cgf4dnySVMA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:19 GMT;Max-Age=5184000
+      - BrowserId=pbEhrlFPSCebjELU95Ykkg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:38 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=54/48000
+      - api-usage=152/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"},"Id":"00vW0000003Q7CIIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:21:17.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"},"Id":"00vW0000003QMafIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:54:36.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:21:17 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:36 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CIIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMafIAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -371,7 +385,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:19 GMT
+      - Thu, 18 Jan 2018 20:49:39 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -380,18 +394,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=_6Uurn-QSpSQ_QRz1kXsGA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:19 GMT;Max-Age=5184000
+      - BrowserId=M1AOk7NMSX6_z4XBHfMqdg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:39 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/48000
+      - api-usage=150/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:19 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/saves_the_decision.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/saves_the_decision.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:13 GMT
+      - Thu, 18 Jan 2018 20:49:31 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=Mn5YvX5WSzqrt0ujckhQNQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:13 GMT;Max-Age=5184000
+      - BrowserId=mlPE_rqgQW2L5VoWpSvhrg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:31 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=53/48000
+      - api-usage=153/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CDIA0"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaaIAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7CDIA0","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMaaIAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:13 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:31 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:13 GMT
+      - Thu, 18 Jan 2018 20:49:31 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,31 +88,33 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=VHbPvM2DR-aKj-XeQBS7xQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:13 GMT;Max-Age=5184000
+      - BrowserId=FGyBw9-0TM6tniW_C9vPHA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:31 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/48000
+      - api-usage=147/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CDIA0"},"Id":"00vW0000003Q7CDIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaaIAG"},"Id":"00vW0000003QMaaIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:13 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:32 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CDIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaaIAG"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:13.875+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:32.037+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -128,7 +132,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:14 GMT
+      - Thu, 18 Jan 2018 20:49:32 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -137,23 +141,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=9EYgZC4oQh22BkIDFXc8aA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:14 GMT;Max-Age=5184000
+      - BrowserId=kTHMqyEmTJKldmzIVXQypQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:32 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/48000
+      - api-usage=151/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:14 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:32 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7CDIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaaIAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +180,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:14 GMT
+      - Thu, 18 Jan 2018 20:49:33 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -183,28 +189,30 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=fopxEAZeTJebnuM8TS-bVA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:14 GMT;Max-Age=5184000
+      - BrowserId=fCnQPz16QMicsOsudA8kLg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:33 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=52/48000
+      - api-usage=149/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CDIA0"},"Id":"00vW0000003Q7CDIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
-        course credit","latest_adoption_decision_at__c":"2018-01-03T04:16:13.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaaIAG"},"Id":"00vW0000003QMaaIAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+        course credit","latest_adoption_decision_at__c":"2018-01-18T20:49:32.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:14 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:33 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CDIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaaIAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +231,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:15 GMT
+      - Thu, 18 Jan 2018 20:49:33 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -232,18 +240,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=Ip1ZWavuS2Oefw-gO_g91A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:15 GMT;Max-Age=5184000
+      - BrowserId=LcnTTFzhQUSe8H4BBoDqhQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:33 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/48000
+      - api-usage=152/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:15 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/saves_the_timestamp.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/adoption_decision/saves_the_timestamp.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:10 GMT
+      - Thu, 18 Jan 2018 20:49:27 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=tvN58RsCTi6SwMftE7ZQbg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:10 GMT;Max-Age=5184000
+      - BrowserId=ron2xmESS7SGdcgqdZC19g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:27 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/48000
+      - api-usage=153/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C8IAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaVIAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7C8IAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMaVIAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:10 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:27 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:10 GMT
+      - Thu, 18 Jan 2018 20:49:28 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=4uFvF2A4RPyGVG1D09acLQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:10 GMT;Max-Age=5184000
+      - BrowserId=18GYDNHCQ8e510MXl9mIUg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:28 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/48000
+      - api-usage=154/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C8IAK"},"Id":"00vW0000003Q7C8IAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaVIAW"},"Id":"00vW0000003QMaVIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C8IAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaVIAW"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","latest_adoption_decision__c":"For
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","latest_adoption_decision__c":"For
         course credit","latest_adoption_decision_at__c":"2017-07-23T23:04:00.000+00:00"}'
     headers:
       User-Agent:
@@ -128,7 +132,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:11 GMT
+      - Thu, 18 Jan 2018 20:49:29 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -137,15 +141,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=_QiRuVMSQBSGwpAFAVFgRA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:11 GMT;Max-Age=5184000
+      - BrowserId=iSqKFk0kR0-dqaAdadcxpA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:29 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=52/48000
+      - api-usage=152/48000
     body:
       encoding: UTF-8
       string: ''
@@ -153,7 +159,7 @@ http_interactions:
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7C8IAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaVIAW%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +180,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:11 GMT
+      - Thu, 18 Jan 2018 20:49:29 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -183,28 +189,30 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=9zsjaFjJTL-0nfbb6poRbA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:11 GMT;Max-Age=5184000
+      - BrowserId=J6lBOlHiT2GmUy2O-wEQdg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:29 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=45/48000
+      - api-usage=146/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C8IAK"},"Id":"00vW0000003Q7C8IAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaVIAW"},"Id":"00vW0000003QMaVIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":"For
         course credit","latest_adoption_decision_at__c":"2017-07-23T23:04:00.000+0000","Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7C8IAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaVIAW"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +231,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:12 GMT
+      - Thu, 18 Jan 2018 20:49:30 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -232,18 +240,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=GtW6jQmFRpesyP5HJ2G9Pw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:12 GMT;Max-Age=5184000
+      - BrowserId=hHhhPWSDQU-d-dvdBKEawA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:30 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/48000
+      - api-usage=149/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:12 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/ask_later_about_like_preview/updates_the_count.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/ask_later_about_like_preview/updates_the_count.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:00 GMT
+      - Thu, 18 Jan 2018 20:49:10 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=1LGIrD10SBy-3yHuvS_2dg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:00 GMT;Max-Age=5184000
+      - BrowserId=XvMCGDYdSdm8VxDpVJPTWg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:10 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=38/48000
+      - api-usage=144/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BtIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMaBIAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:00 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:10 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:00 GMT
+      - Thu, 18 Jan 2018 20:49:11 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=YPmGt4pSRLi71gqGVwUm0g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:00 GMT;Max-Age=5184000
+      - BrowserId=h9Xq_vOITUOqGYsn6jZ_Mw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:11 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=143/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"},"Id":"00vW0000003Q7BtIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"},"Id":"00vW0000003QMaBIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:00 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:11 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","like_preview_ask_later_count__c":1}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","like_preview_ask_later_count__c":1}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:00 GMT
+      - Thu, 18 Jan 2018 20:49:12 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,23 +140,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=D0BuHc3lTxq9KBvZD-Damw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:00 GMT;Max-Age=5184000
+      - BrowserId=QmRQW8C_Td6Ty9LLheXkrA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:12 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=37/48000
+      - api-usage=142/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:01 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:12 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BtIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaBIAW%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:01 GMT
+      - Thu, 18 Jan 2018 20:49:12 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=PqRDsCPZROOMdEFT19vd0Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:01 GMT;Max-Age=5184000
+      - BrowserId=KXc4_jhvQJ2b8_tKIVEkkA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:12 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=38/48000
+      - api-usage=146/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"},"Id":"00vW0000003Q7BtIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":1.0,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"},"Id":"00vW0000003QMaBIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":1.0,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:01 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:12 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +231,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:01 GMT
+      - Thu, 18 Jan 2018 20:49:13 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -232,27 +240,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=6Q21dMV5QJWIl1sM4F5LfQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:01 GMT;Max-Age=5184000
+      - BrowserId=-vIjLmm2TVipfgb142JA9g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:13 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=38/48000
+      - api-usage=145/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"},"Id":"00vW0000003Q7BtIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":1.0,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"},"Id":"00vW0000003QMaBIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":1.0,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:01 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:13 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"
     body:
       encoding: UTF-8
       string: '{"like_preview_ask_later_count__c":2}'
@@ -273,7 +283,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:02 GMT
+      - Thu, 18 Jan 2018 20:49:14 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -282,23 +292,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=oNZVA38pSZaibVIwN8Y88A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:02 GMT;Max-Age=5184000
+      - BrowserId=7UcuRwzuQYaa-gPXVdb_Uw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:14 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=144/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:02 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:14 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BtIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaBIAW%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -319,7 +331,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:02 GMT
+      - Thu, 18 Jan 2018 20:49:15 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -328,27 +340,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=-8ampg6CTsqNsnqK5sKVBA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:02 GMT;Max-Age=5184000
+      - BrowserId=EyTj4SODTkS3XDGCQZppCw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:15 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=39/48000
+      - api-usage=146/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"},"Id":"00vW0000003Q7BtIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":2.0,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"},"Id":"00vW0000003QMaBIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":2.0,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:02 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:15 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BtIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaBIAW"
     body:
       encoding: US-ASCII
       string: ''
@@ -367,7 +381,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:03 GMT
+      - Thu, 18 Jan 2018 20:49:16 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -376,18 +390,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=vCZm6XYUSPaj3nu8iHBG6w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:03 GMT;Max-Age=5184000
+      - BrowserId=WtazOft6TACZzwFg5zllbQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:16 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=37/48000
+      - api-usage=145/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:03 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_preview/does_not_change_preview_created_at_for_2nd_time.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_preview/does_not_change_preview_created_at_for_2nd_time.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:48 GMT
+      - Thu, 18 Jan 2018 20:48:54 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=6esDrQ65TDSOrIa1jYDIWA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:48 GMT;Max-Age=5184000
+      - BrowserId=AxYsU38DTsWVUNypa98WqQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:54 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=134/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BaIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMZwIAO","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:48 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:54 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:48 GMT
+      - Thu, 18 Jan 2018 20:48:55 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=1tNdU7O6Ri-NkI5j7mJwqA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:48 GMT;Max-Age=5184000
+      - BrowserId=iteujdseTn-kDovHblBejg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:55 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=136/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"},"Id":"00vW0000003Q7BaIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"},"Id":"00vW0000003QMZwIAO","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:48 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:55 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","preview_created_at__c":"2018-01-03T04:15:48.708+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","preview_created_at__c":"2018-01-18T20:48:55.379+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:49 GMT
+      - Thu, 18 Jan 2018 20:48:55 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,23 +140,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=zdq_dTaFQmO6puvYAytOWQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:49 GMT;Max-Age=5184000
+      - BrowserId=KbR6SuuSRMW0nQurqpv-8g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:55 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/48000
+      - api-usage=136/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:49 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:55 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BaIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMZwIAO%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:49 GMT
+      - Thu, 18 Jan 2018 20:48:56 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=InvcbG_DRYOSGqpTQ9buuQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:49 GMT;Max-Age=5184000
+      - BrowserId=HAIV6js2QCCDnXptVojHlQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:56 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=37/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"},"Id":"00vW0000003Q7BaIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2018-01-03T04:15:48.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"},"Id":"00vW0000003QMZwIAO","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2018-01-18T20:48:55.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:50 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:56 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +231,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:50 GMT
+      - Thu, 18 Jan 2018 20:48:56 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -232,27 +240,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=5K79mLxlRjO_uMWSCzV5AQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:50 GMT;Max-Age=5184000
+      - BrowserId=1DfbEAcZSkKocCPuLpQVeg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:56 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"},"Id":"00vW0000003Q7BaIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2018-01-03T04:15:48.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"},"Id":"00vW0000003QMZwIAO","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2018-01-18T20:48:55.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:20:50 GMT
+  recorded_at: Thu, 18 Jan 2018 20:53:56 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BaIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMZwIAO%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -273,7 +283,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:50 GMT
+      - Thu, 18 Jan 2018 20:48:57 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -282,27 +292,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=X8DOJBE1Thy_8A3BMq4qYw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:50 GMT;Max-Age=5184000
+      - BrowserId=JybTVA-HTMa_vtWgz1dpIA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:57 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=134/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"},"Id":"00vW0000003Q7BaIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2018-01-03T04:15:48.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"},"Id":"00vW0000003QMZwIAO","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2018-01-18T20:48:55.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:20:50 GMT
+  recorded_at: Thu, 18 Jan 2018 20:53:56 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BaIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZwIAO"
     body:
       encoding: US-ASCII
       string: ''
@@ -321,7 +333,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:51 GMT
+      - Thu, 18 Jan 2018 20:48:58 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -330,18 +342,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=Q5TQ6yBMS_KnjvDBYLD3Xg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:51 GMT;Max-Age=5184000
+      - BrowserId=PSbbXljZRQ-DyG27xgw8ig;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:58 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=135/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:51 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_preview/sets_preview_created_at.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_preview/sets_preview_created_at.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:44 GMT
+      - Thu, 18 Jan 2018 20:48:50 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=1mhlA96aTamCpw8LYUXKng;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:44 GMT;Max-Age=5184000
+      - BrowserId=bpjQYGZrQayQNj4G7i9GPQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:50 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=135/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BZIA0"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZrIAO"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BZIA0","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMZrIAO","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:44 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:50 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:45 GMT
+      - Thu, 18 Jan 2018 20:48:50 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=aNDMu0AFRiS3dgb0qJHA_w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:45 GMT;Max-Age=5184000
+      - BrowserId=WEHqKTpWRHyOMxmu864e-A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:51 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=134/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BZIA0"},"Id":"00vW0000003Q7BZIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZrIAO"},"Id":"00vW0000003QMZrIAO","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BZIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZrIAO"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","preview_created_at__c":"2017-07-23T23:04:00.000+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","preview_created_at__c":"2017-07-23T23:04:00.000+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:45 GMT
+      - Thu, 18 Jan 2018 20:48:51 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,15 +140,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=uijqHm8IT5moj5HVoySSBA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:45 GMT;Max-Age=5184000
+      - BrowserId=P4kn8V86QJSDinYZD8U6uQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:51 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/48000
+      - api-usage=134/48000
     body:
       encoding: UTF-8
       string: ''
@@ -152,7 +158,7 @@ http_interactions:
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BZIA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMZrIAO%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:47 GMT
+      - Thu, 18 Jan 2018 20:48:52 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=s71ED69yRUqqZ4Gb4fbQeg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:47 GMT;Max-Age=5184000
+      - BrowserId=Rt2sbb3xTB-9OPoxtKcdbA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:52 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=33/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BZIA0"},"Id":"00vW0000003Q7BZIA0","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2017-07-23T23:04:00.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZrIAO"},"Id":"00vW0000003QMZrIAO","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":"2017-07-23T23:04:00.000+0000","real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BZIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMZrIAO"
     body:
       encoding: US-ASCII
       string: ''
@@ -221,7 +229,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:47 GMT
+      - Thu, 18 Jan 2018 20:48:53 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -230,18 +238,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=4laKPpDPT7OYsG1YEXm7hA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:47 GMT;Max-Age=5184000
+      - BrowserId=KV_gVJt4Qkm7YB1G7V1NlQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:53 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/48000
+      - api-usage=135/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:47 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_real_course/does_not_change_real_course_created_at_for_2nd_time.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_real_course/does_not_change_real_course_created_at_for_2nd_time.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:56 GMT
+      - Thu, 18 Jan 2018 20:49:06 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=634ZeMiEQ82X3okqsSITug;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:56 GMT;Max-Age=5184000
+      - BrowserId=v29qLf6kScaxi8_cVjXZcw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:06 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=139/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BoIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMa6IAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:57 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:06 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:57 GMT
+      - Thu, 18 Jan 2018 20:49:06 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=xfrhSInCRwSraMOBGFbguA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:57 GMT;Max-Age=5184000
+      - BrowserId=RS7Cvm2_SOqZ_mtjDN1CAw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:06 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=143/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"},"Id":"00vW0000003Q7BoIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"},"Id":"00vW0000003QMa6IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:57 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:06 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","real_course_created_at__c":"2018-01-03T04:15:57.581+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","real_course_created_at__c":"2018-01-18T20:49:06.949+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:57 GMT
+      - Thu, 18 Jan 2018 20:49:07 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,23 +140,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=AwZ-umsUQNe5gDyC50ui5w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:57 GMT;Max-Age=5184000
+      - BrowserId=hsTwh7GITk6hekYi5BCqYQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:07 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=144/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:57 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:07 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BoIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMa6IAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:58 GMT
+      - Thu, 18 Jan 2018 20:49:08 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=DmVsfApXRD-mZ8BTsscHtw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:58 GMT;Max-Age=5184000
+      - BrowserId=MZDiw2o4Q4-VAY75VN4eFA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:08 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=37/48000
+      - api-usage=143/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"},"Id":"00vW0000003Q7BoIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-03T04:15:57.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"},"Id":"00vW0000003QMa6IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-18T20:49:06.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:58 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:08 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +231,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:58 GMT
+      - Thu, 18 Jan 2018 20:49:08 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -232,27 +240,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=tgPxmWI7S9uaEWwo6GHm8A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:58 GMT;Max-Age=5184000
+      - BrowserId=W8ORR2CsRoWsRc-vbZIOzA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:08 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=37/48000
+      - api-usage=143/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"},"Id":"00vW0000003Q7BoIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-03T04:15:57.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"},"Id":"00vW0000003QMa6IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-18T20:49:06.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:20:58 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:08 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BoIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMa6IAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -273,7 +283,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:59 GMT
+      - Thu, 18 Jan 2018 20:49:09 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -282,27 +292,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=OEP-wOC5QWebvnFK3OTUHQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:59 GMT;Max-Age=5184000
+      - BrowserId=meRi-nVwSTuWRXYUwmIguQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:09 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=144/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"},"Id":"00vW0000003Q7BoIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-03T04:15:57.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"},"Id":"00vW0000003QMa6IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-18T20:49:06.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:20:58 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:08 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BoIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa6IAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -321,7 +333,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:59 GMT
+      - Thu, 18 Jan 2018 20:49:10 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -330,18 +342,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=g2EvMaD6SvmnmjlR-GBQJg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:59 GMT;Max-Age=5184000
+      - BrowserId=yytyzLgPTgy6iTVv4tUyog;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:10 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=145/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:59 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_real_course/sets_real_course_created_at.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_real_course/sets_real_course_created_at.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:51 GMT
+      - Thu, 18 Jan 2018 20:48:58 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=d1Ypkd-sQMivkY3JdQuO-Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:51 GMT;Max-Age=5184000
+      - BrowserId=aeEK2L4mQKmTiGHmmEpmqw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:48:58 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/48000
+      - api-usage=136/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BeIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa1IAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BeIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMa1IAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:51 GMT
+  recorded_at: Thu, 18 Jan 2018 20:48:58 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:52 GMT
+      - Thu, 18 Jan 2018 20:49:00 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=s1H1-6hmRVmoAmJJZQ_RGw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:52 GMT;Max-Age=5184000
+      - BrowserId=j5ZHe_JoTQC4yijKTfTLmw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:00 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=136/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BeIAK"},"Id":"00vW0000003Q7BeIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa1IAG"},"Id":"00vW0000003QMa1IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BeIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa1IAG"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","real_course_created_at__c":"2017-07-23T23:04:00.000+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","real_course_created_at__c":"2017-07-23T23:04:00.000+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:53 GMT
+      - Thu, 18 Jan 2018 20:49:00 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,15 +140,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=o4hPjlzgS0Gblo7Vcj8YMg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:53 GMT;Max-Age=5184000
+      - BrowserId=3xQIwBCfQ2urVxtG3JZ1Hg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:00 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=137/48000
     body:
       encoding: UTF-8
       string: ''
@@ -152,7 +158,7 @@ http_interactions:
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BeIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMa1IAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:53 GMT
+      - Thu, 18 Jan 2018 20:49:01 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=A5bZcK7RTDqJl3VwV7HhcA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:53 GMT;Max-Age=5184000
+      - BrowserId=DV2hftRES7yFhmugq-qEzw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:01 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=136/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BeIAK"},"Id":"00vW0000003Q7BeIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2017-07-23T23:04:00.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa1IAG"},"Id":"00vW0000003QMa1IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2017-07-23T23:04:00.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BeIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa1IAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -221,7 +229,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:53 GMT
+      - Thu, 18 Jan 2018 20:49:02 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -230,18 +238,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=uNFWM6dPQNyHQyncr-mcNg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:53 GMT;Max-Age=5184000
+      - BrowserId=V2bkThfoRKudGPGUILEEQw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:02 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=37/48000
+      - api-usage=138/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:54 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_real_course/sets_the_campaign_member_ID_on_the_course.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/created_real_course/sets_the_campaign_member_ID_on_the_course.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:54 GMT
+      - Thu, 18 Jan 2018 20:49:02 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=LXTsIGbIR96paEiKIDzOeA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:54 GMT;Max-Age=5184000
+      - BrowserId=nKaIW-p9Q2aVXAHfvBe1fw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:02 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/48000
+      - api-usage=137/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BjIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa2IAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BjIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMa2IAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:54 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:03 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:55 GMT
+      - Thu, 18 Jan 2018 20:49:03 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=XtROovdbS5mxZCL114rjfQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:55 GMT;Max-Age=5184000
+      - BrowserId=UOE4CpsnQZ2eFgSbsv5FWg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:03 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=36/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BjIAK"},"Id":"00vW0000003Q7BjIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa2IAG"},"Id":"00vW0000003QMa2IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:55 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:03 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BjIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa2IAG"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","real_course_created_at__c":"2018-01-03T04:15:55.263+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","real_course_created_at__c":"2018-01-18T20:49:03.673+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:55 GMT
+      - Thu, 18 Jan 2018 20:49:04 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,23 +140,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=8YMrsIPFTf6bMMxK1MFBoQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:55 GMT;Max-Age=5184000
+      - BrowserId=5EH5CguhS2m-YFV9WvP3hg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:04 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=135/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:55 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:04 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BjIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMa2IAG%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:15:56 GMT
+      - Thu, 18 Jan 2018 20:49:04 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=7YWlMO7cSC-1BNfMc1h7iQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:56 GMT;Max-Age=5184000
+      - BrowserId=xQnnEtYIT-GWMeYHo0l9Ig;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:04 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=135/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BjIAK"},"Id":"00vW0000003Q7BjIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-03T04:15:55.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa2IAG"},"Id":"00vW0000003QMa2IAG","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":"2018-01-18T20:49:03.000+0000","like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:56 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:05 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BjIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMa2IAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -221,7 +229,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:15:56 GMT
+      - Thu, 18 Jan 2018 20:49:05 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -230,18 +238,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=KC4qTiO0SSOXqjiah4UkJA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:15:56 GMT;Max-Age=5184000
+      - BrowserId=0RmAP3XxSx6RkSjeRnOk1Q;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:05 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/48000
+      - api-usage=136/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:15:56 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:05 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/say_yes_to_like_preview/does_not_change_like_preview_yes_for_2nd_preview.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/say_yes_to_like_preview/does_not_change_like_preview_yes_for_2nd_preview.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:06 GMT
+      - Thu, 18 Jan 2018 20:49:21 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=E_aTrgE1R62EwB-1vkymiw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:06 GMT;Max-Age=5184000
+      - BrowserId=4lG-PVRASbOW6RQ_52rgfw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:21 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=41/48000
+      - api-usage=145/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7ByIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMaLIAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:06 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:21 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:06 GMT
+      - Thu, 18 Jan 2018 20:49:21 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=7fsrhqGARaCYQyYTf7EvSg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:06 GMT;Max-Age=5184000
+      - BrowserId=Y3DVASBWQZCkIiROSJMKPA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:21 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=44/48000
+      - api-usage=150/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"},"Id":"00vW0000003Q7ByIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"},"Id":"00vW0000003QMaLIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:06 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:21 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","like_preview_yes_at__c":"2018-01-03T04:16:06.776+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","like_preview_yes_at__c":"2018-01-18T20:49:21.794+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:07 GMT
+      - Thu, 18 Jan 2018 20:49:22 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,23 +140,25 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=_9ewXbo1SRac7-eqtsJ02w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:07 GMT;Max-Age=5184000
+      - BrowserId=hAW-QV0-S6uQysl0SDIrRw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:22 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=42/48000
+      - api-usage=151/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:07 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:22 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7ByIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaLIAW%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:07 GMT
+      - Thu, 18 Jan 2018 20:49:23 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=-mc1esOyQ5ySwozCm5pDWQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:07 GMT;Max-Age=5184000
+      - BrowserId=smcwijZ5TKOzBi8eCAmpqA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:23 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=42/48000
+      - api-usage=150/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"},"Id":"00vW0000003Q7ByIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2018-01-03T04:16:06.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"},"Id":"00vW0000003QMaLIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2018-01-18T20:49:21.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:07 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:23 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -223,7 +231,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:07 GMT
+      - Thu, 18 Jan 2018 20:49:24 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -232,27 +240,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=nJ13873qT0WA377imGA_Sw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:07 GMT;Max-Age=5184000
+      - BrowserId=TIIsOxxUSZiRGP8TWE6lCQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:24 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/48000
+      - api-usage=153/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"},"Id":"00vW0000003Q7ByIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2018-01-03T04:16:06.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"},"Id":"00vW0000003QMaLIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2018-01-18T20:49:21.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:21:07 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:23 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7ByIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaLIAW%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -273,7 +283,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:08 GMT
+      - Thu, 18 Jan 2018 20:49:24 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -282,27 +292,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=dnKCmexmRNezRiKul3MQwg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:08 GMT;Max-Age=5184000
+      - BrowserId=BVbkvPB5S5OALV_cjpu9YA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:24 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/48000
+      - api-usage=152/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"},"Id":"00vW0000003Q7ByIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2018-01-03T04:16:06.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"},"Id":"00vW0000003QMaLIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2018-01-18T20:49:21.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:21:07 GMT
+  recorded_at: Thu, 18 Jan 2018 20:54:23 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7ByIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaLIAW"
     body:
       encoding: US-ASCII
       string: ''
@@ -321,7 +333,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:08 GMT
+      - Thu, 18 Jan 2018 20:49:25 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -330,18 +342,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=ojlp1C_RRP67o9CX9IlOkw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:08 GMT;Max-Age=5184000
+      - BrowserId=zyJy9lnIRq6N8IMjT8Lbaw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:25 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/48000
+      - api-usage=148/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:09 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:25 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/say_yes_to_like_preview/sets_like_preview_yes.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/say_yes_to_like_preview/sets_like_preview_yes.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:03 GMT
+      - Thu, 18 Jan 2018 20:49:16 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=Qu1jY2BiSbGuemFpJj0RSg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:03 GMT;Max-Age=5184000
+      - BrowserId=K6nebUihSeOokDmrw9vRag;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:16 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=42/48000
+      - api-usage=142/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BkIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaGIAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7BkIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMaGIAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:03 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:16 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +79,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:04 GMT
+      - Thu, 18 Jan 2018 20:49:17 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -86,30 +88,32 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=ybMrfz6QSjyvh-UBcjK3JA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:04 GMT;Max-Age=5184000
+      - BrowserId=A6SfUiGqQJ-6sou0lMWVXA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:17 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=43/48000
+      - api-usage=142/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BkIAK"},"Id":"00vW0000003Q7BkIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaGIAW"},"Id":"00vW0000003QMaGIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":null,"pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":null,"arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":null,"latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: patch
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BkIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaGIAW"
     body:
       encoding: UTF-8
-      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","like_preview_yes_at__c":"2017-07-23T23:04:00.000+00:00"}'
+      string: '{"accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","like_preview_yes_at__c":"2017-07-23T23:04:00.000+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -127,7 +131,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:04 GMT
+      - Thu, 18 Jan 2018 20:49:18 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -136,15 +140,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=TlNIpyA6R0ODVV0bGzw04Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:04 GMT;Max-Age=5184000
+      - BrowserId=2d3mIOOUTiSPJP6IN0eSfA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:18 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=44/48000
+      - api-usage=143/48000
     body:
       encoding: UTF-8
       string: ''
@@ -152,7 +158,7 @@ http_interactions:
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003Q7BkIAK%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(Id%20=%20%2700vW0000003QMaGIAW%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +179,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:05 GMT
+      - Thu, 18 Jan 2018 20:49:19 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -182,27 +188,29 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=cT4EcOw5SeyL4SPUfFl2yw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:05 GMT;Max-Age=5184000
+      - BrowserId=MznSmm0dTcuqKv-TQhamZQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:19 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=41/48000
+      - api-usage=143/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BkIAK"},"Id":"00vW0000003Q7BkIAK","CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000l8O4wIAE","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CampaignMember","url":"/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaGIAW"},"Id":"00vW0000003QMaGIAW","CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","pardot_reported_contact_id__c":null,"pardot_reported_piaid__c":null,"pardot_reported_picid__c":null,"first_teacher_contact_id__c":"003W000000ljcV1IAI","arrived_marketing_page_from_pardot_at__c":null,"arrived_marketing_page_not_from_pardot_a__c":null,"preview_created_at__c":null,"real_course_created_at__c":null,"like_preview_ask_later_count__c":null,"like_preview_yes_at__c":"2017-07-23T23:04:00.000+0000","latest_adoption_decision__c":null,"latest_adoption_decision_at__c":null,"Estimated_Enrollment__c":null,"Ignored_OSAs__c":false,"Percent_Enrolled__c":null,"School_Type__c":null,"Students_Registered__c":null,"Students_Reported_by_Teacher__c":null,"Students_with_work__c":null,"SyncField__c":null}]}'
     http_version: 
   recorded_at: Sun, 23 Jul 2017 23:04:00 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7BkIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMaGIAW"
     body:
       encoding: US-ASCII
       string: ''
@@ -221,7 +229,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:05 GMT
+      - Thu, 18 Jan 2018 20:49:20 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -230,18 +238,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=DAKAM-QLQFK6Y0ae8BXoew;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:05 GMT;Max-Age=5184000
+      - BrowserId=tkYLRzYnSmiKlHN-847xyQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:20 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=43/48000
+      - api-usage=147/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:05 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/when_event_unknown/raise_an_exception.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_campaign_member_exists/when_event_unknown/raise_an_exception.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000SlxwIAC","ContactId":"003W000000l8O4wIAE"}'
+      string: '{"CampaignId":"701W0000000Sr5OIAS","ContactId":"003W000000ljcV1IAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,7 +25,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:24 GMT
+      - Thu, 18 Jan 2018 20:49:44 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -34,29 +34,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=haQrhwbgSyu896EMcVKRKA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:24 GMT;Max-Age=5184000
+      - BrowserId=mclrgIwISQKT-XEFNK4eaQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:44 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=53/48000
+      - api-usage=161/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CSIA0"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMapIAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7CSIA0","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMapIAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:24 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:45 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CSIA0"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMapIAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +77,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:24 GMT
+      - Thu, 18 Jan 2018 20:49:45 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -84,18 +86,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=S0cYXG1_RW-ocETrcwOuHQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:24 GMT;Max-Age=5184000
+      - BrowserId=y98_ClTKStuHhEWRiWNDvw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:45 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=53/48000
+      - api-usage=151/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:25 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/TrackTutorOnboardingEvent/when_run_in_background/retries_if_there_are_SF_errors_on_save.yml
+++ b/spec/cassettes/TrackTutorOnboardingEvent/when_run_in_background/retries_if_there_are_SF_errors_on_save.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000l8O4wIAE%27)%20AND%20(CampaignId%20=%20%27701W0000000SlxwIAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5OIAS%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:28 GMT
+      - Thu, 18 Jan 2018 20:49:57 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -32,15 +32,17 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=A-e6Bb23Tzivd1r0ZC3sgg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:28 GMT;Max-Age=5184000
+      - BrowserId=nJsl6ME5Tv6J2EeVmfzv1g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:57 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/48000
+      - api-usage=178/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,13 +51,65 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:29 GMT
+  recorded_at: Thu, 18 Jan 2018 20:49:57 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20CampaignId,%20ContactId,%20accounts_uuid__c,%20pardot_reported_contact_id__c,%20pardot_reported_piaid__c,%20pardot_reported_picid__c,%20first_teacher_contact_id__c,%20arrived_marketing_page_from_pardot_at__c,%20arrived_marketing_page_not_from_pardot_a__c,%20preview_created_at__c,%20real_course_created_at__c,%20like_preview_ask_later_count__c,%20like_preview_yes_at__c,%20latest_adoption_decision__c,%20latest_adoption_decision_at__c,%20Estimated_Enrollment__c,%20Ignored_OSAs__c,%20Percent_Enrolled__c,%20School_Type__c,%20Students_Registered__c,%20Students_Reported_by_Teacher__c,%20Students_with_work__c,%20SyncField__c%20FROM%20CampaignMember%20WHERE%20(ContactId%20=%20%27003W000000ljcV1IAI%27)%20AND%20(CampaignId%20=%20%27701W0000000Sr5TIAS%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - close
+      Date:
+      - Thu, 18 Jan 2018 20:49:58 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=XPvj5vdhS3aR3RmvAeLSFw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:58 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=173/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Thu, 18 Jan 2018 20:49:58 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember"
     body:
       encoding: UTF-8
-      string: '{"CampaignId":"701W0000000Sly1IAC","ContactId":"003W000000l8O4wIAE","accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000l8O4wIAE","like_preview_yes_at__c":"2018-01-03T04:16:29.018+00:00"}'
+      string: '{"CampaignId":"701W0000000Sr5TIAS","ContactId":"003W000000ljcV1IAI","accounts_uuid__c":"<USER_SF_A_UUID>","first_teacher_contact_id__c":"003W000000ljcV1IAI","like_preview_yes_at__c":"2018-01-18T20:49:58.621+00:00"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -75,7 +129,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 03 Jan 2018 04:16:29 GMT
+      - Thu, 18 Jan 2018 20:49:59 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -84,29 +138,31 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=JaNRtqOqSca1Ou4VaIm_eQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:29 GMT;Max-Age=5184000
+      - BrowserId=JiX5X5-XStOVx6d1cAfMRg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:49:59 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=53/48000
+      - api-usage=186/48000
       Location:
-      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CcIAK"
+      - "/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMb4IAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00vW0000003Q7CcIAK","success":true,"errors":[]}'
+      string: '{"id":"00vW0000003QMb4IAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:29 GMT
+  recorded_at: Thu, 18 Jan 2018 20:50:00 GMT
 - request:
     method: delete
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003Q7CcIAK"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/CampaignMember/00vW0000003QMb4IAG"
     body:
       encoding: US-ASCII
       string: ''
@@ -125,7 +181,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 03 Jan 2018 04:16:29 GMT
+      - Thu, 18 Jan 2018 20:50:00 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -134,18 +190,20 @@ http_interactions:
       - 1; mode=block
       Content-Security-Policy:
       - upgrade-insecure-requests
+      X-Robots-Tag:
+      - none
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=XJfYDLMHQtqiJi33-5gs1Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        04-Mar-2018 04:16:29 GMT;Max-Age=5184000
+      - BrowserId=WXmuwEFiRuOGbsbizdUx7g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        19-Mar-2018 20:50:00 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/48000
+      - api-usage=183/48000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 04:16:30 GMT
+  recorded_at: Thu, 18 Jan 2018 20:50:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/routines/track_tutor_onboarding_event_spec.rb
+++ b/spec/routines/track_tutor_onboarding_event_spec.rb
@@ -269,6 +269,18 @@ RSpec.describe TrackTutorOnboardingEvent, type: :routine, vcr: VCR_OPTS do
           cm = expect_call_to_set_timestamp(:like_preview_yes_at)
           expect(cm.campaign_id).to eq @nomad_campaign.id
         end
+
+        it 'tracks on a new campaign member on the nomad campaign and then reuses that next time' do
+          cm = expect_call_to_set_timestamp(:like_preview_yes_at)
+          expect(cm.campaign_id).to eq @nomad_campaign.id
+
+          course = FactoryBot.create(:course_profile_course)
+          cm2 = described_class[user: user,
+                                event: :made_adoption_decision,
+                                data: {decision: "For extra credit",
+                                       course_id: course.id}].reload
+          expect(cm2.id).to eq cm.id
+        end
       end
 
       context "when the nomad campaign ID is NOT set" do


### PR DESCRIPTION
We were not reusing nomad campaign members after first tracking them, leading to `DUPLICATE_VALUE: Already a campaign member.` errors from Salesforce.  This PR changes a `new` call to `find_or_initialize_by` and adds a spec to show this case.