### PR TITLE
Added env vars for db host and port

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,10 @@
 default: &default
-  host: localhost
+  host: <%= ENV['OXT_DB_HOST'] || 'localhost' %>
   adapter: postgresql
   username: <%= ENV['OXT_DB_USER'] || 'ox_tutor' %>
   password: <%= ENV['OXT_DB_PASS'] || 'ox_tutor_secret_password' %>
+  port: <%= ENV['OXT_DB_PORT'] || 5432 %>
+
 
 development:
   <<: *default


### PR DESCRIPTION
I currently use different defaults and it would be nice to simply
override these with an environmental variable.

* Added database host env var OXT_DB_HOST with localhost default
* Added database port env var OXT_DB_PORT with 5432 default