### PR TITLE
Fix scores when late work is accepted and the due date is then moved

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -259,11 +259,11 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def effective_correct_exercise_count
-    correct_on_time_exercise_count + correct_accepted_late_exercise_count
+    [ correct_on_time_exercise_count, correct_accepted_late_exercise_count ].max
   end
 
   def effective_completed_steps_count
-    completed_on_time_steps_count + completed_accepted_late_steps_count
+    [ completed_on_time_steps_count, completed_accepted_late_steps_count ].max
   end
 
   def score
@@ -275,12 +275,9 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def accept_late_work
-    self.completed_accepted_late_steps_count =
-      completed_steps_count - completed_on_time_steps_count
-    self.completed_accepted_late_exercise_steps_count =
-      completed_exercise_steps_count - completed_on_time_exercise_steps_count
-    self.correct_accepted_late_exercise_steps_count =
-      correct_exercise_steps_count - correct_on_time_exercise_steps_count
+    self.completed_accepted_late_steps_count = completed_steps_count
+    self.completed_accepted_late_exercise_steps_count = completed_exercise_steps_count
+    self.correct_accepted_late_exercise_steps_count = correct_exercise_steps_count
     self.accepted_late_at = Time.current
   end
 

--- a/db/migrate/20180223162905_fix_accepted_late_counts.rb
+++ b/db/migrate/20180223162905_fix_accepted_late_counts.rb
@@ -1,18 +1,25 @@
 # Not idempotent, cannot run in the background
+# MIN/MAX are used to fix errors that might already have happened (but they are not perfect)
 class FixAcceptedLateCounts < ActiveRecord::Migration
   def up
     Tasks::Models::Task.select(:id).where.not(accepted_late_at: nil).find_in_batches do |tasks|
       Tasks::Models::Task.where(id: tasks.map(&:id)).update_all(
         <<-UPDATE_SQL.strip_heredoc
-          "correct_accepted_late_exercise_steps_count" =
-            "correct_accepted_late_exercise_steps_count" +
-            "correct_on_time_exercise_steps_count",
-          "completed_accepted_late_exercise_steps_count" =
+          "completed_accepted_late_steps_count" = MIN(
+            "completed_accepted_late_steps_count" +
+            "completed_on_time_steps_count",
+            "completed_steps_count"
+          ),
+          "completed_accepted_late_exercise_steps_count" = MIN(
             "completed_accepted_late_exercise_steps_count" +
             "completed_on_time_exercise_steps_count",
-          "completed_accepted_late_steps_count" =
-            "completed_accepted_late_steps_count" +
-            "completed_on_time_steps_count"
+            "completed_exercise_steps_count"
+          ),
+          "correct_accepted_late_exercise_steps_count" = MIN(
+            "correct_accepted_late_exercise_steps_count" +
+            "correct_on_time_exercise_steps_count",
+            "correct_exercise_steps_count"
+          )
         UPDATE_SQL
       )
     end
@@ -22,15 +29,21 @@ class FixAcceptedLateCounts < ActiveRecord::Migration
     Tasks::Models::Task.select(:id).where.not(accepted_late_at: nil).find_in_batches do |tasks|
       Tasks::Models::Task.where(id: tasks.map(&:id)).update_all(
         <<-UPDATE_SQL.strip_heredoc
-          "correct_accepted_late_exercise_steps_count" =
-            "correct_accepted_late_exercise_steps_count" -
-            "correct_on_time_exercise_steps_count",
-          "completed_accepted_late_exercise_steps_count" =
+          "completed_accepted_late_steps_count" = MAX(
+            "completed_accepted_late_steps_count" -
+            "completed_on_time_steps_count",
+            0
+          ),
+          "completed_accepted_late_exercise_steps_count" = MAX(
             "completed_accepted_late_exercise_steps_count" -
             "completed_on_time_exercise_steps_count",
-          "completed_accepted_late_steps_count" =
-            "completed_accepted_late_steps_count" -
-            "completed_on_time_steps_count"
+            0
+          ),
+          "correct_accepted_late_exercise_steps_count" = MAX(
+            "correct_accepted_late_exercise_steps_count" -
+            "correct_on_time_exercise_steps_count",
+            0
+          )
         UPDATE_SQL
       )
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223002900) do
+ActiveRecord::Schema.define(version: 20180223162905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -571,6 +571,10 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
 
       expect(task.correct_exercise_count).to eq 1
       expect(task.completed_exercise_count).to eq 1
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.completed_accepted_late_exercise_count).to eq 0
+      expect(task.correct_accepted_late_exercise_count).to eq 0
       expect(task.score).to eq 1/3.0
 
       Timecop.freeze(Time.current + 1.day) do
@@ -580,15 +584,21 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
 
       expect(task.correct_exercise_count).to eq 2
       expect(task.completed_exercise_count).to eq 2
+      expect(task.completed_on_time_exercise_count).to eq 1
       expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.completed_accepted_late_exercise_count).to eq 0
       expect(task.correct_accepted_late_exercise_count).to eq 0
       expect(task.score).to eq 1/3.0
 
       task.accept_late_work
       task.save!
 
-      expect(task.correct_accepted_late_exercise_count).to eq 1
-      expect(task.completed_accepted_late_exercise_count).to eq 1
+      expect(task.correct_exercise_count).to eq 2
+      expect(task.completed_exercise_count).to eq 2
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.completed_accepted_late_exercise_count).to eq 2
+      expect(task.correct_accepted_late_exercise_count).to eq 2
       expect(task.score).to eq 2/3.0
       expect(task.accepted_late_at).not_to be_nil
 
@@ -598,27 +608,36 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
       end
 
       expect(task.correct_exercise_count).to eq 3
-      expect(task.correct_accepted_late_exercise_count).to eq 1
-      expect(task.completed_accepted_late_exercise_count).to eq 1
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.completed_accepted_late_exercise_count).to eq 2
+      expect(task.correct_accepted_late_exercise_count).to eq 2
       expect(task.score).to eq 2/3.0
 
       task.accept_late_work
       task.save!
 
-      expect(task.correct_accepted_late_exercise_count).to eq 2
-      expect(task.completed_accepted_late_exercise_count).to eq 2
+      expect(task.correct_exercise_count).to eq 3
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.completed_accepted_late_exercise_count).to eq 3
+      expect(task.correct_accepted_late_exercise_count).to eq 3
       expect(task.score).to eq 1.0
 
       task.reject_late_work
       task.save!
 
+      expect(task.correct_exercise_count).to eq 3
+      expect(task.completed_exercise_count).to eq 3
       expect(task.correct_accepted_late_exercise_count).to eq 0
       expect(task.completed_accepted_late_exercise_count).to eq 0
       expect(task.score).to eq 1/3.0
       expect(task.accepted_late_at).to be_nil
     end
 
-    it 'holds on to accepted late stats regardless of future work' do
+    it 'holds on to accepted late stats regardless of future work and due date changes' do
       task = FactoryBot.create(
         :tasks_task, opens_at: Time.current - 1.week,
                      due_at: Time.current,
@@ -634,6 +653,10 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
 
       expect(task.correct_exercise_count).to eq 1
       expect(task.completed_exercise_count).to eq 1
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.correct_accepted_late_exercise_count).to eq 0
+      expect(task.completed_accepted_late_exercise_count).to eq 0
       expect(task.score).to eq 1/3.0
 
       Timecop.freeze(Time.current + 1.day) do
@@ -643,15 +666,21 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
 
       expect(task.correct_exercise_count).to eq 2
       expect(task.completed_exercise_count).to eq 2
+      expect(task.completed_on_time_exercise_count).to eq 1
       expect(task.correct_on_time_exercise_count).to eq 1
       expect(task.correct_accepted_late_exercise_count).to eq 0
+      expect(task.completed_accepted_late_exercise_count).to eq 0
       expect(task.score).to eq 1/3.0
 
       task.accept_late_work
       task.save!
 
-      expect(task.correct_accepted_late_exercise_count).to eq 1
-      expect(task.completed_accepted_late_exercise_count).to eq 1
+      expect(task.correct_exercise_count).to eq 2
+      expect(task.completed_exercise_count).to eq 2
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.correct_accepted_late_exercise_count).to eq 2
+      expect(task.completed_accepted_late_exercise_count).to eq 2
       expect(task.score).to eq 2/3.0
       expect(task.accepted_late_at).not_to be_nil
 
@@ -661,20 +690,53 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
       end
 
       expect(task.correct_exercise_count).to eq 3
-      expect(task.correct_accepted_late_exercise_count).to eq 1
-      expect(task.completed_accepted_late_exercise_count).to eq 1
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.correct_accepted_late_exercise_count).to eq 2
+      expect(task.completed_accepted_late_exercise_count).to eq 2
       expect(task.score).to eq 2/3.0
 
       task.accept_late_work
       task.save!
 
-      expect(task.correct_accepted_late_exercise_count).to eq 2
-      expect(task.completed_accepted_late_exercise_count).to eq 2
+      expect(task.correct_exercise_count).to eq 3
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.correct_accepted_late_exercise_count).to eq 3
+      expect(task.completed_accepted_late_exercise_count).to eq 3
+      expect(task.score).to eq 1.0
+
+      task.due_at = Time.current + 2.days
+      task.save!
+
+      expect(task.correct_exercise_count).to eq 3
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 3
+      expect(task.correct_on_time_exercise_count).to eq 3
+      expect(task.completed_accepted_late_exercise_count).to eq 3
+      expect(task.correct_accepted_late_exercise_count).to eq 3
+      expect(task.score).to eq 1.0
+
+      task.due_at = Time.current
+      task.save!
+
+      expect(task.correct_exercise_count).to eq 3
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
+      expect(task.completed_accepted_late_exercise_count).to eq 3
+      expect(task.correct_accepted_late_exercise_count).to eq 3
       expect(task.score).to eq 1.0
 
       task.reject_late_work
       task.save!
 
+      expect(task.correct_exercise_count).to eq 3
+      expect(task.completed_exercise_count).to eq 3
+      expect(task.completed_on_time_exercise_count).to eq 1
+      expect(task.correct_on_time_exercise_count).to eq 1
       expect(task.correct_accepted_late_exercise_count).to eq 0
       expect(task.completed_accepted_late_exercise_count).to eq 0
       expect(task.score).to eq 1/3.0


### PR DESCRIPTION
If you accepted late scores and then moved the due date, it would cause scores to go over 100%.
This PR changes how we store the late work acceptance to prevent this.