### PR TITLE
(Hopefully) fix codecov

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,30 @@
 require 'simplecov'
-require 'codecov'
 require 'parallel_tests'
+require 'codecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CI'] == 'true'
+# Deactivate automatic result merging, because we use custom result merging code
+SimpleCov.use_merging false
 
+# Custom result merging code to avoid the many partial merges that SimpleCov usually creates
+# and send to codecov only once
+SimpleCov.at_exit do
+  # Store the result for later merging
+  SimpleCov::ResultMerger.store_result(SimpleCov.result)
+
+  # All processes except one will exit here
+  next unless ParallelTests.last_process?
+
+  # Wait for everyone else to finish
+  ParallelTests.wait_for_other_processes_to_finish
+
+  # Send merged result to codecov only if on CI (will generate HTML report by default locally)
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CI'] == 'true'
+
+  # Merge coverage reports (and maybe send to codecov)
+  SimpleCov::ResultMerger.merged_result.format!
+end
+
+# Start calculating code coverage
 SimpleCov.start('rails') { merge_timeout 3600 }
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
The main thing I'm trying here is to merge results only at the end and send them to codecov only once, rather than sending a bunch of partial merges as the test processes exit.