### PR TITLE
Import more exercises at a time (they are cached now)

### DIFF
--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -1,8 +1,7 @@
 class Content::ImportBook
 
   # Kind of a hack to limit how many exercises we request at a time and avoid timeouts
-  # It is set to 2020 in the test environment so as to not break basically all the cassettes
-  MAX_EXERCISES_REQUEST_LENGTH = Rails.env.test? ? 2020 : 1000
+  MAX_EXERCISES_REQUEST_LENGTH = 2020
 
   lev_routine
 


### PR DESCRIPTION
My main motivation to restore this is to stop special-casing the test environment.