### PR TITLE
Rescue launch nonce reuse better

### DIFF
--- a/app/subsystems/lms/launch.rb
+++ b/app/subsystems/lms/launch.rb
@@ -219,7 +219,7 @@ class Lms::Launch
     else
       begin
         Lms::Models::Nonce.create!({ lms_app_id: app.id, value: request_parameters[:oauth_nonce] })
-      rescue ActiveRecord::RecordNotUnique => ee
+      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => ee
         raise AlreadyUsed
       end
 

--- a/spec/requests/lms_launch_spec.rb
+++ b/spec/requests/lms_launch_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe 'LMS Launch', type: :request do
         expect(response.body).to match("/course/#{course.id}")
         expect_course_score_callback_count(user: bob_user, count: 1)
       end
+
+      it 'complains about reused launch nonce' do
+        simulator.add_student("bob")
+        simulator.launch(user: "bob", assignment: "tutor")
+        simulator.repeat_last_launch
+        expect_error("Please try launching OpenStax Tutor again.")
+      end
     end
 
     context "dropped" do

--- a/spec/support/lms/simulator.rb
+++ b/spec/support/lms/simulator.rb
@@ -2,6 +2,8 @@ require 'webmock/rspec'
 
 class Lms::Simulator
 
+  attr_reader :last_launch
+
   def initialize(spec)
     @spec = spec
     @apps_by_key = {}
@@ -15,6 +17,7 @@ class Lms::Simulator
     @reverse_sourcedids = {}
     @reuse_sourcedids = true
     @next_int = -1
+    @last_launch = nil
 
     succeed_when_receive_score_for_dropped_student!
     stub_outcome_url
@@ -120,6 +123,16 @@ class Lms::Simulator
     sign!(request_params, app)
 
     spec.post app[:launch_path], request_params
+
+    @last_launch = {
+      launch_path: app[:launch_path],
+      request_params: request_params
+    }
+  end
+
+  def repeat_last_launch
+    raise "There is no 'last launch' to repeat" if @last_launch.nil?
+    spec.post @last_launch[:launch_path], @last_launch[:request_params]
   end
 
   def sign!(request_params, app)


### PR DESCRIPTION
We were catching case where LMS launch nonce was being reused, but only catching a database uniqueness error, when in fact the rails model error was being raised.