### PR TITLE
Fix progress average

### DIFF
--- a/app/subsystems/tasks/get_tp_performance_report.rb
+++ b/app/subsystems/tasks/get_tp_performance_report.rb
@@ -214,7 +214,7 @@ module Tasks
           average_score: average_score(
             tasks: tasks, current_time_ntz: current_time_ntz, is_teacher: is_teacher
           ),
-          average_progress: completion_fraction(tasks: tasks)
+          average_progress: average_progress(tasks: tasks, current_time_ntz: current_time_ntz)
         )
       end
     end

--- a/spec/subsystems/tasks/get_tp_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_tp_performance_report_spec.rb
@@ -122,35 +122,35 @@ RSpec.describe Tasks::GetTpPerformanceReport, type: :routine do
       expect(first_period_report.data_headings[0].type).to eq 'homework'
       expect(first_period_report.data_headings[0].due_at).to be_a Time
       expect(first_period_report.data_headings[0].average_score).to be_nil
-      expect(first_period_report.data_headings[0].average_progress).to eq 0.5
+      expect(first_period_report.data_headings[0].average_progress).to be_nil
 
       expect(second_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
       expect(second_period_report.data_headings[0].plan_id).to be_a Integer
       expect(second_period_report.data_headings[0].type).to eq 'homework'
       expect(second_period_report.data_headings[0].due_at).to be_a Time
       expect(second_period_report.data_headings[0].average_score).to be_nil
-      expect(second_period_report.data_headings[0].average_progress).to eq 0.0
+      expect(second_period_report.data_headings[0].average_progress).to be_nil
 
       expect(first_period_report.data_headings[1].title).to eq 'Reading task plan'
       expect(first_period_report.data_headings[1].plan_id).to be_a Integer
       expect(first_period_report.data_headings[1].type).to eq 'reading'
       expect(first_period_report.data_headings[1].due_at).to be_a Time
       expect(first_period_report.data_headings[1].average_score).to be_nil
-      expect(first_period_report.data_headings[1].average_progress).to eq 0.5
+      expect(first_period_report.data_headings[1].average_progress).to be_nil
 
       expect(second_period_report.data_headings[1].title).to eq 'Reading task plan'
       expect(second_period_report.data_headings[1].plan_id).to be_a Integer
       expect(second_period_report.data_headings[1].type).to eq 'reading'
       expect(second_period_report.data_headings[1].due_at).to be_a Time
       expect(second_period_report.data_headings[1].average_score).to be_nil
-      expect(second_period_report.data_headings[1].average_progress).to eq 0.0
+      expect(second_period_report.data_headings[1].average_progress).to be_nil
 
       expect(first_period_report.data_headings[2].title).to eq 'Homework task plan'
       expect(first_period_report.data_headings[2].plan_id).to be_a Integer
       expect(first_period_report.data_headings[2].type).to eq 'homework'
       expect(first_period_report.data_headings[2].due_at).to be_a Time
       expect(first_period_report.data_headings[2].average_score).to be_within(1e-6).of(9/14.0)
-      expect(first_period_report.data_headings[2].average_progress).to eq 0.5
+      expect(first_period_report.data_headings[2].average_progress).to be_within(1e-6).of(11/14.0)
 
       expect(second_period_report.data_headings[2].title).to eq 'Homework task plan'
       expect(second_period_report.data_headings[2].plan_id).to be_a Integer
@@ -354,14 +354,14 @@ RSpec.describe Tasks::GetTpPerformanceReport, type: :routine do
       expect(report.data_headings[0].type).to eq 'homework'
       expect(report.data_headings[0].due_at).to be_a Time
       expect(report.data_headings[0].average_score).to be_nil
-      expect(report.data_headings[0].average_progress).to eq 1.0
+      expect(report.data_headings[0].average_progress).to be_nil
 
       expect(report.data_headings[1].title).to eq 'Reading task plan'
       expect(report.data_headings[1].plan_id).to be_a Integer
       expect(report.data_headings[1].type).to eq 'reading'
       expect(report.data_headings[1].due_at).to be_a Time
       expect(report.data_headings[1].average_score).to be_nil
-      expect(report.data_headings[1].average_progress).to eq 1.0
+      expect(report.data_headings[1].average_progress).to be_nil
 
       expect(report.data_headings[2].title).to eq 'Homework task plan'
       expect(report.data_headings[2].plan_id).to be_a Integer
@@ -434,14 +434,14 @@ RSpec.describe Tasks::GetTpPerformanceReport, type: :routine do
       expect(report.data_headings[0].type).to eq 'homework'
       expect(report.data_headings[0].due_at).to be_a Time
       expect(report.data_headings[0].average_score).to be_nil
-      expect(report.data_headings[0].average_progress).to eq 1.0
+      expect(report.data_headings[0].average_progress).to be_nil
 
       expect(report.data_headings[1].title).to eq 'Reading task plan'
       expect(report.data_headings[1].plan_id).to be_a Integer
       expect(report.data_headings[1].type).to eq 'reading'
       expect(report.data_headings[1].due_at).to be_a Time
       expect(report.data_headings[1].average_score).to be_nil
-      expect(report.data_headings[1].average_progress).to eq 1.0
+      expect(report.data_headings[1].average_progress).to be_nil
 
       expect(report.data_headings[2].title).to eq 'Homework task plan'
       expect(report.data_headings[2].plan_id).to be_a Integer


### PR DESCRIPTION
Progress average was being computed as (tasks fully completed)/(number of tasks).
This PR fixes that. We now compute per-task progress as (number of completed steps)/(number of steps) and use the arithmetic mean of these values for the average.
In addition, only past-due tasks will be included in the progress average.

Also includes https://github.com/openstax/tutor-server/pull/1698