### PR TITLE
Removed background migration transaction

### DIFF
--- a/app/routines/background_migrate.rb
+++ b/app/routines/background_migrate.rb
@@ -1,5 +1,5 @@
 class BackgroundMigrate
-  lev_routine
+  lev_routine transaction: :no_transaction
 
   def self.load_rake_tasks_if_needed
     Rails.application.load_tasks unless defined?(Rake::Task) &&


### PR DESCRIPTION
In general we want migrations to control their transactions, not lev.
We cannot update a ton of rows in a transaction or else we'll lock the entire table and either fail the migration or bring the site down.