### PR TITLE
Fixed (some) N+1 queries when updating an assignment (performance)

### DIFF
--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -30,7 +30,8 @@ class PropagateTaskPlanUpdates
 
     task_plan.tasks.reset
 
-    requests = task_plan.tasks.map { |task| { course: task_plan.owner, task: task } }
+    requests = task_plan.tasks.preload(taskings: { role: :student })
+                              .map { |task| { course: task_plan.owner, task: task } }
     OpenStax::Biglearn::Api.create_update_assignments(requests)
   end
 


### PR DESCRIPTION
Maybe not all... it had an N+1 query that comes from my inline processing of some Biglearn delayed_jobs...