### PR TITLE
Downgraded PopulatePlaceholderSteps transaction to READ COMMITTED

### DIFF
--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -1,6 +1,6 @@
 class Tasks::PopulatePlaceholderSteps
 
-  lev_routine express_output: :task
+  lev_routine transaction: :read_committed, express_output: :task
 
   uses_routine GetTaskCorePageIds, as: :get_task_core_page_ids
   uses_routine TaskExercise, as: :task_exercise


### PR DESCRIPTION
The routine already locks the task to prevent concurrent modifications.
Should fix `[Tutor] (prodtutor) tasks#show (PG::TRSerializationFailure) "ERROR:  could not serialize access due to concurrent update...`