### PR TITLE
In the pages API, use the page ID as a tie-breaker

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -8,9 +8,8 @@ class Api::V1::PagesController < Api::V1::ApiController
     params_uuid = params[:uuid]
     params_version = params[:version]
 
-    query = Content::Models::Page.where { uuid == params_uuid }
+    query = Content::Models::Page.where { uuid == params_uuid }.order(version: :desc, id: :desc)
     query = query.where { version == params_version } if params_version.present?
-    query = query.order(version: :desc)
     page = query.first
 
     page.nil? ?


### PR DESCRIPTION
So pages imported last display preferentially. We fixed a bug in the link rewriter (in the importer code in Tutor), but since that did not change the page version in CNX, the changes were not visible. This PR fixes that.