### PR TITLE
More link rewriter changes + disable it for this release

### DIFF
--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -84,7 +84,7 @@ class Content::ImportBook
 
     outputs.book = book
     outputs.chapters = outs.chapters
-    outputs.pages = run(:update_page_content, book: book, pages: outs.pages).outputs.pages
+    outputs.pages = outs.pages #run(:update_page_content, book: book, pages: outs.pages).outputs.pages
 
     # Send ecosystem information to Biglearn
     OpenStax::Biglearn::Api.create_ecosystem(ecosystem: ecosystem)

--- a/app/subsystems/content/routines/update_page_content.rb
+++ b/app/subsystems/content/routines/update_page_content.rb
@@ -68,13 +68,13 @@ class Content::Routines::UpdatePageContent
 
       # The link actually points to the book itself
       # Remove the path from the link
-      "/books/#{book.ecosystem.id}"
+      "/book/#{book.ecosystem.id}"
     else
       # Check if the page's version is correct
       return if page_version.present? && page.version != page_version
 
       # Change the link's path to the page's book_location
-      "/books/#{book.ecosystem.id}/section/#{page.book_location.reject(&:zero?).join('.')}"
+      "/book/#{book.ecosystem.id}/section/#{page.book_location.reject(&:zero?).join('.')}"
     end
 
     href_attr.value = url.to_s

--- a/app/subsystems/content/routines/update_page_content.rb
+++ b/app/subsystems/content/routines/update_page_content.rb
@@ -68,13 +68,13 @@ class Content::Routines::UpdatePageContent
 
       # The link actually points to the book itself
       # Remove the path from the link
-      "/books/#{book.id}"
+      "/books/#{book.ecosystem.id}"
     else
       # Check if the page's version is correct
       return if page_version.present? && page.version != page_version
 
       # Change the link's path to the page's book_location
-      "/books/#{book.id}/section/#{page.book_location.reject(&:zero?).join('.')}"
+      "/books/#{book.ecosystem.id}/section/#{page.book_location.reject(&:zero?).join('.')}"
     end
 
     href_attr.value = url.to_s

--- a/spec/subsystems/content/import_book_spec.rb
+++ b/spec/subsystems/content/import_book_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Content::ImportBook, type: :routine, vcr: VCR_OPTS, speed: :mediu
         method.call book: book#, save: true
       end
     )
-    expect_any_instance_of(Content::Routines::UpdatePageContent).to(
-      receive(:call).and_wrap_original do |method, book:, pages:, save: true|
-        expect(save).to eq true
+    #expect_any_instance_of(Content::Routines::UpdatePageContent).to(
+    #  receive(:call).and_wrap_original do |method, book:, pages:, save: true|
+    #    expect(save).to eq true
 
-        method.call book: book, pages: pages#, save: true
-      end
-    )
+    #    method.call book: book, pages: pages#, save: true
+    #  end
+    #)
     expect(OpenStax::Biglearn::Api).to receive(:create_ecosystem)
 
     result = nil

--- a/spec/subsystems/content/routines/update_page_content_spec.rb
+++ b/spec/subsystems/content/routines/update_page_content_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -118,7 +119,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + composite_before_hrefs[1..-1]
               end
 
@@ -152,7 +154,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.id}" }
+            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
@@ -212,7 +214,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -245,7 +248,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + composite_before_hrefs[1..-1]
               end
 
@@ -279,7 +283,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.id}" }
+            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
@@ -335,7 +339,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -368,7 +373,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + composite_before_hrefs[1..-1]
               end
 
@@ -402,7 +408,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.id}" }
+            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
@@ -462,7 +468,8 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}"
+                  "/books/#{@book.ecosystem.id}/section/#{
+                  @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -494,7 +501,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
               end
 
               let(:composite_after_hrefs) do
-                [ "/books/#{@book.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}" ] +
+                [ "/books/#{@book.ecosystem.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}" ] +
                 composite_before_hrefs[1..-1]
               end
 
@@ -528,7 +535,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.id}" }
+            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }

--- a/spec/subsystems/content/routines/update_page_content_spec.rb
+++ b/spec/subsystems/content/routines/update_page_content_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
@@ -119,7 +119,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + composite_before_hrefs[1..-1]
               end
@@ -154,7 +154,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
+            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
@@ -214,7 +214,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
@@ -248,7 +248,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + composite_before_hrefs[1..-1]
               end
@@ -283,7 +283,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
+            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
@@ -339,7 +339,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
@@ -373,7 +373,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + composite_before_hrefs[1..-1]
               end
@@ -408,7 +408,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
+            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
@@ -468,7 +468,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/books/#{@book.ecosystem.id}/section/#{
+                  "/book/#{@book.ecosystem.id}/section/#{
                   @page_2.book_location.reject(&:zero?).join('.')}"
                 ] + before_hrefs[1..-1]
               end
@@ -501,7 +501,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
               end
 
               let(:composite_after_hrefs) do
-                [ "/books/#{@book.ecosystem.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}" ] +
+                [ "/book/#{@book.ecosystem.id}/section/#{@page_2.book_location.reject(&:zero?).join('.')}" ] +
                 composite_before_hrefs[1..-1]
               end
 
@@ -535,7 +535,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
           end
 
           context 'book links' do
-            let(:book_after_href) { "/books/#{@book.ecosystem.id}" }
+            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
 
             before do
               before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }


### PR DESCRIPTION
- Rewrite links using the ecosystem id instead of the book id

New URL is `/book/`

Link rewriter is disabled for this release.