### PR TITLE
Rebalance Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ addons:
   chrome: stable
   postgresql: '9.5'
 env:
-  - TAG=~speed:slow
-  - TAG=speed:slow
+  - TAG=speed:fast
+  - TAG=~speed:fast
 script:
   - bundle exec parallel_rspec -o "-t $TAG" ./spec
 branches:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,6 +88,8 @@ RSpec.configure do |config|
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
   end
+
+  config.define_derived_metadata { |metadata| metadata[:speed] ||= :fast }
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
Since the medium + fast examples now take so much longer than the slow examples (because there are so many), group the medium examples with the slow ones to keep the Travis builds balanced.