### PR TITLE
Match anything in the enrollment url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
       # this is handled by the FE
       get :'start/:enroll_token', action: :index, as: :start_enrollment, block_sign_up: false, straight_to_student_sign_up: true
       # we render this to display a splash screen before login/signup
-      get :':enroll_token(/:ignore)', as: :token_enroll, action: :enroll
+      get :':enroll_token(/*ignored)', as: :token_enroll, action: :enroll
     end
   end
 


### PR DESCRIPTION
Needed so that urls with dots in them still match, previously it'd fail with urls like:
https://tutor-dev.openstax.org/enroll/634335/Physics-NOT-U.S.-History--Summer-2018-Spring-2018

Strangely the bug only occurs when nginx is involved, running the local dev server the previous route would be fine