### PR TITLE
Return all offerings with the is_available flag

### DIFF
--- a/app/access_policies/offering_access_policy.rb
+++ b/app/access_policies/offering_access_policy.rb
@@ -6,10 +6,8 @@ class OfferingAccessPolicy
                     !requestor.account.college?
 
     case action.to_sym
-    when :index
+    when :index, :read, :create_course
       true
-    when :read, :create_course
-      offering.is_available
     else
       false
     end

--- a/app/access_policies/offering_access_policy.rb
+++ b/app/access_policies/offering_access_policy.rb
@@ -6,8 +6,10 @@ class OfferingAccessPolicy
                     !requestor.account.college?
 
     case action.to_sym
-    when :index, :read, :create_course
+    when :index, :read
       true
+    when :create_course
+      offering.is_available
     else
       false
     end

--- a/app/controllers/api/v1/offerings_controller.rb
+++ b/app/controllers/api/v1/offerings_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::OfferingsController < Api::V1::ApiController
     #{json_schema(Api::V1::OfferingSearchRepresenter, include: :readable)}
   EOS
   def index
-    standard_index(Catalog::Models::Offering.where(is_available: true),
+    standard_index(Catalog::Models::Offering.all,
                    Api::V1::OfferingSearchRepresenter)
   end
 end

--- a/app/representers/api/v1/offering_representer.rb
+++ b/app/representers/api/v1/offering_representer.rb
@@ -35,6 +35,14 @@ class Api::V1::OfferingRepresenter < Roar::Decorator
              type: 'boolean'
            }
 
+  property :is_available,
+           readable: true,
+           writeable: false,
+           schema_info: {
+             required: true,
+             type: 'boolean'
+           }
+
   property :appearance_code,
            type: String,
            readable: true,

--- a/spec/access_policies/offering_access_policy_spec.rb
+++ b/spec/access_policies/offering_access_policy_spec.rb
@@ -88,17 +88,5 @@ RSpec.describe OfferingAccessPolicy, type: :access_policy do
         end
       end
     end
-
-    context 'unavailable offering' do
-      before{ offering.update_attribute :is_available, false }
-
-      [:read, :create_course].each do |test_action|
-        context test_action.to_s do
-          let(:action) { test_action }
-
-          it { should eq false }
-        end
-      end
-    end
   end
 end

--- a/spec/access_policies/offering_access_policy_spec.rb
+++ b/spec/access_policies/offering_access_policy_spec.rb
@@ -88,5 +88,18 @@ RSpec.describe OfferingAccessPolicy, type: :access_policy do
         end
       end
     end
+
+    context 'unavailable offering' do
+      before{ offering.update_attribute :is_available, false }
+
+      [:create_course].each do |test_action|
+        context test_action.to_s do
+          let(:action) { test_action }
+
+          it { should eq false }
+        end
+      end
+    end
+
   end
 end

--- a/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -25,12 +25,13 @@ RSpec.describe Api::V1::OfferingsController, type: :controller, api: true, versi
       expect{ api_get :index, nil }.to raise_error(SecurityTransgression)
     end
 
-    it 'lists all available offerings for verified college faculty, in order' do
+    it 'lists all offerings for verified college faculty, in order' do
       api_get :index, faculty_access_token
       items = response.body_as_hash[:items].map(&:deep_stringify_keys)
       expect(items).to eq [
         Api::V1::OfferingRepresenter.new(available_offering_2).as_json,
-        Api::V1::OfferingRepresenter.new(available_offering_1).as_json
+        Api::V1::OfferingRepresenter.new(available_offering_1).as_json,
+        Api::V1::OfferingRepresenter.new(unavailable_offering).as_json,
       ]
     end
   end

--- a/spec/representers/api/v1/offering_representer_spec.rb
+++ b/spec/representers/api/v1/offering_representer_spec.rb
@@ -122,4 +122,17 @@ RSpec.describe Api::V1::OfferingRepresenter, type: :representer do
       )
     end
   end
+
+  context 'is_available' do
+    it 'can be read' do
+      expect(representation['is_available']).to eq offering.is_available
+    end
+
+    it 'cannot be written (attempts are silently ignored)' do
+      expect(offering).not_to receive(:is_available=)
+      expect{ described_class.new(offering).from_hash('is_available' => 'true') }.not_to(
+        change{ offering.is_available }
+      )
+    end
+  end
 end


### PR DESCRIPTION
This way the FE can tell the difference between an non-existent offering
and one that is no longer available

Goes along with https://github.com/openstax/tutor-js/pull/2260