### PR TITLE
update mathjax to 2.7.4

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>OpenStax Tutor</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='https://c.la2-c2-dfw.salesforceliveagent.com/content/g/js/39.0/deployment.js'></script>
   <script type='text/javascript' src='<%= Rails.application.secrets[:js_url] %>' async></script>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Hopefully this'll fix some of the weird JS errors that sentry's been reporting