### PR TITLE
Fixed ecosystem ordering

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -20,7 +20,7 @@ class Admin::CoursesController < Admin::BaseController
     @course_infos = result.outputs.items.preload(
       teachers: { role: [:role_user, :profile] },
       periods: :students,
-      ecosystems: :books
+      course_ecosystems: { ecosystem: :books }
     ).try(:paginate, params_for_pagination)
 
     @ecosystems = Content::ListEcosystems[]
@@ -131,8 +131,8 @@ class Admin::CoursesController < Admin::BaseController
       ecosystem = Content::Models::Ecosystem.find(params[:ecosystem_id])
       courses = CourseProfile::Models::Course
         .where { id.in course_ids }
-        .preload(:ecosystems)
-        .select { |course| course.ecosystems.first.try(:id) != ecosystem.id }
+        .preload(course_ecosystems: :ecosystem)
+        .select { |course| course.ecosystem.try!(:id) != ecosystem.id }
       courses.each do |course|
         job_id = CourseContent::AddEcosystemToCourse.perform_later(
           course: course, ecosystem: ecosystem

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -126,9 +126,8 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
       OSU::AccessPolicy.require_action_allowed!(:create, current_api_user, task_plan)
 
       # If this is a cloned assignment, update its ecosystem during creation
-      current_ecosystem = course.ecosystems.first
       task_plan = UpdateTaskPlanEcosystem[
-        task_plan: task_plan, ecosystem: current_ecosystem, save: false
+        task_plan: task_plan, ecosystem: course.ecosystem, save: false
       ] if task_plan.cloned_from_id.present?
 
       uuid = distribute_or_update_tasks(task_plan)

--- a/app/controllers/customer_service/courses_controller.rb
+++ b/app/controllers/customer_service/courses_controller.rb
@@ -13,7 +13,7 @@ class CustomerService::CoursesController < CustomerService::BaseController
       [
         { teachers: { role: [:role_user, :profile] },
           periods: :students,
-          ecosystems: :books },
+          course_ecosystems: { ecosystem: :books } },
         :periods
       ]
     ).paginate(page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 25))

--- a/app/controllers/manager/course_details.rb
+++ b/app/controllers/manager/course_details.rb
@@ -13,7 +13,7 @@ module Manager::CourseDetails
     @ecosystems = Content::ListEcosystems[]
 
     @course_ecosystem = nil
-    ecosystem_model = @course.ecosystems.first
+    ecosystem_model = @course.ecosystem
     return if ecosystem_model.nil?
 
     ecosystem_strategy = ::Content::Strategies::Direct::Ecosystem.new(ecosystem_model)

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -100,14 +100,14 @@ module Api::V1
              type: String,
              readable: true,
              writeable: false,
-             getter: ->(*) { ecosystems.first.try!(:id) },
+             getter: ->(*) { ecosystem.try!(:id) },
              schema_info: { description: "The ID of the course's current ecosystem, if available." }
 
     property :ecosystem_book_uuid,
              type: String,
              readable: true,
              writeable: false,
-             getter: ->(*) { ecosystems.first.try!(:books).try!(:first).try!(:uuid) },
+             getter: ->(*) { ecosystem.try!(:books).try!(:first).try!(:uuid) },
              schema_info: {
                description: "The UUID of the book for the course's current ecosystem, if available."
              }

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -13,7 +13,8 @@ class CollectCourseInfo
   def get_courses(courses:, user:)
     return [courses].flatten unless courses.nil?
 
-    preloads = [ :time_zone, :offering, periods: :students, ecosystems: :books ]
+    preloads = [ :time_zone, :offering, periods: :students,
+                 course_ecosystems: { ecosystem: :books } ]
     return run(:get_user_courses, user: user, preload: preloads).outputs.courses unless user.nil?
 
     CourseProfile::Models::Course.preload(*preloads)

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -70,6 +70,7 @@ class CollectCourseInfo
         reading_score_weight: course.reading_score_weight,
         reading_progress_weight: course.reading_progress_weight,
         ecosystems: course.ecosystems,
+        ecosystem: course.ecosystem,
         periods: periods,
         students: students,
         roles: roles

--- a/app/routines/export_exercise_exclusions.rb
+++ b/app/routines/export_exercise_exclusions.rb
@@ -117,7 +117,7 @@ class ExportExerciseExclusions
   def exercises_by_course
     excluded_exercises.group_by(&:course).map do |course, excluded_exercises|
       numbers = excluded_exercises.map(&:exercise_number)
-      ecosystem = course.ecosystems.first
+      ecosystem = course.ecosystem
       book = ecosystem.try!(:books).try!(:first)
       book_hash = { book_title: book.try!(:title), book_uuid: book.try!(:uuid) }
       exercises_hash = get_exercise_hashes_for_exercise_numbers(numbers: numbers)

--- a/app/routines/get_course_ecosystem.rb
+++ b/app/routines/get_course_ecosystem.rb
@@ -4,8 +4,7 @@ class GetCourseEcosystem
   protected
 
   def exec(course:, strategy_class: ::Content::Strategies::Direct::Ecosystem)
-    # The first ecosystem is the latest
-    content_ecosystem = course.ecosystems.first
+    content_ecosystem = course.ecosystem
 
     if content_ecosystem.nil?
       outputs[:ecosystem] = nil

--- a/app/routines/get_course_ecosystems_map.rb
+++ b/app/routines/get_course_ecosystems_map.rb
@@ -5,8 +5,7 @@ class GetCourseEcosystemsMap
 
   def exec(course:, ecosystem_strategy_class: ::Content::Strategies::Direct::Ecosystem,
                     map_strategy_class: ::Content::Strategies::Generated::Map)
-    # The first ecosystem is the latest
-    to_content_ecosystem = course.ecosystems.first
+    to_content_ecosystem = course.ecosystem
 
     raise 'The given course has no ecosystems' if to_content_ecosystem.nil?
 

--- a/app/routines/populate_preview_course_content.rb
+++ b/app/routines/populate_preview_course_content.rb
@@ -62,7 +62,7 @@ class PopulatePreviewCourseContent
 
     return if course.is_concept_coach
 
-    ecosystem = course.ecosystems.first
+    ecosystem = course.ecosystem
     return if ecosystem.nil?
 
     book = ecosystem.books.first

--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -23,7 +23,7 @@ class SearchCourses
       [school.outer,
        offering.outer,
        teachers.outer.role.outer.profile.outer.account.outer,
-       ecosystems.outer]
+       course_ecosystems.outer.ecosystem.outer]
     end.uniq
 
     run(:search, relation: relation, sortable_fields: SORTABLE_FIELDS, params: params) do |with|
@@ -46,7 +46,7 @@ class SearchCourses
             teachers.role.profile.account.first_name.like_any(sanitized_queries) |
             teachers.role.profile.account.last_name.like_any(sanitized_queries) |
             teachers.role.profile.account.full_name.like_any(sanitized_queries) |
-            ecosystems.title.like_any(sanitized_queries)
+            course_ecosystems.ecosystem.title.like_any(sanitized_queries)
           end
         end
       end
@@ -102,7 +102,9 @@ class SearchCourses
           sanitized_titles = to_string_array(title, append_wildcard: true, prepend_wildcard: true)
           next @items = @items.none if sanitized_titles.empty?
 
-          @items = @items.joins(:ecosystems).where { ecosystems.title.like_any(sanitized_titles) }
+          @items = @items.joins(course_ecosystems: :ecosystem).where do
+            course_ecosystems.ecosystem.title.like_any(sanitized_titles)
+          end
         end
       end
 

--- a/app/subsystems/catalog/update_offering.rb
+++ b/app/subsystems/catalog/update_offering.rb
@@ -19,9 +19,7 @@ module Catalog
 
       return unless update_courses
 
-      courses_to_update = active_courses.select do |course|
-        course.ecosystems.first != new_ecosystem
-      end
+      courses_to_update = active_courses.select { |course| course.ecosystem != new_ecosystem }
       outputs.num_updated_courses = courses_to_update.length
 
       courses_to_update.each do |course|

--- a/app/subsystems/course_content/add_ecosystem_to_course.rb
+++ b/app/subsystems/course_content/add_ecosystem_to_course.rb
@@ -10,7 +10,7 @@ class CourseContent::AddEcosystemToCourse
            map_strategy_class: ::Content::Strategies::Generated::Map)
     fatal_error(code: :ecosystem_already_set,
                 message: 'The given ecosystem is already active for the given course') \
-      if course.lock!.course_ecosystems.first.try!(:content_ecosystem_id) == ecosystem.id
+      if course.lock!.ecosystem.try!(:id) == ecosystem.id
 
     ecosystem = Content::Ecosystem.new(strategy: ecosystem.wrap) \
       if ecosystem.is_a?(Content::Models::Ecosystem)

--- a/app/subsystems/tasks/update_task_caches.rb
+++ b/app/subsystems/tasks/update_task_caches.rb
@@ -136,7 +136,8 @@ class Tasks::UpdateTaskCaches
 
     # Get all relevant courses
     course_ids = task_ids_by_course_id.keys
-    courses = CourseProfile::Models::Course.select(:id).where(id: course_ids).preload(:ecosystems)
+    courses = CourseProfile::Models::Course.select(:id).where(id: course_ids)
+                                           .preload(course_ecosystems: :ecosystem)
 
     # Cache results per task for Quick Look and Student Performance Forecast
     # Pages are mapped to the Course's most recent ecosystem

--- a/lib/demo/base.rb
+++ b/lib/demo/base.rb
@@ -160,8 +160,7 @@ class Demo::Base
 
   def get_auto_assignments(content)
     content.auto_assign.map do |settings|
-      book_locations = content.course.ecosystems.first.pages.map(&:book_location)
-                                                            .sample(settings.steps)
+      book_locations = content.course.ecosystem.pages.map(&:book_location).sample(settings.steps)
 
       1.upto(settings.generate).map do |number|
         Hashie::Mash.new(

--- a/lib/demo/tasks.rb
+++ b/lib/demo/tasks.rb
@@ -34,7 +34,7 @@ class Demo::Tasks < Demo::Base
 
 
   def get_ecosystem(course:)
-    ecosystem_model = course.ecosystems.first
+    ecosystem_model = course.ecosystem
     return if ecosystem_model.nil?
 
     strategy = Content::Strategies::Direct::Ecosystem.new(ecosystem_model)

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -402,7 +402,7 @@ module OpenStax::Biglearn::Api
         # Return the last response received from Biglearn regardless of what it was
         {
           exercises: get_ecosystem_exercises_by_uuids(
-            ecosystem: request[:student].course.ecosystems.first,
+            ecosystem: request[:student].course.ecosystem,
             exercise_uuids: response[:exercise_uuids],
             max_num_exercises: request[:max_num_exercises]
           ),

--- a/lib/openstax/biglearn/api/fake_client.rb
+++ b/lib/openstax/biglearn/api/fake_client.rb
@@ -227,7 +227,7 @@ class OpenStax::Biglearn::Api::FakeClient < OpenStax::Biglearn::Api::Client
   # Always returns 5 random exercises from the correct ecosystem in the FakeClient
   def fetch_practice_worst_areas_exercises(requests)
     requests.map do |request|
-      ecosystem = request[:student].course.ecosystems.first
+      ecosystem = request[:student].course.ecosystem
       exercises = ecosystem.nil? ? [] : ecosystem.exercises.sample(5)
 
       {

--- a/lib/tasks/biglearn.rake
+++ b/lib/tasks/biglearn.rake
@@ -20,9 +20,9 @@ namespace :biglearn do
 
       courses = CourseProfile::Models::Course
         .where(id: course_ids)
-        .joins(:ecosystems)
+        .joins(course_ecosystems: :ecosystem)
         .preload(
-          :ecosystems, periods: { latest_enrollments: :student }
+          course_ecosystems: :ecosystem, periods: { latest_enrollments: :student }
         ).distinct
 
       print_each("Creating #{courses.count} course(s)", courses.find_in_batches) do |courses|

--- a/spec/factories/tasks/task_plans.rb
+++ b/spec/factories/tasks/task_plans.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
       task_plan.assistant ||= Tasks::Models::Assistant.find_by(code_class_name_hash) || \
                               build(:tasks_assistant, code_class_name_hash)
 
-      task_plan.content_ecosystem_id ||= task_plan.owner.ecosystems.first
+      task_plan.content_ecosystem_id ||= task_plan.owner.ecosystem
       task_plan.ecosystem ||= build(:content_ecosystem)
 
       task_plan.tasking_plans = evaluator.num_tasking_plans.times.map do

--- a/spec/features/admin/create_blank_course_spec.rb
+++ b/spec/features/admin/create_blank_course_spec.rb
@@ -33,6 +33,6 @@ RSpec.feature 'Administration' do
     expect(page).to have_text('Hello hi ciao Hey World')
     course = CourseProfile::Models::Course.order(:created_at).last
     expect(course.offering).to eq catalog_offering
-    expect(course.ecosystems.first).to eq catalog_offering.ecosystem
+    expect(course.ecosystem).to eq catalog_offering.ecosystem
   end
 end

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -203,7 +203,7 @@ RSpec.feature 'Admin editing a course', speed: :slow do
     click_on 'Set Ecosystem'
 
     expect(page).to have_content('Course ecosystem updates have been queued')
-    expect(@course.ecosystems.first.books.first.version).to eq('4.4')
+    expect(@course.ecosystem.books.first.version).to eq('4.4')
 
     click_on 'Add Course'
     fill_in 'Name', with: 'Physics II'
@@ -215,8 +215,8 @@ RSpec.feature 'Admin editing a course', speed: :slow do
     find(:id, :ecosystem_id).find("option[value='#{physics_new.id}']").select_option
     click_on 'Set Ecosystem'
     expect(page).to have_content('Course ecosystem updates have been queued')
-    expect(@course.ecosystems.first.books.first.version).to eq('5.1')
-    expect(course_2.ecosystems.first.books.first.version).to eq('5.1')
+    expect(@course.ecosystem.books.first.version).to eq('5.1')
+    expect(course_2.ecosystem.books.first.version).to eq('5.1')
   end
 
   scenario 'Check payment fields on student roster', js: true do

--- a/spec/routines/collect_course_info_spec.rb
+++ b/spec/routines/collect_course_info_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe CollectCourseInfo, type: :routine do
           reading_score_weight: course_1.reading_score_weight,
           reading_progress_weight: course_1.reading_progress_weight,
           ecosystems: course_1.ecosystems,
+          ecosystem: course_1.ecosystem,
           periods: [],
           students: [],
           roles: []
@@ -111,6 +112,7 @@ RSpec.describe CollectCourseInfo, type: :routine do
           reading_score_weight: course_1.reading_score_weight,
           reading_progress_weight: course_1.reading_progress_weight,
           ecosystems: course_1.ecosystems,
+          ecosystem: course_1.ecosystem,
           periods: [],
           students: [],
           roles: []
@@ -147,6 +149,7 @@ RSpec.describe CollectCourseInfo, type: :routine do
           reading_score_weight: course_2.reading_score_weight,
           reading_progress_weight: course_2.reading_progress_weight,
           ecosystems: course_2.ecosystems,
+          ecosystem: course_2.ecosystem,
           periods: [],
           students: [],
           roles: []
@@ -199,6 +202,7 @@ RSpec.describe CollectCourseInfo, type: :routine do
             reading_score_weight: course_1.reading_score_weight,
             reading_progress_weight: course_1.reading_progress_weight,
             ecosystems: course_1.ecosystems,
+            ecosystem: course_1.ecosystem,
             periods: a_collection_containing_exactly(period_1, period_2),
             students: [],
             roles: user_1.to_model.roles
@@ -256,6 +260,7 @@ RSpec.describe CollectCourseInfo, type: :routine do
             reading_score_weight: course_1.reading_score_weight,
             reading_progress_weight: course_1.reading_progress_weight,
             ecosystems: course_1.ecosystems,
+            ecosystem: course_1.ecosystem,
             periods: periods,
             students: students,
             roles: roles

--- a/spec/subsystems/catalog/update_offering_spec.rb
+++ b/spec/subsystems/catalog/update_offering_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Catalog::UpdateOffering, type: :routine do
   let(:courses)       do
     3.times.map do
       FactoryBot.create(:course_profile_course, offering: offering).tap do |course|
-        course.ecosystems << old_ecosystem
+        AddEcosystemToCourse.call(course: course, ecosystem: old_ecosystem)
       end
     end
   end

--- a/spec/subsystems/catalog/update_offering_spec.rb
+++ b/spec/subsystems/catalog/update_offering_spec.rb
@@ -37,21 +37,21 @@ RSpec.describe Catalog::UpdateOffering, type: :routine do
 
   context 'update_courses is true' do
     it "updates associated courses' ecosystems if the ecosystem is changed" do
-      courses.each{ |course| expect(course.ecosystems.first).to eq old_ecosystem }
+      courses.each{ |course| expect(course.ecosystem).to eq old_ecosystem }
 
       described_class.call(offering.id, {ecosystem: new_ecosystem}, true)
 
-      courses.each{ |course| expect(course.reload.ecosystems.first).to eq new_ecosystem }
+      courses.each{ |course| expect(course.reload.ecosystem).to eq new_ecosystem }
     end
   end
 
   context 'update_courses is false' do
     it "does not updates associated courses' ecosystems" do
-      courses.each{ |course| expect(course.ecosystems.first).to eq old_ecosystem }
+      courses.each{ |course| expect(course.ecosystem).to eq old_ecosystem }
 
       described_class.call(offering.id, {ecosystem: new_ecosystem}, false)
 
-      courses.each{ |course| expect(course.reload.ecosystems.first).to eq old_ecosystem }
+      courses.each{ |course| expect(course.reload.ecosystem).to eq old_ecosystem }
     end
   end
 

--- a/spec/subsystems/course_profile/models/course_spec.rb
+++ b/spec/subsystems/course_profile/models/course_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe CourseProfile::Models::Course, type: :model do
   it { is_expected.to have_many(:students).dependent(:destroy) }
 
   it { is_expected.to have_many(:course_ecosystems) }
-  it { is_expected.to have_many(:ecosystems) }
 
   it { is_expected.to have_many(:course_assistants) }
 

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).not_to be_valid
     expect(task_plan.ecosystem).to be_nil
 
-    task_plan.owner.ecosystems << ecosystem
+    AddEcosystemToCourse.call(course: task_plan.owner, ecosystem: ecosystem)
     expect(task_plan).to be_valid
     expect(task_plan.ecosystem).to eq ecosystem
   end

--- a/spec/subsystems/tasks/update_period_caches_spec.rb
+++ b/spec/subsystems/tasks/update_period_caches_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
     end
   end
   let(:num_period_caches)     { periods.size }
-  let(:ecosystem)             { course.ecosystems.first }
+  let(:ecosystem)             { course.ecosystem }
 
   context 'reading' do
     before(:all)                do
@@ -175,7 +175,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
       period_caches.each do |period_cache|
         period = period_cache.period
         expect(period).to be_in periods
-        expect(period_cache.ecosystem).to eq course.ecosystems.first
+        expect(period_cache.ecosystem).to eq course.ecosystem
         expect(period_cache.student_ids).to match_array period.students.map(&:id)
 
         expect(period_cache.as_toc.deep_symbolize_keys).to match expected_unworked_toc
@@ -199,7 +199,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
       period_caches.each do |period_cache|
         period = period_cache.period
         expect(period).to be_in periods
-        expect(period_cache.ecosystem).to eq course.ecosystems.first
+        expect(period_cache.ecosystem).to eq course.ecosystem
         expect(period_cache.student_ids).to match_array period.students.map(&:id)
 
         expect(period_cache.as_toc.deep_symbolize_keys).to match expected_unworked_toc
@@ -232,7 +232,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
         is_first_period = period == first_period
 
         expect(period).to be_in periods
-        expect(period_cache.ecosystem).to eq course.ecosystems.first
+        expect(period_cache.ecosystem).to eq course.ecosystem
         expect(period_cache.student_ids).to match_array period.students.map(&:id)
 
         expect(period_cache.as_toc.deep_symbolize_keys).to match(
@@ -303,7 +303,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
         end
 
         it 'is called when a new ecosystem is added to the course' do
-          ecosystem = course.ecosystems.first
+          ecosystem = course.ecosystem
           course.course_ecosystems.delete_all :delete_all
 
           expect(configured_job).to receive(:perform_later) do |period_ids:|
@@ -384,7 +384,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
         end
 
         it 'is called when a new ecosystem is added to the course' do
-          ecosystem = course.ecosystems.first
+          ecosystem = course.ecosystem
           course.course_ecosystems.delete_all :delete_all
 
           expect(configured_job).to receive(:perform_later) do |period_ids:|
@@ -499,7 +499,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
       period_caches.each do |period_cache|
         period = period_cache.period
         expect(period).to be_in periods
-        expect(period_cache.ecosystem).to eq course.ecosystems.first
+        expect(period_cache.ecosystem).to eq course.ecosystem
         expect(period_cache.student_ids).to match_array period.students.map(&:id)
 
         expect(period_cache.as_toc.deep_symbolize_keys).to match expected_unworked_toc
@@ -523,7 +523,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
       period_caches.each do |period_cache|
         period = period_cache.period
         expect(period).to be_in periods
-        expect(period_cache.ecosystem).to eq course.ecosystems.first
+        expect(period_cache.ecosystem).to eq course.ecosystem
         expect(period_cache.student_ids).to match_array period.students.map(&:id)
 
         expect(period_cache.as_toc.deep_symbolize_keys).to match expected_unworked_toc
@@ -556,7 +556,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
         is_first_period = period == first_period
 
         expect(period).to be_in periods
-        expect(period_cache.ecosystem).to eq course.ecosystems.first
+        expect(period_cache.ecosystem).to eq course.ecosystem
         expect(period_cache.student_ids).to match_array period.students.map(&:id)
 
         expect(period_cache.as_toc.deep_symbolize_keys).to match(

--- a/spec/subsystems/tasks/update_task_caches_spec.rb
+++ b/spec/subsystems/tasks/update_task_caches_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           task = task_cache.task
           expect(task).to be_in tasks
           expect(task_cache.task_type).to eq (task.task_type)
-          expect(task_cache.ecosystem).to eq course.ecosystems.first
+          expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
           )
@@ -231,7 +231,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           task = task_cache.task
           expect(task).to be_in tasks
           expect(task_cache.task_type).to eq (task.task_type)
-          expect(task_cache.ecosystem).to eq course.ecosystems.first
+          expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
           )
@@ -264,7 +264,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
 
           expect(task).to be_in tasks
           expect(task_cache.task_type).to eq (task.task_type)
-          expect(task_cache.ecosystem).to eq course.ecosystems.first
+          expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
           )
@@ -322,7 +322,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
       end
 
       it 'is called when a new ecosystem is added to the course' do
-        ecosystem = course.ecosystems.first
+        ecosystem = course.ecosystem
         course.course_ecosystems.delete_all :delete_all
 
         expect(configured_job).to receive(:perform_later) do |task_ids:, queue:|
@@ -368,7 +368,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           task = task_cache.task
           expect(task).to be_in tasks
           expect(task_cache.task_type).to eq (task.task_type)
-          expect(task_cache.ecosystem).to eq course.ecosystems.first
+          expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
           )
@@ -393,7 +393,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           task = task_cache.task
           expect(task).to be_in tasks
           expect(task_cache.task_type).to eq (task.task_type)
-          expect(task_cache.ecosystem).to eq course.ecosystems.first
+          expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
           )
@@ -426,7 +426,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
 
           expect(task).to be_in tasks
           expect(task_cache.task_type).to eq (task.task_type)
-          expect(task_cache.ecosystem).to eq course.ecosystems.first
+          expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
           )
@@ -488,7 +488,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
       end
 
       it 'is called when a new ecosystem is added to the course' do
-        ecosystem = course.ecosystems.first
+        ecosystem = course.ecosystem
         course.course_ecosystems.delete_all :delete_all
 
         expect(configured_job).to receive(:perform_later) do |task_ids:, queue:|
@@ -583,7 +583,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         task = task_cache.task
         expect(task).to be_in tasks
         expect(task_cache.task_type).to eq (task.task_type)
-        expect(task_cache.ecosystem).to eq course.ecosystems.first
+        expect(task_cache.ecosystem).to eq course.ecosystem
         expect(task_cache.student_ids).to match_array task.taskings.map { |tt| tt.role.student.id }
         expect(task_cache.student_names).to match_array(
           task.taskings.map { |tt| tt.role.student.name }
@@ -606,7 +606,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         task = task_cache.task
         expect(task).to be_in tasks
         expect(task_cache.task_type).to eq (task.task_type)
-        expect(task_cache.ecosystem).to eq course.ecosystems.first
+        expect(task_cache.ecosystem).to eq course.ecosystem
         expect(task_cache.student_ids).to match_array task.taskings.map { |tt| tt.role.student.id }
         expect(task_cache.student_names).to match_array(
           task.taskings.map { |tt| tt.role.student.name }
@@ -636,7 +636,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
 
         expect(task).to be_in tasks
         expect(task_cache.task_type).to eq (task.task_type)
-        expect(task_cache.ecosystem).to eq course.ecosystems.first
+        expect(task_cache.ecosystem).to eq course.ecosystem
         expect(task_cache.student_ids).to match_array task.taskings.map { |tt| tt.role.student.id }
 
         expect(task_cache.as_toc.deep_symbolize_keys).to match(


### PR DESCRIPTION
Fixed a corner case where Tutor would fail to get CLUes if the latest course ecosystem is not the latest imported ecosystem.