### PR TITLE
update small screen styles for main nav on homepage

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -142,6 +142,10 @@ header {
       background: #fff;
     }
 
+    .navbar-header {
+      float: left;
+    }
+
     .navbar-brand {
       display: block;
       height: 41px;
@@ -151,7 +155,30 @@ header {
       background-size: 100%;
     }
 
-    .navbar-brand-rice {
+    .navbar-default {
+      .sign-in { @include tutor-button(); }
+    }
+
+    .navbar-right {
+      margin: 0;
+      float: right;
+
+      li {
+        float: left;
+      }
+    }
+
+    .navbar-nav.links {
+      li a {
+        // enforce uniform size for all navbar links
+        font-size: 16px;
+        line-height: 1.4;
+        padding: 9px 18px;
+        margin: 0 10px;
+      }
+    }
+
+    .navbar-nav.links li a.navbar-brand-rice {
       display: block;
       float: right;
       margin: 5px 0 0 30px;
@@ -160,25 +187,6 @@ header {
       height: 30px;
       width: 85px;
     }
-
-    .navbar-default {
-
-      .sign-in { @include tutor-button(); }
-
-    }
-
-    .navbar-nav.links {
-
-      li a {
-        // enforce uniform size for all navbar links
-        font-size: 16px;
-        line-height: 1.4;
-        padding: 9px 18px;
-        margin: 0 10px;
-      }
-
-    }
-
   }
 
 }
@@ -412,10 +420,6 @@ footer p a:hover {
 
   .tutor-home {
 
-    header .navbar-default .navbar-brand {
-      margin: 10px 0 0 15px !important;
-    }
-
     .intro-header {
       background-position: -40px -40px;
     }
@@ -427,21 +431,6 @@ footer p a:hover {
 
       }
 
-    }
-
-  }
-
-}
-
-/* #header fix
-================================================== */
-
-@media only screen and (min-width: 768px) and (max-width: 1020px) {
-
-  .tutor-home {
-
-    header .navbar-default .navbar-brand {
-      margin: 5px 0 0 0 !important;
     }
 
   }
@@ -460,10 +449,6 @@ footer p a:hover {
   }
 
   .tutor-home {
-
-    header .navbar-default .navbar-brand {
-      margin: 10px 0 0 15px !important;
-    }
 
     .intro-header {
       height: 600px;
@@ -505,10 +490,6 @@ footer p a:hover {
 @media only screen and (min-width: 480px) and (max-width: 680px) {
 
   .tutor-home {
-
-    header .navbar-default .navbar-brand {
-      margin: 10px 0 0 15px !important;
-    }
 
     .intro-header {
       height: 700px;

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -24,22 +24,12 @@
   <nav class="navbar navbar-default navbar-fixed-top top-nav" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        </button>
         <a class="navbar-brand" href="#home" aria-label="home"></a>
       </div>
-      <!-- Collect the nav links, forms, and other content for toggling -->
-      <div class="collapse navbar-collapse navbar-right navbar-ex1-collapse">
-        <ul class="nav navbar-nav links">
-          <li><a href="<%= TUTOR_HELPDESK_URL %>" target="_blank">Help</a></li>
-        </ul>
-        <a class="navbar-brand-rice" href="http://www.rice.edu" target="_blank" aria-label="rice university"></a>
-      </div>
-      <!-- /.navbar-collapse -->
+      <ul class="nav navbar-nav navbar-right links">
+        <li><a href="<%= TUTOR_HELPDESK_URL %>" target="_blank">Help</a></li>
+        <li><a class="navbar-brand-rice" href="http://www.rice.edu" target="_blank" aria-label="rice university"></a></li>
+      </ul>
     </div>
     <!-- /.container -->
   </nav>


### PR DESCRIPTION
I removed the collapsing behavior from the nav so the links on the right show inline until there is literally no more room for them and then they bump below the logo. at that point it looks a little funny but I don't see how anybody could reasonably get their screen that small anyway.

before:
![image](https://user-images.githubusercontent.com/636227/43006747-7efa59c6-8c04-11e8-8ed5-f1f7fee0ab94.png)

after:
![image](https://user-images.githubusercontent.com/636227/43006772-9403ed5a-8c04-11e8-8e4b-1a9e1913d540.png)
