### PR TITLE
relax hypothesis token so it doesn't expire

### DIFF
--- a/lib/hypothesis.rb
+++ b/lib/hypothesis.rb
@@ -1,6 +1,5 @@
 module Hypothesis
   def self.generate_grant_token(account)
-      now = Time.now.to_i
       # openstax_uid is almost always present except for some fake accounts,
       # in which case we fall back to the account's uuid
       user_id = "acct:" + (account.openstax_uid || account.uuid).abs.to_s + "@openstax.org"
@@ -8,9 +7,7 @@ module Hypothesis
       payload = {
         aud: Rails.application.secrets[:hypothesis]['host'],
         iss: Rails.application.secrets[:hypothesis]['client_id'] || '',
-        sub: user_id,
-        nbf: now,
-        exp: now + 600
+        sub: user_id
       }
       JWT.encode payload, Rails.application.secrets[:hypothesis]['client_secret'] || '', 'HS256'
   end


### PR DESCRIPTION
And remove the "not before time" check so server clocks doesn't have to match.

This will hopefully fix the strange hypothesis errors we've been getting where the server returns forbidden while users attempt to annotate.  

Since most sessions will last more than 5 minutes they never get a new token