### PR TITLE
Fix the dashboard all_tasks_are_ready flag

### DIFF
--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -31,8 +31,10 @@ module DashboardRoutineMethods
   end
 
   def load_tasks(role, role_type, start_at_ntz = nil, end_at_ntz = nil, current_time = Time.current)
-    tasks = run(:get_tasks, roles: role, start_at_ntz: start_at_ntz, end_at_ntz: end_at_ntz)
-              .outputs.tasks.preload(:time_zone, :task_plan, :task_steps).reject(&:hidden?)
+    all_tasks = run(:get_tasks, roles: role, start_at_ntz: start_at_ntz, end_at_ntz: end_at_ntz)
+                  .outputs.tasks.preload(:time_zone, :task_plan, :task_steps).to_a
+
+    tasks = all_tasks.reject(&:hidden?)
 
     tasks = tasks.select do |task|
       task.past_open? current_time: current_time
@@ -57,6 +59,6 @@ module DashboardRoutineMethods
                                       target_type: 'CourseMembership::Models::Period'
                                     })
                                     .where { first_published_at != nil }
-                                    .count <= outputs.tasks.size
+                                    .count <= all_tasks.size
   end
 end


### PR DESCRIPTION
Fix the dashboard all_tasks_are_ready flag so it can return true when there are unopened or hidden assignments.