### PR TITLE
Set time zones properly for the performance report export

### DIFF
--- a/app/subsystems/tasks/performance_report/export_xlsx.rb
+++ b/app/subsystems/tasks/performance_report/export_xlsx.rb
@@ -270,7 +270,7 @@ module Tasks
         meta_rows = [
           [["Tutor Student Scores", style: @title]],
           [[@course.name, style: @course_section]],
-          [["Exported #{Date.today.strftime("%m/%d/%Y")}", style: @italic]],
+          [["Exported #{@course.time_zone.to_tz.today.strftime("%m/%d/%Y")}", style: @italic]],
           [""],
           [[report[:period][:name], style: @course_section]],
           [""]

--- a/app/subsystems/tasks/performance_report_routine.rb
+++ b/app/subsystems/tasks/performance_report_routine.rb
@@ -70,9 +70,9 @@ module Tasks::PerformanceReportRoutine
           type: type,
           id: tt.id,
           due_at: due_at,
-          last_worked_at: tt.last_worked_at,
+          last_worked_at: tt.last_worked_at.try!(:in_time_zone, tz),
           is_late_work_accepted: tt.accepted_late_at.present?,
-          accepted_late_at: tt.accepted_late_at,
+          accepted_late_at: tt.accepted_late_at.try!(:in_time_zone, tz),
           is_included_in_averages: included_in_progress_averages?(
             task: tt, current_time_ntz: current_time_ntz
           )


### PR DESCRIPTION
To fix the issue where last_worked_at in the excel spreadsheet does not match due_at's timezone.