### PR TITLE
Explicitly return early from PopulatePlaceholderSteps and don't populate SPEs when loading the dashboard

### DIFF
--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -41,12 +41,15 @@ module DashboardRoutineMethods
     end if role_type != :teacher
 
     had_pes, need_pes = tasks.partition(&:pes_are_assigned)
-    need_pes.each { |task| Tasks::PopulatePlaceholderSteps.call task: task, skip_unready: true }
+    need_pes.each do |task|
+      Tasks::PopulatePlaceholderSteps.call task: task, skip_unready: true, populate_spes: false
+    end
 
     got_pes, still_need_pes = need_pes.partition(&:pes_are_assigned)
     still_need_pes.each do |task|
-      Tasks::PopulatePlaceholderSteps.set(queue: :low_priority)
-                                     .perform_later task: task, background: true
+      Tasks::PopulatePlaceholderSteps.set(queue: :low_priority).perform_later(
+        task: task, background: true, populate_spes: false
+      )
     end
 
     outputs.tasks = had_pes + got_pes

--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -41,7 +41,7 @@ module DashboardRoutineMethods
     end if role_type != :teacher
 
     had_pes, need_pes = tasks.partition(&:pes_are_assigned)
-    need_pes.each { |task| Tasks::PopulatePlaceholderSteps[task: task] }
+    need_pes.each { |task| Tasks::PopulatePlaceholderSteps.call task: task, skip_unready: true }
 
     got_pes, still_need_pes = need_pes.partition(&:pes_are_assigned)
     still_need_pes.each do |task|


### PR DESCRIPTION
Return early only when the skip_unready flag is specified. This is trying to fix a 404 when populating spaced practice exercises, likely caused by the Populate routine aborting when it shouldn't.

Don't populate SPEs when loading the dashboard to prevent students getting spaced practice out of order when multiple assignments are due at the same time.