### PR TITLE
Fix warning in cohort_spec

### DIFF
--- a/spec/subsystems/research/models/cohort_spec.rb
+++ b/spec/subsystems/research/models/cohort_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Research::Models::Cohort, type: :model do
     Research::Models::CohortMember.create(cohort: cohort, student: students[0])
     cohort.destroy
     expect(cohort.errors.full_messages).to include(/destroy a cohort with members/)
-    expect{described_class.find(cohort.id)}.not_to raise_error(ActiveRecord::RecordNotFound)
+    expect{described_class.find(cohort.id)}.not_to raise_error
   end
 
   it "can be destroyed if no members" do


### PR DESCRIPTION
```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`.
```