### PR TITLE
no longer cache tasks/task_step json.

### DIFF
--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
   api :GET, '/steps/:step_id', 'Gets the specified TaskStep'
   def show
     Research::ModifiedTaskForDisplay[task: @tasked.task_step.task]
-    standard_read(@tasked, Api::V1::TaskedRepresenterMapper.representer_for(@tasked), true)
+    standard_read(@tasked, Api::V1::TaskedRepresenterMapper.representer_for(@tasked))
   end
 
   ###############################################################

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::TasksController < Api::V1::ApiController
   EOS
   def show
     ScoutHelper.ignore!(0.8)
-    standard_read(Research::ModifiedTaskForDisplay[task: @task], Api::V1::TaskRepresenter, true)
+    standard_read(Research::ModifiedTaskForDisplay[task: @task], Api::V1::TaskRepresenter)
   end
 
   api :PUT, '/tasks/:id/accept_late_work', 'Accept late work in the task score'


### PR DESCRIPTION
The "is_feedback_available" field is date dependant and should be true whenever
the due date is past.  However browser's were caching the json and not re-fetching it