### PR TITLE
Change task step update API to match completed API

### DIFF
--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -28,22 +28,8 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
 
   api :PUT, '/steps/:step_id', 'Updates the specified TaskStep'
   def update
-    ScoutHelper.ignore!(0.8)
-
-    @tasked = Research::ModifiedTaskedForUpdate[tasked: @tasked]
-
-    if @task_step.completed?
-      # Update last_completed_at if the task_step is already completed
-      update_and_complete_task_step
-
-      respond_with(
-        @tasked,
-        responder: ResponderWithPutPatchDeleteContent,
-        represent_with: Api::V1::TaskedRepresenterMapper.representer_for(@tasked)
-      )
-    else
-      standard_update(@tasked, Api::V1::TaskedRepresenterMapper.representer_for(@tasked))
-    end
+    # We only update last_completed_at if the task_step is already completed
+    update_task_step(mark_completed: @task_step.completed?)
   end
 
   ###############################################################
@@ -59,18 +45,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
     #{json_schema(Api::V1::TaskRepresenter, include: :readable)}
   EOS
   def completed
-    ScoutHelper.ignore!(0.8)
-
-    @tasked = Research::ModifiedTaskedForUpdate[tasked: @tasked]
-
-    update_and_complete_task_step
-
-    task = Research::ModifiedTaskForDisplay[task: @tasked.task_step.task]
-    respond_with(
-      task,
-      responder: ResponderWithPutPatchDeleteContent,
-      represent_with: Api::V1::TaskRepresenter
-    )
+    update_task_step(mark_completed: true)
   end
 
   ###############################################################
@@ -120,18 +95,32 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
     @tasked.reload
   end
 
-  def update_and_complete_task_step
+  def update_task_step(mark_completed:)
+    ScoutHelper.ignore!(0.8)
+
+    @tasked = Research::ModifiedTaskedForUpdate[tasked: @tasked]
+
     OSU::AccessPolicy.require_action_allowed!(:update, current_api_user, @tasked)
-    OSU::AccessPolicy.require_action_allowed!(:mark_completed, current_api_user, @tasked)
+    OSU::AccessPolicy.require_action_allowed!(:mark_completed, current_api_user, @tasked) \
+      if mark_completed
 
     consume!(@tasked, represent_with: Api::V1::TaskedRepresenterMapper.representer_for(@tasked))
     @tasked.save
 
-    # Task already locked in around_action
-    result = MarkTaskStepCompleted.call(task_step: @task_step, lock_task: false)
+    if mark_completed
+      # Task already locked in around_action
+      result = MarkTaskStepCompleted.call(task_step: @task_step, lock_task: false)
+      raise(ActiveRecord::Rollback) if render_api_errors(result.errors)
+    end
 
-    raise(ActiveRecord::Rollback) if render_api_errors(result.errors)
     raise(ActiveRecord::Rollback) if render_api_errors(@tasked.errors)
+
+    task = Research::ModifiedTaskForDisplay[task: @tasked.task_step.task]
+    respond_with(
+      task,
+      responder: ResponderWithPutPatchDeleteContent,
+      represent_with: Api::V1::TaskRepresenter
+    )
   end
 
 end

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true,
 
       expect(response).to have_http_status(:success)
 
-      expect(response.body).to eq(
-        Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked.reload).to_json
+      expect(response.body_as_hash).to(
+        eq Api::V1::TaskRepresenter.new(tasked.reload.task_step.task).to_hash.deep_symbolize_keys
       )
 
       expect(tasked.reload.free_response).to eq "Ipsum lorem"
@@ -134,8 +134,8 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true,
 
       expect(response).to have_http_status(:success)
 
-      expect(response.body).to eq(
-        Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked.reload).to_json
+      expect(response.body_as_hash).to(
+        eq Api::V1::TaskRepresenter.new(tasked.reload.task_step.task).to_hash.deep_symbolize_keys
       )
 
       expect(tasked.reload.answer_id).to eq answer_id
@@ -181,21 +181,21 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true,
 
       expect(response).to have_http_status(:success)
 
-      expect(response.body_as_hash).to eq(
-        Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked).to_hash.deep_symbolize_keys
+      expect(response.body_as_hash).to(
+        eq Api::V1::TaskRepresenter.new(task_step.reload.task).to_hash.deep_symbolize_keys
       )
 
-      expect(task_step.reload.last_completed_at).not_to be_nil
+      expect(task_step.last_completed_at).not_to be_nil
       expect(task_step.last_completed_at).not_to eq completed_at
       expect(tasked.free_response).to eq 'A sentence explaining all the things!'
     end
 
     context 'research' do
-      let!(:study)    { FactoryBot.create :research_study }
-      let!(:cohort)   { FactoryBot.create :research_cohort, name: 'control', study: study }
-      before(:each) {
+      let!(:study)  { FactoryBot.create :research_study }
+      let!(:cohort) { FactoryBot.create :research_cohort, name: 'control', study: study }
+      before(:each) do
         Research::AddCourseToStudy[course: @course, study: study]
-      }
+      end
 
       it "can override requiring free-response format" do
         expect(tasked.parser.question_formats_for_students).to eq ["multiple-choice", "free-response"]
@@ -224,14 +224,14 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true,
         api_put :recovery, @user_1_token, parameters: {
           id: @tasked_exercise_with_related.task_step.id
         }
-      end.to change { @tasked_exercise_with_related.task_step.task.reload.task_steps.count }
+      end.to change { @tasked_exercise_with_related.reload.task_step.task.task_steps.count }
       expect(response).to have_http_status(:success)
 
       related_exercise_step = @tasked_exercise_with_related.task_step.next_by_number
       tasked = related_exercise_step.tasked
 
-      expect(response.body).to(
-        eq Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked).to_json
+      expect(response.body_as_hash).to eq(
+        Api::V1::Tasks::TaskedExerciseRepresenter.new(tasked).to_hash.deep_symbolize_keys
       )
 
       expect(tasked.los & @tasked_exercise_with_related.parser.los).not_to be_empty


### PR DESCRIPTION
Return the entire task instead of just the task step.