### PR TITLE
Add missing update_course_active_date events

### DIFF
--- a/db/migrate/20181120020412_fix_missing_update_course_active_date_events.rb
+++ b/db/migrate/20181120020412_fix_missing_update_course_active_date_events.rb
@@ -1,0 +1,12 @@
+class FixMissingUpdateCourseActiveDateEvents < ActiveRecord::Migration
+  def up
+    CourseProfile::Models::Course
+      .where("\"created_at\" < '#{DateTime.new(2018).to_s(:db)}'")
+      .where('"sequence_number" > 0').find_each do |course|
+      OpenStax::Biglearn::Api.update_course_active_dates course: course
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181112190157) do
+ActiveRecord::Schema.define(version: 20181120020412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/biglearn.rake
+++ b/lib/tasks/biglearn.rake
@@ -33,6 +33,8 @@ namespace :biglearn do
 
           OpenStax::Biglearn::Api.create_course course: course, ecosystem: ecosystems.first
 
+          OpenStax::Biglearn::Api.update_course_active_dates course: course
+
           OpenStax::Biglearn::Api.update_globally_excluded_exercises course: course
 
           OpenStax::Biglearn::Api.update_course_excluded_exercises course: course

--- a/spec/lib/tasks/biglearn_spec.rb
+++ b/spec/lib/tasks/biglearn_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'biglearn:initialize', type: :rake do
   it 'sends the correct number of records to Biglearn' do
     expect(OpenStax::Biglearn::Api).to receive(:create_ecosystem).twice
     expect(OpenStax::Biglearn::Api).to receive(:create_course).exactly(6).times
+    expect(OpenStax::Biglearn::Api).to receive(:update_course_active_dates).exactly(6).times
     expect(OpenStax::Biglearn::Api).to receive(:update_globally_excluded_exercises).exactly(6).times
     expect(OpenStax::Biglearn::Api).to receive(:update_course_excluded_exercises).exactly(6).times
     expect(OpenStax::Biglearn::Api).to receive(:prepare_course_ecosystem).twice


### PR DESCRIPTION
Add missing update_course_active_date events (due to it not being present in the biglearn initialization task)

About half of all courses are missing these dates in Biglearn-Api.