### PR TITLE
Baked book reference view compatibility

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -1,19 +1,20 @@
 class Api::V1::PagesController < Api::V1::ApiController
 
-  api :GET, '/pages/:uuid(@:version)', 'Return content html of the page'
+  api :GET, '/ecosystems/:ecosystem_id/pages/:uuid(@:version)', 'Returns the content html of a page'
   description <<-EOS
+    Returns the content html of a page
+
     #{json_schema(Api::V1::PageRepresenter, include: :readable)}
   EOS
-  def get_page
-    params_uuid = params[:uuid]
-    params_version = params[:version]
+  def show
+    uuid, version = params[:id].split('@', 2)
 
-    query = Content::Models::Page.where { uuid == params_uuid }.order(version: :desc, id: :desc)
-    query = query.where { version == params_version } if params_version.present?
-    page = query.first
+    pages = Content::Models::Page.joins(chapter: :book).where(
+      uuid: uuid, chapter: { book: { content_ecosystem_id: params[:ecosystem_id] } }
+    )
+    pages = pages.where(version: version) unless version.nil?
+    page = pages.order(version: :desc, id: :desc).first
 
-    page.nil? ?
-      head(:not_found) :
-      respond_with(page, represent_with: Api::V1::PageRepresenter)
+    page.nil? ? head(:not_found) : respond_with(page, represent_with: Api::V1::PageRepresenter)
   end
 end

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::PagesController < Api::V1::ApiController
     #{json_schema(Api::V1::PageRepresenter, include: :readable)}
   EOS
   def show
-    uuid, version = params[:id].split('@', 2)
+    uuid, version = params[:cnx_id].split('@', 2)
 
     pages = Content::Models::Page.joins(chapter: :book).where(
       uuid: uuid, chapter: { book: { content_ecosystem_id: params[:ecosystem_id] } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,7 +180,7 @@ Rails.application.routes.draw do
         get :'exercises(/:pool_types)', action: :exercises
       end
 
-      resources :pages, only: [:show]
+      get 'pages/*cnx_id', to: 'pages#show', format: false
     end
 
     resources :enrollment, only: [:create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,13 +11,11 @@ Rails.application.routes.draw do
     # The routes below would be served by the webview catch-all route,
     # but we define them so we can use them as helpers that point to certain FE pages
     scope action: :index do
-
       # routes that are handled by the FE
       get :dashboard
       get :'course/:id', as: :course_dashboard
       get :'course/:course_id/task/:task_id', as: :student_task
       get :'course/:course_id/t/month/:date/plan/:task_id', as: :teacher_task_plan_review
-
     end
 
     scope :enroll do
@@ -176,16 +174,13 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :pages do
-      get :':uuid@:version', action: :get_page
-      get :':uuid', action: :get_page
-    end
-
     resources :ecosystems, only: [:index] do
       member do
         get :readings
         get :'exercises(/:pool_types)', action: :exercises
       end
+
+      resources :pages, only: [:show]
     end
 
     resources :enrollment, only: [:create] do

--- a/spec/controllers/api/v1/pages_controller_spec.rb
+++ b/spec/controllers/api/v1/pages_controller_spec.rb
@@ -17,24 +17,24 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
 
     context 'GET show' do
       it 'returns not found if the version is not found' do
-        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, id: "#{@page_uuid}@100" }
+        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, cnx_id: "#{@page_uuid}@100" }
         expect(response).to have_http_status(404)
       end
 
       it 'returns not found if the uuid is not found' do
         api_get :show, nil, parameters: {
-          ecosystem_id: @ecosystem.id, id: "b5cd5a64-34a1-434e-b8ba-769000fbec30@1"
+          ecosystem_id: @ecosystem.id, cnx_id: "b5cd5a64-34a1-434e-b8ba-769000fbec30@1"
         }
         expect(response).to have_http_status(404)
       end
 
       it 'returns not found if the version is not a number' do
-        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, id: "#{@page_uuid}@x" }
+        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, cnx_id: "#{@page_uuid}@x" }
         expect(response).to have_http_status(404)
       end
 
       it 'returns absolutized exercise urls' do
-        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, id: @page_uuid }
+        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, cnx_id: @page_uuid }
 
         expect(response.body_as_hash[:content_html]).not_to include(
           '#ost/api/ex/k12phys-ch04-ex001'
@@ -61,7 +61,7 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
         end
 
         it 'returns the page with the correct uuid' do
-          api_get :show, nil, parameters: { ecosystem_id: @old_ecosystem.id, id: @page_uuid }
+          api_get :show, nil, parameters: { ecosystem_id: @old_ecosystem.id, cnx_id: @page_uuid }
           expect(response).to have_http_status(200)
           expect(response.body_as_hash).to eq(
             title: @old_page.title,
@@ -72,7 +72,9 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
         end
 
         it 'returns the page with the correct uuid and version' do
-          api_get :show, nil, parameters: { ecosystem_id: @old_ecosystem.id, id: "#{@page_uuid}@2" }
+          api_get :show, nil, parameters: {
+            ecosystem_id: @old_ecosystem.id, cnx_id: "#{@page_uuid}@2"
+          }
           expect(response).to have_http_status(200)
           expect(response.body_as_hash).to eq(
             title: @old_page.title,

--- a/spec/controllers/api/v1/pages_controller_spec.rb
+++ b/spec/controllers/api/v1/pages_controller_spec.rb
@@ -15,70 +15,72 @@ RSpec.describe Api::V1::PagesController, type: :controller, api: true,
       @page_uuid = '95e61258-2faf-41d4-af92-f62e1414175a'
     end
 
-    it 'returns not found if the version is not found' do
-      api_get :get_page, nil, parameters: { uuid: @page_uuid, version: '100' }
-      expect(response).to have_http_status(404)
-    end
+    context 'GET show' do
+      it 'returns not found if the version is not found' do
+        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, id: "#{@page_uuid}@100" }
+        expect(response).to have_http_status(404)
+      end
 
-    it 'returns not found if the uuid is not found' do
-      api_get :get_page, nil, parameters: {
-        uuid: 'b5cd5a64-34a1-434e-b8ba-769000fbec30', version: '1'
-      }
-      expect(response).to have_http_status(404)
-    end
+      it 'returns not found if the uuid is not found' do
+        api_get :show, nil, parameters: {
+          ecosystem_id: @ecosystem.id, id: "b5cd5a64-34a1-434e-b8ba-769000fbec30@1"
+        }
+        expect(response).to have_http_status(404)
+      end
 
-    it 'returns not found if the version is not a number' do
-      api_get :get_page, nil, parameters: { uuid: @page_uuid, version: 'x' }
-      expect(response).to have_http_status(404)
-    end
+      it 'returns not found if the version is not a number' do
+        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, id: "#{@page_uuid}@x" }
+        expect(response).to have_http_status(404)
+      end
 
-    it 'returns absolutized exercise urls' do
-      api_get :get_page, nil, parameters: { uuid: @page_uuid }
+      it 'returns absolutized exercise urls' do
+        api_get :show, nil, parameters: { ecosystem_id: @ecosystem.id, id: @page_uuid }
 
-      expect(response.body_as_hash[:content_html]).not_to include(
-        '#ost/api/ex/k12phys-ch04-ex001'
-      )
+        expect(response.body_as_hash[:content_html]).not_to include(
+          '#ost/api/ex/k12phys-ch04-ex001'
+        )
 
-      exercises_url_base = Rails.application.secrets.openstax['exercises']['url']
-      expect(response.body_as_hash[:content_html]).to include(
-        "#{exercises_url_base}/api/exercises?q=tag%3A%22k12phys-ch04-ex001%22"
-      )
-    end
+        exercises_url_base = Rails.application.secrets.openstax['exercises']['url']
+        expect(response.body_as_hash[:content_html]).to include(
+          "#{exercises_url_base}/api/exercises?q=tag%3A%22k12phys-ch04-ex001%22"
+        )
+      end
 
-    context 'with an old version of force' do
-      before(:all) do
-        page_hash = { id: "#{@page_uuid}@2", title: 'Force' }
+      context 'with an old version of force' do
+        before(:all) do
+          page_hash = { id: "#{@page_uuid}@2", title: 'Force' }
 
-        chapter = FactoryBot.create :content_chapter
-        cnx_page = OpenStax::Cnx::V1::Page.new(page_hash)
-        VCR.use_cassette("Api_V1_PagesController/with_an_old_version_of_force", VCR_OPTS) do
-          @old_page = Content::Routines::ImportPage.call(
-            cnx_page: cnx_page, chapter: chapter, book_location: [1, 1]
-          ).outputs.page
+          chapter = FactoryBot.create :content_chapter
+          @old_ecosystem = chapter.ecosystem
+          cnx_page = OpenStax::Cnx::V1::Page.new(page_hash)
+          VCR.use_cassette("Api_V1_PagesController/with_an_old_version_of_force", VCR_OPTS) do
+            @old_page = Content::Routines::ImportPage.call(
+              cnx_page: cnx_page, chapter: chapter, book_location: [1, 1]
+            ).outputs.page
+          end
         end
-      end
 
-      it 'returns the page with the correct uuid and version' do
-        api_get :get_page, nil, parameters: { uuid: @page_uuid, version: '2' }
-        expect(response).to have_http_status(200)
-        expect(response.body_as_hash).to eq(
-          title: @old_page.title,
-          chapter_section: @old_page.book_location,
-          content_html: @old_page.content,
-          spy: { ecosystem_title: @old_page.ecosystem.title }
-        )
-      end
+        it 'returns the page with the correct uuid' do
+          api_get :show, nil, parameters: { ecosystem_id: @old_ecosystem.id, id: @page_uuid }
+          expect(response).to have_http_status(200)
+          expect(response.body_as_hash).to eq(
+            title: @old_page.title,
+            chapter_section: @old_page.book_location,
+            content_html: @old_page.content,
+            spy: { ecosystem_title: @old_ecosystem.title }
+          )
+        end
 
-      it 'returns the page with the correct uuid and latest version if version is empty' do
-        api_get :get_page, nil, parameters: { uuid: @page_uuid }
-        page = Content::Models::Page.where(uuid: @page_uuid).order(version: :desc).first
-        expect(response).to have_http_status(200)
-        expect(response.body_as_hash).to eq(
-          title: page.title,
-          chapter_section: page.book_location,
-          content_html: page.content,
-          spy: { ecosystem_title: page.ecosystem.title }
-        )
+        it 'returns the page with the correct uuid and version' do
+          api_get :show, nil, parameters: { ecosystem_id: @old_ecosystem.id, id: "#{@page_uuid}@2" }
+          expect(response).to have_http_status(200)
+          expect(response.body_as_hash).to eq(
+            title: @old_page.title,
+            chapter_section: @old_page.book_location,
+            content_html: @old_page.content,
+            spy: { ecosystem_title: @old_ecosystem.title }
+          )
+        end
       end
     end
   end

--- a/spec/routing/api/v1/pages_controller_routing_spec.rb
+++ b/spec/routing/api/v1/pages_controller_routing_spec.rb
@@ -3,23 +3,33 @@ require "rails_helper"
 RSpec.describe Api::V1::PagesController, type: :routing, api: true, version: :v1 do
 
   context 'GET /api/ecosystems/:ecosystem_id/pages/:uuid(@:version)' do
-    it "routes with a version" do
-      expect(get: "/api/ecosystems/42/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2").to route_to(
-        format: "json",
-        controller: "api/v1/pages",
-        action: "show",
-        ecosystem_id: "42",
-        id: "1bb611e9-0ded-48d6-a107-fbb9bd900851@2"
-      )
-    end
-
     it "routes without a version" do
       expect(get: "/api/ecosystems/84/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851").to route_to(
         format: "json",
         controller: "api/v1/pages",
         action: "show",
         ecosystem_id: "84",
-        id: "1bb611e9-0ded-48d6-a107-fbb9bd900851"
+        cnx_id: "1bb611e9-0ded-48d6-a107-fbb9bd900851"
+      )
+    end
+
+    it "routes with an integer version" do
+      expect(get: "/api/ecosystems/42/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2").to route_to(
+        format: "json",
+        controller: "api/v1/pages",
+        action: "show",
+        ecosystem_id: "42",
+        cnx_id: "1bb611e9-0ded-48d6-a107-fbb9bd900851@2"
+      )
+    end
+
+    it "routes with a version with a decimal point" do
+      expect(get: "/api/ecosystems/42/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2.1").to route_to(
+        format: "json",
+        controller: "api/v1/pages",
+        action: "show",
+        ecosystem_id: "42",
+        cnx_id: "1bb611e9-0ded-48d6-a107-fbb9bd900851@2.1"
       )
     end
   end

--- a/spec/routing/api/v1/pages_controller_routing_spec.rb
+++ b/spec/routing/api/v1/pages_controller_routing_spec.rb
@@ -2,23 +2,24 @@ require "rails_helper"
 
 RSpec.describe Api::V1::PagesController, type: :routing, api: true, version: :v1 do
 
-  context 'GET /api/pages/:uuid' do
+  context 'GET /api/ecosystems/:ecosystem_id/pages/:uuid(@:version)' do
     it "routes with a version" do
-      expect(get: "/api/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2").to route_to(
+      expect(get: "/api/ecosystems/42/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851@2").to route_to(
         format: "json",
         controller: "api/v1/pages",
-        action: "get_page",
-        uuid: "1bb611e9-0ded-48d6-a107-fbb9bd900851",
-        version: "2"
+        action: "show",
+        ecosystem_id: "42",
+        id: "1bb611e9-0ded-48d6-a107-fbb9bd900851@2"
       )
     end
 
     it "routes without a version" do
-      expect(get: "/api/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851").to route_to(
+      expect(get: "/api/ecosystems/84/pages/1bb611e9-0ded-48d6-a107-fbb9bd900851").to route_to(
         format: "json",
         controller: "api/v1/pages",
-        action: "get_page",
-        uuid: "1bb611e9-0ded-48d6-a107-fbb9bd900851"
+        action: "show",
+        ecosystem_id: "84",
+        id: "1bb611e9-0ded-48d6-a107-fbb9bd900851"
       )
     end
   end


### PR DESCRIPTION
- Nest the /pages API under /ecosystems so we always know which ecosystem to look at (fixed baked book imports interfering with unbaked books)
- Use wildcard matching and `format: false` in the pages route so Rails does not interpret the decimal point in the baked-only page versions as a format