### PR TITLE
re-instate non-null with default clause on book_location columns

### DIFF
--- a/db/migrate/20181203172559_add_baked_book_location_columns.rb
+++ b/db/migrate/20181203172559_add_baked_book_location_columns.rb
@@ -1,7 +1,7 @@
 class AddBakedBookLocationColumns < ActiveRecord::Migration
   def change
-    add_column :content_chapters, :baked_book_location, :text
-    add_column :content_pages, :baked_book_location, :text
-    add_column :tasks_tasked_readings, :baked_book_location, :text
+    add_column :content_chapters, :baked_book_location, :text, null: false, default: '[]'
+    add_column :content_pages, :baked_book_location, :text, null: false, default: '[]'
+    add_column :tasks_tasked_readings, :baked_book_location, :text, null: false, default: '[]'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20181203172559) do
     t.integer  "content_all_exercises_pool_id"
     t.text     "book_location",                 default: "[]",                null: false
     t.uuid     "tutor_uuid",                    default: "gen_random_uuid()"
-    t.text     "baked_book_location"
+    t.text     "baked_book_location",           default: "[]",                null: false
   end
 
   add_index "content_chapters", ["content_book_id", "number"], name: "index_content_chapters_on_content_book_id_and_number", unique: true, using: :btree
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 20181203172559) do
     t.text     "fragments",                        default: "[]",                null: false
     t.text     "snap_labs",                        default: "[]",                null: false
     t.uuid     "tutor_uuid",                       default: "gen_random_uuid()"
-    t.text     "baked_book_location"
+    t.text     "baked_book_location",              default: "[]",                null: false
   end
 
   add_index "content_pages", ["content_chapter_id", "number"], name: "index_content_pages_on_content_chapter_id_and_number", unique: true, using: :btree
@@ -1002,7 +1002,7 @@ ActiveRecord::Schema.define(version: 20181203172559) do
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
     t.text     "book_location",       default: "[]", null: false
-    t.text     "baked_book_location"
+    t.text     "baked_book_location", default: "[]", null: false
   end
 
   create_table "tasks_tasked_videos", force: :cascade do |t|


### PR DESCRIPTION
Otherwise the db wrappers fail the verify_and_return checks.  

Those checks could be removed but since it's late in the release cycle we're just going to remove the earlier commit