### PR TITLE
Fix bug preventing concurrent willo labs pairing

### DIFF
--- a/spec/subsystems/lms/launch_spec.rb
+++ b/spec/subsystems/lms/launch_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe Lms::Launch do
 
   let(:course) { FactoryBot.create :course_profile_course, is_lms_enabled: true }
   let(:app) { FactoryBot.create(:lms_app, owner: course) }
+  let(:message) {
+    OpenStruct.new(context_id: '1234', tool_consumer_instance_guid: '4242')
+  }
+  let(:authenticator) {
+    OpenStruct.new(:valid_signature? => true, message: message)
+  }
+
 
   it 'creates context' do
-    expect_any_instance_of(
-      ::IMS::LTI::Services::MessageAuthenticator
-    ).to receive(:valid_signature?).and_return(true)
-
     launch = Lms::Launch.from_request(
-      FactoryBot.create(:launch_request, app: app)
+      FactoryBot.create(:launch_request, app: app),
+      authenticator: authenticator
     )
     expect {
       launch.persist!
@@ -20,11 +24,22 @@ RSpec.describe Lms::Launch do
   end
 
   it 'verifies nonce unused' do
-    expect_any_instance_of(
-      ::IMS::LTI::Services::MessageAuthenticator
-    ).to receive(:valid_signature?).and_return(true)
     request = FactoryBot.create(:launch_request, app: app)
-    Lms::Launch.from_request(request)
+    Lms::Launch.from_request(request, authenticator: authenticator)
     expect { Lms::Launch.from_request(request) }.to raise_error(Lms::Launch::AlreadyUsed)
+  end
+
+  it 'multiple concurrent contexts without course can be launched' do
+    app = Lms::WilloLabs.new
+    3.times do |i|
+      expect {
+        message.context_id = "launch-#{i}"
+        launch = Lms::Launch.from_request(
+          FactoryBot.create(:launch_request, app: app),
+          authenticator: authenticator
+        )
+        launch.persist!
+      }.to change { Lms::Models::Context.count }.by 1
+    end
   end
 end


### PR DESCRIPTION
Don't check for context using the course if course wasn't found, otherwise it'll find and create one with null course and then future will raise keys in use error