### PR TITLE
Add user roster to cohorts

### DIFF
--- a/app/controllers/research/cohorts_controller.rb
+++ b/app/controllers/research/cohorts_controller.rb
@@ -1,7 +1,7 @@
 class Research::CohortsController < Research::BaseController
 
   before_action :get_study, only: [:create]
-  before_action :get_cohort, only: [:show, :edit, :update, :destroy, :reassign_members]
+  before_action :get_cohort, only: [:show, :edit, :update, :members, :destroy, :reassign_members]
 
   def new
     @cohort = Research::Models::Cohort.new

--- a/app/views/research/cohorts/members.html.erb
+++ b/app/views/research/cohorts/members.html.erb
@@ -1,0 +1,23 @@
+  <div>
+    Study: <%= link_to @cohort.study.name, research_study_path(@cohort.study) %>
+  </div>
+  <div>
+    <h3>Cohort <%= @cohort.name %> Members</h3>
+  </div>
+<hr>
+<table class="table">
+  <thead>
+    <tr>
+      <td>Login</td>
+      <th>Identifier</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @cohort.cohort_members.includes(student: { role: :profile }).each do |cm| %>
+    <tr>
+      <td><%= link_to cm.student.role.username, info_admin_users_path(id: cm.student.role.profile.id) %></td>
+      <td><%= cm.student.student_identifier %></td>
+    </tr>
+    <% end %>
+  </tbody>
+  </table>

--- a/app/views/research/studies/show.html.erb
+++ b/app/views/research/studies/show.html.erb
@@ -42,7 +42,7 @@
     <div class="course_listing_entries">
       <% @study.cohorts.each do |cohort| %>
         <div class="cohort_entry">
-          <%= link_to cohort.name, research_cohort_path(cohort) %> / ID: <%= cohort.id %> / <%= cohort.cohort_members_count %> Members
+          <%= link_to cohort.name, research_cohort_path(cohort) %> / <%= link_to "#{cohort.cohort_members_count} Members", research_cohort_members_path(cohort) %>
         </div>
       <% end %>
       <% if !@study.active? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -388,6 +388,7 @@ Rails.application.routes.draw do
       resources :brains, shallow: true
       resources :cohorts, shallow: true do
         put 'reassign_members'
+        get 'members'
       end
     end
 

--- a/spec/controllers/research/cohorts_controller_spec.rb
+++ b/spec/controllers/research/cohorts_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Research::CohortsController, type: :controller do
+  let(:cohort) { FactoryBot.create :research_cohort }
+
+  let(:researcher) { FactoryBot.create :user, :researcher }
+
+  before { controller.sign_in(researcher) }
+
+  context 'GET #members' do
+    render_views
+
+    it 'lists members' do
+      student = FactoryBot.create :course_membership_student
+      student.role.update_attributes profile: FactoryBot.create(:user_profile)
+      Research::CohortMembershipManager.new(cohort.study).add_student_to_a_cohort(student)
+      get :members, cohort_id: cohort.id
+      expect(response.body).to include student.role.profile.username
+    end
+  end
+end

--- a/spec/features/research/cohorts_spec.rb
+++ b/spec/features/research/cohorts_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Cohorts', js: true do
       fill_in 'Name', with: 'AAA'
       click_button 'Save'
 
-      expect(page).to have_content(/Cohorts:.*AAA \/ ID:/)
+      expect(page).to have_content(/Cohorts:.*AAA \/ 0 Members/)
     end
   end
 

--- a/spec/research-studies/remove_free_response_format_spec.rb
+++ b/spec/research-studies/remove_free_response_format_spec.rb
@@ -93,6 +93,10 @@ EOC
                       study: @study,
                       name: 'chapter 1-3 save without free-response',
                       code: <<~EOC
+unless tasked.task_step.exercise?
+  manipulation.ignore!
+  return
+end
 
 chosen_sections = %w{
   1,1 1,2 1,3 1,4 2,1 2,2 2,3 2,4 2,5 2,6 2,7 2,8 3,1 3,2 3,3 3,4 3,5


### PR DESCRIPTION
Roster is needed so that testers can tell which student is in which cohort

also fix bug with study brain so it only manipulates exercise steps for study
Otherwise it has an error with `parser` not being defined.