### PR TITLE
add admin control to unlink a course from a lms

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -33,6 +33,11 @@ class Admin::CoursesController < Admin::BaseController
     get_new_course
   end
 
+  def unpair_lms
+    Lms::UnpairCourse.call(course: CourseProfile::Models::Course.find(params[:id]))
+    redirect_to admin_courses_path
+  end
+
   def create
     handle_with(Admin::CoursesCreate,
                 success: ->(*) {

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -14,7 +14,7 @@ class CourseProfile::Models::Course < ApplicationRecord
 
   belongs_to :school, subsystem: :school_district
   belongs_to :offering, subsystem: :catalog
-
+  has_one :lms_context, subsystem: :lms, class_name: 'Lms::Models::Context'
   has_many :periods, subsystem: :course_membership,
                      dependent: :destroy,
                      inverse_of: :course

--- a/app/subsystems/lms/models/context.rb
+++ b/app/subsystems/lms/models/context.rb
@@ -6,6 +6,18 @@ module Lms
 
       belongs_to :tool_consumer
       belongs_to :course, subsystem: :course_profile
+
+      before_destroy :confirm_course_access_is_switchable
+
+      protected
+
+      def confirm_course_access_is_switchable
+        if course && !course.is_access_switchable?
+          errors.add(:course, 'access is not switchable')
+        end
+      end
+
     end
+
   end
 end

--- a/app/subsystems/lms/unpair_course.rb
+++ b/app/subsystems/lms/unpair_course.rb
@@ -1,0 +1,14 @@
+class Lms::UnpairCourse
+
+  lev_routine
+
+  def exec(course:)
+    unless course.is_access_switchable?
+      fatal_error(code: :course_access_is_locked, message: "Course access is locked")
+    end
+    if course.lms_context.present?
+      course.lms_context.destroy
+    end
+    transfer_errors_from(course, {type: :verbatim})
+  end
+end

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -111,14 +111,25 @@
                 } archived) / #{total_periods} periods (#{archived_periods} archived)"
               %> /
               <%= course_info.does_cost ? "Does Cost" : "Does NOT Cost" %> /
-              LMS: <%= course_info.is_lms_enabling_allowed ? "enable allowed" : "enable not allowed" %> -
-              <% if course_info.is_lms_enabled.nil? %>
+              LMS:
+              <% if !course_info.is_lms_enabling_allowed %>
+                enable not allowed
+              <% elsif course_info.is_lms_enabled.nil? %>
                 no choice made
               <% elsif course_info.is_lms_enabled %>
                 enabled
+                <% if course_info.is_access_switchable? %>
+                  <% if course_info.lms_context.present? %>
+                    &amp; paired (<%= link_to('unpair', unpair_lms_admin_course_path(course_info),
+                                method: :delete, data: { confirm: 'Are you sure?' })%>)
+                  <% end %>
+                <% else %>
+                   LOCKED
+                <% end %>
               <% else %>
                 disabled
               <% end %>
+
             </div>
           </div>
           <div class="card-content-right">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,6 +257,7 @@ Rails.application.routes.draw do
         post :set_ecosystem
         post :set_catalog_offering
         post :teachers, controller: :teachers
+        delete :unpair_lms
       end
 
       post :bulk_update, on: :collection

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -254,6 +254,16 @@ RSpec.describe Admin::CoursesController, type: :controller, speed: :medium do
     end
   end
 
+  context 'DELETE #unpair_lms' do
+    let(:course) { FactoryBot.create :course_profile_course }
+    it 'calls unpair routine' do
+      expect_any_instance_of(Lms::UnpairCourse).to(
+        receive(:call).with(course: course)
+      )
+      delete :unpair_lms, id: course.id
+    end
+  end
+
   context 'DELETE #destroy' do
     let(:course) { FactoryBot.create :course_profile_course }
 

--- a/spec/features/admin/bulk_set_flag_spec.rb
+++ b/spec/features/admin/bulk_set_flag_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Bulk set course flag', js: true do
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('.flash_notice', text: 'Flag values were updated')
-    expect(page).to have_text('LMS: enable allowed')
+    expect(page).to have_text('LMS: no choice made')
   end
 
   scenario 'select all on all pages with no query' do
@@ -47,7 +47,7 @@ RSpec.feature 'Bulk set course flag', js: true do
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('.flash_notice', text: 'Flag values were updated')
-    expect(page).to have_text('LMS: enable allowed')
+    expect(page).to have_text('LMS: no choice made')
   end
 
   scenario 'select all on all pages with query' do
@@ -65,7 +65,7 @@ RSpec.feature 'Bulk set course flag', js: true do
 
     expect(current_path).to eq(admin_courses_path)
     expect(page).to have_css('.flash_notice', text: 'Flag values were updated')
-    expect(page).to have_text('LMS: enable allowed')
+    expect(page).to have_text('LMS: no choice made')
   end
 
 end

--- a/spec/subsystems/lms/unpair_course_spec.rb
+++ b/spec/subsystems/lms/unpair_course_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Lms::UnpairCourse do
+
+  let(:message) {
+    OpenStruct.new(context_id: '1234', tool_consumer_instance_guid: '4242')
+  }
+  let(:authenticator) {
+    OpenStruct.new(:valid_signature? => true, message: message)
+  }
+  let(:launch) {
+    Lms::Launch.from_request(
+      FactoryBot.create(:launch_request, app: Lms::WilloLabs.new),
+      authenticator: authenticator
+    )
+  }
+  let(:course) { FactoryBot.create :course_profile_course }
+
+  before(:each) {
+    Lms::PairLaunchToCourse.call(launch_id: launch.persist!, course: course)
+    course.reload
+  }
+
+  it "errors unless access is switchable" do
+    course.update_attributes! is_access_switchable: false
+    expect{
+      result = subject.call(course: course)
+      expect(result.errors).not_to be_empty
+    }.to_not change{ Lms::Models::Context.count }
+    expect(course.reload.lms_context).to be_present
+  end
+
+  it "deletes the lms context" do
+    expect(course.lms_context).to be_present
+    expect{
+      result = subject.call(course: course)
+      expect(result.errors).to be_empty
+    }.to change{ Lms::Models::Context.count }.by -1
+    expect(course.reload.lms_context).to be_nil
+  end
+end


### PR DESCRIPTION
This way the keys can be re-used with a different LMS system.

Is needed to accomodate the case of a teacher who enters them into the wrong
place in their system

![image](https://user-images.githubusercontent.com/79566/50018284-60dae100-ff94-11e8-9527-fd6657f26f67.png)
