### PR TITLE
drop "os" prefix from urls

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -92,7 +92,7 @@ development:
       url: <%= ENV["OPENSTAX_PAYMENTS_URL"] %>
       stub: <%= ENV.fetch("OPENSTAX_PAYMENTS_STUB", true) %>
     osweb:
-      base_url: <%= ENV["OPENSTAX_OSWEB_BASE_URL"] || 'https://oscms.openstax.org' %>
+      base_url: <%= ENV["OPENSTAX_OSWEB_BASE_URL"] || 'https://cms-qa.openstax.org' %>
 
 test:
   secret_key_base: c839cca39849dacab21de5bdfe69d921502e74c1b6c176208161ce4c1b84fd0a
@@ -177,4 +177,4 @@ test:
       product_uuid: <%= ENV["OPENSTAX_PAYMENTS_PRODUCT_UUID"] || '6d60ab29-3b3d-575a-93ef-57d62e30984c' %>
       stub: true
     osweb:
-      base_url: https://oscms.openstax.org
+      base_url: https://cms.openstax.org

--- a/spec/representers/api/v1/bootstrap_data_representer_spec.rb
+++ b/spec/representers/api/v1/bootstrap_data_representer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::BootstrapDataRepresenter, type: :representer do
       "courses" => [], # not testing this since it's too expensive to generate meaningful course data
       "accounts_api_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'api',
       "accounts_profile_url" => OpenStax::Accounts.configuration.openstax_accounts_url + 'profile',
-      "osweb_base_url" => 'https://oscms.openstax.org',
+      "osweb_base_url" => 'https://cms.openstax.org',
       "tutor_api_url" => 'https://example.com/api',
       "hypothesis" => a_hash_including(
         "host" => Rails.application.secrets['hypothesis']['host'],


### PR DESCRIPTION
They're now of the form "https://cms-qa.openstax.org/"