### PR TITLE
hide deleted periods from enrollment

### DIFF
--- a/app/representers/api/v1/course_enrollments_representer.rb
+++ b/app/representers/api/v1/course_enrollments_representer.rb
@@ -35,5 +35,7 @@ class Api::V1::CourseEnrollmentsRepresenter < Roar::Decorator
            writeable: false,
            schema_info: { required: true, type: 'boolean' }
 
-  collection :periods, extend: PeriodsRepresenter
+  collection :periods,
+             extend: PeriodsRepresenter,
+             getter: -> (*) { periods.without_deleted }
 end

--- a/spec/representers/api/v1/course_enrollments_representer_spec.rb
+++ b/spec/representers/api/v1/course_enrollments_representer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require_relative 'course_representer_shared_examples'
+
+RSpec.describe Api::V1::CourseEnrollmentsRepresenter, type: :representer do
+
+    let(:course) do
+      FactoryBot.create :course_profile_course, name: 'Test course'
+    end
+
+    let(:period) {
+        FactoryBot.create :course_membership_period, course: course, name: '1st'
+    }
+
+    subject(:represented) { described_class.new(course).as_json }
+
+    it 'shows the course name' do
+      expect(represented['name']).to eq course.name
+    end
+
+
+    it 'hides archived periods' do
+        period_name = period.name
+        archived = FactoryBot.create :course_membership_period, course: course, name: 'Deleted!'
+        archived.destroy
+        periods = represented['periods'].map{|p|p['name']}
+        expect(periods).to eq [period_name]
+    end
+
+end


### PR DESCRIPTION
Currently they're still appearing for LMS enrollments to select from