### PR TITLE
map LMS admin type roles to "Instructor"

### DIFF
--- a/app/subsystems/lms/launch.rb
+++ b/app/subsystems/lms/launch.rb
@@ -87,19 +87,23 @@ class Lms::Launch
   end
 
   def role
-    # Let's start with recognizing only definite instructor and student roles; there
-    # are a zillion roles defined in LIS and JP thinks we should be aware of the roles
-    # we are handling and which we consider to be instructors.
-    @role ||= begin
-      lms_roles = (request_parameters[:roles] || '').split(',')
-      if lms_roles.any?{|lms_role| lms_role.match(/Instructor|Creator|Faculty|Mentor|Staff|Support|Admin/)}
-        :instructor
-      elsif lms_roles.any?{|lms_role| lms_role.match(/Student|Learner/)}
-        :student
-      else
-        :other
+      # We start with recognizing only the roles that we can logically map to
+      # either an instructor or student
+      # There are a zillion other roles that we don't support
+      # The accounts service does support other types of accounts such as
+      # "Administrator", "Adjunct", and "Librarian", but we only send
+      # "instructor" or "student" because that's what we need returned in order
+      # for Tutor to setup the user with the proper access
+      @role ||= begin
+        lms_roles = (request_parameters[:roles] || '').split(',')
+        if lms_roles.any?{|lms_role| lms_role.match(/Instructor|Creator|Faculty|Mentor|Staff|Support|Admin/)}
+          :instructor
+        elsif lms_roles.any?{|lms_role| lms_role.match(/Student|Learner/)}
+          :student
+        else
+          :other
+        end
       end
-    end
   end
 
   def is_student?

--- a/app/subsystems/lms/launch.rb
+++ b/app/subsystems/lms/launch.rb
@@ -90,10 +90,9 @@ class Lms::Launch
     # Let's start with recognizing only definite instructor and student roles; there
     # are a zillion roles defined in LIS and JP thinks we should be aware of the roles
     # we are handling and which we consider to be instructors.
-
     @role ||= begin
       lms_roles = (request_parameters[:roles] || '').split(',')
-      if lms_roles.any?{|lms_role| lms_role.match(/Instructor/)}
+      if lms_roles.any?{|lms_role| lms_role.match(/Instructor|Creator|Faculty|Mentor|Staff|Support|Admin/)}
         :instructor
       elsif lms_roles.any?{|lms_role| lms_role.match(/Student|Learner/)}
         :student

--- a/spec/requests/lms_launch_spec.rb
+++ b/spec/requests/lms_launch_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe 'LMS Launch', type: :request do
     context "not enrolled" do
       it 'redirects the student to enrollment' do
         expect_any_instance_of(Lms::Launch).to receive(:update_tool_consumer_metadata!)
-
         simulator.add_student("bob")
         simulator.launch(user: "bob", assignment: "tutor")
         bob_user = launch_helper.complete_the_launch_locally
@@ -129,8 +128,9 @@ RSpec.describe 'LMS Launch', type: :request do
   end
 
   it 'gives an error for unsupported role' do
-    simulator.add_administrator("admin")
-    simulator.launch(user: "admin", assignment: "tutor")
+    params = simulator.launch(
+      user: "bob", assignment: "tutor",
+    )
     expect_error("Only the course instructor and enrolled")
   end
 

--- a/spec/subsystems/lms/launch_spec.rb
+++ b/spec/subsystems/lms/launch_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe Lms::Launch do
     expect { Lms::Launch.from_request(request) }.to raise_error(Lms::Launch::AlreadyUsed)
   end
 
+  it 'maps roles' do
+      { instructor: %w{Instructor Creator Faculty Mentor Staff SysAdmin SysSupport AccountAdmin Administrator},
+        student: %w{Student Learner ProspectiveStudent}
+      }.each do |role, mappings|
+          mappings.each do |type|
+              req = FactoryBot.create(:launch_request, app: app)
+              req.request_parameters[:roles] = "IMS::LIS::Roles::Context::URNs::#{type}"
+              launch = Lms::Launch.from_request(req,authenticator: authenticator)
+              expect(launch.role).to eq role
+          end
+      end
+  end
+
   it 'multiple concurrent contexts without course can be launched' do
     app = Lms::WilloLabs.new
     3.times do |i|


### PR DESCRIPTION
We've encountered a school that gives admin roles to instructors.  According to Willo labs this isn't uncommon 