### PR TITLE
don't error if nonce already exists

### DIFF
--- a/app/controllers/lms_controller.rb
+++ b/app/controllers/lms_controller.rb
@@ -74,8 +74,6 @@ class LmsController < ApplicationController
       fail_for_course_score_in_use(launch) and return
     rescue Lms::Launch::CourseKeysAlreadyUsed => ee
       fail_for_course_keys_already_used(launch) and return
-    rescue Lms::Launch::AlreadyUsed => ee
-      fail_for_already_used and return
     rescue Lms::Launch::AppNotFound, Lms::Launch::InvalidSignature => ee
       fail_for_invalid_key_secret(launch) and return
     rescue Lms::Launch::HandledError => ee
@@ -92,8 +90,6 @@ class LmsController < ApplicationController
 
     begin
       launch = Lms::Launch.from_id(session[:launch_id])
-    rescue Lms::Launch::CouldNotLoadLaunch => ee
-      fail_for_already_used and return
     end
 
     # Always send users to accounts when a launch happens.  We may decide
@@ -198,11 +194,6 @@ class LmsController < ApplicationController
   def fail_for_course_keys_already_used(launch)
     log(:info) { "Launch #{session[:launch_id]} failing because course keys already used for another context"}
     render_minimal_error(:fail_course_keys_already_used, locals: { launch: launch })
-  end
-
-  def fail_for_already_used
-    log(:info) { "Nonce reused in launch #{session[:launch_id]}"}
-    render_minimal_error(:fail_already_used)
   end
 
   def fail_for_course_score_in_use(launch)

--- a/app/subsystems/lms/launch.rb
+++ b/app/subsystems/lms/launch.rb
@@ -241,11 +241,7 @@ class Lms::Launch
         @message.launch_url = request_url
       end
     else
-      begin
-        Lms::Models::Nonce.create!({ lms_app_id: app.id, value: request_parameters[:oauth_nonce] })
-      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => ee
-        raise AlreadyUsed
-      end
+      Lms::Models::Nonce.find_or_create_by!({ lms_app_id: app.id, value: request_parameters[:oauth_nonce] })
 
       with_warnings(warning_verbosity) do
         authenticator = authenticator || ::IMS::LTI::Services::MessageAuthenticator.new(

--- a/app/views/lms/fail_already_used.html.erb
+++ b/app/views/lms/fail_already_used.html.erb
@@ -1,7 +1,0 @@
-<% content_for :title do %>
-  There has been an error launching your course
-<% end %>
-
-<% content_for :body do %>
-  Please try launching OpenStax Tutor again.
-<% end %>

--- a/spec/requests/lms_launch_spec.rb
+++ b/spec/requests/lms_launch_spec.rb
@@ -73,12 +73,6 @@ RSpec.describe 'LMS Launch', type: :request do
         expect_error("already been used for a registration")
       end
 
-      it 'complains about reused launch nonce' do
-        simulator.add_student("bob")
-        simulator.launch(user: "bob", assignment: "tutor")
-        simulator.repeat_last_launch
-        expect_error("Please try launching OpenStax Tutor again.")
-      end
     end
 
     context "dropped" do

--- a/spec/subsystems/lms/launch_spec.rb
+++ b/spec/subsystems/lms/launch_spec.rb
@@ -45,23 +45,17 @@ RSpec.describe Lms::Launch do
     expect(launch.context).not_to be_nil
   end
 
-  it 'verifies nonce unused' do
-    request = FactoryBot.create(:launch_request, app: app)
-    Lms::Launch.from_request(request, authenticator: authenticator)
-    expect { Lms::Launch.from_request(request) }.to raise_error(Lms::Launch::AlreadyUsed)
-  end
-
   it 'maps roles' do
-      { instructor: %w{Instructor Creator Faculty Mentor Staff SysAdmin SysSupport AccountAdmin Administrator},
-        student: %w{Student Learner ProspectiveStudent}
-      }.each do |role, mappings|
-          mappings.each do |type|
-              req = FactoryBot.create(:launch_request, app: app)
-              req.request_parameters[:roles] = "IMS::LIS::Roles::Context::URNs::#{type}"
-              launch = Lms::Launch.from_request(req,authenticator: authenticator)
-              expect(launch.role).to eq role
-          end
+    { instructor: %w{Instructor Creator Faculty Mentor Staff SysAdmin SysSupport AccountAdmin Administrator},
+      student: %w{Student Learner ProspectiveStudent}
+    }.each do |role, mappings|
+      mappings.each do |type|
+        req = FactoryBot.create(:launch_request, app: app)
+        req.request_parameters[:roles] = "IMS::LIS::Roles::Context::URNs::#{type}"
+        launch = Lms::Launch.from_request(req,authenticator: authenticator)
+        expect(launch.role).to eq role
       end
+    end
   end
 
   it 'multiple concurrent contexts without course can be launched' do


### PR DESCRIPTION
We've had Moodle and blackboard send non-unique nonce.   
https://www.google.com/search?q=lms+nonce+duplicate suggests that this is fairly common 😭 