### PR TITLE
Add a new metatasks controller and json serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Ignore bundler config
 /.bundle
-.env
+.env*
 
 # Ignore the default SQLite database and yaml_db database files
 /db/*.sqlite3*
@@ -16,6 +16,9 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp/**/*
+
+# Ignore rubymine files
+/.idea
 
 # Ignore files containing keys and passwords
 config/secrets.yml

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,8 @@ gem 'ims-lti', '~> 2.2.1'
 # Also, do not use Roar::Hypermedia links
 gem 'roar', '1.0.3'
 
+gem 'nokogiri'
+
 # Background job status store
 gem 'jobba', '~> 1.8.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -778,6 +778,7 @@ DEPENDENCIES
   maruku
   mini_magick
   nifty-generators
+  nokogiri
   oauth (~> 0.5.1)
   oj
   oj_mimic_json

--- a/app/controllers/api/v1/metatasks_controller.rb
+++ b/app/controllers/api/v1/metatasks_controller.rb
@@ -1,0 +1,55 @@
+class Api::V1::MetatasksController < Api::V1::ApiController
+
+  before_action :get_task
+  before_filter :error_if_student_and_needs_to_pay, only: [:show, :destroy]
+  before_action :populate_placeholders, only: :show
+
+  resource_description do
+    api_versions "v1"
+    short_description 'Represents a metatask, a light weight task'
+    description <<-EOS
+      Metatasks are a light weight representation of something that a user
+      needs to do in the system (something that has been assigned by
+      another part of the system).  They contain dates like due_at as
+      well as information about whether the task is shared
+    EOS
+  end
+
+  ###############################################################
+  # show
+  ###############################################################
+
+  api :GET, '/metatasks/:id', 'Gets the specified metatask'
+  description <<-EOS
+    #{json_schema(Api::V1::MetataskRepresenter, include: :readable)}
+  EOS
+  def show
+    ScoutHelper.ignore!(0.8)
+    standard_read(Research::ModifiedTaskForDisplay[task: @task], Api::V1::MetataskRepresenter)
+  end
+
+  api :DELETE, '/tasks/:id', 'Hide the task from the student\'s dashboard'
+  description <<-EOS
+    Hides the Task from the student's dashboard
+  EOS
+  def destroy
+    OSU::AccessPolicy.require_action_allowed!(:hide, current_api_user, @task)
+    @task.hide.save!
+    respond_with @task, represent_with: Api::V1::MetataskRepresenter,
+                 responder: ResponderWithPutPatchDeleteContent
+  end
+
+  protected
+
+  def get_task
+    @task = ::Tasks::Models::Task.preload(
+      :research_study_brains,
+      task_steps: [:tasked, :page]
+    ).find(params[:id])
+  end
+
+  def populate_placeholders
+    Tasks::PopulatePlaceholderSteps[task: @task]
+  end
+
+end

--- a/app/representers/api/v1/metatask_representer.rb
+++ b/app/representers/api/v1/metatask_representer.rb
@@ -32,8 +32,7 @@ module Api::V1
                description: "When the metatask was last worked (nil means not yet worked)"
              }
 
-    collection :metatask_steps,
-               as: :metatask_steps,
+    collection :steps,
                writeable: false,
                readable: true,
                extend: MetataskStepRepresenter,

--- a/app/representers/api/v1/metatask_representer.rb
+++ b/app/representers/api/v1/metatask_representer.rb
@@ -1,0 +1,59 @@
+module Api::V1
+  class MetataskRepresenter < Roar::Decorator
+
+    include Roar::JSON
+    include Representable::Coercion
+
+    property :id,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: { required: true }
+
+    property :title,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: { required: true }
+
+    property :due_at,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { DateTimeUtilities.to_api_s(due_at) },
+             schema_info: { description: "When the metatask is due (nil means never due)" }
+
+    property :last_worked_at,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { DateTimeUtilities.to_api_s(last_worked_at) },
+             schema_info: {
+               description: "When the metatask was last worked (nil means not yet worked)"
+             }
+
+    collection :metatask_steps,
+               as: :metatask_steps,
+               writeable: false,
+               readable: true,
+               extend: MetataskStepRepresenter,
+               getter: ->(*) do
+                 task_steps.tap do |task_steps|
+                   ActiveRecord::Associations::Preloader.new.preload(
+                     task_steps, [:tasked, page: :chapter]
+                   )
+                 end
+               end,
+               schema_info: {
+                 required: true,
+                 description: "The steps which this Metatask is composed of"
+               }
+
+    property :feedback_available?,
+             as: :is_feedback_available,
+             writeable: false,
+             readable: true,
+             schema_info: { type: 'boolean',
+                            description: "If the feedback should be shown for the task" }
+  end
+end

--- a/app/representers/api/v1/metatask_step_representer.rb
+++ b/app/representers/api/v1/metatask_step_representer.rb
@@ -1,0 +1,9 @@
+module Api::V1
+  class MetataskStepRepresenter < Roar::Decorator
+
+    def self.prepare(task_step)
+      tasked = task_step.tasked
+      MetataskedRepresenterMapper.representer_for(tasked).prepare(tasked)
+    end
+  end
+end

--- a/app/representers/api/v1/metatasked_representer_mapper.rb
+++ b/app/representers/api/v1/metatasked_representer_mapper.rb
@@ -1,0 +1,32 @@
+module Api::V1
+  class MetataskedRepresenterMapper
+
+    REPRESENTER_MAP = {
+      'Tasks::Models::TaskedExercise'    => '::Api::V1::Metatasks::TaskedExerciseRepresenter',
+      'Tasks::Models::TaskedInteractive' => '::Api::V1::Metatasks::TaskedInteractiveRepresenter',
+      'Tasks::Models::TaskedPlaceholder' => '::Api::V1::Metatasks::TaskedPlaceholderRepresenter',
+      'Tasks::Models::TaskedReading'     => '::Api::V1::Metatasks::TaskedReadingRepresenter',
+      'Tasks::Models::TaskedVideo'       => '::Api::V1::Metatasks::TaskedVideoRepresenter',
+      'Tasks::Models::TaskedExternalUrl' => '::Api::V1::Metatasks::TaskedExternalUrlRepresenter'
+    }
+
+    include Uber::Callable
+
+    def self.representer_for(task_step_or_tasked)
+      tasked_class = task_step_or_tasked.is_a?(::Tasks::Models::TaskStep) ?
+                       task_step_or_tasked.tasked.class :
+                       task_step_or_tasked.class
+      representer = REPRESENTER_MAP[tasked_class.name].constantize
+      representer || (raise NotYetImplemented)
+    end
+
+    def call(*args)
+      if args[2].is_a?(Hash) && args[2][:all_sub_representers]
+        self.class.representers
+      else
+        self.class.representer_for(args[1])
+      end
+    end
+
+  end
+end

--- a/app/representers/api/v1/metatasks/task_step_representer.rb
+++ b/app/representers/api/v1/metatasks/task_step_representer.rb
@@ -22,19 +22,7 @@ module Api::V1::Metatasks
              getter: ->(*) { task_step.id },
              schema_info: {
                required: true
-             },
-             if: NOT_FEEDBACK_ONLY
-
-    property :task_id,
-             type: String,
-             writeable: false,
-             readable: true,
-             getter: ->(*) { task_step.tasks_task_id },
-             schema_info: {
-                 required: true,
-                 description: "The id of the Task"
-             },
-             if: NOT_FEEDBACK_ONLY
+             }
 
     property :type,
              type: String,
@@ -44,8 +32,7 @@ module Api::V1::Metatasks
              schema_info: {
                required: true,
                description: "The type of this TaskStep (exercise, reading, video, placeholder, etc.)"
-             },
-             if: NOT_FEEDBACK_ONLY
+             }
 
     property :is_completed,
              writeable: false,
@@ -55,7 +42,6 @@ module Api::V1::Metatasks
                required: true,
                type: 'boolean',
                description: "Whether or not this step is complete"
-             },
-             if: NOT_FEEDBACK_ONLY
+             }
   end
 end

--- a/app/representers/api/v1/metatasks/task_step_representer.rb
+++ b/app/representers/api/v1/metatasks/task_step_representer.rb
@@ -1,0 +1,61 @@
+module Api::V1::Metatasks
+  class TaskStepRepresenter < Roar::Decorator
+
+    include Roar::JSON
+    include Representable::Coercion
+
+    FEEDBACK          = ->(user_options:, **) { !user_options.try! :[], :no_feedback }
+    NOT_FEEDBACK_ONLY = ->(user_options:, **) { !user_options.try! :[], :feedback_only }
+
+    # These properties will be included in specific Tasked steps; therefore
+    # their getters will be called from that context and so must call up to
+    # the "task_step" to access data in the TaskStep "base" class.
+    #
+    # Using included properties instead of decorator inheritance makes it easier
+    # to render and parse json -- there is no confusion about which level to use
+    # it is always just the Tasked level and properties that access "base" class
+    # values always reach up to it.
+
+    property :id,
+             type: String,
+             writeable: false,
+             getter: ->(*) { task_step.id },
+             schema_info: {
+               required: true
+             },
+             if: NOT_FEEDBACK_ONLY
+
+    property :task_id,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { task_step.tasks_task_id },
+             schema_info: {
+                 required: true,
+                 description: "The id of the Task"
+             },
+             if: NOT_FEEDBACK_ONLY
+
+    property :type,
+             type: String,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { self.class.name.demodulize.remove("Tasked").underscore.downcase },
+             schema_info: {
+               required: true,
+               description: "The type of this TaskStep (exercise, reading, video, placeholder, etc.)"
+             },
+             if: NOT_FEEDBACK_ONLY
+
+    property :is_completed,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { task_step.completed? },
+             schema_info: {
+               required: true,
+               type: 'boolean',
+               description: "Whether or not this step is complete"
+             },
+             if: NOT_FEEDBACK_ONLY
+  end
+end

--- a/app/representers/api/v1/metatasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_exercise_representer.rb
@@ -1,25 +1,5 @@
 module Api::V1::Metatasks
   class TaskedExerciseRepresenter < TaskStepRepresenter
-    property :url,
-             as: :content_url,
-             type: String,
-             writeable: false,
-             readable: true,
-             schema_info: {
-               required: false,
-               description: "The source URL for the Exercise containing the question being asked"
-             },
-             if: NOT_FEEDBACK_ONLY
-
-    property :title,
-             type: String,
-             writeable: false,
-             readable: true,
-             schema_info: {
-               required: true,
-               description: "The title of this Exercise"
-             },
-             if: NOT_FEEDBACK_ONLY
 
     property :content_preview,
              type: String,
@@ -28,7 +8,6 @@ module Api::V1::Metatasks
              schema_info: {
                required: false,
                description: "The content preview as exercise tasked"
-             },
-             if: NOT_FEEDBACK_ONLY
+             }
   end
 end

--- a/app/representers/api/v1/metatasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_exercise_representer.rb
@@ -1,0 +1,34 @@
+module Api::V1::Metatasks
+  class TaskedExerciseRepresenter < TaskStepRepresenter
+    property :url,
+             as: :content_url,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The source URL for the Exercise containing the question being asked"
+             },
+             if: NOT_FEEDBACK_ONLY
+
+    property :title,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true,
+               description: "The title of this Exercise"
+             },
+             if: NOT_FEEDBACK_ONLY
+
+    property :content_preview,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The content preview as exercise tasked"
+             },
+             if: NOT_FEEDBACK_ONLY
+  end
+end

--- a/app/representers/api/v1/metatasks/tasked_external_url_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_external_url_representer.rb
@@ -1,0 +1,32 @@
+module Api::V1::Metatasks
+  class TaskedExternalUrlRepresenter < TaskStepRepresenter
+    property :url,
+             as: :external_url,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true,
+               description: 'The URL for this external assignment'
+             }
+
+    property :title,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: 'The title for this external assignment'
+             }
+
+    property :content_preview,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The content preview as external url tasked"
+             },
+             if: NOT_FEEDBACK_ONLY
+  end
+end

--- a/app/representers/api/v1/metatasks/tasked_interactive_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_interactive_representer.rb
@@ -1,0 +1,31 @@
+module Api::V1::Metatasks
+  class TaskedInteractiveRepresenter < TaskStepRepresenter
+    property :url,
+             type: String,
+             writeable: false,
+             readable: true,
+             as: :content_url,
+             schema_info: {
+               required: false,
+               description: "The source URL for this Interactive"
+             }
+
+    property :title,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true,
+               description: "The title of this Interactive"
+             }
+
+    property :content_preview,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The content preview as interactive tasked"
+             }
+  end
+end

--- a/app/representers/api/v1/metatasks/tasked_placeholder_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_placeholder_representer.rb
@@ -1,0 +1,15 @@
+module Api::V1::Metatasks
+  class TaskedPlaceholderRepresenter < TaskStepRepresenter
+
+    property :placeholder_type,
+             as: :placeholder_for,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+                required: true,
+                description: "What this Placeholder is standing in for"
+             }
+
+  end
+end

--- a/app/representers/api/v1/metatasks/tasked_reading_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_reading_representer.rb
@@ -1,0 +1,31 @@
+module Api::V1::Metatasks
+  class TaskedReadingRepresenter < TaskStepRepresenter
+    property :url,
+             type: String,
+             writeable: false,
+             readable: true,
+             as: :content_url,
+             schema_info: {
+               required: false,
+               description: "The source URL for this Reading"
+             }
+
+    property :title,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true,
+               description: "The title of this Reading"
+             }
+
+    property :content_preview,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The content preview for reading tasked"
+             }
+  end
+end

--- a/app/representers/api/v1/metatasks/tasked_video_representer.rb
+++ b/app/representers/api/v1/metatasks/tasked_video_representer.rb
@@ -1,0 +1,31 @@
+module Api::V1::Metatasks
+  class TaskedVideoRepresenter < TaskStepRepresenter
+    property :url,
+             type: String,
+             writeable: false,
+             readable: true,
+             as: :content_url,
+             schema_info: {
+               required: false,
+               description: "The source URL for this Video"
+             }
+
+    property :title,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true,
+               description: "The title of this Video"
+             }
+
+    property :content_preview,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The content preview for video tasked"
+             }
+  end
+end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -95,6 +95,10 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     self.correct_answer_id = correct_question_answer_ids[0].first
   end
 
+  def content_preview
+    JSON(content)["questions"].first["stem_html"]
+  end
+
   protected
 
   def free_response_required

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -96,7 +96,8 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
   end
 
   def content_preview
-    JSON(content)["questions"].first["stem_html"]
+    content_preview_from_json = JSON(content)["questions"].try(:first).try(:[], "stem_html")
+    content_preview_from_json || "Exercise step ##{id}"
   end
 
   protected

--- a/app/subsystems/tasks/models/tasked_external_url.rb
+++ b/app/subsystems/tasks/models/tasked_external_url.rb
@@ -4,6 +4,6 @@ class Tasks::Models::TaskedExternalUrl < IndestructibleRecord
   validates :url, presence: true
 
   def content_preview
-    "#{title}: #{description}"
+    title || "External Url step ##{id}"
   end
 end

--- a/app/subsystems/tasks/models/tasked_external_url.rb
+++ b/app/subsystems/tasks/models/tasked_external_url.rb
@@ -2,4 +2,8 @@ class Tasks::Models::TaskedExternalUrl < IndestructibleRecord
   acts_as_tasked
 
   validates :url, presence: true
+
+  def content_preview
+    "#{title}: #{description}"
+  end
 end

--- a/app/subsystems/tasks/models/tasked_interactive.rb
+++ b/app/subsystems/tasks/models/tasked_interactive.rb
@@ -9,6 +9,6 @@ class Tasks::Models::TaskedInteractive < IndestructibleRecord
   end
 
   def content_preview
-    title
+    title || "External Interactive step ##{id}"
   end
 end

--- a/app/subsystems/tasks/models/tasked_interactive.rb
+++ b/app/subsystems/tasks/models/tasked_interactive.rb
@@ -7,4 +7,8 @@ class Tasks::Models::TaskedInteractive < IndestructibleRecord
   def has_content?
     true
   end
+
+  def content_preview
+    title
+  end
 end

--- a/app/subsystems/tasks/models/tasked_reading.rb
+++ b/app/subsystems/tasks/models/tasked_reading.rb
@@ -13,7 +13,7 @@ class Tasks::Models::TaskedReading < IndestructibleRecord
 
   def content_preview
     text = document_title.presence || data_title.presence || class_title.presence
-    text || "Unknown"
+    text || "Reading Step ##{id}"
   end
 
   private
@@ -24,11 +24,11 @@ class Tasks::Models::TaskedReading < IndestructibleRecord
   end
 
   def document_title
-    content_dom.xpath("//*[contains(@data-type, 'document-title')]").first.try(:text).try(:strip)
+    content_dom.xpath("//*[@data-type='document-title']").first.try(:text).try(:strip)
   end
 
   def data_title
-    content_dom.xpath("//*[contains(@data-type, 'title')]").first.try(:text).try(:strip)
+    content_dom.xpath("//*[@data-type='title']").first.try(:text).try(:strip)
   end
 
   def content_dom

--- a/app/subsystems/tasks/models/tasked_reading.rb
+++ b/app/subsystems/tasks/models/tasked_reading.rb
@@ -10,4 +10,28 @@ class Tasks::Models::TaskedReading < IndestructibleRecord
   def has_content?
     true
   end
+
+  def content_preview
+    text = document_title.presence || data_title.presence || class_title.presence
+    text || "Unknown"
+  end
+
+  private
+
+  def class_title
+    text = content_dom.xpath("//*[contains(@class, 'os-title')]").first.try(:text).try(:strip)
+    text.try(:split, /\n+/).try(:first)
+  end
+
+  def document_title
+    content_dom.xpath("//*[contains(@data-type, 'document-title')]").first.try(:text).try(:strip)
+  end
+
+  def data_title
+    content_dom.xpath("//*[contains(@data-type, 'title')]").first.try(:text).try(:strip)
+  end
+
+  def content_dom
+    @content_dom ||= Nokogiri::HTML(content)
+  end
 end

--- a/app/subsystems/tasks/models/tasked_video.rb
+++ b/app/subsystems/tasks/models/tasked_video.rb
@@ -7,4 +7,8 @@ class Tasks::Models::TaskedVideo < IndestructibleRecord
   def has_content?
     true
   end
+
+  def content_preview
+    title
+  end
 end

--- a/app/subsystems/tasks/models/tasked_video.rb
+++ b/app/subsystems/tasks/models/tasked_video.rb
@@ -9,6 +9,6 @@ class Tasks::Models::TaskedVideo < IndestructibleRecord
   end
 
   def content_preview
-    title
+    title || "External Reading step ##{id}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,10 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :metatasks, only: [:show, :destroy] do
+      resources :metasteps, controller: :metatask_steps, shallow: true, only: [:show, :update]
+    end
+
     resources :research_surveys, only: [:update]
 
     namespace :cc do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Rails.application.routes.draw do
     end
 
     resources :metatasks, only: [:show, :destroy] do
-      resources :metasteps, controller: :metatask_steps, shallow: true, only: [:show, :update]
+      # resources :metasteps, controller: :metatask_steps, shallow: true, only: [:show, :update]
     end
 
     resources :research_surveys, only: [:update]

--- a/spec/controllers/api/v1/metatasks_controller_spec.rb
+++ b/spec/controllers/api/v1/metatasks_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::MetatasksController,
+               type: :controller, api: true,
+               version: :v1, speed: :medium do
+
+  let(:course)             { FactoryBot.create :course_profile_course }
+  let(:period)             { FactoryBot.create :course_membership_period, course: course }
+
+  let(:application)        { FactoryBot.create :doorkeeper_application }
+  let(:user_1)             { FactoryBot.create(:user) }
+  let(:task_plan_1)        { FactoryBot.create :tasks_task_plan, owner: course }
+  let!(:user_1_role) { AddUserAsPeriodStudent[user: user_1, period: period] }
+  let!(:tasking_1)   { FactoryBot.create :tasks_tasking, role: user_1_role, task: task_1 }
+  let(:user_1_token)       do
+    FactoryBot.create :doorkeeper_access_token, application: application,
+                      resource_owner_id: user_1.id
+  end
+  let(:task_1) do
+    FactoryBot.create :tasks_task, title: 'A Task Title',
+                      task_plan: task_plan_1,
+                      step_types: [:tasks_tasked_reading, :tasks_tasked_exercise]
+  end
+
+  context "#show" do
+    it "should work on the happy path" do
+      api_get :show, user_1_token, parameters: {id: task_1.id}
+      expect(response.code).to eq '200'
+      expect(response.body_as_hash).to include(id: task_1.id.to_s)
+      expect(response.body_as_hash).to include(title: 'A Task Title')
+      expect(response.body_as_hash).to have_key(:metatask_steps)
+      expect(response.body_as_hash[:metatask_steps][0]).to include(type: 'reading')
+      expect(response.body_as_hash[:metatask_steps][1]).to include(type: 'exercise')
+    end
+  end
+end

--- a/spec/factories/tasks/tasked_interactives.rb
+++ b/spec/factories/tasks/tasked_interactives.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :tasks_tasked_interactive, class: '::Tasks::Models::TaskedInteractive' do
+    transient do
+      skip_task false
+    end
+
+    task_step nil
+    url { Faker::Internet.url }
+    title { Faker::Lorem.sentence(3) }
+
+    after(:build) do |tasked_interactive, evaluator|
+      options = { tasked: tasked_interactive, skip_task: evaluator.skip_task }
+
+      tasked_interactive.task_step ||= FactoryBot.build(:tasks_task_step, options)
+    end
+  end
+end

--- a/spec/representers/api/v1/metatasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/metatasks/tasked_exercise_representer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Metatasks::TaskedExerciseRepresenter, type: :representer do
+  let(:task_step) { FactoryBot.build(:tasks_tasked_exercise).task_step }
+  let(:expected_json) do
+    {
+      type: 'exercise',
+      is_completed: false,
+      content_preview: task_step.tasked.content_preview
+    }.stringify_keys
+  end
+
+  subject(:tasked_representer) do
+    Api::V1::Metatasks::TaskedExerciseRepresenter.new(task_step.tasked)
+  end
+
+  it 'should represent a tasked exercise' do
+    expect(JSON.parse(tasked_representer.to_json)).to include(expected_json)
+  end
+end

--- a/spec/representers/api/v1/metatasks/tasked_external_url_representer_spec.rb
+++ b/spec/representers/api/v1/metatasks/tasked_external_url_representer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Metatasks::TaskedExternalUrlRepresenter, type: :representer do
+  let(:task_step) { FactoryBot.build(:tasks_tasked_external_url).task_step }
+  let(:expected_json) do
+    {
+      type: 'external_url',
+      is_completed: false,
+      content_preview: task_step.tasked.title
+    }.stringify_keys
+  end
+
+  subject(:tasked_representer) do
+    Api::V1::Metatasks::TaskedExternalUrlRepresenter.new(task_step.tasked)
+  end
+
+  it 'should represent a tasked external url' do
+    expect(JSON.parse(tasked_representer.to_json)).to include(expected_json)
+  end
+end

--- a/spec/representers/api/v1/metatasks/tasked_placeholder_representer_spec.rb
+++ b/spec/representers/api/v1/metatasks/tasked_placeholder_representer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Metatasks::TaskedPlaceholderRepresenter, type: :representer do
+  let(:task_step) { FactoryBot.build(:tasks_tasked_placeholder).task_step }
+
+  let(:expected_json) do
+    {
+      is_completed: false,
+      placeholder_for: "unknown_type",
+      type: "placeholder"
+    }.stringify_keys
+  end
+
+  subject(:tasked_representer) do
+    Api::V1::Metatasks::TaskedPlaceholderRepresenter.new(task_step.tasked)
+  end
+
+  it "has the correct 'placeholder_for'" do
+    expect(JSON.parse(tasked_representer.to_json)).to include(expected_json)
+  end
+end

--- a/spec/representers/api/v1/metatasks/tasked_reading_presenter_spec.rb
+++ b/spec/representers/api/v1/metatasks/tasked_reading_presenter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Metatasks::TaskedReadingRepresenter, type: :representer do
+  let(:task_step) { FactoryBot.build(:tasks_tasked_reading).task_step }
+
+  let(:expected_json) do
+    {
+      is_completed: false,
+      content_preview: 'Unknown',
+      type: 'reading',
+    }.stringify_keys
+  end
+
+  subject(:tasked_representer) do
+    Api::V1::Metatasks::TaskedReadingRepresenter.new(task_step.tasked)
+  end
+
+  it "has the correct 'placeholder_for'" do
+    expect(JSON.parse(tasked_representer.to_json)).to include(expected_json)
+  end
+end

--- a/spec/representers/api/v1/metatasks/tasked_video_representer_spec.rb
+++ b/spec/representers/api/v1/metatasks/tasked_video_representer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Metatasks::TaskedVideoRepresenter, type: :representer do
+  let(:task_step) { FactoryBot.build(:tasks_tasked_video).task_step }
+
+  let(:expected_json) do
+    {
+      is_completed: false,
+      content_preview: 'Dolores provident est quos nemo iusto dolore.',
+      type: 'video',
+    }.stringify_keys
+  end
+
+  subject(:tasked_representer) do
+    Api::V1::Metatasks::TaskedVideoRepresenter.new(task_step.tasked)
+  end
+
+  it "has the correct 'placeholder_for'" do
+    expect(JSON.parse(tasked_representer.to_json)).to include(expected_json)
+  end
+end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -80,4 +80,22 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     tasked_exercise.answer_id = tasked_exercise.answer_ids.first
     expect { tasked_exercise.save! }.to change{ tasked_exercise.task_step.task.cache_key }
   end
+
+  describe '#content_preview' do
+    let(:default_exercise_copy) { "Exercise step ##{tasked_exercise.id}" }
+    let(:content_body) { 'exercise content' }
+    let(:content) do
+      { "questions" => [ {"stem_html" => content_body } ] }.to_json
+    end
+
+    it "parses the content for the content preview" do
+      tasked_exercise.content = content
+      expect(tasked_exercise.content_preview).to eq(content_body)
+    end
+
+    it "provides a default if the content preview is missing" do
+      tasked_exercise.content = { blah: "preview missing" }.to_json
+      expect(tasked_exercise.content_preview).to eq(default_exercise_copy)
+    end
+  end
 end

--- a/spec/subsystems/tasks/models/tasked_external_url_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_external_url_spec.rb
@@ -2,4 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Tasks::Models::TaskedExternalUrl, type: :model do
   it { is_expected.to validate_presence_of(:url) }
+
+  describe '#content_preview' do
+    subject(:tasked_exercise) do
+      FactoryBot.build(:tasks_tasked_external_url)
+    end
+
+    let(:default_content_preview) { "External Url step ##{tasked_exercise.id}" }
+
+    it "parses the content for the content preview" do
+      expect(tasked_exercise.content_preview).to eq(tasked_exercise.title)
+    end
+
+    it "provides a default if the content preview is missing" do
+      tasked_exercise.title = nil
+      expect(tasked_exercise.content_preview).to eq(default_content_preview)
+    end
+  end
 end

--- a/spec/subsystems/tasks/models/tasked_interactive_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_interactive_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::Models::TaskedInteractive, type: :model do
+  it { is_expected.to validate_presence_of(:url) }
+
+  describe '#content_preview' do
+    subject(:tasked_interactive) do
+      FactoryBot.build(:tasks_tasked_interactive)
+    end
+
+    let(:default_content_preview) { "External Interactive step ##{tasked_interactive.id}" }
+
+    it "parses the content for the content preview" do
+      expect(tasked_interactive.content_preview).to eq(tasked_interactive.title)
+    end
+
+    it "provides a default if the content preview is missing" do
+      tasked_interactive.title = nil
+      tasked_interactive.id = 1
+      expect(tasked_interactive.content_preview).to eq(default_content_preview)
+    end
+  end
+end

--- a/spec/subsystems/tasks/models/tasked_reading_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_reading_spec.rb
@@ -1,6 +1,85 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::Models::TaskedReading, type: :model do
+  subject(:tasked_reading) do
+    FactoryBot.build(:tasks_tasked_reading, id: 1)
+  end
+
   it { is_expected.to validate_presence_of(:url) }
   it { is_expected.to validate_presence_of(:content) }
+
+  describe '#content_preview' do
+    let(:default_reading_copy) { "Reading Step ##{tasked_reading.id}" }
+
+    before do
+      tasked_reading.content = content
+    end
+
+    context "When document title is present" do
+      let(:content_preview_doc_title) { "Introduction to Science Doc Title" }
+
+      let(:content) do
+        <<~HTML
+        <body>
+          <div data-type="document-title" id="35337">
+            <span class="os-text">#{content_preview_doc_title}</span>
+          </div>
+        </body>
+        HTML
+      end
+
+      it "parses the content for the content preview" do
+        expect(tasked_reading.content_preview).to eq(content_preview_doc_title)
+      end
+    end
+
+    context "When document title is missing but contains a data-type title" do
+      let(:content_preview_title) { "Introduction to Science Title" }
+
+      let(:content) do
+        <<~HTML
+        <body>
+          <div data-type="title" id="35337">
+            <span class="os-text">#{content_preview_title}</span>
+          </div>
+        </body>
+        HTML
+      end
+
+      it "parses the content for the content preview" do
+        expect(tasked_reading.content_preview).to eq(content_preview_title)
+      end
+    end
+
+    context "When data title is missing but contains a class title" do
+      let(:content_preview_class) { "Introduction to Science Class" }
+
+      let(:content) do
+        <<~HTML
+        <body>
+          <div class="os-chapter-outline">
+            <h3 class="os-title">#{content_preview_class}</h3>
+          </div>
+        </body>
+        HTML
+      end
+
+      it "parses the content for the content preview" do
+        expect(tasked_reading.content_preview).to eq(content_preview_class)
+      end
+    end
+
+    context "When there is no markup with title content" do
+      let(:content) do
+        <<~HTML
+        <body>
+        </body>
+        HTML
+      end
+
+      it "defaults to an expected copy" do
+        expect(tasked_reading.content_preview).to eq(default_reading_copy)
+      end
+    end
+  end
 end

--- a/spec/subsystems/tasks/models/tasked_video_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_video_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::Models::TaskedReading, type: :model do
+  it { is_expected.to validate_presence_of(:url) }
+
+  describe '#content_preview' do
+    subject(:tasked_video) do
+      FactoryBot.build(:tasks_tasked_video)
+    end
+
+    let(:default_content_preview) { "External Reading step ##{tasked_video.id}" }
+
+    it "parses the content for the content preview" do
+      expect(tasked_video.content_preview).to eq(tasked_video.title)
+    end
+
+    it "provides a default if the content preview is missing" do
+      tasked_video.title = nil
+      tasked_video.id = 1
+      expect(tasked_video.content_preview).to eq(default_content_preview)
+    end
+  end
+end


### PR DESCRIPTION
Metatasks are lightweight versions of tutoring tasks.  Used to load first more quickly, then when clicked, the full task would load thru the regular /api/tasks API.

https://app.zenhub.com/workspaces/openstax-tutor-560aef617a763234615d6a0f/issues/openstax/tutor-server/1849