### PR TITLE
Fix 403's when creating notes on staging/production

### DIFF
--- a/app/access_policies/note_access_policy.rb
+++ b/app/access_policies/note_access_policy.rb
@@ -6,7 +6,7 @@ class NoteAccessPolicy
     when :index, :read
       true
     when :create, :update, :destroy
-      note.role.profile.account_id == requestor.id
+      note.role.role_user.user_profile_id == requestor.id
     else
       false
     end

--- a/spec/access_policies/note_access_policy_spec.rb
+++ b/spec/access_policies/note_access_policy_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe NoteAccessPolicy, type: :access_policy, speed: :medium do
+  let(:requestor)    { FactoryBot.create(:user) }
+  let(:course)       { FactoryBot.create :course_profile_course }
+  let(:period)       { FactoryBot.create :course_membership_period, course: course }
+  let(:student_user) { FactoryBot.create(:user) }
+  let(:student_role) { AddUserAsPeriodStudent[user: student_user, period: period] }
+
+  let(:note) { FactoryBot.create :content_note, role: student_role }
+
+  subject(:action_allowed) { described_class.action_allowed?(action, requestor, note) }
+
+  context 'when the action is show' do
+    let(:action) { :show }
+    context 'and the requestor is anonymous' do
+      before do
+        allow(requestor).to receive(:id) { nil }
+      end
+      it { should eq false }
+    end
+  end
+
+  context 'when the action is create' do
+    let(:action) { :create }
+
+    context 'and the requestor matches user' do
+      before do
+        allow(requestor).to receive(:id) { student_role.role_user.user_profile_id }
+      end
+      it { should eq true }
+    end
+  end
+end


### PR DESCRIPTION
Previously we were testing the account_id against the user_profile_id.  Since every user has a single profile the id's tend to match until a record has failed somewhere, then the sequences will differ.

We got unlucky and QA matches, but staging and production are different which exposed this bug.

