### PR TITLE
allow updating steps to record the free-response info

### DIFF
--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -107,6 +107,16 @@ module Api::V1::Tasks
              },
              if: FEEDBACK_AVAILABLE
 
+    property :context,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The Exercise's context (only present if required by the Exercise)"
+             },
+             if: INCLUDE_CONTENT
+
     property :content_hash_for_students,
              as: :content,
              type: String,

--- a/app/representers/api/v1/tasks/tasked_reading_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_reading_representer.rb
@@ -11,6 +11,7 @@ module Api::V1::Tasks
              }
 
     property :title,
+             getter: -> (*) { title.present? ? title : task_step.page.title },
              type: String,
              writeable: false,
              readable: true,

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -22,7 +22,6 @@ class Tasks::Models::TaskStep < ApplicationRecord
   validates :group_type, presence: true
   validates :fragment_index,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
-  validate  :no_feedback
 
   delegate :can_be_answered?, :has_correctness?, :has_content?, to: :tasked
 
@@ -92,16 +91,6 @@ class Tasks::Models::TaskStep < ApplicationRecord
 
   def related_content
     page.nil? ? [] : [ page.related_content ]
-  end
-
-  def no_feedback
-    # Cannot mark as completed after feedback is available
-    # Feedback is available immediately for iReadings, or at the due date for HW,
-    # but waits until the step is marked as completed
-    return if first_completed_at_was.nil? || !task.try!(:feedback_available?)
-
-    errors.add(:base, 'cannot be marked as completed after feedback becomes available')
-    false
   end
 
   def spy

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -132,10 +132,10 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     # Cannot change the answer after feedback is available
     # Feedback is available immediately for iReadings, or at the due date for HW,
     # but waits until the step is marked as completed
-    return unless task_step.try!(:feedback_available?)
-
-    errors.add(:base, 'cannot be updated after feedback becomes available')
-    false
+    if task_step.try!(:feedback_available?) &&
+       (answer_id_changed? || free_response_changed?)
+      errors.add(:base, 'cannot be updated after feedback becomes available')
+      end
   end
 
 end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -132,10 +132,14 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     # Cannot change the answer after feedback is available
     # Feedback is available immediately for iReadings, or at the due date for HW,
     # but waits until the step is marked as completed
-    if task_step.try!(:feedback_available?) &&
-       (answer_id_changed? || free_response_changed?)
-      errors.add(:base, 'cannot be updated after feedback becomes available')
+    if task_step.try!(:feedback_available?)
+      [:answer_id, :free_response].each do |attr|
+        errors.add(
+          attr,
+          'cannot be updated after feedback becomes available'
+        ) if changes[attr].present?
       end
+    end
   end
 
 end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
     instance_double(Tasks::Models::TaskedExercise).tap do |exercise|
       ## Avoid rspec double class when figuring out :type
       allow(exercise).to receive(:class).and_return(Tasks::Models::TaskedExercise)
-
       allow(exercise).to receive(:task_step).and_return(task_step)
 
       ## TaskedExercise-specific properties
 
       allow(exercise).to receive(:title).and_return('Some title')
+      allow(exercise).to receive(:context).and_return('Some Context')
 
       allow(exercise).to receive(:content_hash_for_students).and_return('Some content')
       allow(exercise).to receive(:question_formats_for_students).and_return('Some question formats')
@@ -65,6 +65,10 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
 
     it "has the correct 'title'" do
       expect(representation).to include("title" => 'Some title')
+    end
+
+    it "has the correct 'context'" do
+      expect(complete_representation).to include("context" => 'Some Context')
     end
 
     it "has the correct 'content_preview'" do

--- a/spec/requests/api/v1/exercise_update_progression_spec.rb
+++ b/spec/requests/api/v1/exercise_update_progression_spec.rb
@@ -111,7 +111,9 @@ RSpec.describe "Exercise update progression", type: :request, api: true, version
     expect(tasked.free_response).to eq 'Something else!'
 
     # Multiple choice cannot be changed
-    new_answer_id = tasked.answer_ids.first
+    new_answer_id = tasked.answer_ids.last
+    expect(new_answer_id).not_to eq tasked.answer_id
+
     api_put("#{step_route_base}", user_1_token,
             raw_post_data: {answer_id: new_answer_id}.to_json)
     expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
 
   it 'does not accept a multiple choice answer before a free response' +
      ' unless the free-response format is not present' do
-    tasked_exercise.answer_id = tasked_exercise.answer_ids.last
+    expect(tasked_exercise.answer_id).not_to eq tasked_exercise.answer_ids.first
+    tasked_exercise.answer_id = tasked_exercise.answer_ids.first
+
     expect(tasked_exercise).not_to be_valid
     expect(tasked_exercise.errors).to include :free_response
 
@@ -50,7 +52,7 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     expect(tasked_exercise).to be_valid
   end
 
-  it 'cannot be updated after the step is completed and feedback is available' do
+  it 'cannot have answer or free response updated after feedback is available' do
     tasked_exercise.task_step.task.feedback_at = nil
     tasked_exercise.task_step.task.save!
 
@@ -62,17 +64,18 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
 
     tasked_exercise.complete!
 
-    expect(tasked_exercise.reload).not_to be_valid
+    expect(tasked_exercise.reload).to be_valid
 
     tasked_exercise.task_step.task.feedback_at = Time.current.yesterday
     tasked_exercise.task_step.task.save!
 
-    expect(tasked_exercise.reload).not_to be_valid
-
-    tasked_exercise.task_step.task.feedback_at = Time.current.tomorrow
-    tasked_exercise.task_step.task.save!
+    expect(tasked_exercise.reload).to be_valid
+    tasked_exercise.answer_id = tasked_exercise.answer_ids.last
+    expect(tasked_exercise).not_to be_valid
 
     expect(tasked_exercise.reload).to be_valid
+    tasked_exercise.free_response = 'some new thing'
+    expect(tasked_exercise).not_to be_valid
   end
 
   it "invalidates task's cache when updated" do


### PR DESCRIPTION
Currently any step updates after the initial one fails because of this validation.

