### PR TITLE
remove outdated references to js_url from secrets

### DIFF
--- a/app/representers/api/v1/updates_representer.rb
+++ b/app/representers/api/v1/updates_representer.rb
@@ -9,7 +9,7 @@ module Api::V1
              type: String,
              readable: true,
              writeable: false,
-             getter: ->(**) { Rails.application.secrets.js_url }
+             getter: ->(**) { Tutor::Assets::Scripts[:tutor] }
 
     property :payments, writeable: false, readable: true, getter: ->(*) {
       {

--- a/spec/controllers/api/v1/updates_controller_spec.rb
+++ b/spec/controllers/api/v1/updates_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Api::V1::UpdatesController, type: :controller, api: true, version
 
     it 'includes the tutor js url' do
       api_get :index, nil
-      expect(response.body_as_hash[:tutor_js_url]).to eq Rails.application.secrets.js_url
+      expect(response.body_as_hash[:tutor_js_url]).to eq Tutor::Assets::Scripts[:tutor]
     end
 
     it 'includes the payment status' do

--- a/spec/representers/api/v1/updates_representer_spec.rb
+++ b/spec/representers/api/v1/updates_representer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UpdatesRepresenter, type: :representer do
+
+  let(:notifications) { [] }
+  let(:representation) {
+    described_class.new(
+      OpenStruct.new(notifications: notifications)
+    )
+  }
+
+  it 'updates tutor_js_url when it changes' do
+    expect(Tutor::Assets::Scripts).to receive(:[]).with(:tutor) { '/a/url' }
+    expect(
+      representation.to_hash
+    ).to include 'tutor_js_url' => '/a/url'
+
+    expect(Tutor::Assets::Scripts).to receive(:[]).with(:tutor) { '/a/new/url' }
+    expect(
+      representation.to_hash
+    ).to include 'tutor_js_url' => '/a/new/url'
+  end
+end


### PR DESCRIPTION
Looks like the updates representer never got updated when we changed how the scripts url was generated, which means we've been operating without update toasts for awhile 😭 


![image](https://user-images.githubusercontent.com/79566/56975859-4bc3b080-6b37-11e9-8172-46f997f3669d.png)
