### PR TITLE
Fix old migration that had been broken

### DIFF
--- a/db/migrate/20170208182122_add_uuid_and_group_uuid_to_content_exercises.rb
+++ b/db/migrate/20170208182122_add_uuid_and_group_uuid_to_content_exercises.rb
@@ -2,9 +2,10 @@ class AddUuidAndGroupUuidToContentExercises < ActiveRecord::Migration
   def change
     enable_extension 'pgcrypto'
 
-    add_column :content_exercises, :uuid, :uuid, null: false, index: true
+    add_column :content_exercises, :uuid, :uuid, null: false
     add_column :content_exercises, :group_uuid, :uuid, null: false
 
+    add_index :content_exercises, :uuid
     add_index :content_exercises, [:group_uuid, :version]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,9 +15,9 @@ ActiveRecord::Schema.define(version: 20190411181631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "citext"
   enable_extension "hstore"
   enable_extension "pgcrypto"
+  enable_extension "citext"
 
   create_table "catalog_offerings", force: :cascade do |t|
     t.string   "salesforce_book_name",                 null: false


### PR DESCRIPTION
This migration was added 2 years ago and broken 5 months ago when I deleted a large portion of it due to another change. We probably don't need to worry about re-running it, but this change might be useful for newer systems and for when we recreate our dev databases.