### PR TITLE
Restored the optional role_id in the student guide route

### DIFF
--- a/app/controllers/api/v1/guides_controller.rb
+++ b/app/controllers/api/v1/guides_controller.rb
@@ -12,13 +12,19 @@ module Api
         EOS
       end
 
-      api :GET, '/courses/:course_id/guide',
+      api :GET, '/courses/:course_id/guide(/role/:role_id)',
                 'Returns a student course guide for Learning Guide'
       description <<-EOS
         #{json_schema(Api::V1::CourseGuidePeriodRepresenter, include: :readable)}
       EOS
       def student
-        role = get_course_role(course: @course, allowed_role_types: [:student, :teacher_student])
+        role = if params[:role_id].blank?
+          get_course_role(course: @course, allowed_role_types: [:student, :teacher_student])
+        else
+          Entity::Role.where(
+            role_type: Entity::Role.role_types.values_at(:student, :teacher_student)
+          ).find(params[:role_id])
+        end
 
         student = role.course_member
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,7 +155,7 @@ Rails.application.routes.draw do
       get :highlighted_sections, controller: :notes
 
       scope controller: :guides do
-        get :guide, action: :student
+        get :'guide(/role/:role_id)', action: :student
         get :teacher_guide, action: :teacher
       end
 

--- a/spec/controllers/api/v1/guides_controller_spec.rb
+++ b/spec/controllers/api/v1/guides_controller_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe Api::V1::GuidesController, type: :controller, api: true,
         api_get :student, user_2_token, parameters: { course_id: course.id }
       end
 
+      it 'returns the student guide for a teacher providing a student role ID' do
+        expect(GetStudentGuide).to receive(:[]).with(role: student_3_role).and_return(course_guide)
+
+        api_get :student, user_1_token,
+                parameters: { course_id: course.id, role_id: student_3_role.id }
+      end
+
       it 'raises SecurityTransgression if the student has been dropped' do
         student_role.student.destroy
 

--- a/spec/routing/api/v1/guides_controller_routing_spec.rb
+++ b/spec/routing/api/v1/guides_controller_routing_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::GuidesController, type: :routing, api: true, version: :v1 do
+  context 'GET /api/courses/:course_id/guide' do
+    it 'routes to #student' do
+      expect(get '/api/courses/21/guide').to(
+        route_to('api/v1/guides#student', format: 'json', course_id: '21')
+      )
+    end
+  end
+
+  context 'GET /api/courses/:course_id/guide/role/:role_id' do
+    it 'routes to #student' do
+      expect(get '/api/courses/21/guide/role/42').to(
+        route_to('api/v1/guides#student', format: 'json', course_id: '21', role_id: '42')
+      )
+    end
+  end
+
+  context 'GET /api/courses/:course_id/teacher_guide' do
+    it 'routes to #teacher' do
+      expect(get '/api/courses/21/teacher_guide').to(
+        route_to('api/v1/guides#teacher', format: 'json', course_id: '21')
+      )
+    end
+  end
+end


### PR DESCRIPTION
Turns out this was actually used by something.