### PR TITLE
Fix exception rescues failing due to nil backtrace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
     kgio (2.11.2)
     launchy (2.4.3)
       addressable (~> 2.3)
-    lev (9.0.1)
+    lev (9.0.2)
       actionpack (>= 4.2)
       active_attr
       activejob
@@ -445,7 +445,7 @@ GEM
       uber (< 0.1.0)
     openstax_healthcheck (0.0.3)
       rails (>= 3.0)
-    openstax_rescue_from (4.0.1)
+    openstax_rescue_from (4.0.2)
       rails (>= 3.1, < 6.0)
     openstax_salesforce (3.0.0)
       active_force

--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -210,7 +210,7 @@ class ExportAndUploadResearchData
               raise ex if !Rails.env.production? || ex.is_a?(Timeout::Error)
 
               Rails.logger.error do
-                "Skipped step #{step.id} due to #{ex.inspect} @ #{ex.backtrace.first}"
+                "Skipped step #{step.id} due to #{ex.inspect} @ #{ex.backtrace&.first}"
               end
             end
           end
@@ -304,7 +304,7 @@ class ExportAndUploadResearchData
 
                 Rails.logger.error do
                   "Skipped page #{page.id} fragment #{fragment_index + 1
-                  } due to #{ex.inspect} @ #{ex.backtrace.first}"
+                  } due to #{ex.inspect} @ #{ex.backtrace&.first}"
                 end
               end
             end
@@ -385,7 +385,7 @@ class ExportAndUploadResearchData
 
                 Rails.logger.error do
                   "Skipped exercise #{exercise.id} question #{question.try(:[], :id)
-                  } due to #{ex.inspect} @ #{ex.backtrace.first}"
+                  } due to #{ex.inspect} @ #{ex.backtrace&.first}"
                 end
               end
             end

--- a/app/subsystems/research/export_and_upload_survey_data.rb
+++ b/app/subsystems/research/export_and_upload_survey_data.rb
@@ -62,7 +62,7 @@ class Research::ExportAndUploadSurveyData
             raise ex if !Rails.env.production? || ex.is_a?(Timeout::Error)
 
             Rails.logger.error do
-              "Skipped survey #{survey.id} due to #{ex.inspect} @ #{ex.backtrace.first}"
+              "Skipped survey #{survey.id} due to #{ex.inspect} @ #{ex.backtrace&.first}"
             end
           end
         end


### PR DESCRIPTION
Greg was getting some failed jobs on -dev and we couldn't figure out what they were because the exception reporting was failing due to a nil backtrace.