### PR TITLE
QA APIs Fixes

### DIFF
--- a/app/controllers/api/v1/demo_controller.rb
+++ b/app/controllers/api/v1/demo_controller.rb
@@ -1,7 +1,10 @@
 class Api::V1::DemoController < Api::V1::ApiController
   respond_to :html
   skip_before_action :force_json_content_type
+
   before_action :not_real_production, :verify_requested_format!
+
+  rescue_from ActiveRecord::RecordInvalid, with: :render_api_errors
 
   resource_description do
     api_versions "v1"

--- a/app/models/entity/role.rb
+++ b/app/models/entity/role.rb
@@ -12,7 +12,8 @@ module Entity
 
     belongs_to :profile, subsystem: :user, inverse_of: :roles
 
-    delegate :username, :first_name, :last_name, :full_name, :name, to: :profile, allow_nil: true
+    delegate :username, :first_name, :last_name, :full_name, :name, :is_test,
+             to: :profile, allow_nil: true
     delegate :course, :period, :course_profile_course_id, to: :course_member, allow_nil: true
 
     unique_token :research_identifier, mode: :hex, length: 4, prefix: 'r'

--- a/app/routines/demo/base.rb
+++ b/app/routines/demo/base.rb
@@ -19,13 +19,17 @@ class Demo::Base
     random_seed.nil? ? Random.srand : Random.srand(random_seed)
   end
 
+  def find_course_by_id(id)
+    CourseProfile::Models::Course.find_by id: id
+  end
+
   def find_course(course)
     if course[:id].blank?
       raise(ArgumentError, "Can't find a Course without a name or id") if course[:name].blank?
 
       CourseProfile::Models::Course.order(created_at: :desc).find_by name: course[:name]
     else
-      CourseProfile::Models::Course.find_by id: course[:id]
+      find_course_by_id course[:id]
     end
   end
 

--- a/app/subsystems/course_membership/models/student.rb
+++ b/app/subsystems/course_membership/models/student.rb
@@ -25,7 +25,7 @@ class CourseMembership::Models::Student < ApplicationRecord
 
   before_save :init_payment_due_at
 
-  delegate :username, :first_name, :last_name, :full_name, :name, to: :role
+  delegate :username, :first_name, :last_name, :full_name, :name, :is_test, to: :role
 
   def dropped?
     deleted?

--- a/app/subsystems/course_membership/models/teacher.rb
+++ b/app/subsystems/course_membership/models/teacher.rb
@@ -7,6 +7,6 @@ class CourseMembership::Models::Teacher < ApplicationRecord
 
   validates :role,   uniqueness: true
 
-  delegate :username, :first_name, :last_name, :full_name, :name, to: :role
+  delegate :username, :first_name, :last_name, :full_name, :name, :is_test, to: :role
 
 end

--- a/app/subsystems/course_membership/models/teacher_student.rb
+++ b/app/subsystems/course_membership/models/teacher_student.rb
@@ -10,6 +10,6 @@ class CourseMembership::Models::TeacherStudent < ApplicationRecord
 
   validates :role,   uniqueness: true
 
-  delegate :username, :first_name, :last_name, :full_name, :name, to: :role
+  delegate :username, :first_name, :last_name, :full_name, :name, :is_test, to: :role
 
 end

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -27,15 +27,13 @@ class Tasks::Models::TaskPlan < ApplicationRecord
 
   json_serialize :settings, Hash
 
-  before_validation :trim_text
+  before_validation :trim_text, :set_ecosystem
 
   validates :title, presence: true
   validates :type, presence: true
   validates :tasking_plans, presence: true
 
   validate :valid_settings, :same_ecosystem, :changes_allowed, :not_past_due_when_publishing
-
-  before_validation :set_ecosystem
 
   scope :preload_tasking_plans, -> { preload(tasking_plans: :time_zone) }
 

--- a/lib/active_job/after_commit_runner.rb
+++ b/lib/active_job/after_commit_runner.rb
@@ -25,12 +25,12 @@ class ActiveJob::AfterCommitRunner
   def set_transaction_state(state)
   end
 
+  def add_to_transaction
+    ActiveRecord::Base.connection.current_transaction.add_record self
+  end
+
   def run_after_commit
-    if ActiveRecord::Base.connection.transaction_open?
-      ActiveRecord::Base.connection.current_transaction.add_record self
-    else
-      committed!
-    end
+    ActiveRecord::Base.connection.transaction_open? ? add_to_transaction : committed!
   end
 
   protected

--- a/spec/factories/course_profile/courses.rb
+++ b/spec/factories/course_profile/courses.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :course_profile_course, class: '::CourseProfile::Models::Course' do
-    transient             { consistent_times { false } }
+    transient             do
+      consistent_times { false }
+      num_teachers     { 0 }
+      num_students     { 0 }
+    end
 
     name                  { Faker::Lorem.words.join(' ') }
 
@@ -24,12 +28,19 @@ FactoryBot.define do
 
     association :offering, factory: :catalog_offering
 
-    after(:build) do |course|
+    after(:build) do |course, evaluator|
       course.course_ecosystems << build(
         :course_content_course_ecosystem,
         course: course,
         ecosystem: course.offering.ecosystem
       ) if course.offering.present?
+
+      course.teachers = evaluator.num_teachers.times.map do
+        FactoryBot.build :course_membership_teacher, course: course
+      end
+      course.students = evaluator.num_students.times.map do
+        FactoryBot.build :course_membership_student, course: course
+      end
     end
 
     trait(:with_assistants) do

--- a/spec/factories/course_profile/courses.rb
+++ b/spec/factories/course_profile/courses.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :course_profile_course, class: '::CourseProfile::Models::Course' do
     transient             do
       consistent_times { false }
-      num_teachers     { 0 }
-      num_students     { 0 }
+      num_teachers     { nil }
+      num_students     { nil }
     end
 
     name                  { Faker::Lorem.words.join(' ') }
@@ -37,10 +37,10 @@ FactoryBot.define do
 
       course.teachers = evaluator.num_teachers.times.map do
         FactoryBot.build :course_membership_teacher, course: course
-      end
+      end unless evaluator.num_teachers.nil?
       course.students = evaluator.num_students.times.map do
         FactoryBot.build :course_membership_student, course: course
-      end
+      end unless evaluator.num_students.nil?
     end
 
     trait(:with_assistants) do

--- a/spec/requests/api/v1/demo_controller_spec.rb
+++ b/spec/requests/api/v1/demo_controller_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Api::V1::DemoController, type: :request, api: true, version: :v1 
   let(:ecosystem)        { FactoryBot.create :content_ecosystem, books: [ book ] }
   let(:catalog_offering) { FactoryBot.create :catalog_offering, ecosystem: ecosystem }
 
-  let(:course)           { FactoryBot.create :course_profile_course, offering: catalog_offering }
+  let(:course)           do
+    FactoryBot.create :course_profile_course, num_teachers: 1, num_students: 2
+  end
 
   let(:task_plans)       { 2.times.map { FactoryBot.create :tasks_task_plan, owner: course } }
 

--- a/spec/requests/api/v1/demo_controller_spec.rb
+++ b/spec/requests/api/v1/demo_controller_spec.rb
@@ -181,6 +181,32 @@ RSpec.describe Api::V1::DemoController, type: :request, api: true, version: :v1 
         expect(task_plan_hash).to be_in task_plans_attributes
       end
     end
+
+    it 'renders 422 Unprocessable Entity if a record is invalid' do
+      task_plan = task_plans.first
+      time = Time.current
+      task_plan.tasking_plans += [
+        FactoryBot.build(
+          :tasks_tasking_plan, task_plan: task_plan, opens_at: time, due_at: time - 1.day
+        )
+      ]
+      expect(task_plan).not_to be_valid
+
+      expect(Demo::Assign).to receive(:call) do |assign:|
+        expect(assign).to eq assign_params
+        task_plan.save! # raises ActiveRecord::RecordInvalid
+      end
+
+      api_post 'demo/assign', nil, params: assign_params.to_json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body_as_hash).to eq(
+        errors: [
+          code: 'validation failed: tasking plans is invalid',
+          message: 'Validation failed: tasking plans is invalid'
+        ], status: 422
+      )
+    end
   end
 
   context '#work' do

--- a/spec/routines/demo/course_spec.rb
+++ b/spec/routines/demo/course_spec.rb
@@ -1,52 +1,91 @@
 require 'rails_helper'
 
 RSpec.describe Demo::Course, type: :routine do
-  let!(:catalog_offering) { FactoryBot.create :catalog_offering, title: 'AP US History' }
-  let(:config_base_dir)   { File.join Rails.root, 'spec', 'fixtures', 'demo' }
-  let(:user_config)       do
+  let!(:catalog_offering)  { FactoryBot.create :catalog_offering, title: 'AP US History' }
+  let(:config_base_dir)    { File.join Rails.root, 'spec', 'fixtures', 'demo' }
+  let(:user_config)        do
     {
       users: Api::V1::Demo::Users::Representer.new(Demo::Mash.new).from_hash(
         YAML.load_file File.join(config_base_dir, 'users', 'review', 'apush.yml')
       ).deep_symbolize_keys
     }
   end
-  let(:course_config)     do
+  let(:course_config_base) do
     {
       course: Api::V1::Demo::Course::Representer.new(Demo::Mash.new).from_hash(
         YAML.load_file File.join(config_base_dir, 'course', 'review', 'apush.yml')
       ).deep_symbolize_keys
     }
   end
-  let(:result)            { described_class.call course_config }
+  let(:result)             { described_class.call course_config }
 
-  before                  { Demo::Users.call user_config }
+  before                   { Demo::Users.call user_config }
 
-  it 'creates a demo course with demo teachers and students' do
-    course = nil
-    expect do
-      expect(result.errors).to be_empty
-      course = result.outputs.course
-    end.to  change { CourseProfile::Models::Course.count }.by(1)
-       .and change { CourseMembership::Models::Period.count }.by(2)
-       .and change { CourseMembership::Models::Teacher.count }.by(1)
-       .and change { CourseMembership::Models::Student.count }.by(6)
+  context 'course does not exist' do
+    let(:course_config) { course_config_base }
 
-    expect(course.name).to eq 'AP US History Review'
-    expect(course.offering).to eq catalog_offering
-    expect(course.ecosystems).to eq [catalog_offering.ecosystem]
-    expect(course.is_college).to eq true
+    it 'creates a demo course with demo teachers and students' do
+      course = nil
+      expect do
+        expect(result.errors).to be_empty
+        course = result.outputs.course
+      end.to  change { CourseProfile::Models::Course.count }.by(1)
+         .and change { CourseMembership::Models::Period.count }.by(2)
+         .and change { CourseMembership::Models::Teacher.count }.by(1)
+         .and change { CourseMembership::Models::Student.count }.by(6)
 
-    teachers = course.teachers
-    expect(teachers.map(&:username)).to eq [ 'reviewteacher' ]
+      expect(course.name).to eq 'AP US History Review'
+      expect(course.offering).to eq catalog_offering
+      expect(course.ecosystems).to eq [catalog_offering.ecosystem]
+      expect(course.is_college).to eq true
 
-    periods = course.periods
-    expect(periods.size).to eq 2
-    periods.each do |period|
-      expect(period.name).to be_in ['1st', '2nd']
+      teachers = course.teachers
+      expect(teachers.map(&:username)).to eq [ 'reviewteacher' ]
 
-      students = period.students
-      expect(students.size).to eq 3
-      students.each { |student| expect(student.username).to match /reviewstudent\d/ }
+      periods = course.periods
+      expect(periods.size).to eq 2
+      periods.each do |period|
+        expect(period.name).to be_in ['1st', '2nd']
+
+        students = period.students
+        expect(students.size).to eq 3
+        students.each { |student| expect(student.username).to match /reviewstudent\d/ }
+      end
+    end
+  end
+
+  context 'course already exists' do
+    let!(:course)       { FactoryBot.create :course_profile_course }
+    let(:course_config) do
+      course_config_base.dup.tap { |config| config[:course][:course][:id] = course.id }
+    end
+
+    it 'updates the demo course with the given attributes and demo teachers and students' do
+      expect do
+        expect(result.errors).to be_empty
+        expect(result.outputs.course).to eq course
+      end.to  not_change { CourseProfile::Models::Course.count }
+         .and change     { CourseMembership::Models::Period.count }.by(2)
+         .and change     { CourseMembership::Models::Teacher.count }.by(1)
+         .and change     { CourseMembership::Models::Student.count }.by(6)
+         .and not_change { course.reload.is_college }
+
+      expect(course.name).to eq 'AP US History Review'
+      expect(course.offering).to eq catalog_offering
+      expect(course.ecosystems.first).to eq catalog_offering.ecosystem
+
+      teachers = course.teachers
+      expect(teachers.map(&:username)).to eq [ 'reviewteacher' ]
+
+      periods = course.periods
+      expect(periods.size).to eq 2
+      periods.each do |period|
+        expect(period.name).to be_in ['1st', '2nd']
+
+        students = period.students
+        expect(students.size).to eq 3
+        students.each { |student| expect(student.username).to match /reviewstudent\d/ }
+      end
     end
   end
 end


### PR DESCRIPTION
- Fixed the AfterCommitRunner in transactions nested inside a joinable transaction
- Fixed user creation behavior in demo script to retry on uniqueness violations
- Fixed error when reusing a demo course in `demo:course`
- Courses are now only reused if an id is specified