### PR TITLE
Fix lms/salesforce exception reporting again

### DIFF
--- a/app/routines/push_salesforce_course_stats.rb
+++ b/app/routines/push_salesforce_course_stats.rb
@@ -228,9 +228,9 @@ class PushSalesforceCourseStats
       exception = error[:exception]
 
       if exception.nil?
-        Raven.capture_message error[:message], error.except(:message)
+        Raven.capture_message error[:message], extra: error.except(:message)
       else
-        Raven.capture_exception exception, error.except(:exception)
+        Raven.capture_exception exception, extra: error.except(:exception)
       end
     end
   end

--- a/app/subsystems/lms/send_course_scores.rb
+++ b/app/subsystems/lms/send_course_scores.rb
@@ -131,9 +131,9 @@ class Lms::SendCourseScores
       exception = error[:exception]
 
       if exception.nil?
-        Raven.capture_message error[:message], error.except(:message)
+        Raven.capture_message error[:message], extra: error.except(:message)
       else
-        Raven.capture_exception exception, error.except(:exception)
+        Raven.capture_exception exception, extra: error.except(:exception)
       end
     end
   end


### PR DESCRIPTION
The extra hash needs to be inside `extra:` or else the reporting fails.