### PR TITLE
Fix changing assignment open date when it is already open for 1 period (but not all periods)

### DIFF
--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -159,7 +159,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
 
       if task_plan.out_to_students?
         # Store current open dates for each TaskingPlan that is already open in the TaskPlan
-        opens_at_ntzs = Hash.new{ |hash, key| hash[key] = {} }
+        opens_at_ntzs = Hash.new { |hash, key| hash[key] = {} }
         open_tasking_plans = task_plan.tasking_plans.select(&:past_open?)
         open_tasking_plans.each do |tp|
           opens_at_ntzs[tp.target_type][tp.target_id] = tp.opens_at_ntz

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -158,7 +158,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
       course = task_plan.owner
 
       if task_plan.out_to_students?
-        # Store current open dates for each TaskingPlan that is already open in the TaskPlan
+        # Store current open dates for all TaskingPlans that are already open
         opens_at_ntzs = Hash.new { |hash, key| hash[key] = {} }
         open_tasking_plans = task_plan.tasking_plans.select(&:past_open?)
         open_tasking_plans.each do |tp|

--- a/app/routines/propagate_task_plan_updates.rb
+++ b/app/routines/propagate_task_plan_updates.rb
@@ -7,11 +7,15 @@ class PropagateTaskPlanUpdates
   def updated_attributes_for(tasking_plan:)
     task_plan = tasking_plan.task_plan
 
-    # This routine is only called after tasks are open and
-    # we do not allow changing the open date after open
+    # This routine is only called after tasks are open and we do not allow changing the open date
+    # after tasks are open. However, it is possible the task_plan is assigned to multiple periods
+    # and it is not yet open for all periods, so we must propagate opens_at in that case.
+    # TaskPlansController#update already enforces that we don't change open dates for periods
+    # whose assignments are already out to students.
     {
       title: task_plan.title,
       description: task_plan.description,
+      opens_at_ntz: tasking_plan.opens_at_ntz,
       due_at_ntz: tasking_plan.due_at_ntz,
       feedback_at_ntz: task_plan.is_feedback_immediate ? nil : tasking_plan.due_at_ntz
     }

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -214,7 +214,7 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def preview?
-    taskings.none?{ |tasking| tasking.role.try!(:student?) }
+    taskings.none? { |tasking| tasking.role&.student? }
   end
 
   def core_task_steps(preload_tasked: false)

--- a/spec/factories/tasks/taskings.rb
+++ b/spec/factories/tasks/taskings.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     after(:build) do |tasking|
       tasking.role ||= build(:course_membership_student).role
-      tasking.period ||= tasking.role.student.try!(:period)
+      tasking.period ||= tasking.role.student&.period
     end
   end
 end

--- a/spec/factories/tasks/tasks.rb
+++ b/spec/factories/tasks/tasks.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
       step_types { [] }
       tasked_to { [] }
       num_random_taskings { 0 }
-      current_time { time_zone.try!(:to_tz).try!(:now) || Time.current }
+      current_time { time_zone&.to_tz&.now || Time.current }
     end
 
     task_type { :reading }

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
               expect(task_plan).not_to be_out_to_students
               task = task_plan.tasks.first
               expect(task.taskings.first.role).to eq teacher_student_role
-              expect(task.opens_at).to eq tasking_plan.opens_at
+              expect(task.opens_at).to be_within(1e-6).of(tasking_plan.opens_at)
 
               tasking_plan.update_attribute :opens_at, tasking_plan.time_zone.to_tz.now + 1.hour
               result = DistributeTasks.call(task_plan: task_plan, preview: true)
@@ -129,7 +129,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
               expect(task_plan).not_to be_out_to_students
               task = task_plan.tasks.first
               expect(task.taskings.first.role).to eq teacher_student_role
-              expect(task.opens_at).to eq tasking_plan.opens_at
+              expect(task.opens_at).to be_within(1e-6).of(tasking_plan.opens_at)
             end
 
             it 'does not save plan if it is new' do
@@ -147,7 +147,9 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
             expect(result.errors).to be_empty
             expect(task_plan.reload.tasks.size).to eq 3
             expect(task_plan).not_to be_out_to_students
-            task_plan.tasks.each { |task| expect(task.opens_at).to eq tasking_plan.opens_at }
+            task_plan.tasks.each do |task|
+              expect(task.opens_at).to be_within(1e-6).of(tasking_plan.opens_at)
+            end
           end
 
           it 'sets the published_at fields' do
@@ -187,7 +189,9 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
             expect(result.errors).to be_empty
             expect(task_plan.reload.tasks.size).to eq 3
             expect(task_plan).to be_out_to_students
-            task_plan.tasks.each { |task| expect(task.opens_at).to eq tasking_plan.opens_at }
+            task_plan.tasks.each do |task|
+              expect(task.opens_at).to be_within(1e-6).of(tasking_plan.opens_at)
+            end
           end
 
           it 'sets the published_at fields' do
@@ -237,7 +241,9 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
             expect(result.errors).to be_empty
             expect(task_plan.reload.tasks.size).to eq 3
             expect(task_plan).not_to be_out_to_students
-            task_plan.tasks.each { |task| expect(task.opens_at).to eq tasking_plan.opens_at }
+            task_plan.tasks.each do |task|
+              expect(task.opens_at).to be_within(1e-6).of(tasking_plan.opens_at)
+            end
           end
 
           it 'does not set the first_published_at field' do
@@ -267,9 +273,13 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
             expect(task_plan.reload.tasks.size).to eq 3
             expect(task_plan).to be_out_to_students
             new_task = task_plan.tasks.max_by(&:created_at)
-            task_plan.tasks.each { |task| expect(task.opens_at).to eq tasking_plan.opens_at }
             task_plan.tasks.each do |task|
-              expect(task.due_at).to eq task == new_task ? tasking_plan.due_at : previous_due_at
+              expect(task.opens_at).to be_within(1e-6).of(tasking_plan.opens_at)
+            end
+            task_plan.tasks.each do |task|
+              expect(task.due_at).to be_within(1e-6).of(
+                task == new_task ? tasking_plan.due_at : previous_due_at
+              )
             end
           end
 

--- a/spec/routines/propagate_task_plan_updates_spec.rb
+++ b/spec/routines/propagate_task_plan_updates_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
   let(:new_opens_at)    { time_zone.now + 10.seconds }
   let(:new_due_at)      { time_zone.now + 1.week + 10.seconds }
 
+  let!(:teacher_student_role) do
+    FactoryBot.create(:course_membership_teacher_student, period: period).role
+  end
+
   context 'unpublished task_plan' do
     before(:each) do
       task_plan.title = 'New title'

--- a/spec/routines/propagate_task_plan_updates_spec.rb
+++ b/spec/routines/propagate_task_plan_updates_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
     end
 
     context 'homework' do
-      it 'propagates task_plan changes (except opens_at) to all of its tasks' do
+      it 'propagates task_plan changes (including opens_at) to all of its tasks' do
         task_plan.type = 'homework'
         task_plan.is_feedback_immediate = false
         task_plan.save!(validate: false)
@@ -95,7 +95,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
         task_plan.tasks.each do |task|
           expect(task.title).to       eq new_title
           expect(task.description).to eq new_description
-          expect(task.opens_at).to    be_within(1e-6).of(old_opens_at)
+          expect(task.opens_at).to    be_within(1e-6).of(new_opens_at)
           expect(task.due_at).to      be_within(1e-6).of(new_due_at)
           expect(task.feedback_at).to eq task.due_at
         end
@@ -115,7 +115,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
     end
 
     context 'reading' do
-      it 'propagates task_plan changes (except opens_at) to all of its tasks' do
+      it 'propagates task_plan changes (including opens_at) to all of its tasks' do
         task_plan.update_attribute(:type, 'reading')
         expect(task_plan.tasks).not_to be_empty
         task_plan.tasks.each do |task|
@@ -133,7 +133,7 @@ RSpec.describe PropagateTaskPlanUpdates, type: :routine do
         task_plan.tasks.each do |task|
           expect(task.title).to       eq new_title
           expect(task.description).to eq new_description
-          expect(task.opens_at).to    be_within(1e-6).of(old_opens_at)
+          expect(task.opens_at).to    be_within(1e-6).of(new_opens_at)
           expect(task.due_at).to      be_within(1e-6).of(new_due_at)
           expect(task.feedback_available?).to be_truthy
         end


### PR DESCRIPTION
Turns out the code that enforces the open date not changing after the plan is open is in the TaskPlansController.

- Modified spec to ensure due dates can be updated after tasks are open
- Added specs for propagating changes in assignment dates
- Propagate the opens_at change in PropagateTaskPlanUpdates