### PR TITLE
Keep all preview course background jobs in the lower priority queues

### DIFF
--- a/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
+++ b/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
@@ -103,7 +103,7 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
       return [] if modified_requests.empty?
 
       # Create a background job to guarantee the sequence_number request will reach Biglearn
-      OpenStax::Biglearn::Api::Job.set(queue: queue).perform_later(
+      OpenStax::Biglearn::Api::Job.set(queue: queue.to_sym).perform_later(
         method: method.to_s,
         requests: modified_requests,
         response_status_key: response_status_key.try!(:to_s),

--- a/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
+++ b/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
@@ -15,7 +15,7 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
   end
 
   def perform(
-    method:, requests:, create:, sequence_number_model_key:, sequence_number_model_class:,
+    method:, requests:, create:, sequence_number_model_key:, sequence_number_model_class:, queue:,
     response_status_key: nil, accepted_response_status: []
   )
     ScoutHelper.ignore!(0.8)
@@ -103,7 +103,7 @@ class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::
       return [] if modified_requests.empty?
 
       # Create a background job to guarantee the sequence_number request will reach Biglearn
-      OpenStax::Biglearn::Api::Job.perform_later(
+      OpenStax::Biglearn::Api::Job.set(queue: queue).perform_later(
         method: method.to_s,
         requests: modified_requests,
         response_status_key: response_status_key.try!(:to_s),

--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -32,8 +32,8 @@ class CreateCourse
       ) if term.blank? || year.blank?
     end
 
-    is_concept_coach = catalog_offering.try!(:is_concept_coach) if is_concept_coach.nil?
-    does_cost = (catalog_offering.try!(:does_cost) || false) if does_cost.nil?
+    is_concept_coach = catalog_offering&.is_concept_coach if is_concept_coach.nil?
+    does_cost = (catalog_offering&.does_cost || false) if does_cost.nil?
 
     fatal_error(
       code: :is_concept_coach_blank,
@@ -46,7 +46,7 @@ class CreateCourse
     #   make a copy to avoid linking the 2 courses' time_zones to the same record
     if time_zone.present?
       if time_zone.is_a?(TimeZone)
-        time_zone = time_zone.dup if time_zone.course.try!(:persisted?)
+        time_zone = time_zone.dup if time_zone.course&.persisted?
       else
         time_zone = TimeZone.new(name: time_zone)
       end
@@ -84,7 +84,7 @@ class CreateCourse
       run(:add_ecosystem, course: outputs.course, ecosystem: ecosystem)
     end
 
-    num_sections.times{ run(:create_period, course: outputs.course) }
+    num_sections.times { run(:create_period, course: outputs.course) }
 
     run(:create_course_assistants, course: outputs.course)
   end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -93,30 +93,6 @@ Delayed::Worker.class_exec do
   prepend HandleFailedJobInstantly
 end
 
-# https://github.com/rails/rails/pull/19910
-ActiveJob::QueueAdapters::DelayedJobAdapter.class_exec do
-  class << self
-    def enqueue(job) #:nodoc:
-      delayed_job = Delayed::Job.enqueue(
-        ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(job.serialize),
-        queue: job.queue_name
-      )
-      job.provider_job_id = delayed_job.id
-      delayed_job
-    end
-
-    def enqueue_at(job, timestamp) #:nodoc:
-      delayed_job = Delayed::Job.enqueue(
-        ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(job.serialize),
-        queue: job.queue_name,
-        run_at: Time.at(timestamp)
-      )
-      job.provider_job_id = delayed_job.id
-      delayed_job
-    end
-  end
-end
-
 # The following are custom ActiveJob patches
 # to allow access to the provider_job_id during job execution
 ActiveJob::Base.class_exec do

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -524,7 +524,7 @@ module OpenStax::Biglearn::Api
 
       job_class = if include_sequence_number
         is_preview = request[sequence_number_model_key.to_sym].try(:is_preview)
-        args[:queue] = is_preview ? 'lowest_priority' : 'high_priority'
+        args[:queue] = is_preview ? 'low_priority' : 'high_priority'
 
         OpenStax::Biglearn::Api::JobWithSequenceNumber
       else
@@ -605,7 +605,7 @@ module OpenStax::Biglearn::Api
         is_preview = requests.is_a?(Array) ? requests.all? do |request|
           request[sequence_number_model_key.to_sym].try(:is_preview)
         end : requests[sequence_number_model_key.to_sym].try(:is_preview)
-        args[:queue] = is_preview ? 'lowest_priority' : 'high_priority'
+        args[:queue] = is_preview ? 'low_priority' : 'high_priority'
 
         OpenStax::Biglearn::Api::JobWithSequenceNumber
       else

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -48,7 +48,6 @@ module OpenStax::Biglearn::Api
         request: { ecosystem: request[:ecosystem].to_model },
         keys: :ecosystem,
         create: true,
-        perform_later: true,
         sequence_number_model_key: :ecosystem,
         sequence_number_model_class: Content::Models::Ecosystem
       )
@@ -103,7 +102,6 @@ module OpenStax::Biglearn::Api
         request: request,
         keys: [:course, :ecosystem],
         create: true,
-        perform_later: true,
         sequence_number_model_key: :course,
         sequence_number_model_class: CourseProfile::Models::Course
       )
@@ -121,7 +119,6 @@ module OpenStax::Biglearn::Api
         method: :prepare_course_ecosystem,
         request: request.merge(preparation_uuid: preparation_uuid),
         keys: [:preparation_uuid, :course, :from_ecosystem, :to_ecosystem],
-        perform_later: true,
         sequence_number_model_key: :course,
         sequence_number_model_class: CourseProfile::Models::Course
       )
@@ -158,7 +155,6 @@ module OpenStax::Biglearn::Api
         method: :sequentially_prepare_and_update_course_ecosystem,
         request: request.merge(preparation_uuid: preparation_uuid),
         keys: [:preparation_uuid, :course, :from_ecosystem, :to_ecosystem],
-        perform_later: true,
         sequence_number_model_key: :course,
         sequence_number_model_class: CourseProfile::Models::Course
       )
@@ -228,7 +224,6 @@ module OpenStax::Biglearn::Api
         method: :update_globally_excluded_exercises,
         request: request,
         keys: [:course],
-        perform_later: true,
         sequence_number_model_key: :course,
         sequence_number_model_class: CourseProfile::Models::Course
       )
@@ -243,7 +238,6 @@ module OpenStax::Biglearn::Api
         method: :update_course_excluded_exercises,
         request: request,
         keys: [:course],
-        perform_later: true,
         sequence_number_model_key: :course,
         sequence_number_model_class: CourseProfile::Models::Course
       )
@@ -263,7 +257,6 @@ module OpenStax::Biglearn::Api
         method: :update_course_active_dates,
         request: request,
         keys: [:course],
-        perform_later: true,
         sequence_number_model_key: :course,
         sequence_number_model_class: CourseProfile::Models::Course
       )
@@ -502,7 +495,7 @@ module OpenStax::Biglearn::Api
     def single_api_request(method:, request:, keys:, optional_keys: [],
                            result_class: Hash, uuid_key: :request_uuid,
                            sequence_number_model_key: nil, sequence_number_model_class: nil,
-                           create: false, perform_later: false,
+                           create: false, perform_later: true,
                            response_status_key: nil, accepted_response_status: [],
                            inline_max_attempts: 1, inline_sleep_interval: 0, enable_warnings: true)
       include_sequence_number = sequence_number_model_key.present? &&
@@ -528,7 +521,10 @@ module OpenStax::Biglearn::Api
 
         OpenStax::Biglearn::Api::JobWithSequenceNumber
       else
+        # :nocov:
+        # No API call currently uses this branch of the code
         OpenStax::Biglearn::Api::Job
+        # :nocov:
       end
 
       if perform_later
@@ -540,6 +536,8 @@ module OpenStax::Biglearn::Api
 
         job_class.perform_later args
       else
+        # :nocov:
+        # No API call currently uses this branch of the code
         args.merge! method: method,
                     sequence_number_model_key: sequence_number_model_key,
                     sequence_number_model_class: sequence_number_model_class
@@ -565,6 +563,7 @@ module OpenStax::Biglearn::Api
           result: block_given? ? yield(request, response, accepted) : response,
           result_class: result_class
         )
+        # :nocov:
       end
     end
 

--- a/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
+++ b/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
       requests: requests,
       create: create,
       sequence_number_model_key: sequence_number_model_key.to_s,
-      sequence_number_model_class: sequence_number_model_class.to_s
+      sequence_number_model_class: sequence_number_model_class.to_s,
+      queue: 'low_priority'
     }
   end
   let(:perform_args)                   do
@@ -23,7 +24,8 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
       requests: requests,
       create: create,
       sequence_number_model_key: sequence_number_model_key,
-      sequence_number_model_class: sequence_number_model_class
+      sequence_number_model_class: sequence_number_model_class,
+      queue: 'high_priority'
     }
   end
   let(:job_args)                      do
@@ -75,6 +77,9 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
 
         context '#perform' do
           it 'creates a new OpenStax::Biglearn::Api::Job with same args plus sequence_numbers' do
+            expect(OpenStax::Biglearn::Api::Job).to(
+              receive(:set).with(queue: 'high_priority').and_return(OpenStax::Biglearn::Api::Job)
+            )
             expect(OpenStax::Biglearn::Api::Job).to(
               receive(:perform_later).with(job_args).and_call_original
             )
@@ -144,6 +149,9 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
 
         context '#perform' do
           it 'creates a new OpenStax::Biglearn::Api::Job with same args plus sequence_numbers' do
+            expect(OpenStax::Biglearn::Api::Job).to(
+              receive(:set).with(queue: 'high_priority').and_return(OpenStax::Biglearn::Api::Job)
+            )
             expect(OpenStax::Biglearn::Api::Job).to(
               receive(:perform_later).with(job_args).and_call_original
             )

--- a/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
+++ b/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
         context '#perform' do
           it 'creates a new OpenStax::Biglearn::Api::Job with same args plus sequence_numbers' do
             expect(OpenStax::Biglearn::Api::Job).to(
-              receive(:set).with(queue: 'high_priority').and_return(OpenStax::Biglearn::Api::Job)
+              receive(:set).with(queue: :high_priority).and_return(OpenStax::Biglearn::Api::Job)
             )
             expect(OpenStax::Biglearn::Api::Job).to(
               receive(:perform_later).with(job_args).and_call_original
@@ -150,7 +150,7 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
         context '#perform' do
           it 'creates a new OpenStax::Biglearn::Api::Job with same args plus sequence_numbers' do
             expect(OpenStax::Biglearn::Api::Job).to(
-              receive(:set).with(queue: 'high_priority').and_return(OpenStax::Biglearn::Api::Job)
+              receive(:set).with(queue: :high_priority).and_return(OpenStax::Biglearn::Api::Job)
             )
             expect(OpenStax::Biglearn::Api::Job).to(
               receive(:perform_later).with(job_args).and_call_original


### PR DESCRIPTION
That way they should not interfere with higher priority background jobs.