### PR TITLE
Performance forecast fixes

### DIFF
--- a/app/representers/api/v1/course_guide_child_representer.rb
+++ b/app/representers/api/v1/course_guide_child_representer.rb
@@ -40,11 +40,21 @@ module Api::V1
     collection :page_ids,
                readable: true,
                writeable: false,
-               getter: ->(*) { page_ids && page_ids.map(&:to_s) },
+               getter: ->(*) { (page_ids || []).map(&:to_s) },
                schema_info: {
                  required: true,
                  description: "Page IDs as strings ['1', '2', ...]"
                }
+
+    property :first_worked_at,
+             type: String,
+             readable: true,
+             writeable: false
+
+    property :last_worked_at,
+             type: String,
+             readable: true,
+             writeable: false
 
     collection :children,
                readable: true,

--- a/app/representers/api/v1/course_guide_period_representer.rb
+++ b/app/representers/api/v1/course_guide_period_representer.rb
@@ -1,12 +1,12 @@
 module Api::V1
   class CourseGuidePeriodRepresenter < Roar::Decorator
     include Roar::JSON
+    include Representable::Coercion
 
     property :period_id,
              type: String,
              readable: true,
-             writeable: false,
-             getter: ->(*) { period_id.to_s }
+             writeable: false
 
     property :title,
              type: String,
@@ -16,11 +16,21 @@ module Api::V1
     collection :page_ids,
                readable: true,
                writeable: false,
-               getter: ->(*) { page_ids && page_ids.map(&:to_s) },
+               getter: ->(*) { (page_ids || []).map(&:to_s) },
                schema_info: {
                  required: true,
                  description: "Page IDs as strings ['1', '2', ...]"
                }
+
+    property :first_worked_at,
+             type: String,
+             readable: true,
+             writeable: false
+
+    property :last_worked_at,
+             type: String,
+             readable: true,
+             writeable: false
 
     collection :children,
                readable: true,

--- a/app/routines/calculate_task_stats.rb
+++ b/app/routines/calculate_task_stats.rb
@@ -33,7 +33,7 @@ class CalculateTaskStats
 
     # Get unmapped cached Task stats (for the Task's original ecosystem)
     task_caches = Tasks::Models::TaskCache
-      .select([ :tasks_task_id, :student_ids, :student_names, :due_at, :as_toc ])
+      .select(:tasks_task_id, :student_ids, :student_names, :due_at, :as_toc)
       .joins(:task)
       .where(tasks_task_id: task_ids)
       .where('"tasks_task_caches"."content_ecosystem_id" = "tasks_tasks"."content_ecosystem_id"')

--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -32,9 +32,12 @@ class GetStudentGuide
     tc = Tasks::Models::TaskCache.arel_table
     task_caches = Tasks::Models::TaskCache
       .select([ :tasks_task_id, :content_ecosystem_id, :task_type, :as_toc ])
+      .joins(:task)
+      .left_joins(task: :task_plan)
       .where(content_ecosystem_id: ecosystem_ids)
       .where("\"tasks_task_caches\".\"#{student_ids_column}\" && ARRAY[#{student.id}]")
       .where(tc[:opens_at].eq(nil).or tc[:opens_at].lteq(current_time))
+      .where(task: { task_plan: { withdrawn_at: nil } })
       .sort_by { |task_cache| index_by_ecosystem_id[task_cache.content_ecosystem_id] }
       .uniq { |task_cache| task_cache.tasks_task_id }
 

--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -31,13 +31,11 @@ class GetStudentGuide
     # Get cached Task stats, prioritizing the most recent ecosystem available for each one
     tc = Tasks::Models::TaskCache.arel_table
     task_caches = Tasks::Models::TaskCache
-      .select([ :tasks_task_id, :content_ecosystem_id, :task_type, :as_toc ])
-      .joins(:task)
-      .left_joins(task: :task_plan)
+      .select(:tasks_task_id, :content_ecosystem_id, :task_type, :as_toc)
       .where(content_ecosystem_id: ecosystem_ids)
       .where("\"tasks_task_caches\".\"#{student_ids_column}\" && ARRAY[#{student.id}]")
       .where(tc[:opens_at].eq(nil).or tc[:opens_at].lteq(current_time))
-      .where(task: { task_plan: { withdrawn_at: nil } })
+      .where(withdrawn_at: nil)
       .sort_by { |task_cache| index_by_ecosystem_id[task_cache.content_ecosystem_id] }
       .uniq { |task_cache| task_cache.tasks_task_id }
 

--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -57,7 +57,7 @@ class GetStudentGuide
     # Get mapped page and chapter UUIDs
     page_ids = chs.flat_map { |ch| ch[:pages].map { |pg| pg[:id] } }
     pages = Content::Models::Page
-      .select([:tutor_uuid, :content_chapter_id])
+      .select(:tutor_uuid, :content_chapter_id)
       .where(id: page_ids)
       .preload(chapter: { book: :ecosystem })
     chapters = pages.map(&:chapter).uniq
@@ -90,7 +90,9 @@ class GetStudentGuide
           student_count: 1,
           questions_answered_count: questions_answered_count,
           clue: clue,
-          page_ids: [ preferred_pg[:id] ]
+          page_ids: [ preferred_pg[:id] ],
+          first_worked_at: pgs.map { |pg| pg[:first_worked_at] }.compact.min,
+          last_worked_at: pgs.map { |pg| pg[:last_worked_at] }.compact.max,
         }
       end
 
@@ -108,6 +110,8 @@ class GetStudentGuide
         questions_answered_count: questions_answered_count,
         clue: clue,
         page_ids: page_ids,
+        first_worked_at: chs.map { |ch| ch[:first_worked_at] }.compact.min,
+        last_worked_at: chs.map { |ch| ch[:last_worked_at] }.compact.max,
         children: page_guides
       }
     end

--- a/app/subsystems/tasks/models/task_cache.rb
+++ b/app/subsystems/tasks/models/task_cache.rb
@@ -2,6 +2,7 @@ class Tasks::Models::TaskCache < ApplicationRecord
   json_serialize :as_toc, Hash
 
   belongs_to :task
+  belongs_to :task_plan, optional: true
   belongs_to :ecosystem, subsystem: :content
 
   enum task_type: Tasks::Models::Task.task_types.keys
@@ -9,7 +10,8 @@ class Tasks::Models::TaskCache < ApplicationRecord
   validates :task_type, presence: true
   validates :ecosystem, uniqueness: { scope: :tasks_task_id }
 
-  validates :opens_at, :due_at, :feedback_at, timeliness: { type: :date }, allow_nil: true
+  validates :opens_at, :due_at, :feedback_at, :withdrawn_at,
+            timeliness: { type: :date }, allow_nil: true
   validates :is_cached_for_period, inclusion: { in: [ true, false ] }
 
   def practice?

--- a/app/subsystems/tasks/update_period_caches.rb
+++ b/app/subsystems/tasks/update_period_caches.rb
@@ -18,6 +18,8 @@ class Tasks::UpdatePeriodCaches
 
       task_cache_query = Tasks::Models::TaskCache
         .joins(:task)
+        .left_joins(task: :task_plan)
+        .where(task: { task_plan: { withdrawn_at: nil } })
         .where("\"tasks_task_caches\".\"student_ids\" && ARRAY[#{student_ids.join(', ')}]")
 
       # Get relevant TaskPlans

--- a/app/subsystems/tasks/update_task_caches.rb
+++ b/app/subsystems/tasks/update_task_caches.rb
@@ -16,7 +16,7 @@ class Tasks::UpdateTaskCaches
     tasks = Tasks::Models::Task
       .where(id: task_ids)
       .lock('FOR NO KEY UPDATE SKIP LOCKED')
-      .preload(:ecosystem, :time_zone, taskings: { role: { student: :period } })
+      .preload(:task_plan, :ecosystem, :time_zone, taskings: { role: { student: :period } })
       .to_a
     tasks_by_id = tasks.index_by(&:id)
     locked_task_ids = tasks_by_id.keys
@@ -33,7 +33,7 @@ class Tasks::UpdateTaskCaches
 
     # Get TaskSteps for each given task
     task_steps = Tasks::Models::TaskStep
-      .select([
+      .select(
         :tasks_task_id,
         :number,
         :first_completed_at,
@@ -42,7 +42,7 @@ class Tasks::UpdateTaskCaches
         :group_type,
         :tasked_type,
         :tasked_id
-      ])
+      )
       .where(tasks_task_id: task_ids)
       .order(:number)
       .to_a
@@ -79,25 +79,25 @@ class Tasks::UpdateTaskCaches
 
     # Get student and course IDs
     students = CourseMembership::Models::Student
-      .select([
+      .select(
         :id,
         :course_profile_course_id,
         :course_membership_period_id,
         '"tasks_taskings"."tasks_task_id"',
         '"user_profiles"."account_id"'
-      ])
+      )
       .joins(role: [ :taskings, profile: :account ])
       .where(role: { taskings: { tasks_task_id: task_ids } })
       .to_a
 
       teacher_students = CourseMembership::Models::TeacherStudent
-        .select([
+        .select(
           :id,
           :course_profile_course_id,
           :course_membership_period_id,
           '"tasks_taskings"."tasks_task_id"',
           '"user_profiles"."account_id"'
-        ])
+        )
         .joins(role: [ :taskings, profile: :account ])
         .where(role: { taskings: { tasks_task_id: task_ids } })
         .to_a
@@ -108,7 +108,7 @@ class Tasks::UpdateTaskCaches
 
     # Get student names (throws an error if faculty_status is not loaded for some reason)
     student_name_by_account_id = OpenStax::Accounts::Account
-      .select([ :id, :username, :first_name, :last_name, :full_name, :faculty_status ])
+      .select(:id, :username, :first_name, :last_name, :full_name, :faculty_status)
       .where(id: account_ids)
       .map { |account| [ account.id, account.name ] }
       .to_h
@@ -135,7 +135,7 @@ class Tasks::UpdateTaskCaches
     # Get all relevant pages
     page_ids = task_steps_by_task_id_and_page_id.values.flat_map(&:keys).compact.uniq
     pages_by_id = Content::Models::Page
-      .select([
+      .select(
         :id,
         :uuid,
         :tutor_uuid,
@@ -144,7 +144,7 @@ class Tasks::UpdateTaskCaches
         :baked_book_location,
         :content_chapter_id,
         :content_all_exercises_pool_id
-      ])
+      )
       .where(id: page_ids)
       .map { |page| Content::Page.new strategy: page.wrap }
       .index_by(&:id)
@@ -155,7 +155,8 @@ class Tasks::UpdateTaskCaches
 
     # Get all relevant courses
     course_ids = task_ids_by_course_id.keys
-    courses = CourseProfile::Models::Course.select(:id).where(id: course_ids)
+    courses = CourseProfile::Models::Course.select(:id)
+                                           .where(id: course_ids)
                                            .preload(course_ecosystems: :ecosystem)
 
     # Cache results per task for Quick Look and Student Performance Forecast
@@ -235,9 +236,11 @@ class Tasks::UpdateTaskCaches
     Tasks::Models::TaskCache.import task_caches, validate: false, on_duplicate_key_update: {
       conflict_target: [ :tasks_task_id, :content_ecosystem_id ],
       columns: [
+        :tasks_task_plan_id,
         :opens_at,
         :due_at,
         :feedback_at,
+        :withdrawn_at,
         :student_ids,
         :teacher_student_ids,
         :student_names,
@@ -262,6 +265,8 @@ class Tasks::UpdateTaskCaches
     teacher_student_ids:,
     student_names:
   )
+    task_plan = task.task_plan
+
     books_array = pages_by_mapped_book_chapter_and_page
       .map do |mapped_book, pages_by_mapped_chapter_and_page|
       chapters_array = pages_by_mapped_chapter_and_page
@@ -287,7 +292,9 @@ class Tasks::UpdateTaskCaches
               free_response: tasked_exercise.free_response,
               selected_answer_id: tasked_exercise.answer_id,
               completed: task_step.completed?,
-              correct: tasked_exercise.is_correct?
+              correct: tasked_exercise.is_correct?,
+              first_completed_at: task_step.first_completed_at,
+              last_completed_at: task_step.last_completed_at
             }
           end
           completed_exercises_array = exercises_array.select { |exercise| exercise[:completed] }
@@ -311,6 +318,8 @@ class Tasks::UpdateTaskCaches
               exercise[:correct]
             end,
             num_assigned_placeholders: num_tasked_placeholders,
+            first_worked_at: task_steps.map(&:first_completed_at).compact.min,
+            last_worked_at: task_steps.map(&:last_completed_at).compact.max,
             exercises: exercises_array
           }
         end.sort_by { |page| page[:book_location] }
@@ -329,6 +338,8 @@ class Tasks::UpdateTaskCaches
           num_completed_exercises: pages_array.sum { |pg| pg[:num_completed_exercises] },
           num_correct_exercises: pages_array.sum { |pg| pg[:num_correct_exercises] },
           num_assigned_placeholders: pages_array.sum { |pg| pg[:num_assigned_placeholders] },
+          first_worked_at: pages_array.map { |pg| pg[:first_worked_at] }.compact.min,
+          last_worked_at: pages_array.map { |pg| pg[:last_worked_at] }.compact.max,
           pages: pages_array
         }
       end.sort_by { |chapter| chapter[:book_location] }
@@ -344,6 +355,8 @@ class Tasks::UpdateTaskCaches
         num_completed_exercises: chapters_array.sum { |ch| ch[:num_completed_exercises] },
         num_correct_exercises: chapters_array.sum { |ch| ch[:num_correct_exercises] },
         num_assigned_placeholders: chapters_array.sum { |ch| ch[:num_assigned_placeholders] },
+        first_worked_at: chapters_array.map { |ch| ch[:first_worked_at] }.compact.min,
+        last_worked_at: chapters_array.map { |ch| ch[:last_worked_at] }.compact.max,
         chapters: chapters_array
       }
     end.sort_by { |book| book[:title] }
@@ -366,6 +379,7 @@ class Tasks::UpdateTaskCaches
 
     Tasks::Models::TaskCache.new(
       task: task,
+      task_plan: task_plan,
       ecosystem: ecosystem.to_model,
       task_type: task.task_type,
       opens_at: task.opens_at,
@@ -374,6 +388,7 @@ class Tasks::UpdateTaskCaches
       student_ids: student_ids,
       teacher_student_ids: teacher_student_ids,
       student_names: student_names,
+      withdrawn_at: task_plan&.withdrawn_at,
       as_toc: toc,
       is_cached_for_period: false
     )

--- a/app/subsystems/tasks/update_task_caches.rb
+++ b/app/subsystems/tasks/update_task_caches.rb
@@ -297,7 +297,7 @@ class Tasks::UpdateTaskCaches
               last_completed_at: task_step.last_completed_at
             }
           end
-          completed_exercises_array = exercises_array.select { |exercise| exercise[:completed] }
+          completed_ex_array = exercises_array.select { |exercise| exercise[:completed] }
 
           is_spaced_practice = num_tasked_placeholders == 0 && exercises_array.all? do |ex|
             ex[:group_type] == 'spaced_practice_group'
@@ -313,13 +313,11 @@ class Tasks::UpdateTaskCaches
             num_assigned_steps: task_steps.size,
             num_completed_steps: task_steps.count(&:completed?),
             num_assigned_exercises: exercises_array.size,
-            num_completed_exercises: completed_exercises_array.size,
-            num_correct_exercises: completed_exercises_array.count do |exercise|
-              exercise[:correct]
-            end,
+            num_completed_exercises: completed_ex_array.size,
+            num_correct_exercises: completed_ex_array.count { |ex| ex[:correct] },
             num_assigned_placeholders: num_tasked_placeholders,
-            first_worked_at: task_steps.map(&:first_completed_at).compact.min,
-            last_worked_at: task_steps.map(&:last_completed_at).compact.max,
+            first_worked_at: completed_ex_array.map { |ex| ex[:first_completed_at] }.compact.min,
+            last_worked_at: completed_ex_array.map { |ex| ex[:last_completed_at] }.compact.max,
             exercises: exercises_array
           }
         end.sort_by { |page| page[:book_location] }

--- a/db/migrate/20190923160455_add_task_plan_and_withdrawn_at_to_task_caches.rb
+++ b/db/migrate/20190923160455_add_task_plan_and_withdrawn_at_to_task_caches.rb
@@ -1,0 +1,11 @@
+class AddTaskPlanAndWithdrawnAtToTaskCaches < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks_task_caches, :tasks_task_plan,
+                  foreign_key: { on_update: :cascade, on_delete: :cascade }
+    add_column :tasks_task_caches, :withdrawn_at, :datetime
+
+    Tasks::Models::Task.select(:id).find_in_batches(batch_size: 100) do |tasks|
+      Tasks::UpdateTaskCaches.set(queue: :lowest_priority).perform_later task_ids: tasks.map(&:id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_11_001122) do
+ActiveRecord::Schema.define(version: 2019_09_23_160455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -844,6 +844,8 @@ ActiveRecord::Schema.define(version: 2019_07_11_001122) do
     t.datetime "updated_at", null: false
     t.boolean "is_cached_for_period", null: false
     t.integer "teacher_student_ids", null: false, array: true
+    t.bigint "tasks_task_plan_id"
+    t.datetime "withdrawn_at"
     t.index ["content_ecosystem_id"], name: "index_tasks_task_caches_on_content_ecosystem_id"
     t.index ["due_at"], name: "index_tasks_task_caches_on_due_at"
     t.index ["feedback_at"], name: "index_tasks_task_caches_on_feedback_at"
@@ -852,6 +854,7 @@ ActiveRecord::Schema.define(version: 2019_07_11_001122) do
     t.index ["student_ids"], name: "index_tasks_task_caches_on_student_ids", using: :gin
     t.index ["task_type"], name: "index_tasks_task_caches_on_task_type"
     t.index ["tasks_task_id", "content_ecosystem_id"], name: "index_task_caches_on_task_id_and_ecosystem_id", unique: true
+    t.index ["tasks_task_plan_id"], name: "index_tasks_task_caches_on_tasks_task_plan_id"
     t.index ["teacher_student_ids"], name: "index_tasks_task_caches_on_teacher_student_ids", using: :gin
   end
 
@@ -1170,6 +1173,7 @@ ActiveRecord::Schema.define(version: 2019_07_11_001122) do
   add_foreign_key "tasks_period_caches", "course_membership_periods", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_period_caches", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_task_caches", "content_ecosystems", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "tasks_task_caches", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_task_caches", "tasks_tasks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_task_plans", "content_ecosystems", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_task_plans", "tasks_assistants", on_update: :cascade, on_delete: :cascade

--- a/spec/routines/get_student_guide_spec.rb
+++ b/spec/routines/get_student_guide_spec.rb
@@ -120,6 +120,8 @@ RSpec.describe GetStudentGuide, type: :routine do
             questions_answered_count: 2,
             clue: clue_matcher,
             page_ids: [kind_of(Integer)]*2,
+            first_worked_at: kind_of(String),
+            last_worked_at: kind_of(String),
             children: [kind_of(Hash)]*2
           )
 
@@ -132,6 +134,8 @@ RSpec.describe GetStudentGuide, type: :routine do
             questions_answered_count: 7,
             clue: clue_matcher,
             page_ids: [kind_of(Integer)]*4,
+            first_worked_at: kind_of(String),
+            last_worked_at: kind_of(String),
             children: [kind_of(Hash)]*4
           )
         end
@@ -148,7 +152,9 @@ RSpec.describe GetStudentGuide, type: :routine do
               student_count: 1,
               questions_answered_count: 2,
               clue: clue_matcher,
-              page_ids: [kind_of(Integer)]
+              page_ids: [kind_of(Integer)],
+              first_worked_at: kind_of(String),
+              last_worked_at: kind_of(String)
             },
             {
               title: "Representing Acceleration with Equations and Graphs",
@@ -157,7 +163,9 @@ RSpec.describe GetStudentGuide, type: :routine do
               student_count: 1,
               questions_answered_count: 0,
               clue: clue_matcher,
-              page_ids: [kind_of(Integer)]
+              page_ids: [kind_of(Integer)],
+              first_worked_at: nil,
+              last_worked_at: nil
             }
           ]
 
@@ -170,7 +178,9 @@ RSpec.describe GetStudentGuide, type: :routine do
               student_count: 1,
               questions_answered_count: 2,
               clue: clue_matcher,
-              page_ids: [kind_of(Integer)]
+              page_ids: [kind_of(Integer)],
+              first_worked_at: kind_of(String),
+              last_worked_at: kind_of(String)
             },
             {
               title: "Newton's First Law of Motion: Inertia",
@@ -179,7 +189,9 @@ RSpec.describe GetStudentGuide, type: :routine do
               student_count: 1,
               questions_answered_count: 5,
               clue: clue_matcher,
-              page_ids: [kind_of(Integer)]
+              page_ids: [kind_of(Integer)],
+              first_worked_at: kind_of(String),
+              last_worked_at: kind_of(String)
             },
             {
               title: "Newton's Second Law of Motion",
@@ -188,7 +200,9 @@ RSpec.describe GetStudentGuide, type: :routine do
               student_count: 1,
               questions_answered_count: 0,
               clue: clue_matcher,
-              page_ids: [kind_of(Integer)]
+              page_ids: [kind_of(Integer)],
+              first_worked_at: nil,
+              last_worked_at: nil
             },
             {
               title: "Newton's Third Law of Motion",
@@ -197,7 +211,9 @@ RSpec.describe GetStudentGuide, type: :routine do
               student_count: 1,
               questions_answered_count: 0,
               clue: clue_matcher,
-              page_ids: [kind_of(Integer)]
+              page_ids: [kind_of(Integer)],
+              first_worked_at: nil,
+              last_worked_at: nil
             }
           ]
         end

--- a/spec/routines/get_student_guide_spec.rb
+++ b/spec/routines/get_student_guide_spec.rb
@@ -3,7 +3,6 @@ require 'vcr_helper'
 require 'database_cleaner'
 
 RSpec.describe GetStudentGuide, type: :routine do
-
   before(:all) do
     @course = FactoryBot.create :course_profile_course
 
@@ -31,7 +30,6 @@ RSpec.describe GetStudentGuide, type: :routine do
   ].each do |role_type, routine_class|
 
     context "#{role_type} role" do
-
       before(:all) do
         DatabaseCleaner.start
 
@@ -42,7 +40,6 @@ RSpec.describe GetStudentGuide, type: :routine do
       after(:all)  { DatabaseCleaner.clean }
 
       context 'without work' do
-
         before(:all) do
           DatabaseCleaner.start
 
@@ -69,11 +66,9 @@ RSpec.describe GetStudentGuide, type: :routine do
             }
           )
         end
-
       end
 
       context 'with work' do
-
         before(:all) do
           DatabaseCleaner.start
 
@@ -206,11 +201,7 @@ RSpec.describe GetStudentGuide, type: :routine do
             }
           ]
         end
-
       end
-
     end
-
   end
-
 end

--- a/spec/subsystems/tasks/update_task_caches_spec.rb
+++ b/spec/subsystems/tasks/update_task_caches_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
             num_completed_exercises: 0,
             num_correct_exercises: 0,
             num_assigned_placeholders: 3,
+            first_worked_at: nil,
+            last_worked_at: nil,
             chapters: [
               {
                 id: chapter.id,
@@ -73,6 +75,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
                 num_completed_exercises: 0,
                 num_correct_exercises: 0,
                 num_assigned_placeholders: 3,
+                first_worked_at: nil,
+                last_worked_at: nil,
                 pages: [
                   {
                     id: page.id,
@@ -88,6 +92,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
                     num_completed_exercises: 0,
                     num_correct_exercises: 0,
                     num_assigned_placeholders: 3,
+                    first_worked_at: nil,
+                    last_worked_at: nil,
                     exercises: [3, 5].map do |number|
                       {
                         id: kind_of(Integer),
@@ -99,7 +105,9 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
                         free_response: nil,
                         selected_answer_id: nil,
                         completed: false,
-                        correct: false
+                        correct: false,
+                        first_completed_at: nil,
+                        last_completed_at: nil
                       }
                     end
                   }
@@ -136,6 +144,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
             num_completed_exercises: 8,
             num_correct_exercises: 8,
             num_assigned_placeholders: 0,
+            first_worked_at: kind_of(String),
+            last_worked_at: kind_of(String),
             chapters: [
               {
                 id: chapter.id,
@@ -151,6 +161,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
                 num_completed_exercises: 8,
                 num_correct_exercises: 8,
                 num_assigned_placeholders: 0,
+                first_worked_at: kind_of(String),
+                last_worked_at: kind_of(String),
                 pages: [
                   {
                     id: page.id,
@@ -166,6 +178,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
                     num_completed_exercises: 8,
                     num_correct_exercises: 8,
                     num_assigned_placeholders: 0,
+                    first_worked_at: kind_of(String),
+                    last_worked_at: kind_of(String),
                     exercises: [3, 5, 6, 7, 8, 9, 10, 11].map do |number|
                       {
                         id: kind_of(Integer),
@@ -177,7 +191,9 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
                         free_response: "A sentence explaining all the things!",
                         selected_answer_id: kind_of(String),
                         completed: true,
-                        correct: true
+                        correct: true,
+                        first_completed_at: kind_of(String),
+                        last_completed_at: kind_of(String)
                       }
                     end
                   }
@@ -212,7 +228,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         task_caches.each do |task_cache|
           task = task_cache.task
           expect(task).to be_in tasks
-          expect(task_cache.task_type).to eq (task.task_type)
+          expect(task_cache.task_type).to eq task.task_type
+          expect(task_cache.task_plan).to eq task.task_plan
           expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
@@ -227,6 +244,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
           expect(task_cache.due_at).to be_within(1).of(task.due_at)
           expect(task_cache.feedback_at).to be_nil
+          expect(task_cache.withdrawn_at).to be_nil
           expect(task_cache.is_cached_for_period).to eq false
         end
       end
@@ -238,7 +256,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         task_caches.each do |task_cache|
           task = task_cache.task
           expect(task).to be_in tasks
-          expect(task_cache.task_type).to eq (task.task_type)
+          expect(task_cache.task_type).to eq task.task_type
+          expect(task_cache.task_plan).to eq task.task_plan
           expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
@@ -253,6 +272,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
           expect(task_cache.due_at).to be_within(1).of(task.due_at)
           expect(task_cache.feedback_at).to be_nil
+          expect(task_cache.withdrawn_at).to be_nil
           expect(task_cache.is_cached_for_period).to eq true
         end
 
@@ -272,7 +292,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           is_first_task = task == first_task
 
           expect(task).to be_in tasks
-          expect(task_cache.task_type).to eq (task.task_type)
+          expect(task_cache.task_type).to eq task.task_type
+          expect(task_cache.task_plan).to eq task.task_plan
           expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
@@ -286,6 +307,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
           expect(task_cache.due_at).to be_within(1).of(task.due_at)
           expect(task_cache.feedback_at).to be_nil
+          expect(task_cache.withdrawn_at).to be_nil
           expect(task_cache.is_cached_for_period).to eq false
         end
       end
@@ -377,7 +399,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         task_caches.each do |task_cache|
           task = task_cache.task
           expect(task).to be_in tasks
-          expect(task_cache.task_type).to eq (task.task_type)
+          expect(task_cache.task_type).to eq task.task_type
+          expect(task_cache.task_plan).to eq task.task_plan
           expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
@@ -392,6 +415,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
           expect(task_cache.due_at).to be_within(1).of(task.due_at)
           expect(task_cache.feedback_at).to be_nil
+          expect(task_cache.withdrawn_at).to be_nil
           expect(task_cache.is_cached_for_period).to eq false
         end
       end
@@ -403,7 +427,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         task_caches.each do |task_cache|
           task = task_cache.task
           expect(task).to be_in tasks
-          expect(task_cache.task_type).to eq (task.task_type)
+          expect(task_cache.task_type).to eq task.task_type
+          expect(task_cache.task_plan).to eq task.task_plan
           expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
@@ -418,6 +443,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
           expect(task_cache.due_at).to be_within(1).of(task.due_at)
           expect(task_cache.feedback_at).to be_nil
+          expect(task_cache.withdrawn_at).to be_nil
           expect(task_cache.is_cached_for_period).to eq true
         end
 
@@ -437,7 +463,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           is_first_task = task == first_task
 
           expect(task).to be_in tasks
-          expect(task_cache.task_type).to eq (task.task_type)
+          expect(task_cache.task_type).to eq task.task_type
+          expect(task_cache.task_plan).to eq task.task_plan
           expect(task_cache.ecosystem).to eq course.ecosystem
           expect(task_cache.student_ids).to(
             match_array task.taskings.map { |tt| tt.role.student.id }
@@ -451,6 +478,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
           expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
           expect(task_cache.due_at).to be_within(1).of(task.due_at)
           expect(task_cache.feedback_at).to be_nil
+          expect(task_cache.withdrawn_at).to be_nil
           expect(task_cache.is_cached_for_period).to eq false
         end
       end
@@ -597,7 +625,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
       task_caches.each do |task_cache|
         task = task_cache.task
         expect(task).to be_in tasks
-        expect(task_cache.task_type).to eq (task.task_type)
+        expect(task_cache.task_type).to eq task.task_type
+        expect(task_cache.task_plan).to eq task.task_plan
         expect(task_cache.ecosystem).to eq course.ecosystem
         expect(task_cache.student_ids).to match_array task.taskings.map { |tt| tt.role.student.id }
         expect(task_cache.teacher_student_ids).to eq []
@@ -610,6 +639,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
         expect(task_cache.due_at).to be_within(1).of(task.due_at)
         expect(task_cache.feedback_at).to be_nil
+        expect(task_cache.withdrawn_at).to be_nil
         expect(task_cache.is_cached_for_period).to eq false
       end
     end
@@ -621,7 +651,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
       task_caches.each do |task_cache|
         task = task_cache.task
         expect(task).to be_in tasks
-        expect(task_cache.task_type).to eq (task.task_type)
+        expect(task_cache.task_type).to eq task.task_type
+        expect(task_cache.task_plan).to eq task.task_plan
         expect(task_cache.ecosystem).to eq course.ecosystem
         expect(task_cache.student_ids).to match_array task.taskings.map { |tt| tt.role.student.id }
         expect(task_cache.teacher_student_ids).to eq []
@@ -634,6 +665,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
         expect(task_cache.due_at).to be_within(1).of(task.due_at)
         expect(task_cache.feedback_at).to be_nil
+        expect(task_cache.withdrawn_at).to be_nil
         expect(task_cache.is_cached_for_period).to eq true
       end
 
@@ -652,7 +684,8 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         is_first_task = task == first_task
 
         expect(task).to be_in tasks
-        expect(task_cache.task_type).to eq (task.task_type)
+        expect(task_cache.task_type).to eq task.task_type
+        expect(task_cache.task_plan).to eq task.task_plan
         expect(task_cache.ecosystem).to eq course.ecosystem
         expect(task_cache.student_ids).to match_array task.taskings.map { |tt| tt.role.student.id }
         expect(task_cache.teacher_student_ids).to eq []
@@ -664,6 +697,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         expect(task_cache.opens_at).to be_within(1).of(task.opens_at)
         expect(task_cache.due_at).to be_within(1).of(task.due_at)
         expect(task_cache.feedback_at).to be_nil
+        expect(task_cache.withdrawn_at).to be_nil
         expect(task_cache.is_cached_for_period).to eq false
       end
     end

--- a/spec/support/create_student_history.rb
+++ b/spec/support/create_student_history.rb
@@ -63,8 +63,12 @@ class CreateStudentHistory
     periods = [periods].flatten.compact
     run(:distribute_tasks, task_plan: create_ireading_task_plan(ecosystem, course, periods))
 
-    task_plan = create_homework_task_plan(ecosystem, course, periods)
-    tasks = run(:distribute_tasks, task_plan: task_plan).outputs.tasks
+    withdrawn = create_homework_task_plan(ecosystem, course, periods, 3, 2, 0)
+    run(:distribute_tasks, task_plan: withdrawn)
+    withdrawn.destroy!
+
+    homework = create_homework_task_plan(ecosystem, course, periods, 2, 1, 0)
+    tasks = run(:distribute_tasks, task_plan: homework).outputs.tasks
     tasks.each { |task| answer_correctly(task, 2) }
   end
 
@@ -123,8 +127,8 @@ class CreateStudentHistory
     end
   end
 
-  def create_homework_task_plan(ecosystem, course, periods)
-    exercise_ids = [ecosystem.chapters[2].pages[1].exercises[0].id.to_s]
+  def create_homework_task_plan(ecosystem, course, periods, chapter, page, exercise)
+    exercise_ids = [ecosystem.chapters[chapter].pages[page].exercises[exercise].id.to_s]
 
     task_plan = FactoryBot.build(
       :tasks_task_plan,


### PR DESCRIPTION
- Don't use withdrawn tasks in the student guide and period caches.
  Period caches are used to display teacher stuff and teachers don't care about withdrawn assignments.
- Added task_plan-related fields to task_caches.
- Add first_worked_at/last_worked_at to task_caches. Only exercise steps set those.
- Send first_worked_at/last_worked_at to the frontend.

Needed for: https://github.com/openstax/tutor-js/pull/2741