### PR TITLE
Fix N+1 query in the student dashboard

### DIFF
--- a/app/representers/api/v1/tasks/task_step_representer.rb
+++ b/app/representers/api/v1/tasks/task_step_representer.rb
@@ -4,7 +4,7 @@ module Api::V1::Tasks
     include Roar::JSON
     include Representable::Coercion
 
-    INCLUDE_CONTENT = ->(user_options:, **) { user_options.try!(:[], :include_content) }
+    INCLUDE_CONTENT = ->(user_options:, **) { user_options&.[] :include_content }
 
     # These properties will be included in specific Tasked steps; therefore
     # their getters will be called from that context and so must call up to
@@ -26,21 +26,20 @@ module Api::V1::Tasks
              type: String,
              writeable: false,
              readable: true,
-             getter: ->(*) { self.class.name.demodulize.remove("Tasked").underscore.downcase },
+             getter: ->(*) { self.class.name.demodulize.remove('Tasked').underscore.downcase },
              schema_info: {
                required: true,
-               description: "The type of this TaskStep (exercise, reading, video, placeholder, etc.)"
+               description: 'The type of this TaskStep (exercise, reading, video, placeholder, etc)'
              }
 
-    property :group_name,
-             as: :group,
+    property :group,
              type: String,
              writeable: false,
              readable: true,
              getter: ->(*) { task_step.group_name },
              schema_info: {
                 required: true,
-                description: "Which group this TaskStep belongs to (default,core,spaced practice,personalized)"
+                description: 'Which group this TaskStep belongs to (default,core,spaced practice,personalized)'
              }
 
     property :is_completed,
@@ -50,14 +49,14 @@ module Api::V1::Tasks
              schema_info: {
                required: true,
                type: 'boolean',
-               description: "Whether or not this step is complete"
+               description: 'Whether or not this step is complete'
              }
 
     property :spy,
              type: Object,
              readable: true,
              writeable: false,
-             getter: ->(*) { task_step.spy },
+             getter: ->(*) { task_step.spy_with_response_validation },
              if: INCLUDE_CONTENT
   end
 end

--- a/app/routines/get_dashboard.rb
+++ b/app/routines/get_dashboard.rb
@@ -1,5 +1,4 @@
 class GetDashboard
-
   include DashboardRoutineMethods
 
   uses_routine Tasks::GetTaskPlans, as: :get_plans
@@ -22,8 +21,8 @@ class GetDashboard
 
   def load_research_surveys(course, role)
     surveys = role.student.surveys
-                .preload(:survey_plan)
-                .where(completed_at: nil, hidden_at: nil, deleted_at: nil)
+                          .preload(:survey_plan)
+                          .where(completed_at: nil, hidden_at: nil, deleted_at: nil)
     outputs.research_surveys = surveys if surveys.any?
   end
 
@@ -33,7 +32,7 @@ class GetDashboard
                              end_at_ntz: end_at_ntz).outputs
     task_plan_ids = result.plans.map(&:id)
     period_caches_by_task_plan_id = Tasks::Models::PeriodCache
-      .select([ :tasks_task_plan_id, :due_at, :student_ids, :as_toc ])
+      .select(:tasks_task_plan_id, :due_at, :student_ids, :as_toc)
       .joins(:task_plan)
       .where(task_plan: { id: task_plan_ids })
       .where(
@@ -84,5 +83,4 @@ class GetDashboard
       num_correct < 0.5 * num_completed
     end
   end
-
 end

--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -94,7 +94,7 @@ class Content::Models::Page < IndestructibleRecord
     return [] unless cache_fragments_and_snap_labs
 
     frags = super
-    @fragments = frags.nil? ? nil : frags.map{ |yaml| YAML.load(yaml) }
+    @fragments = frags.nil? ? nil : frags.map { |yaml| YAML.load(yaml) }
   end
 
   def snap_labs
@@ -104,7 +104,7 @@ class Content::Models::Page < IndestructibleRecord
     sls = super
     @snap_labs = sls.nil? ? nil : sls.map do |snap_lab|
       sl = snap_lab.symbolize_keys
-      sl.merge(fragments: sl[:fragments].map{ |yaml| YAML.load(yaml) })
+      sl.merge fragments: sl[:fragments].map { |yaml| YAML.load(yaml) }
     end
   end
 

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -91,10 +91,10 @@ class Tasks::Models::TaskStep < ApplicationRecord
     page.nil? ? [] : [ page.related_content ]
   end
 
-  def spy
-    return super unless exercise? && tasked.response_validation.present?
+  def spy_with_response_validation
+    return spy unless exercise? && tasked.response_validation.present?
 
-    super.merge response_validation: tasked.response_validation
+    spy.merge response_validation: tasked.response_validation
   end
 
 end

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -92,8 +92,9 @@ class Tasks::Models::TaskStep < ApplicationRecord
   end
 
   def spy
-    spy = super
-    exercise? && tasked.response_validation.present? ? spy.merge({ response_validation: tasked.response_validation }) : spy
+    return super unless exercise? && tasked.response_validation.present?
+
+    super.merge response_validation: tasked.response_validation
   end
 
 end

--- a/lib/json_serialize.rb
+++ b/lib/json_serialize.rb
@@ -21,14 +21,14 @@ module JsonSerialize
       define_method(options[:typecast_method]) do
         return unless has_attribute?(attribute)
 
-        value = send attribute
+        value = read_attribute attribute
         if options[:array]
           if value.is_a?(type) && !value.is_a?(Array)
             value = [value]
             send options[:setter_method], value
           end
 
-          return if value.to_a.all?{ |val| val.is_a? type }
+          return if value.to_a.all? { |val| val.is_a? type }
         else
           return if value.is_a?(type)
         end

--- a/lib/json_serialize.rb
+++ b/lib/json_serialize.rb
@@ -21,7 +21,7 @@ module JsonSerialize
       define_method(options[:typecast_method]) do
         return unless has_attribute?(attribute)
 
-        value = read_attribute attribute
+        value = send attribute
         if options[:array]
           if value.is_a?(type) && !value.is_a?(Array)
             value = [value]

--- a/spec/representers/api/v1/task_step_representer_spec.rb
+++ b/spec/representers/api/v1/task_step_representer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::TaskStepRepresenter, type: :representer do
     last_time = Time.current
     first_time = last_time - 1.week
     task_step = FactoryBot.create(:tasks_task_step, first_completed_at: first_time,
-                                                     last_completed_at: last_time)
+                                                    last_completed_at: last_time)
 
     representation = described_class.prepare(task_step).to_hash
 

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
       allow(step).to receive(:feedback_available?).and_return(false)
       allow(step).to receive(:labels).and_return([])
       allow(step).to receive(:related_content).and_return('RelatedContent')
-      allow(step).to receive(:spy).and_return(response_validation: { valid: false })
+      allow(step).to receive(:spy_with_response_validation).and_return(
+        response_validation: { valid: false }
+      )
     end
   end
 

--- a/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, type: :representer 
       allow(step).to receive(:group_name).and_return('Some group')
       allow(step).to receive(:completed?).and_return(false)
 
-      allow(step).to receive(:spy).and_return({})
+      allow(step).to receive(:spy_with_response_validation).and_return({})
     end
   end
 

--- a/spec/subsystems/tasks/models/task_step_spec.rb
+++ b/spec/subsystems/tasks/models/task_step_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe Tasks::Models::TaskStep, type: :model, speed: :medium do
     expect { task_step.save! }.to change { task_step.task.cache_version }
   end
 
-  it 'includes garbage_detection in spy' do
+  it 'includes garbage_detection in spy_with_response_validation' do
     task_step.tasked = FactoryBot.build :tasks_tasked_exercise,
                                         task_step: task_step,
                                         response_validation: { valid: false }
-    expect(task_step.spy).to eq(response_validation: {"valid"=>false})
+    expect(task_step.spy_with_response_validation).to eq(response_validation: { "valid"=>false })
   end
 
   context "group types" do


### PR DESCRIPTION
The spy method was being called by json_serialize to typecast the value to a hash but really it should be calling the spy attribute not the overridden method. Fixed that to fix an N+1 query in the student dashboard.