### PR TITLE
Added more, renamed and reordered queues

### DIFF
--- a/app/jobs/openstax/biglearn/api/job.rb
+++ b/app/jobs/openstax/biglearn/api/job.rb
@@ -1,5 +1,5 @@
 class OpenStax::Biglearn::Api::Job < ApplicationJob
-  queue_as :high_priority
+  queue_as :biglearn
 
   def perform(method:, requests:, response_status_key: nil, accepted_response_status: [], **ignored)
     OpenStax::Biglearn::Api.client.public_send(method, requests).tap do |response|

--- a/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
+++ b/app/jobs/openstax/biglearn/api/job_with_sequence_number.rb
@@ -2,7 +2,7 @@
 # then queues up another job to make the Biglearn request itself
 # Then attempts to lock the job and, after the transaction is committed, work it inline
 class OpenStax::Biglearn::Api::JobWithSequenceNumber < OpenStax::Biglearn::Api::Job
-  queue_as :high_priority
+  queue_as :biglearn
 
   def self.perform_later(*_)
     super.tap do |job|

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -107,7 +107,7 @@ class DistributeTasks
     tasks.each(&:update_step_counts)
     Tasks::Models::Task.import tasks, recursive: true, validate: false
 
-    queue = task_plan.is_preview ? :lowest_priority : :low_priority
+    queue = task_plan.is_preview ? :preview : :dashboard
     Tasks::UpdateTaskCaches.set(queue: queue)
                            .perform_later(task_ids: tasks.map(&:id), queue: queue.to_s)
 

--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -5,7 +5,7 @@ class ExportAndUploadResearchData
 
   BATCH_SIZE = 1000
 
-  lev_routine active_job_enqueue_options: { queue: :lowest_priority },
+  lev_routine active_job_enqueue_options: { queue: :maintenance },
               express_output: :filename,
               transaction: :no_transaction
 

--- a/app/routines/export_exercise_exclusions.rb
+++ b/app/routines/export_exercise_exclusions.rb
@@ -1,6 +1,6 @@
 class ExportExerciseExclusions
 
-  lev_routine active_job_enqueue_options: { queue: :lowest_priority }
+  lev_routine active_job_enqueue_options: { queue: :maintenance }
 
   protected
 

--- a/app/routines/import_ecosystem_manifest.rb
+++ b/app/routines/import_ecosystem_manifest.rb
@@ -1,7 +1,7 @@
 class ImportEcosystemManifest
 
   lev_routine express_output: :ecosystem,
-              active_job_enqueue_options: { queue: :lowest_priority },
+              active_job_enqueue_options: { queue: :maintenance },
               use_jobba: true
 
   uses_routine FetchAndImportBookAndCreateEcosystem, as: :fetch_and_import,

--- a/app/routines/import_roster.rb
+++ b/app/routines/import_roster.rb
@@ -1,6 +1,6 @@
 class ImportRoster
 
-  lev_routine active_job_enqueue_options: { queue: :lowest_priority }
+  lev_routine active_job_enqueue_options: { queue: :maintenance }
 
   uses_routine User::FindOrCreateUser, as: :find_or_create_user,
                                        translations: { outputs: { type: :verbatim } }

--- a/app/routines/populate_preview_course_content.rb
+++ b/app/routines/populate_preview_course_content.rb
@@ -12,7 +12,7 @@ class PopulatePreviewCourseContent
   # Should correspond to the total preview course duration, in weeks
   MAX_NUM_ASSIGNED_CHAPTERS = 10
 
-  lev_routine active_job_enqueue_options: { queue: :lowest_priority }
+  lev_routine active_job_enqueue_options: { queue: :preview }
 
   uses_routine User::CreateUser, as: :create_user
   uses_routine CourseMembership::CreatePeriod, as: :create_period

--- a/app/routines/send_global_exercise_exclusions_to_biglearn.rb
+++ b/app/routines/send_global_exercise_exclusions_to_biglearn.rb
@@ -1,5 +1,5 @@
 class SendGlobalExerciseExclusionsToBiglearn
-  lev_routine active_job_enqueue_options: { queue: :high_priority }
+  lev_routine active_job_enqueue_options: { queue: :biglearn }
 
   protected
 

--- a/app/routines/work_preview_course_tasks.rb
+++ b/app/routines/work_preview_course_tasks.rb
@@ -6,7 +6,7 @@ class WorkPreviewCourseTasks
 
   FREE_RESPONSE = 'This is where you can see each student’s answer in his or her own words.'
 
-  lev_routine active_job_enqueue_options: { queue: :lowest_priority, wait: 60.seconds }
+  lev_routine active_job_enqueue_options: { queue: :preview, wait: 60.seconds }
 
   uses_routine Preview::WorkTask, as: :work_task
 

--- a/app/subsystems/course_content/add_ecosystem_to_course.rb
+++ b/app/subsystems/course_content/add_ecosystem_to_course.rb
@@ -43,7 +43,7 @@ class CourseContent::AddEcosystemToCourse
         .where(taskings: { role: { student: { course_profile_course_id: course.id } } })
         .pluck(:id)
 
-      queue = course.is_preview ? :lowest_priority : :low_priority
+      queue = course.is_preview ? :preview : :dashboard
       all_task_ids.each_slice(100) do |task_ids|
         Tasks::UpdateTaskCaches.set(queue: queue)
                                .perform_later(task_ids: task_ids, queue: queue.to_s)

--- a/app/subsystems/course_membership/activate_student.rb
+++ b/app/subsystems/course_membership/activate_student.rb
@@ -15,7 +15,7 @@ module CourseMembership
       period = student.period
       ReassignPublishedPeriodTaskPlans[period: student.period]
 
-      queue = student.course.is_preview ? :lowest_priority : :low_priority
+      queue = student.course.is_preview ? :preview : :dashboard
       Tasks::UpdatePeriodCaches.set(queue: queue).perform_later(period_ids: period.id, force: true)
 
       outputs.student = student

--- a/app/subsystems/course_membership/inactivate_student.rb
+++ b/app/subsystems/course_membership/inactivate_student.rb
@@ -20,7 +20,7 @@ module CourseMembership
       ).destroy_all
 
       period_id = student.period.id
-      queue = student.course.is_preview ? :lowest_priority : :low_priority
+      queue = student.course.is_preview ? :preview : :dashboard
       Tasks::UpdatePeriodCaches.set(queue: queue).perform_later(period_ids: period_id, force: true)
 
       outputs.student = student

--- a/app/subsystems/research/export_and_upload_survey_data.rb
+++ b/app/subsystems/research/export_and_upload_survey_data.rb
@@ -1,6 +1,6 @@
 class Research::ExportAndUploadSurveyData
 
-  lev_routine active_job_enqueue_options: { queue: :lowest_priority },
+  lev_routine active_job_enqueue_options: { queue: :maintenance },
               express_output: :filename,
               transaction: :no_transaction
 

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -121,7 +121,7 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def update_caches_later(update_step_counts: true)
-    queue = is_preview ? :lowest_priority : :low_priority
+    queue = is_preview ? :preview : :dashboard
     Tasks::UpdateTaskCaches.set(queue: queue).perform_later(
       task_ids: id, update_step_counts: update_step_counts, queue: queue.to_s
     )

--- a/app/subsystems/tasks/update_period_caches.rb
+++ b/app/subsystems/tasks/update_period_caches.rb
@@ -1,6 +1,6 @@
 # Updates the PeriodCaches, used by the Teacher dashboard Trouble Flag and Performance Forecast
 class Tasks::UpdatePeriodCaches
-  lev_routine active_job_enqueue_options: { queue: :low_priority }, transaction: :read_committed
+  lev_routine active_job_enqueue_options: { queue: :dashboard }, transaction: :read_committed
 
   protected
 

--- a/app/subsystems/tasks/update_task_caches.rb
+++ b/app/subsystems/tasks/update_task_caches.rb
@@ -1,13 +1,13 @@
 # Updates the TaskCaches, used by the Quick Look and Student Performance Forecast
 # Tasks not assigned to a student (preview tasks) are ignored
 class Tasks::UpdateTaskCaches
-  lev_routine active_job_enqueue_options: { queue: :low_priority }, transaction: :read_committed
+  lev_routine active_job_enqueue_options: { queue: :dashboard }, transaction: :read_committed
 
   uses_routine GetCourseEcosystemsMap, as: :get_course_ecosystems_map
 
   protected
 
-  def exec(task_ids:, update_step_counts: false, queue: 'low_priority')
+  def exec(task_ids:, update_step_counts: false, queue: 'dashboard')
     ScoutHelper.ignore!(0.995)
 
     task_ids = [task_ids].flatten

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -23,10 +23,11 @@ Delayed::Worker.max_run_time = 8.hours
 
 # Default queue priorities
 Delayed::Worker.queue_attributes = {
-  high_priority:   { priority: -5 },
-  default:         { priority:  0 },
-  low_priority:    { priority:  5 },
-  lowest_priority: { priority: 10 }
+  biglearn:    { priority: -5 },
+  default:     { priority:  0 },
+  dashboard:   { priority:  5 },
+  maintenance: { priority: 10 },
+  preview:     { priority: 15 }
 }
 
 # Allows us to use this gem in tests instead of setting the ActiveJob adapter to :inline

--- a/db/migrate/20180222174206_reset_task_caches.rb
+++ b/db/migrate/20180222174206_reset_task_caches.rb
@@ -1,8 +1,8 @@
 class ResetTaskCaches < ActiveRecord::Migration[4.2]
   def up
     Tasks::Models::Task.select(:id).find_in_batches(batch_size: 100) do |tasks|
-      Tasks::UpdateTaskCaches.set(queue: :lowest_priority)
-                             .perform_later(task_ids: tasks.map(&:id), queue: 'lowest_priority')
+      Tasks::UpdateTaskCaches.set(queue: :maintenance)
+                             .perform_later(task_ids: tasks.map(&:id), queue: 'maintenance')
     end
   end
 

--- a/db/migrate/20190923160455_add_task_plan_and_withdrawn_at_to_task_caches.rb
+++ b/db/migrate/20190923160455_add_task_plan_and_withdrawn_at_to_task_caches.rb
@@ -5,7 +5,8 @@ class AddTaskPlanAndWithdrawnAtToTaskCaches < ActiveRecord::Migration[5.2]
     add_column :tasks_task_caches, :withdrawn_at, :datetime
 
     Tasks::Models::Task.select(:id).find_in_batches(batch_size: 100) do |tasks|
-      Tasks::UpdateTaskCaches.set(queue: :lowest_priority).perform_later task_ids: tasks.map(&:id)
+      Tasks::UpdateTaskCaches.set(queue: :maintenance).perform_later task_ids: tasks.map(&:id),
+                                                                     queue: 'maintenance'
     end
   end
 end

--- a/lib/openstax/biglearn/api.rb
+++ b/lib/openstax/biglearn/api.rb
@@ -517,7 +517,7 @@ module OpenStax::Biglearn::Api
 
       job_class = if include_sequence_number
         is_preview = request[sequence_number_model_key.to_sym].try(:is_preview)
-        args[:queue] = is_preview ? 'low_priority' : 'high_priority'
+        args[:queue] = is_preview ? 'preview' : 'biglearn'
 
         OpenStax::Biglearn::Api::JobWithSequenceNumber
       else
@@ -604,7 +604,7 @@ module OpenStax::Biglearn::Api
         is_preview = requests.is_a?(Array) ? requests.all? do |request|
           request[sequence_number_model_key.to_sym].try(:is_preview)
         end : requests[sequence_number_model_key.to_sym].try(:is_preview)
-        args[:queue] = is_preview ? 'low_priority' : 'high_priority'
+        args[:queue] = is_preview ? 'preview' : 'biglearn'
 
         OpenStax::Biglearn::Api::JobWithSequenceNumber
       else

--- a/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
+++ b/spec/jobs/openstax/biglearn/api/job_with_sequence_number_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
       create: create,
       sequence_number_model_key: sequence_number_model_key.to_s,
       sequence_number_model_class: sequence_number_model_class.to_s,
-      queue: 'low_priority'
+      queue: 'preview'
     }
   end
   let(:perform_args)                   do
@@ -25,7 +25,7 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
       create: create,
       sequence_number_model_key: sequence_number_model_key,
       sequence_number_model_class: sequence_number_model_class,
-      queue: 'high_priority'
+      queue: 'biglearn'
     }
   end
   let(:job_args)                      do
@@ -78,7 +78,7 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
         context '#perform' do
           it 'creates a new OpenStax::Biglearn::Api::Job with same args plus sequence_numbers' do
             expect(OpenStax::Biglearn::Api::Job).to(
-              receive(:set).with(queue: :high_priority).and_return(OpenStax::Biglearn::Api::Job)
+              receive(:set).with(queue: :biglearn).and_return(OpenStax::Biglearn::Api::Job)
             )
             expect(OpenStax::Biglearn::Api::Job).to(
               receive(:perform_later).with(job_args).and_call_original
@@ -150,7 +150,7 @@ RSpec.describe OpenStax::Biglearn::Api::JobWithSequenceNumber, type: :job do
         context '#perform' do
           it 'creates a new OpenStax::Biglearn::Api::Job with same args plus sequence_numbers' do
             expect(OpenStax::Biglearn::Api::Job).to(
-              receive(:set).with(queue: :high_priority).and_return(OpenStax::Biglearn::Api::Job)
+              receive(:set).with(queue: :biglearn).and_return(OpenStax::Biglearn::Api::Job)
             )
             expect(OpenStax::Biglearn::Api::Job).to(
               receive(:perform_later).with(job_args).and_call_original

--- a/spec/lib/tasks/exercises.rake_spec.rb
+++ b/spec/lib/tasks/exercises.rake_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'exercises:remove', type: :rake do
   let(:uid)       { @tasks.first.tasked_exercises.first.exercise.uid }
   let(:num_tasks) { @tasks.size }
 
-  let(:queue)          { :low_priority }
+  let(:queue)          { :dashboard }
   let(:configured_job) { Lev::ActiveJob::ConfiguredJob.new(Tasks::UpdateTaskCaches, queue: queue) }
 
   before do

--- a/spec/subsystems/tasks/update_period_caches_spec.rb
+++ b/spec/subsystems/tasks/update_period_caches_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
           @task_plan.update_attribute :is_preview, true
         end
 
-        let(:queue) { :lowest_priority }
+        let(:queue) { :preview }
 
         it 'is called when a task_plan is published' do
           @task_plan.tasks.delete_all
@@ -356,7 +356,7 @@ RSpec.describe Tasks::UpdatePeriodCaches, type: :routine, speed: :medium do
       end
 
       context 'not preview' do
-        let(:queue) { :low_priority }
+        let(:queue) { :dashboard }
 
         it 'is called when a task_plan is published' do
           @task_plan.tasks.delete_all

--- a/spec/subsystems/tasks/update_task_caches_spec.rb
+++ b/spec/subsystems/tasks/update_task_caches_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
         @task_plan.update_attribute :is_preview, true
       end
 
-      let(:queue) { :lowest_priority }
+      let(:queue) { :preview }
 
       it 'creates a Tasks::TaskCache for the given tasks' do
         Tasks::Models::TaskCache.where(tasks_task_id: task_ids).delete_all
@@ -383,7 +383,7 @@ RSpec.describe Tasks::UpdateTaskCaches, type: :routine, speed: :medium do
     end
 
     context 'not preview' do
-      let(:queue) { :low_priority }
+      let(:queue) { :dashboard }
 
       it 'creates a Tasks::TaskCache for the given tasks' do
         Tasks::Models::TaskCache.where(tasks_task_id: task_ids).delete_all


### PR DESCRIPTION
So we can run migrations etc without interfering with dashboard stuff.

Goes with https://github.com/openstax/tutor-deployment/pull/502