### PR TITLE
Fix course search by ID

### DIFF
--- a/app/routines/search_courses.rb
+++ b/app/routines/search_courses.rb
@@ -40,11 +40,12 @@ class SearchCourses
 
       with.keyword :any do |queries|
         queries.each do |query|
+          sanitized_ids = to_number_array(query)
           sanitized_queries = to_string_array(query, append_wildcard: true, prepend_wildcard: true)
-          next @items = @items.none if sanitized_queries.empty?
+          next @items = @items.none if sanitized_ids.empty? && sanitized_queries.empty?
 
           @items = @items.where(
-            co[:id].in(sanitized_queries).or(
+            co[:id].in(sanitized_ids).or(
               co[:name].matches_any(sanitized_queries)
             ).or(
               sc[:name].matches_any(sanitized_queries)
@@ -75,7 +76,7 @@ class SearchCourses
 
       with.keyword :id do |ids|
         ids.each do |id|
-          sanitized_ids = to_string_array(id, append_wildcard: false, prepend_wildcard: false)
+          sanitized_ids = to_number_array(id)
           next @items = @items.none if sanitized_ids.empty?
           @items = @items.where(id: sanitized_ids)
         end

--- a/spec/routines/search_courses_spec.rb
+++ b/spec/routines/search_courses_spec.rb
@@ -81,6 +81,26 @@ RSpec.describe SearchCourses, type: :routine, speed: :medium do
 
     courses = described_class[query: 'physics'].to_a
     expect(courses).to eq [course_3, course_1]
+
+    courses = described_class[query: course_1.id.to_s].to_a
+    expect(courses).to include course_1
+
+    courses = described_class[query: course_2.id.to_s].to_a
+    expect(courses).to include course_2
+
+    courses = described_class[query: course_3.id.to_s].to_a
+    expect(courses).to include course_3
+  end
+
+  it 'returns courses whose id matches the given query' do
+    courses = described_class[query: "id:#{course_1.id}"].to_a
+    expect(courses).to eq [ course_1 ]
+
+    courses = described_class[query: "id:#{course_2.id}"].to_a
+    expect(courses).to eq [ course_2 ]
+
+    courses = described_class[query: "id:#{course_3.id}"].to_a
+    expect(courses).to eq [ course_3 ]
   end
 
   it 'returns courses whose name matches the given query, in alphabetical order' do


### PR DESCRIPTION
Should return a course by id if you just type that id in the admin page