### PR TITLE
Post is_core migration changes

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -186,9 +186,7 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def core_task_steps_completed?
-    core_task_steps.all?(&:completed?)
-    # Revert to the following line once the is_core background migration is complete:
-    # task_steps.loaded? ? core_task_steps.all?(&:completed?) : !task_steps.core.incomplete.exists?
+    task_steps.loaded? ? core_task_steps.all?(&:completed?) : !task_steps.core.incomplete.exists?
   end
 
   def hide(current_time: Time.current)

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -26,9 +26,8 @@ class Tasks::Models::TaskStep < ApplicationRecord
   scope :complete,   -> { where.not first_completed_at: nil }
   scope :incomplete, -> { where     first_completed_at: nil }
 
-  # Enable these scopes once the is_core background migration is complete
-  # scope :core,       -> { where is_core: true  }
-  # scope :dynamic,    -> { where is_core: false }
+  scope :core,       -> { where is_core: true  }
+  scope :dynamic,    -> { where is_core: false }
 
   scope :exercises,  -> { where tasked_type: Tasks::Models::TaskedExercise.name }
 
@@ -37,16 +36,6 @@ class Tasks::Models::TaskStep < ApplicationRecord
     task&.lock! *args
 
     super
-  end
-
-  # Remove this method once the background migration for is_core has finished
-  # (and is_core becomes NOT NULL)
-  def is_core?
-    return is_core unless is_core.nil?
-
-    fixed_group? || tasked_type == Tasks::Models::TaskedExternalUrl.name || (
-      personalized_group? && task.reading? && !task.task_steps.last(3).include?(self)
-    )
   end
 
   def is_dynamic?


### PR DESCRIPTION
Removes code that was left in place for backwards compatibility while the `is_core` column was being migrated in the background.

Production already has: `is_core              | boolean                     | not null`