### PR TITLE
Change fragment-only links not found in the current page to reference view

### DIFF
--- a/app/subsystems/content/models/book.rb
+++ b/app/subsystems/content/models/book.rb
@@ -1,5 +1,4 @@
 class Content::Models::Book < IndestructibleRecord
-
   wrapped_by ::Content::Strategies::Direct::Book
 
   acts_as_resource
@@ -50,4 +49,7 @@ class Content::Models::Book < IndestructibleRecord
     ecosystem.update_attribute(:title, ecosystem.set_title)
   end
 
+  def reference_view_url
+    "/book/#{ecosystem.id}"
+  end
 end

--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -1,5 +1,4 @@
 class Content::Models::Page < IndestructibleRecord
-
   wrapped_by ::Content::Strategies::Direct::Page
 
   acts_as_resource
@@ -131,6 +130,10 @@ class Content::Models::Page < IndestructibleRecord
     @context_for_feature_ids[feature_ids] = feature_node.try(:to_html)
   end
 
+  def reference_view_url(book = chapter.book)
+    "#{book.reference_view_url}/page/#{id}"
+  end
+
   protected
 
   def parser_class
@@ -142,10 +145,10 @@ class Content::Models::Page < IndestructibleRecord
   end
 
   def fragment_splitter
-    return if chapter.try(:book).nil?
+    return if chapter&.book.nil?
 
     @fragment_splitter ||= OpenStax::Cnx::V1::FragmentSplitter.new(
-      chapter.book.reading_processing_instructions
+      chapter.book.reading_processing_instructions, reference_view_url
     )
   end
 
@@ -164,5 +167,4 @@ class Content::Models::Page < IndestructibleRecord
 
     true
   end
-
 end

--- a/app/subsystems/content/routines/update_page_content.rb
+++ b/app/subsystems/content/routines/update_page_content.rb
@@ -1,11 +1,9 @@
 class Content::Routines::UpdatePageContent
-
   # Extract the uuid and version from paths like:
   #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b
   #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@3
   #   /contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@3#figure-1
   #   /contents/031da8d3-b525-429c-80cf-6c8ed997733a@9.98:127f63f7-d67f-4710-8625-2b1d4128ef6b@3
-
   CNX_ID_REGEX_STRING = <<-LINK_REGEX.strip_heredoc.gsub(/[\s\t]*/, '')
     /contents/
     (?:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:@([\\d\\.]+))?:)?
@@ -37,6 +35,7 @@ class Content::Routines::UpdatePageContent
     outputs.pages = pages
   end
 
+  # Transforms absolute CNX urls to absolute reference view URLs
   # If the link goes to a page in the book, change the link to just the page's book_location
   def change_page_link(href_attr, book, pages_by_uuid)
     url = Addressable::URI.parse(href_attr.value) rescue return
@@ -68,13 +67,13 @@ class Content::Routines::UpdatePageContent
 
       # The link actually points to the book itself
       # Remove the path from the link
-      "/book/#{book.ecosystem.id}"
+      book.reference_view_url
     else
       # Check if the page's version is correct
       return if page_version.present? && page.version != page_version
 
       # Change the link's path to the page's book_location
-      "/book/#{book.ecosystem.id}/section/#{page.book_location.reject(&:zero?).join('.')}"
+      page.reference_view_url book
     end
 
     href_attr.value = url.to_s

--- a/lib/openstax/cnx/v1/book.rb
+++ b/lib/openstax/cnx/v1/book.rb
@@ -1,6 +1,5 @@
 module OpenStax::Cnx::V1
   class Book
-
     def initialize(id: nil, hash: nil, title: nil, tree: nil, root_book_part: nil)
       @id             = id
       @hash           = hash
@@ -54,6 +53,5 @@ module OpenStax::Cnx::V1
     def root_book_part
       @root_book_part ||= BookPart.new(hash: tree, is_root: true, book: self)
     end
-
   end
 end

--- a/lib/openstax/cnx/v1/book_part.rb
+++ b/lib/openstax/cnx/v1/book_part.rb
@@ -1,6 +1,5 @@
 module OpenStax::Cnx::V1
   class BookPart
-
     def initialize(hash: {}, is_root: false, book: nil)
       @hash = hash
       @is_root = is_root
@@ -43,6 +42,5 @@ module OpenStax::Cnx::V1
       # A BookPart is a chapter if none of its children are BookParts
       @is_chapter ||= parts.none? { |part| part.is_a?(self.class) }
     end
-
   end
 end

--- a/lib/openstax/cnx/v1/fragment.rb
+++ b/lib/openstax/cnx/v1/fragment.rb
@@ -1,7 +1,6 @@
 # All fragment subclasses must be serializable with to_yaml and YAML.load
 # Nokogiri nodes are not serializable, so they must be processed in the initialize method
 class OpenStax::Cnx::V1::Fragment
-
   attr_reader :title, :labels, :node_id
 
   def initialize(node:, title: nil, labels: nil)
@@ -13,5 +12,4 @@ class OpenStax::Cnx::V1::Fragment
   def blank?
     false
   end
-
 end

--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -1,6 +1,5 @@
 module OpenStax::Cnx::V1
   class Fragment::Embedded < Fragment
-
     # Used to get the title
     TITLE_CSS = '[data-type="title"]'
 
@@ -48,6 +47,5 @@ module OpenStax::Cnx::V1
     def blank?
       url.blank?
     end
-
   end
 end

--- a/lib/openstax/cnx/v1/fragment/exercise.rb
+++ b/lib/openstax/cnx/v1/fragment/exercise.rb
@@ -1,6 +1,5 @@
 module OpenStax::Cnx::V1
   class Fragment::Exercise < Fragment
-
     # CSS to find the embed code attributes
     EXERCISE_EMBED_URL_CSS = 'a[href^="#"]'
 
@@ -55,6 +54,5 @@ module OpenStax::Cnx::V1
     def blank?
       embed_queries.empty? && node_id.blank?
     end
-
   end
 end

--- a/lib/openstax/cnx/v1/fragment/interactive.rb
+++ b/lib/openstax/cnx/v1/fragment/interactive.rb
@@ -1,6 +1,5 @@
 class OpenStax::Cnx::V1::Fragment
   class Interactive < Embedded
-
     # CSS to find interactive containers (anything inside may be replaced with an iframe)
     CONTAINER_CSS = 'figure.ost-embed-container, .os-figure:has-descendants("a.os-interactive-link"), figure:has-descendants("a.os-interactive-link")'
 
@@ -35,6 +34,5 @@ class OpenStax::Cnx::V1::Fragment
 
       node
     end
-
   end
 end

--- a/lib/openstax/cnx/v1/fragment/reading.rb
+++ b/lib/openstax/cnx/v1/fragment/reading.rb
@@ -1,17 +1,34 @@
 module OpenStax::Cnx::V1
   class Fragment::Reading < Fragment
-
     attr_reader :to_html
 
-    def initialize(node:, title: nil, labels: nil)
-      super
+    def initialize(node:, title: nil, labels: nil, reference_view_url: nil)
+      super node: node, title: title, labels: labels
+
+      node.css('[href]').each do |link|
+        href = link.attributes['href']
+        uri = Addressable::URI.parse(href.value) rescue nil
+
+        # Modify only fragment-only links
+        next if uri.nil? || uri.absolute? || !uri.path.blank?
+
+        # Abort if the link target is still present in this fragment
+        target = uri.fragment
+        next if node.at_css("##{target}, [name=\"#{target}\"]")
+
+        # Change the link to point to the reference view
+        href.value = "#{reference_view_url}##{target}"
+      end unless reference_view_url.nil?
 
       @to_html = node.to_html
+    end
+
+    def to_html
+      @to_html ||= node.to_html
     end
 
     def blank?
       to_html.blank?
     end
-
   end
 end

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -1,6 +1,5 @@
 module OpenStax::Cnx::V1
   class Page
-
     # Start parsing here
     ROOT_CSS = 'html > body'
 
@@ -227,6 +226,8 @@ module OpenStax::Cnx::V1
       node
     end
 
+    # Transforms relative URLs that point to other CNX pages to absolute URLs
+    # Transforms absolute http URLs to https
     def absolutize_and_secure_urls(node)
       # Absolutize exercise urls
       node = OpenStax::Cnx::V1::Fragment::Exercise.absolutize_exercise_urls(node.dup)
@@ -277,6 +278,5 @@ module OpenStax::Cnx::V1
 
       node
     end
-
   end
 end

--- a/spec/lib/openstax/cnx/v1/book_part_spec.rb
+++ b/spec/lib/openstax/cnx/v1/book_part_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe OpenStax::Cnx::V1::BookPart, type: :external do
-
   cnx_book_infos = [
     { id: "93e2b09d-261c-4007-a987-0b3062fe154b",
       contents: [
@@ -63,5 +62,4 @@ RSpec.describe OpenStax::Cnx::V1::BookPart, type: :external do
       )
     end
   end
-
 end

--- a/spec/lib/openstax/cnx/v1/book_spec.rb
+++ b/spec/lib/openstax/cnx/v1/book_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe OpenStax::Cnx::V1::Book, type: :external, vcr: VCR_OPTS do
-
   cnx_book_id = '93e2b09d-261c-4007-a987-0b3062fe154b'
 
   let(:expected_book_url) {
@@ -20,5 +19,4 @@ RSpec.describe OpenStax::Cnx::V1::Book, type: :external, vcr: VCR_OPTS do
     expect(book.tree).not_to be_nil
     expect(book.root_book_part).to be_a OpenStax::Cnx::V1::BookPart
   end
-
 end

--- a/spec/lib/openstax/cnx/v1/fragment/exercise_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/exercise_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Exercise, type: :external, vcr: VCR_
   let(:reading_processing_instructions) do
     FactoryBot.build(:content_book).reading_processing_instructions
   end
-  let(:fragment_splitter)  do
-    OpenStax::Cnx::V1::FragmentSplitter.new(reading_processing_instructions)
+  let(:reference_view_url) { Faker::Internet.url }
+  let(:fragment_splitter) do
+    OpenStax::Cnx::V1::FragmentSplitter.new reading_processing_instructions, reference_view_url
   end
   let(:cnx_page_id)        { '640e3e84-09a5-4033-b2a7-b7fe5ec29dc6@4' }
   let(:cnx_page)           { OpenStax::Cnx::V1::Page.new(id: cnx_page_id) }

--- a/spec/lib/openstax/cnx/v1/fragment/interactive_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/interactive_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Interactive, type: :external, vcr: V
   let(:reading_processing_instructions) do
     FactoryBot.build(:content_book).reading_processing_instructions
   end
-  let(:fragment_splitter)     do
-    OpenStax::Cnx::V1::FragmentSplitter.new(reading_processing_instructions)
+  let(:reference_view_url) { Faker::Internet.url }
+  let(:fragment_splitter) do
+    OpenStax::Cnx::V1::FragmentSplitter.new reading_processing_instructions, reference_view_url
   end
   let(:cnx_page_id)           { '640e3e84-09a5-4033-b2a7-b7fe5ec29dc6@4' }
   let(:cnx_page)              { OpenStax::Cnx::V1::Page.new(id: cnx_page_id) }

--- a/spec/lib/openstax/cnx/v1/fragment/optional_exercise_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/optional_exercise_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe OpenStax::Cnx::V1::Fragment::OptionalExercise, type: :external, vcr: VCR_OPTS do
-  let(:reading_processing_instructions) {
+  let(:reading_processing_instructions) do
     FactoryBot.build(:content_book).reading_processing_instructions
-  }
-  let(:fragment_splitter)  {
-    OpenStax::Cnx::V1::FragmentSplitter.new(reading_processing_instructions)
-  }
+  end
+  let(:reference_view_url) { Faker::Internet.url }
+  let(:fragment_splitter) do
+    OpenStax::Cnx::V1::FragmentSplitter.new reading_processing_instructions, reference_view_url
+  end
   let(:cnx_page_id)        { '548a8717-71e1-4d65-80f0-7b8c6ed4b4c0@3' }
   let(:cnx_page)           { OpenStax::Cnx::V1::Page.new(id: cnx_page_id) }
   let(:fragments)          { fragment_splitter.split_into_fragments(cnx_page.converted_root) }

--- a/spec/lib/openstax/cnx/v1/fragment/reading_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/reading_spec.rb
@@ -2,21 +2,49 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe OpenStax::Cnx::V1::Fragment::Reading, type: :external, vcr: VCR_OPTS do
-  let(:reading_processing_instructions) {
+  let(:reading_processing_instructions) do
     FactoryBot.build(:content_book).reading_processing_instructions
-  }
-  let(:fragment_splitter) {
-    OpenStax::Cnx::V1::FragmentSplitter.new(reading_processing_instructions)
-  }
+  end
+  let(:reference_view_url) { Faker::Internet.url }
+  let(:fragment_splitter) do
+    OpenStax::Cnx::V1::FragmentSplitter.new reading_processing_instructions, reference_view_url
+  end
   let(:cnx_page_id)       { '95e61258-2faf-41d4-af92-f62e1414175a@4' }
   let(:cnx_page)          { OpenStax::Cnx::V1::Page.new(id: cnx_page_id) }
   let(:fragments)         { fragment_splitter.split_into_fragments(cnx_page.converted_root) }
   let(:reading_fragments) { fragments.select { |f| f.instance_of? described_class } }
 
-  it "provides info about the reading fragment" do
+  it 'provides info about the reading fragment' do
     reading_fragments.each do |fragment|
       expect(fragment.title).to be_nil
       expect(fragment.to_html).not_to be_blank
     end
+  end
+
+  it 'changes links to objects not found in this fragment to point to the reference view' do
+    cnx_page.instance_variable_set :@content, <<~HTML
+      <html>
+        <body>
+          <div id="content">
+            <a href="#content">Content</a>
+
+            <a href="#query">Query</a>
+            <input name="query" type="text"/>
+
+            <a href="#test">Test</a>
+          </div>
+        </body>
+      </html>
+    HTML
+
+    expect(reading_fragments.size).to eq 1
+    reading_fragment = reading_fragments.first
+
+    doc = Nokogiri::HTML(reading_fragment.to_html)
+    body = doc.at_css('body')
+    expect(body.at_css('[href="#content"]')).not_to be_nil
+    expect(body.at_css('[href="#query"]')).not_to be_nil
+    expect(body.at_css('[href="#test"]')).to be_nil
+    expect(body.at_css("[href=\"#{reference_view_url}#test\"]")).not_to be_nil
   end
 end

--- a/spec/lib/openstax/cnx/v1/fragment/video_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/video_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Video, type: :external, vcr: VCR_OPT
   let(:reading_processing_instructions) do
     FactoryBot.build(:content_book).reading_processing_instructions
   end
+  let(:reference_view_url) { Faker::Internet.url }
   let(:fragment_splitter) do
-    OpenStax::Cnx::V1::FragmentSplitter.new(reading_processing_instructions)
+    OpenStax::Cnx::V1::FragmentSplitter.new reading_processing_instructions, reference_view_url
   end
   let(:cnx_page_id)       { '640e3e84-09a5-4033-b2a7-b7fe5ec29dc6@4' }
   let(:cnx_page)          { OpenStax::Cnx::V1::Page.new(id: cnx_page_id) }

--- a/spec/lib/openstax/cnx/v1/fragment_splitter_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment_splitter_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe OpenStax::Cnx::V1::FragmentSplitter, type: :lib, vcr: VCR_OPTS do
-  let(:reading_processing_instructions) {
+  let(:reading_processing_instructions) do
     FactoryBot.build(:content_book).reading_processing_instructions
-  }
+  end
+  let(:reference_view_url) { Faker::Internet.url }
 
-  let(:fragment_splitter)  { described_class.new(reading_processing_instructions) }
+  let(:fragment_splitter)  do
+    described_class.new reading_processing_instructions, reference_view_url
+  end
 
   context 'with page' do
     before(:all) do
@@ -61,7 +64,7 @@ RSpec.describe OpenStax::Cnx::V1::FragmentSplitter, type: :lib, vcr: VCR_OPTS do
 
     it "splits the given pages into the expected fragments for HS" do
       hs_processing_instructions = FactoryBot.build(:content_book).reading_processing_instructions
-      fragment_splitter = described_class.new(hs_processing_instructions)
+      fragment_splitter = described_class.new hs_processing_instructions, reference_view_url
 
       @cnx_page_fragment_infos.each do |hash|
         fragments = fragment_splitter.split_into_fragments(hash[:page].converted_root)
@@ -76,7 +79,9 @@ RSpec.describe OpenStax::Cnx::V1::FragmentSplitter, type: :lib, vcr: VCR_OPTS do
           fragments: [], except: 'snap-lab' },
         { css: '.worked-example', fragments: ['node', 'optional_exercise'] }
       ]
-      fragment_splitter = described_class.new(worked_example_processing_instructions)
+      fragment_splitter = described_class.new(
+        worked_example_processing_instructions, reference_view_url
+      )
 
       hash = @cnx_page_fragment_infos.first
       fragments = fragment_splitter.split_into_fragments(hash[:page].converted_root)

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
-
   context 'with parts of k12phys' do
     before(:all) do
       cnx_page_infos = [
@@ -246,5 +245,4 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
   def page_for(hash)
     OpenStax::Cnx::V1::Page.new(hash: HashWithIndifferentAccess.new(hash).except(:expected))
   end
-
 end

--- a/spec/subsystems/content/routines/update_page_content_spec.rb
+++ b/spec/subsystems/content/routines/update_page_content_spec.rb
@@ -85,8 +85,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -119,8 +118,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + composite_before_hrefs[1..-1]
               end
 
@@ -214,8 +212,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -248,8 +245,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + composite_before_hrefs[1..-1]
               end
 
@@ -339,8 +335,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -373,8 +368,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + composite_before_hrefs[1..-1]
               end
 
@@ -468,8 +462,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
             context 'simple' do
               let(:after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                  @page_2.book_location.reject(&:zero?).join('.')}"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + before_hrefs[1..-1]
               end
 
@@ -502,9 +495,7 @@ RSpec.describe Content::Routines::UpdatePageContent, type: :routine do
 
               let(:composite_after_hrefs) do
                 [
-                  "/book/#{@book.ecosystem.id}/section/#{
-                    @page_2.book_location.reject(&:zero?).join('.')
-                  }"
+                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
                 ] + composite_before_hrefs[1..-1]
               end
 


### PR DESCRIPTION
Fix for footnotes etc linking to stuff that does not exist in the current step

Will need to reimport books to see any change