### PR TITLE
Optimize order of Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
     - OXT_TEST_DB=travis_ci_test
     - PARALLEL_TEST_PROCESSORS=2
   matrix:
-    - LINT=true
-    - ASSETS=true
-    - TAG=speed:fast
     - TAG=~speed:fast
+    - TAG=speed:fast
+    - ASSETS=true
+    - LINT=true
 rvm: 2.6.1
 cache: bundler
 before_install:


### PR DESCRIPTION
Travis seems to run the builds in order, so put the builds that take the longest at the top so they start first.