### PR TITLE
Don't send null is_deleted to biglearn

### DIFF
--- a/lib/openstax/biglearn/api/real_client.rb
+++ b/lib/openstax/biglearn/api/real_client.rb
@@ -422,7 +422,7 @@ class OpenStax::Biglearn::Api::RealClient < OpenStax::Biglearn::RealClient
         course_uuid: request.fetch(:course).uuid,
         sequence_number: request.fetch(:sequence_number),
         assignment_uuid: task.uuid,
-        is_deleted: task.task_plan.try!(:withdrawn?),
+        is_deleted: task.withdrawn?,
         ecosystem_uuid: ecosystem.tutor_uuid,
         student_uuid: student.uuid,
         assignment_type: task_type,


### PR DESCRIPTION
Biglearn-scheduler was blowing up because of the nils