### PR TITLE
don't blow up if link's href is '#'

### DIFF
--- a/lib/openstax/cnx/v1/fragment/reading.rb
+++ b/lib/openstax/cnx/v1/fragment/reading.rb
@@ -12,19 +12,15 @@ module OpenStax::Cnx::V1
         # Modify only fragment-only links
         next if uri.nil? || uri.absolute? || !uri.path.blank?
 
-        # Abort if the link target is still present in this fragment
+        # Abort if there is not a target or it's still present in this fragment
         target = uri.fragment
-        next if node.at_css("##{target}, [name=\"#{target}\"]")
+        next if target.blank? || node.at_css("##{target}, [name=\"#{target}\"]")
 
         # Change the link to point to the reference view
         href.value = "#{reference_view_url}##{target}"
       end unless reference_view_url.nil?
 
       @to_html = node.to_html
-    end
-
-    def to_html
-      @to_html ||= node.to_html
     end
 
     def blank?

--- a/spec/lib/openstax/cnx/v1/fragment/reading_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/reading_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Reading, type: :external, vcr: VCR_O
             <input name="query" type="text"/>
 
             <a href="#test">Test</a>
+
+            <a href="#">Test random bad link</a>
           </div>
         </body>
       </html>
@@ -42,6 +44,7 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Reading, type: :external, vcr: VCR_O
 
     doc = Nokogiri::HTML(reading_fragment.to_html)
     body = doc.at_css('body')
+    expect(body.at_css('[href="#"]')).not_to be_nil
     expect(body.at_css('[href="#content"]')).not_to be_nil
     expect(body.at_css('[href="#query"]')).not_to be_nil
     expect(body.at_css('[href="#test"]')).to be_nil


### PR DESCRIPTION
previously the selector wouldn't be valid for links with href="#"