### PR TITLE
Remove duplicate sections from highlights

### DIFF
--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -87,10 +87,13 @@ class Api::V1::NotesController < Api::V1::ApiController
   EOS
 
   def highlighted_sections
-    pages = Content::Models::Page.select(:id, :title, :uuid, :book_location, 'COUNT(*) as "notes_count"')
-                                 .joins(:book, :notes)
-                                 .where(book: { uuid: params[:book_uuid] }, notes: { role: @roles })
-                                 .group(:id)
+    model = Content::Models::Page
+    pages = model.select(:id, :title, :uuid, :book_location).where(
+        id: model.select("max(#{model.table_name}.id) as id")
+          .joins(:book, :notes)
+          .where(book: { uuid: params[:book_uuid] }, notes: { role: @roles })
+          .group(:book_location)
+    )
     respond_with pages, represent_with: Api::V1::HighlightRepresenter
   end
 

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -91,9 +91,9 @@ class Api::V1::NotesController < Api::V1::ApiController
       .joins(:book, :notes)
       .where(book: { uuid: params[:book_uuid] }, notes: { role: @roles })
       .group(:id)
-      .sort_by(&:created_at).reverse
-      .uniq(&:uuid)
-      .sort_by(&:book_location)
+      .sort_by(&:created_at).reverse  # this is ruby, get most recent page
+      .uniq(&:uuid)                   # then remove any other pages
+      .sort_by(&:book_location)       # sort so the FE doesn't need to
 
     respond_with pages, represent_with: Api::V1::HighlightRepresenter
   end

--- a/app/representers/api/v1/highlight_representer.rb
+++ b/app/representers/api/v1/highlight_representer.rb
@@ -35,10 +35,6 @@ module Api::V1
                 description: 'The title of the page'
               }
 
-      property :notes_count,
-               type: Integer,
-               readable: true,
-               writable: false
     end
 
     include Roar::JSON

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe Api::V1::NotesController, type: :controller, api: true, version: 
       expect(response).to be_ok
       expect(response.body_as_hash[:pages]).to be_empty
     end
+
+    it 'does not fetch duplicates' do
+      new_note = FactoryBot.create :content_note, role: student_role
+      new_note.page.update_attributes! uuid: note.page.uuid
+      new_note.page.book.update_attributes! uuid: note.page.book.uuid
+
+      api_get :highlighted_sections, student_token, params: highlighted_sections_params
+
+      expect(response).to be_ok
+      expect(response.body_as_hash[:pages].length).to eq 1
+    end
   end
 
 end


### PR DESCRIPTION
If ecosystem was updated there could be duplicate pages.  The notes_count was removed since it was not in use