### PR TITLE
remove notes_count from highlight summary

### DIFF
--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -87,7 +87,7 @@ class Api::V1::NotesController < Api::V1::ApiController
   EOS
 
   def highlighted_sections
-    pages = Content::Models::Page.select(:id, :title, :uuid, :book_location, :created_at, 'COUNT(*) as "notes_count"')
+    pages = Content::Models::Page.select(:id, :title, :uuid, :book_location, :created_at)
       .joins(:book, :notes)
       .where(book: { uuid: params[:book_uuid] }, notes: { role: @roles })
       .group(:id)


### PR DESCRIPTION
It's not currently used by the FE and wasn't accurate since it wasn't
being added when notes where grouped