### PR TITLE
Fix scout_apm version in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ gem 'boxr'
 # OAuth gem for generating and validating lti requests
 gem 'oauth', '~> 0.5.1'
 
-gem 'scout_apm', '~> 3.0.x'
+gem 'scout_apm', '~> 3.0.0.pre28'
 
 # Respond to ELB healthchecks in /ping and /ping/
 gem 'openstax_healthcheck'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -820,7 +820,7 @@ DEPENDENCIES
   rspec-retry
   rubocop
   sass-rails (~> 5.0.7)
-  scout_apm (~> 3.0.x)
+  scout_apm (~> 3.0.0.pre28)
   sentry-raven
   shoulda-matchers
   sortability


### PR DESCRIPTION
We were already using this version.

rubygems released a new version that rejects our scout_apm version in the Gemfile so we need to fix it.