### PR TITLE
display paired count and only remove last LMS pairing

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -34,7 +34,7 @@ class Admin::CoursesController < Admin::BaseController
   end
 
   def unpair_lms
-    Lms::UnpairCourse.call(course: CourseProfile::Models::Course.find(params[:id]))
+    Lms::RemoveLastCoursePairing.call(course: CourseProfile::Models::Course.find(params[:id]))
     redirect_to admin_courses_path
   end
 

--- a/app/subsystems/lms/remove_last_course_pairing.rb
+++ b/app/subsystems/lms/remove_last_course_pairing.rb
@@ -1,4 +1,4 @@
-class Lms::UnpairCourse
+class Lms::RemoveLastCoursePairing
 
   lev_routine
 
@@ -7,7 +7,7 @@ class Lms::UnpairCourse
       fatal_error(code: :course_access_is_locked, message: "Course access is locked")
     end
     if course.lms_contexts.any?
-      course.lms_contexts.destroy_all
+      course.lms_contexts.order(:created_at).last.destroy
     end
     transfer_errors_from(course, {type: :verbatim})
   end

--- a/app/views/manager/courses/_index.html.erb
+++ b/app/views/manager/courses/_index.html.erb
@@ -120,7 +120,7 @@
                 enabled
                 <% if course_info.is_access_switchable? %>
                   <% if course_info.lms_contexts.any? %>
-                    &amp; paired (<%= link_to('unpair', unpair_lms_admin_course_path(course_info),
+                    &amp; paired to <%= course_info.lms_contexts.count %> LMS (<%= link_to('unpair last', unpair_lms_admin_course_path(course_info),
                                 method: :delete, data: { confirm: 'Are you sure?' })%>)
                   <% end %>
                 <% else %>

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Admin::CoursesController, type: :controller, speed: :medium do
   context 'DELETE #unpair_lms' do
     let(:course) { FactoryBot.create :course_profile_course }
     it 'calls unpair routine' do
-      expect_any_instance_of(Lms::UnpairCourse).to(
+      expect_any_instance_of(Lms::RemoveLastCoursePairing).to(
         receive(:call).with(course: course)
       )
       delete :unpair_lms, params: { id: course.id }

--- a/spec/subsystems/lms/remove_last_course_pairing_spec.rb
+++ b/spec/subsystems/lms/remove_last_course_pairing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Lms::UnpairCourse do
+RSpec.describe Lms::RemoveLastCoursePairing do
 
   let(:message) {
     OpenStruct.new(context_id: '1234', tool_consumer_instance_guid: '4242')
@@ -30,12 +30,23 @@ RSpec.describe Lms::UnpairCourse do
     expect(course.reload.lms_contexts).to be_present
   end
 
-  it "deletes the lms context" do
-    expect(course.lms_contexts).to be_present
+  it "deletes the last lms context" do
+    first_context = course.lms_contexts.first
+
+    new_launch = Lms::Launch.from_request(
+      FactoryBot.create(:launch_request, app: Lms::WilloLabs.new),
+      authenticator: authenticator
+    ).validate!
+    Lms::PairLaunchToCourse.call(launch_id: new_launch.persist!, course: course)
+
+    expect(course.lms_contexts.count).to eq 2
+
     expect do
       result = subject.call(course: course)
       expect(result.errors).to be_empty
     end.to change{ Lms::Models::Context.count }.by -1
-    expect(course.reload.lms_contexts).to be_empty
+
+    expect(course.reload.lms_contexts.count).to eq 1
+    expect(course.reload.lms_contexts.first).to eq first_context
   end
 end


### PR DESCRIPTION
This way admins won't need to remove all the LMS pairs, only the last which is what they almost always want