### PR TITLE
Populate practice task placeholder steps in the background

### DIFF
--- a/app/controllers/api/v1/practices_controller.rb
+++ b/app/controllers/api/v1/practices_controller.rb
@@ -39,15 +39,6 @@ module Api::V1
       )
     end
 
-    api :GET, '/courses/:course_id/practice', 'Gets the most recent practice widget'
-    def show
-      task = ::Tasks::GetPracticeTask[role: @role]
-
-      return head(:not_found) if task.nil?
-
-      respond_with task, represent_with: Api::V1::TaskRepresenter
-    end
-
     protected
 
     def get_course_and_practice_role

--- a/app/controllers/api/v1/research_surveys_controller.rb
+++ b/app/controllers/api/v1/research_surveys_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::ResearchSurveysController < Api::V1::ApiController
   EOS
   def update
     OSU::AccessPolicy.require_action_allowed!(:complete, current_api_user, survey)
-    result = Research::CompleteSurvey.call(
+    result = ::Research::CompleteSurvey.call(
       survey: survey, **consumed(Api::V1::ResearchSurveyRepresenter)
     )
     if result.errors.any?
@@ -20,7 +20,7 @@ class Api::V1::ResearchSurveysController < Api::V1::ApiController
   protected
 
   def survey
-    @survey ||= Research::Models::Survey.find(params[:id])
+    @survey ||= ::Research::Models::Survey.find(params[:id])
   end
 
 end

--- a/app/controllers/api/v1/task_steps_controller.rb
+++ b/app/controllers/api/v1/task_steps_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
   api :GET, '/steps/:step_id', 'Gets the specified TaskStep'
   def show
     standard_read(
-      Research::ModifiedTasked[tasked: @tasked],
+      ::Research::ModifiedTasked[tasked: @tasked],
       Api::V1::TaskedRepresenterMapper.representer_for(@tasked),
       false,
       include_content: true
@@ -55,7 +55,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
 
   def fetch_step
     @task_step = ::Tasks::Models::TaskStep.find(params[:id])
-    @tasked = Research::ModifiedTasked[tasked: @task_step.tasked]
+    @tasked = ::Research::ModifiedTasked[tasked: @task_step.tasked]
   end
 
   def with_task_step_and_tasked
@@ -71,7 +71,7 @@ class Api::V1::TaskStepsController < Api::V1::ApiController
       return render_api_errors(:no_exercises, :not_found) if @task.nil?
 
       @task_step = @task.task_steps.to_a.find { |task_step| task_step.id == params[:id].to_i }
-      @tasked = Research::ModifiedTasked[tasked: @task_step.tasked]
+      @tasked = ::Research::ModifiedTasked[tasked: @task_step.tasked]
       yield
     end
   end

--- a/app/controllers/research/studies_controller.rb
+++ b/app/controllers/research/studies_controller.rb
@@ -1,5 +1,4 @@
 class Research::StudiesController < Research::BaseController
-
   before_action :get_study, only: [:show, :edit, :update, :destroy, :activate, :deactivate]
 
   def index
@@ -96,5 +95,4 @@ class Research::StudiesController < Research::BaseController
   def get_study
     @study = Research::Models::Study.find(params[:id])
   end
-
 end

--- a/app/controllers/research/study_courses_controller.rb
+++ b/app/controllers/research/study_courses_controller.rb
@@ -1,7 +1,6 @@
 class Research::StudyCoursesController < Research::BaseController
-
   def create
-    @study = Research::Models::Study.find(params[:study_id])
+    @study = ::Research::Models::Study.find(params[:study_id])
 
     course_ids = SharedCourseSearchHelper.get_course_ids(params)
 
@@ -40,5 +39,4 @@ class Research::StudyCoursesController < Research::BaseController
       redirect_to research_study_path(study)
     end
   end
-
 end

--- a/app/routines/concerns/create_practice_task_routine.rb
+++ b/app/routines/concerns/create_practice_task_routine.rb
@@ -1,5 +1,4 @@
 module CreatePracticeTaskRoutine
-
   NUM_BIGLEARN_EXERCISES = 5
 
   extend ActiveSupport::Concern
@@ -69,5 +68,4 @@ module CreatePracticeTaskRoutine
 
     send_task_to_biglearn
   end
-
 end

--- a/app/routines/create_practice_worst_topics_task.rb
+++ b/app/routines/create_practice_worst_topics_task.rb
@@ -1,5 +1,4 @@
 class CreatePracticeWorstTopicsTask
-
   include CreatePracticeTaskRoutine
 
   uses_routine GetCourseEcosystem, as: :get_course_ecosystem
@@ -41,5 +40,4 @@ class CreatePracticeWorstTopicsTask
                               spy: @task.spy.merge(spy_info.except('exercises'))
     end
   end
-
 end

--- a/app/subsystems/research/modified_task.rb
+++ b/app/subsystems/research/modified_task.rb
@@ -1,5 +1,4 @@
 class Research::ModifiedTask
-
   lev_routine express_output: :task
 
   def exec(task:)
@@ -13,5 +12,4 @@ class Research::ModifiedTask
       end
     end
   end
-
 end

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -1,5 +1,4 @@
 class Tasks::PopulatePlaceholderSteps
-  BIGLEARN_PRACTICE_ATTEMPTS = 30
   BIGLEARN_BACKGROUND_ATTEMPTS = 600
   BIGLEARN_SLEEP_INTERVAL = 1.second
 
@@ -88,13 +87,7 @@ class Tasks::PopulatePlaceholderSteps
     core_page_ids = run(:get_task_core_page_ids, tasks: task)
       .outputs.task_id_to_core_page_ids_map[task.id] if group_type == :spaced_practice_group
     biglearn_api_method = "fetch_assignment_#{exercise_type}s".to_sym
-    max_attempts = if !skip_unready && background
-      BIGLEARN_BACKGROUND_ATTEMPTS
-    elsif !skip_unready && task.practice?
-      BIGLEARN_PRACTICE_ATTEMPTS
-    else
-      1
-    end
+    max_attempts = !skip_unready && background ? BIGLEARN_BACKGROUND_ATTEMPTS : 1
     boolean_attribute = "#{exercise_type}s_are_assigned"
 
     task_steps_to_upsert = []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
         get :'performance/exports(/role/:role_id)', action: :exports
       end
 
-      resource :practices, path: :'practice/(/role/:role_id)', only: [ :show, :create ]
+      resource :practices, path: :'practice/(/role/:role_id)', only: [ :create ]
       post :'practice/worst(/role/:role_id)', controller: :practices, action: :create_worst
 
       scope controller: :guides do

--- a/spec/controllers/api/v1/practices_controller_spec.rb
+++ b/spec/controllers/api/v1/practices_controller_spec.rb
@@ -167,47 +167,4 @@ RSpec.describe Api::V1::PracticesController, type: :controller, api: true,
       end
     end
   end
-
-  context 'GET #show' do
-    it 'returns nothing when practice widget not yet set' do
-      api_get :show, user_1_token, params: { course_id: course.id }
-
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it 'returns a practice widget' do
-      CreatePracticeSpecificTopicsTask[course: course, role: role, page_ids: [page.id]]
-      CreatePracticeSpecificTopicsTask[course: course, role: role, page_ids: [page.id]]
-
-      api_get :show, user_1_token, params: { course_id: course.id, role_id: role.id }
-
-      expect(response).to have_http_status(:success)
-
-      expect(response.body_as_hash).to(
-        include(id: be_kind_of(String), title: 'Practice', steps: have(5).items)
-      )
-    end
-
-    it "422's if needs to pay" do
-      make_payment_required_and_expect_422(course: course, user: user_1) do
-        api_get :show, user_1_token, params: { course_id: course.id }
-      end
-    end
-
-    it 'raises SecurityTransgression if user is anonymous or not in the course as a student' do
-      expect do
-        api_get :show, nil, params: { course_id: course.id }
-      end.to raise_error(SecurityTransgression)
-
-      expect do
-        api_get :show, user_1_token, params: { course_id: course.id }
-      end.to raise_error(SecurityTransgression)
-
-      AddUserAsCourseTeacher.call(course: course, user: user_1)
-
-      expect do
-        api_get :show, user_1_token, params: { course_id: course.id }
-      end.to raise_error(SecurityTransgression)
-    end
-  end
 end

--- a/spec/routines/create_practice_specific_topics_task_spec.rb
+++ b/spec/routines/create_practice_specific_topics_task_spec.rb
@@ -14,13 +14,12 @@ RSpec.describe CreatePracticeSpecificTopicsTask, type: :routine, speed: :medium 
         spy_info: {}
       }
     )
-    expect { result }
+    expect { expect(result.errors.first.code).to eq :no_exercises }
       .to  change { Tasks::Models::Task.count }.by(1)
       .and change { Tasks::Models::Tasking.count }.by(1)
       .and not_change { Tasks::Models::TaskStep.count }
-      .and not_change { Tasks::Models::TaskedExercise.count }
+      .and not_change { Tasks::Models::TaskedPlaceholder.count }
       .and change { course.reload.sequence_number }.by(2)
-    expect(result.errors.first.code).to eq :no_exercises
   end
 
   it 'non-fatal errors when Biglearn does not return an accepted response after max attempts' do
@@ -31,13 +30,12 @@ RSpec.describe CreatePracticeSpecificTopicsTask, type: :routine, speed: :medium 
         spy_info: {}
       }
     )
-    expect { result }
+    expect { expect(result.errors).to be_empty }
       .to  change { Tasks::Models::Task.count }.by(1)
       .and change { Tasks::Models::Tasking.count }.by(1)
-      .and not_change { Tasks::Models::TaskStep.count }
-      .and not_change { Tasks::Models::TaskedExercise.count }
+      .and change { Tasks::Models::TaskStep.count }.by(1)
+      .and change { Tasks::Models::TaskedPlaceholder.count }.by(1)
       .and change { course.reload.sequence_number }.by(2)
-    expect(result.errors.first.code).to eq :biglearn_not_ready
   end
 
 end

--- a/spec/routing/api/v1/practices_controller_routing_spec.rb
+++ b/spec/routing/api/v1/practices_controller_routing_spec.rb
@@ -1,32 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::PracticesController, type: :routing, api: true, version: :v1 do
-  context 'GET /api/courses/:course_id/practice(/role/:role_id)' do
-    context 'no role_id' do
-      it 'routes to #show' do
-        expect(get '/api/courses/42/practice').to route_to(
-          'api/v1/practices#show', format: 'json', course_id: '42'
-        )
-      end
-    end
-
-    context 'role_id in path' do
-      it 'routes to #show' do
-        expect(get '/api/courses/21/practice/role/42').to route_to(
-          'api/v1/practices#show', format: 'json', course_id: '21', role_id: '42'
-        )
-      end
-    end
-
-    context 'role_id in query params' do
-      it 'routes to #show' do
-        expect(get '/api/courses/21/practice?role_id=42').to route_to(
-          'api/v1/practices#show', format: 'json', course_id: '21', role_id: '42'
-        )
-      end
-    end
-  end
-
   context 'POST /api/courses/:course_id/practice(/role/:role_id)' do
     context 'no role_id' do
       it 'routes to #create' do


### PR DESCRIPTION
Research stuff was causing errors in dev, so I added some ::

The real changes are:
- Removing the 30 retries for practice tasks
- skip_unready for practice tasks so their placeholders don't get immediately deleted

Goes with https://github.com/openstax/tutor-js/pull/2890