### PR TITLE
Footnotes fix

### DIFF
--- a/app/subsystems/tasks/models/tasked_reading.rb
+++ b/app/subsystems/tasks/models/tasked_reading.rb
@@ -22,18 +22,18 @@ class Tasks::Models::TaskedReading < IndestructibleRecord
   private
 
   def class_title
-    content_dom.xpath("//*[contains(@class, 'os-title')]").first&.inner_html&.strip
+    content_dom.css('.os-title').first&.inner_html&.strip
   end
 
   def document_title
-    content_dom.xpath("//*[@data-type='document-title']").first&.inner_html&.strip
+    content_dom.css('[data-type="document-title"]').first&.inner_html&.strip
   end
 
   def data_title
-    content_dom.xpath("//*[@data-type='title']").first&.inner_html&.strip
+    content_dom.css('[data-type="title"]').first&.inner_html&.strip
   end
 
   def content_dom
-    @content_dom ||= Nokogiri::HTML(content)
+    @content_dom ||= Nokogiri::HTML.fragment(content)
   end
 end

--- a/lib/json_serialize.rb
+++ b/lib/json_serialize.rb
@@ -50,13 +50,11 @@ end
 
 # validator to go along with JsonSerialize
 class MaxJsonLengthValidator < ActiveModel::EachValidator
-
   def validate_each(record, attribute, value)
     if record[attribute].to_s.length > options[:with]
       record.errors[attribute] << (options[:message] || "is too long")
     end
   end
-
 end
 
 ActiveRecord::Base.extend JsonSerialize::ClassMethods

--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -6,6 +6,7 @@ require_relative './v1/configuration'
 require_relative './v1/custom_css'
 
 require_relative './v1/fragment'
+require_relative './v1/fragment/html'
 require_relative './v1/fragment/embedded'
 require_relative './v1/fragment/video'
 require_relative './v1/fragment/interactive'

--- a/lib/openstax/cnx/v1/fragment.rb
+++ b/lib/openstax/cnx/v1/fragment.rb
@@ -27,7 +27,8 @@ class OpenStax::Cnx::V1::Fragment
 
   def append(new_node)
     content_node = node
-    content_node.root << new_node
+    parent = content_node.at_css('body') || content_node.root
+    parent << new_node
     @to_html = content_node.to_html
   end
 end

--- a/lib/openstax/cnx/v1/fragment.rb
+++ b/lib/openstax/cnx/v1/fragment.rb
@@ -13,22 +13,7 @@ class OpenStax::Cnx::V1::Fragment
     false
   end
 
-  def node
-    raise "#{self.class.name} has no content" unless respond_to?(:to_html)
-
-    Nokogiri::HTML to_html
-  end
-
-  def has_css?(css, custom_css)
-    return false unless respond_to?(:to_html)
-
-    !node.at_css(css, custom_css).nil?
-  end
-
-  def append(new_node)
-    content_node = node
-    parent = content_node.at_css('body') || content_node.root
-    parent << new_node
-    @to_html = content_node.to_html
+  def html?
+    false
   end
 end

--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -4,7 +4,7 @@ module OpenStax::Cnx::V1
     TITLE_CSS = '[data-type="title"]'
 
     # Used to get the title if there are no title nodes
-    LABEL_ATTRIBUTE = 'data-label'
+    LABEL_ATTRIBUTE = '[data-label]'
 
     # CSS to find embedded content urls
     TAGGED_URL_CSS = 'iframe.os-embed, a.os-embed, .os-embed iframe, .os-embed a'
@@ -18,13 +18,17 @@ module OpenStax::Cnx::V1
     attr_reader :url, :width, :height
 
     def initialize(node:, title: nil, labels: nil)
+      super
+
       @title ||= begin
-        title_nodes = node.css(TITLE_CSS)
-        title_nodes.empty? ? node.attr(LABEL_ATTRIBUTE) :
-                             title_nodes.map { |node| node.content.strip }.uniq.join('; ')
+        title_nodes = @node.css(TITLE_CSS)
+        titles = title_nodes.empty? ? @node.css(LABEL_ATTRIBUTE).map do |label|
+          label.attr('data-label')
+        end : title_nodes.map { |node| node.content.strip }
+        titles.uniq.join('; ')
       end
 
-      url_node = node.at_css(TAGGED_URL_CSS) || node.css(UNTAGGED_URL_CSS).last
+      url_node = @node.at_css(TAGGED_URL_CSS) || @node.css(UNTAGGED_URL_CSS).last
 
       @width = url_node.try(:[], 'width') || default_width
       @height = url_node.try(:[], 'height') || default_height
@@ -39,7 +43,7 @@ module OpenStax::Cnx::V1
         url_node['height'] ||= default_height
       end
 
-      super
+      @to_html = @node.to_html
     end
 
     def blank?

--- a/lib/openstax/cnx/v1/fragment/embedded.rb
+++ b/lib/openstax/cnx/v1/fragment/embedded.rb
@@ -1,5 +1,5 @@
 module OpenStax::Cnx::V1
-  class Fragment::Embedded < Fragment
+  class Fragment::Embedded < Fragment::Html
     # Used to get the title
     TITLE_CSS = '[data-type="title"]'
 
@@ -15,11 +15,9 @@ module OpenStax::Cnx::V1
     self.iframe_classes = ['os-embed']
     self.iframe_title = ''
 
-    attr_reader :url, :width, :height, :to_html
+    attr_reader :url, :width, :height
 
     def initialize(node:, title: nil, labels: nil)
-      super
-
       @title ||= begin
         title_nodes = node.css(TITLE_CSS)
         title_nodes.empty? ? node.attr(LABEL_ATTRIBUTE) :
@@ -41,7 +39,7 @@ module OpenStax::Cnx::V1
         url_node['height'] ||= default_height
       end
 
-      @to_html = node.to_html
+      super
     end
 
     def blank?

--- a/lib/openstax/cnx/v1/fragment/html.rb
+++ b/lib/openstax/cnx/v1/fragment/html.rb
@@ -4,7 +4,8 @@ class OpenStax::Cnx::V1::Fragment::Html < OpenStax::Cnx::V1::Fragment
   def initialize(node:, title: nil, labels: nil)
     super
 
-    @to_html = node.to_html
+    @node = Nokogiri::HTML.fragment node.to_html
+    @to_html = @node.to_html
   end
 
   def as_json(*args)
@@ -21,7 +22,7 @@ class OpenStax::Cnx::V1::Fragment::Html < OpenStax::Cnx::V1::Fragment
   end
 
   def node
-    @node ||= Nokogiri::HTML to_html
+    @node ||= Nokogiri::HTML.fragment to_html
   end
 
   def has_css?(css, custom_css)

--- a/lib/openstax/cnx/v1/fragment/html.rb
+++ b/lib/openstax/cnx/v1/fragment/html.rb
@@ -1,0 +1,57 @@
+class OpenStax::Cnx::V1::Fragment::Html < OpenStax::Cnx::V1::Fragment
+  attr_reader :to_html
+
+  def initialize(node:, title: nil, labels: nil)
+    super
+
+    @to_html = node.to_html
+  end
+
+  def as_json(*args)
+    # Don't attempt to serialize @node (it would fail)
+    super.except('node')
+  end
+
+  def html?
+    !to_html.blank?
+  end
+
+  def blank?
+    !html?
+  end
+
+  def node
+    @node ||= Nokogiri::HTML to_html
+  end
+
+  def has_css?(css, custom_css)
+    !node.at_css(css, custom_css).nil?
+  end
+
+  def append(new_node)
+    (node.at_css('body') || node.root) << new_node
+
+    @to_html = node.to_html
+  end
+
+  def transform_links!
+    node.css('[href]').each do |link|
+      href = link.attributes['href']
+      uri = Addressable::URI.parse(href.value) rescue nil
+
+      # Modify only fragment-only links
+      next if uri.nil? || uri.absolute? || !uri.path.blank?
+
+      # Abort if there is no target or it contains double quotes
+      # or it's still present in this fragment
+      target = uri.fragment
+      next if target.blank? || target.include?('"') ||
+              node.at_css("[id=\"#{target}\"], [name=\"#{target}\"]")
+
+      # Change the link to point to the reference view
+      href.value = "#{@reference_view_url}##{target}"
+    end unless @reference_view_url.nil?
+
+    @to_html = node.to_html
+  end
+end

--- a/lib/openstax/cnx/v1/fragment/reading.rb
+++ b/lib/openstax/cnx/v1/fragment/reading.rb
@@ -1,32 +1,9 @@
 module OpenStax::Cnx::V1
-  class Fragment::Reading < Fragment
-    attr_reader :to_html
-
+  class Fragment::Reading < Fragment::Html
     def initialize(node:, title: nil, labels: nil, reference_view_url: nil)
       super node: node, title: title, labels: labels
 
-      node.css('[href]').each do |link|
-        href = link.attributes['href']
-        uri = Addressable::URI.parse(href.value) rescue nil
-
-        # Modify only fragment-only links
-        next if uri.nil? || uri.absolute? || !uri.path.blank?
-
-        # Abort if there is no target or it contains double quotes
-        # or it's still present in this fragment
-        target = uri.fragment
-        next if target.blank? || target.include?('"') ||
-                node.at_css("[id=\"#{target}\"], [name=\"#{target}\"]")
-
-        # Change the link to point to the reference view
-        href.value = "#{reference_view_url}##{target}"
-      end unless reference_view_url.nil?
-
-      @to_html = node.to_html
-    end
-
-    def blank?
-      to_html.blank?
+      @reference_view_url = reference_view_url
     end
   end
 end

--- a/lib/openstax/cnx/v1/fragment_splitter.rb
+++ b/lib/openstax/cnx/v1/fragment_splitter.rb
@@ -49,10 +49,13 @@ module OpenStax::Cnx::V1
             css_array << "[href$=\"##{linkable[:name]}\"]" unless linkable[:name].nil?
             css = css_array.join(', ')
 
-            result.select { |fragment| fragment.has_css? css, custom_css }
+            result.select(&:html?)
+                  .select { |fragment| fragment.has_css? css, custom_css }
                   .each   { |fragment| fragment.append node.dup }
           end
         end
+
+        result.select(&:html?).each(&:transform_links!)
       end
     end
 

--- a/spec/lib/openstax/cnx/v1/fragment/reading_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment/reading_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OpenStax::Cnx::V1::Fragment::Reading, type: :external, vcr: VCR_O
     expect(reading_fragments.size).to eq 1
     reading_fragment = reading_fragments.first
 
-    doc = Nokogiri::HTML(reading_fragment.to_html)
+    doc = Nokogiri::HTML.fragment(reading_fragment.to_html)
     body = doc.at_css('body')
     expect(body.at_css('[href="#"]')).not_to be_nil
     expect(body.at_css('[href="#content"]')).not_to be_nil

--- a/spec/lib/openstax/cnx/v1/fragment_splitter_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment_splitter_spec.rb
@@ -121,7 +121,9 @@ RSpec.describe OpenStax::Cnx::V1::FragmentSplitter, type: :lib, vcr: VCR_OPTS do
 
     it 'moves footnotes to the fragments that link to them' do
       expect(fragments.map(&:class)).to eq [ OpenStax::Cnx::V1::Fragment::Reading ] * 5
-      expect(fragments.first.to_html.last(250)).to include('Quoted by Steve Vogel in')
+      expect(Nokogiri::HTML(fragments.first.to_html).at_css('body').text).to(
+        include('Quoted by Steve Vogel in')
+      )
       fragments[1..-1].each do |fragment|
         expect(fragment.to_html).not_to include('Quoted by Steve Vogel in')
       end

--- a/spec/lib/openstax/cnx/v1/fragment_splitter_spec.rb
+++ b/spec/lib/openstax/cnx/v1/fragment_splitter_spec.rb
@@ -119,11 +119,10 @@ RSpec.describe OpenStax::Cnx::V1::FragmentSplitter, type: :lib, vcr: VCR_OPTS do
 
     let(:fragments)         { fragment_splitter.split_into_fragments(@page.root) }
 
-    it 'moves footnotes to the fragments that link to them' do
+    it 'moves footnotes to the fragments that link to them and changes links to be relative' do
       expect(fragments.map(&:class)).to eq [ OpenStax::Cnx::V1::Fragment::Reading ] * 5
-      expect(Nokogiri::HTML(fragments.first.to_html).at_css('body').text).to(
-        include('Quoted by Steve Vogel in')
-      )
+      expect(fragments.first.node.at_css('[href="#footnote1"]')).not_to be_nil
+      expect(fragments.first.node.at_css('body').text).to include('Quoted by Steve Vogel in')
       fragments[1..-1].each do |fragment|
         expect(fragment.to_html).not_to include('Quoted by Steve Vogel in')
       end

--- a/spec/subsystems/content/import_book_spec.rb
+++ b/spec/subsystems/content/import_book_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Content::ImportBook, type: :routine, vcr: VCR_OPTS, speed: :mediu
         end
 
         page.fragments.each do |fragment|
-          Nokogiri::HTML(fragment.to_html).css('[href]').each do |link|
+          Nokogiri::HTML.fragment(fragment.to_html).css('[href]').each do |link|
             expect(link.attr('href')).not_to include 'cnx.org'
           end
         end

--- a/spec/subsystems/tasks/models/tasked_reading_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_reading_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe Tasks::Models::TaskedReading, type: :model do
 
       let(:content) do
         <<~HTML
-        <body>
           <div data-type="document-title" id="35337">
             #{content_preview_doc_title}
           </div>
-        </body>
         HTML
       end
 
@@ -37,11 +35,9 @@ RSpec.describe Tasks::Models::TaskedReading, type: :model do
 
       let(:content) do
         <<~HTML
-        <body>
           <div data-type="title" id="35337">
             #{content_preview_title}
           </div>
-        </body>
         HTML
       end
 
@@ -55,11 +51,9 @@ RSpec.describe Tasks::Models::TaskedReading, type: :model do
 
       let(:content) do
         <<~HTML
-        <body>
           <div class="os-title">
             #{content_preview_class}
           </div>
-        </body>
         HTML
       end
 
@@ -69,12 +63,7 @@ RSpec.describe Tasks::Models::TaskedReading, type: :model do
     end
 
     context "When there is no markup with title content" do
-      let(:content) do
-        <<~HTML
-        <body>
-        </body>
-        HTML
-      end
+      let(:content) { '' }
 
       it "defaults to page title" do
         expect(tasked_reading.content_preview).to eq(tasked_reading.task_step.page.title)


### PR DESCRIPTION
Make sure footnotes end up inside the reading page body
Fix links to footnotes in readings

Still needs some BE or FE change to make the footnote display as media in reading assignments, but it's not clear what is missing.