### PR TITLE
Fix practice tasks

### DIFF
--- a/app/routines/concerns/create_practice_task_routine.rb
+++ b/app/routines/concerns/create_practice_task_routine.rb
@@ -26,11 +26,7 @@ module CreatePracticeTaskRoutine
   end
 
   def send_task_to_biglearn
-    OpenStax::Biglearn::Api.create_update_assignments(
-      course: @course,
-      task: @task,
-      goal_num_tutor_assigned_pes: NUM_BIGLEARN_EXERCISES
-    )
+    OpenStax::Biglearn::Api.create_update_assignments course: @course, task: @task
   end
 
   def exec(course:, role:, **args)

--- a/app/routines/create_practice_specific_topics_task.rb
+++ b/app/routines/create_practice_specific_topics_task.rb
@@ -41,17 +41,16 @@ class CreatePracticeSpecificTopicsTask
     after_transaction do
       # This needs to happen after the transaction where the task is created
       # so it can be sent to Biglearn in the background
-      outs = Tasks::PopulatePlaceholderSteps.call(task: @task, skip_unready: true).outputs
-      outputs.task = outs.task
-
-      next unless outs.accepted && outs.task.task_steps.reject(&:placeholder?).empty?
+      outputs.task = Tasks::PopulatePlaceholderSteps.call(
+        task: @task, skip_unready: true
+      ).outputs.task
 
       nonfatal_error(
         code: :no_exercises,
         message: "No exercises were returned from Biglearn to build the Practice Widget." +
                  " [Course: #{@course.id} - Role: #{@role.id}" +
                  " - Task Type: #{@task_type} - Ecosystem: #{@ecosystem.title}]"
-      )
+      ) if outputs.task.pes_are_assigned && outputs.task.task_steps.empty?
     end
   end
 end

--- a/app/routines/create_practice_worst_topics_task.rb
+++ b/app/routines/create_practice_worst_topics_task.rb
@@ -17,7 +17,7 @@ class CreatePracticeWorstTopicsTask
     result = OpenStax::Biglearn::Api.fetch_practice_worst_areas_exercises(
       student: @role.course_member
     )
-    exercises = result[:exercises].first(CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES)
+    exercises = result[:exercises].first CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES
     spy_info = run(:translate_biglearn_spy_info, spy_info: result[:spy_info]).outputs.spy_info
 
     fatal_error(

--- a/lib/openstax/biglearn/api/real_client.rb
+++ b/lib/openstax/biglearn/api/real_client.rb
@@ -412,9 +412,13 @@ class OpenStax::Biglearn::Api::RealClient < OpenStax::Biglearn::RealClient
 
       goal_num_tutor_assigned_pes = request[:goal_num_tutor_assigned_pes]
       if goal_num_tutor_assigned_pes.nil?
-        p_steps = task.task_steps.personalized_group.to_a
-        pe_steps = p_steps.select { |step| step.exercise? || step.placeholder? }
-        goal_num_tutor_assigned_pes = pe_steps.size
+        if task.practice?
+          goal_num_tutor_assigned_pes = CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES
+        else
+          p_steps = task.task_steps.personalized_group.to_a
+          pe_steps = p_steps.select { |step| step.exercise? || step.placeholder? }
+          goal_num_tutor_assigned_pes = pe_steps.size
+        end
       end
 
       {

--- a/spec/routines/create_practice_specific_topics_task_spec.rb
+++ b/spec/routines/create_practice_specific_topics_task_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 require_relative 'shared_examples_for_create_practice_task_routines'
 
 RSpec.describe CreatePracticeSpecificTopicsTask, type: :routine, speed: :medium do
-
   include_examples 'a routine that creates practice tasks',
                    -> { described_class.call course: course, role: role, page_ids: [ page.id ] }
 
@@ -35,7 +34,6 @@ RSpec.describe CreatePracticeSpecificTopicsTask, type: :routine, speed: :medium 
       .and change { Tasks::Models::Tasking.count }.by(1)
       .and change { Tasks::Models::TaskStep.count }.by(1)
       .and change { Tasks::Models::TaskedPlaceholder.count }.by(1)
-      .and change { course.reload.sequence_number }.by(2)
+      .and change { course.reload.sequence_number }.by(1)
   end
-
 end


### PR DESCRIPTION
- Don't send practice tasks to Biglearn multiple times
- Ensure practice tasks sent to Biglearn always request 5 exercises

The practice tasks were being sent twice and apparently the second time Tutor would request only 1 exercise (due to the task having only 1 placeholder step).