### PR TITLE
Fix the accounts sync task call in the crontab

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,7 +10,7 @@ set :runner_command, "#{bundle_command} rails runner"
 #   * https://github.com/javan/whenever/pull/239
 
 every 1.minute do
-  rake 'openstax:accounts:sync:all'
+  rake 'openstax:accounts:sync:accounts'
 end
 
 every 1.day, at: '8:30 AM' do  # ~ 2:30am central


### PR DESCRIPTION
accounts-rails 9.0.0 removed the `all` task and I forgot to switch the crontab to the new task.
Manually fixed in prod for now...