### PR TITLE
When deleting a teacher, also delete their teacher_students

### DIFF
--- a/db/migrate/20200204192400_delete_teacher_students_for_deleted_teachers.rb
+++ b/db/migrate/20200204192400_delete_teacher_students_for_deleted_teachers.rb
@@ -1,0 +1,14 @@
+class DeleteTeacherStudentsForDeletedTeachers < ActiveRecord::Migration[5.2]
+  def up
+    CourseMembership::Models::Teacher.where.not(deleted_at: nil).preload(
+      role: { profile: { roles: :teacher_student } }
+    ).find_each do |teacher|
+      teacher.role.profile.roles.map(&:teacher_student).compact.select do |teacher_student|
+        teacher_student.course_profile_course_id == teacher.course_profile_course_id
+      end.reject(&:deleted?).each(&:destroy!)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20200204192400_delete_teacher_students_for_deleted_teachers.rb
+++ b/db/migrate/20200204192400_delete_teacher_students_for_deleted_teachers.rb
@@ -1,6 +1,6 @@
 class DeleteTeacherStudentsForDeletedTeachers < ActiveRecord::Migration[5.2]
   def up
-    CourseMembership::Models::Teacher.where.not(deleted_at: nil).preload(
+    CourseMembership::Models::Teacher.only_deleted.preload(
       role: { profile: { roles: :teacher_student } }
     ).find_each do |teacher|
       teacher.role.profile.roles.map(&:teacher_student).compact.select do |teacher_student|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_153226) do
+ActiveRecord::Schema.define(version: 2020_02_04_192400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/controllers/api/v1/teachers_controller_spec.rb
+++ b/spec/controllers/api/v1/teachers_controller_spec.rb
@@ -1,48 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::TeachersController, type: :controller, api: true, version: :v1 do
-  let(:application)       { FactoryBot.create :doorkeeper_application }
+  let(:application)      { FactoryBot.create :doorkeeper_application }
 
-  let(:course)            { FactoryBot.create :course_profile_course }
-  let(:period)            { FactoryBot.create :course_membership_period, course: course }
+  let(:course)           { FactoryBot.create :course_profile_course }
+  let(:period)           { FactoryBot.create :course_membership_period, course: course }
 
-  let(:student_user)      { FactoryBot.create(:user) }
-  let(:student_role)      { AddUserAsPeriodStudent[user: student_user, period: period] }
-  let!(:student)          { student_role.student }
-  let(:student_token)     { FactoryBot.create :doorkeeper_access_token,
-                                               application: application,
-                                               resource_owner_id: student_user.id }
+  let(:student_user)     { FactoryBot.create(:user) }
+  let(:student_role)     { AddUserAsPeriodStudent[user: student_user, period: period] }
+  let!(:student)         { student_role.student }
+  let(:student_token)    do
+    FactoryBot.create :doorkeeper_access_token, application: application,
+                                                resource_owner_id: student_user.id
+  end
 
-  let(:teacher_user)      { FactoryBot.create(:user) }
-  let(:teacher_role)      { AddUserAsCourseTeacher[user: teacher_user, course: course] }
-  let!(:teacher)          { teacher_role.teacher }
-  let(:teacher_token)     { FactoryBot.create :doorkeeper_access_token,
-                                               application: application,
-                                               resource_owner_id: teacher_user.id }
+  let(:teacher_user)     { FactoryBot.create(:user) }
+  let!(:teacher)         { AddUserAsCourseTeacher[user: teacher_user, course: course].teacher }
+  let!(:teacher_student) do
+    CreateOrResetTeacherStudent[user: teacher_user, period: period].teacher_student
+  end
+  let(:teacher_token)    do
+    FactoryBot.create :doorkeeper_access_token, application: application,
+                                                resource_owner_id: teacher_user.id
+  end
 
   context '#destroy' do
+    before do
+      expect(UserIsCourseTeacher[course: course, user: teacher_user]).to eq true
+      expect(teacher.deleted?).to eq false
+      expect(teacher_student.deleted?).to eq false
+    end
+
     context 'anonymous user' do
       it 'raises SecurityTransgression' do
-        expect {
+        expect do
           api_delete :destroy, nil, params: { id: teacher.id }
-        }.to raise_error(SecurityTransgression)
-        expect(UserIsCourseTeacher[course: course, user: teacher_user]).to be true
+        end.to  raise_error(SecurityTransgression)
+           .and not_change { UserIsCourseTeacher[course: course, user: teacher_user] }
+           .and not_change { teacher.reload.deleted? }
+           .and not_change { teacher_student.reload.deleted? }
       end
     end
 
     context 'user is a student' do
       it 'raises SecurityTransgression' do
-        expect {
+        expect do
           api_delete :destroy, student_token, params: { id: teacher.id }
-        }.to raise_error(SecurityTransgression)
-        expect(UserIsCourseTeacher[course: course, user: teacher_user]).to be true
+        end.to  raise_error(SecurityTransgression)
+           .and not_change { UserIsCourseTeacher[course: course, user: teacher_user] }
+           .and not_change { teacher.reload.deleted? }
+           .and not_change { teacher_student.reload.deleted? }
       end
     end
 
     context 'user is a teacher' do
-      it 'removes the teacher' do
-        api_delete :destroy, teacher_token, params: { id: teacher.id }
-        expect(UserIsCourseTeacher[course: course, user: teacher_user]).to be false
+      it 'removes the teacher and their teacher_students' do
+        expect do
+          api_delete :destroy, teacher_token, params: { id: teacher.id }
+        end.to  change { UserIsCourseTeacher[course: course, user: teacher_user] }.to(false)
+           .and change { teacher.reload.deleted? }.to(true)
+           .and change { teacher_student.reload.deleted? }.to(true)
       end
     end
   end


### PR DESCRIPTION
For example, teacher01 in prod was removed for a course but still sees the course in their dashboard due to the teacher_student roles, even though they get a 403 error if they click the course.