### PR TITLE
Ensure teacher_students are properly deleted when a teacher is dropped by an admin

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -7,9 +7,9 @@ class Admin::StudentsController < Admin::BaseController
     local_params = params[:course_membership_models_student].permit(:is_comped, :payment_due_at)
 
     if local_params[:payment_due_at].present?
-      local_params[:payment_due_at] =
-        DateTimeUtilities.parse_in_zone(string: local_params[:payment_due_at],
-                                        zone: student.course.time_zone.name).midnight + 1.day - 1.second
+      local_params[:payment_due_at] = DateTimeUtilities.parse_in_zone(
+        string: local_params[:payment_due_at], zone: student.course.time_zone.name
+      ).midnight + 1.day - 1.second
     end
 
     respond_to do |format|
@@ -38,5 +38,4 @@ class Admin::StudentsController < Admin::BaseController
     CourseMembership::ActivateStudent[student: student]
     redirect_to edit_admin_course_path(student.course) + '#roster'
   end
-
 end

--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -16,15 +16,21 @@ class Admin::TeachersController < Admin::BaseController
   end
 
   def destroy
-    teacher = CourseMembership::Models::Teacher.find(params[:id])
+    teacher = CourseMembership::Models::Teacher.find params[:id]
     teacher.destroy
+    teacher.role.profile.roles.teacher_student.map(&:teacher_student).compact.select do |ts|
+      ts.course_profile_course_id == teacher.course_profile_course_id
+    end.reject(&:deleted?).each(&:destroy!)
     flash[:notice] = "Teacher \"#{teacher.role.name}\" removed from course."
     redirect_to edit_admin_course_path(teacher.course, anchor: 'teachers')
   end
 
   def restore
-    teacher = CourseMembership::Models::Teacher.find(params[:id])
+    teacher = CourseMembership::Models::Teacher.find params[:id]
     teacher.restore
+    teacher.role.profile.roles.teacher_student.map(&:teacher_student).compact.select do |ts|
+      ts.course_profile_course_id == teacher.course_profile_course_id
+    end.select(&:deleted?).each(&:restore!)
     flash[:notice] = "Teacher \"#{teacher.role.name}\" readded to course."
     redirect_to edit_admin_course_path(teacher.course, anchor: 'teachers')
   end

--- a/spec/controllers/admin/teachers_controller_spec.rb
+++ b/spec/controllers/admin/teachers_controller_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Admin::TeachersController, type: :controller do
+  let(:admin)  { FactoryBot.create :user, :administrator }
+
+  let(:user_1) { FactoryBot.create :user }
+  let(:user_2) { FactoryBot.create :user }
+
+  let(:period) { FactoryBot.create :course_membership_period }
+  let(:course) { period.course }
+
+  before       { controller.sign_in(admin) }
+
+  context 'POST #teachers' do
+    before do
+      expect(UserIsCourseTeacher[course: course, user: user_1]).to eq false
+      expect(UserIsCourseTeacher[course: course, user: user_2]).to eq false
+    end
+
+    it 'adds the Users with the given teacher_ids to the Course' do
+      expect do
+        post :teachers, params: { id: course.id, teacher_ids: [ user_1.id, user_2.id ] }
+      end.to  change { CourseMembership::Models::Teacher.count }.by(2)
+         .and change { UserIsCourseTeacher[course: course, user: user_1] }.to(true)
+         .and change { UserIsCourseTeacher[course: course, user: user_2] }.to(true)
+    end
+  end
+
+  context '#destroy/#restore' do
+    let!(:teacher)           { AddUserAsCourseTeacher[user: user_1, course: course].teacher }
+    let!(:teacher_student_1) do
+      CreateOrResetTeacherStudent[user: user_1, period: period].teacher_student
+    end
+    let!(:teacher_student_2) do
+      CreateOrResetTeacherStudent[user: user_1, period: period].teacher_student
+    end
+
+    before do
+      expect(teacher_student_1.reload.deleted?).to eq true
+      expect(teacher_student_2.reload.deleted?).to eq false
+    end
+
+    it 'drops a teacher and all of their teacher_students' do
+      expect(UserIsCourseTeacher[course: course, user: user_1]).to eq true
+      expect(teacher.reload.deleted?).to eq false
+
+      expect do
+        delete :destroy, params: { course_id: course.id, id: teacher.id }
+      end.to  change     { UserIsCourseTeacher[course: course, user: user_1] }.to(false)
+         .and change     { teacher.reload.deleted? }.to(true)
+         .and not_change { teacher_student_1.reload.deleted? }
+         .and change     { teacher_student_2.reload.deleted? }.to(true)
+
+      expect(response).to redirect_to edit_admin_course_path(course, anchor: 'teachers')
+    end
+
+    it 'restores a teacher and all of their teacher_students' do
+      teacher.destroy!
+      expect(UserIsCourseTeacher[course: course, user: user_1]).to eq false
+      expect(teacher.reload.deleted?).to eq true
+
+      expect do
+        post :restore, params: { course_id: course.id, id: teacher.id }
+      end.to  change     { UserIsCourseTeacher[course: course, user: user_1] }.to(true)
+         .and change     { teacher.reload.deleted? }.to(false)
+         .and change     { teacher_student_1.reload.deleted? }.to(false)
+         .and not_change { teacher_student_2.reload.deleted? }
+
+      expect(response).to redirect_to edit_admin_course_path(course, anchor: 'teachers')
+    end
+  end
+end

--- a/spec/controllers/api/v1/teachers_controller_spec.rb
+++ b/spec/controllers/api/v1/teachers_controller_spec.rb
@@ -1,25 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::TeachersController, type: :controller, api: true, version: :v1 do
-  let(:application)      { FactoryBot.create :doorkeeper_application }
+  let(:application)        { FactoryBot.create :doorkeeper_application }
 
-  let(:course)           { FactoryBot.create :course_profile_course }
-  let(:period)           { FactoryBot.create :course_membership_period, course: course }
+  let(:course)             { FactoryBot.create :course_profile_course }
+  let(:period)             { FactoryBot.create :course_membership_period, course: course }
 
-  let(:student_user)     { FactoryBot.create(:user) }
-  let(:student_role)     { AddUserAsPeriodStudent[user: student_user, period: period] }
-  let!(:student)         { student_role.student }
-  let(:student_token)    do
+  let(:student_user)       { FactoryBot.create(:user) }
+  let(:student_role)       { AddUserAsPeriodStudent[user: student_user, period: period] }
+  let!(:student)           { student_role.student }
+  let(:student_token)      do
     FactoryBot.create :doorkeeper_access_token, application: application,
                                                 resource_owner_id: student_user.id
   end
 
-  let(:teacher_user)     { FactoryBot.create(:user) }
-  let!(:teacher)         { AddUserAsCourseTeacher[user: teacher_user, course: course].teacher }
-  let!(:teacher_student) do
+  let(:teacher_user)       { FactoryBot.create(:user) }
+  let!(:teacher)           { AddUserAsCourseTeacher[user: teacher_user, course: course].teacher }
+  let!(:teacher_student_1) do
     CreateOrResetTeacherStudent[user: teacher_user, period: period].teacher_student
   end
-  let(:teacher_token)    do
+  let!(:teacher_student_2) do
+    CreateOrResetTeacherStudent[user: teacher_user, period: period].teacher_student
+  end
+  let(:teacher_token)      do
     FactoryBot.create :doorkeeper_access_token, application: application,
                                                 resource_owner_id: teacher_user.id
   end
@@ -27,8 +30,9 @@ RSpec.describe Api::V1::TeachersController, type: :controller, api: true, versio
   context '#destroy' do
     before do
       expect(UserIsCourseTeacher[course: course, user: teacher_user]).to eq true
-      expect(teacher.deleted?).to eq false
-      expect(teacher_student.deleted?).to eq false
+      expect(teacher.reload.deleted?).to eq false
+      expect(teacher_student_1.reload.deleted?).to eq true
+      expect(teacher_student_2.reload.deleted?).to eq false
     end
 
     context 'anonymous user' do
@@ -38,7 +42,8 @@ RSpec.describe Api::V1::TeachersController, type: :controller, api: true, versio
         end.to  raise_error(SecurityTransgression)
            .and not_change { UserIsCourseTeacher[course: course, user: teacher_user] }
            .and not_change { teacher.reload.deleted? }
-           .and not_change { teacher_student.reload.deleted? }
+           .and not_change { teacher_student_1.reload.deleted? }
+           .and not_change { teacher_student_2.reload.deleted? }
       end
     end
 
@@ -49,7 +54,8 @@ RSpec.describe Api::V1::TeachersController, type: :controller, api: true, versio
         end.to  raise_error(SecurityTransgression)
            .and not_change { UserIsCourseTeacher[course: course, user: teacher_user] }
            .and not_change { teacher.reload.deleted? }
-           .and not_change { teacher_student.reload.deleted? }
+           .and not_change { teacher_student_1.reload.deleted? }
+           .and not_change { teacher_student_2.reload.deleted? }
       end
     end
 
@@ -57,9 +63,10 @@ RSpec.describe Api::V1::TeachersController, type: :controller, api: true, versio
       it 'removes the teacher and their teacher_students' do
         expect do
           api_delete :destroy, teacher_token, params: { id: teacher.id }
-        end.to  change { UserIsCourseTeacher[course: course, user: teacher_user] }.to(false)
-           .and change { teacher.reload.deleted? }.to(true)
-           .and change { teacher_student.reload.deleted? }.to(true)
+        end.to  change     { UserIsCourseTeacher[course: course, user: teacher_user] }.to(false)
+           .and change     { teacher.reload.deleted? }.to(true)
+           .and not_change { teacher_student_1.reload.deleted? }
+           .and change     { teacher_student_2.reload.deleted? }.to(true)
       end
     end
   end


### PR DESCRIPTION
The previous fix only fixed the API, not the admin controller.