### PR TITLE
Added points to homework task plans

### DIFF
--- a/app/representers/api/v1/demo/assign/course/task_plan/representer.rb
+++ b/app/representers/api/v1/demo/assign/course/task_plan/representer.rb
@@ -25,7 +25,7 @@ class Api::V1::Demo::Assign::Course::TaskPlan::Representer < Api::V1::Demo::Task
            type: Integer,
            readable: true,
            writeable: true,
-           getter: ->(*) { settings['exercise_ids']&.size }
+           getter: ->(*) { settings['exercises']&.size }
 
   property :exercises_count_dynamic,
            type: Integer,

--- a/app/routines/demo/assign.rb
+++ b/app/routines/demo/assign.rb
@@ -93,9 +93,12 @@ class Demo::Assign < Demo::Base
           "Not enough Exercises to assign (using #{OpenStax::Exercises::V1.server_url})"
         ) if exercise_ids.size < task_plan[:exercises_count_core]
 
+        exercises = Content::Models::Exercise.where(id: exercise_ids).select(:id, :content)
         attrs[:settings].merge!(
           page_ids: page_ids,
-          exercise_ids: exercise_ids.shuffle.take(task_plan[:exercises_count_core]).map(&:to_s),
+          exercises: exercises.shuffle.take(task_plan[:exercises_count_core]).map do |exercise|
+            { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+          end,
           exercises_count_dynamic: task_plan[:exercises_count_dynamic]
         )
       when 'external'

--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -359,7 +359,7 @@ class ExportAndUploadResearchData
             stimulus = exercise.content_hash['stimulus_html']
             json = exercise.content
 
-            exercise.questions_hash.each_with_index do |question, q_index|
+            exercise.to_model.questions.each_with_index do |question, q_index|
               begin
                 solution = (question['collaborator_solutions'] || []).first
                 correct_answers = []

--- a/app/routines/task_exercise.rb
+++ b/app/routines/task_exercise.rb
@@ -1,5 +1,4 @@
 class TaskExercise
-
   lev_routine transaction: :read_committed
 
   protected
@@ -28,7 +27,8 @@ class TaskExercise
     labels = current_step.labels
     spy = current_step.spy
 
-    questions = exercise.content_as_independent_questions
+    questions = exercise_model.questions
+    is_in_multipart = questions.size > 1
     outputs.task_steps = questions.each_with_index.map do |question, ii|
       # Make sure that all steps after the first exercise part get their own new step
       if ii > 0
@@ -53,10 +53,10 @@ class TaskExercise
         url: exercise.url,
         title: title || exercise.title,
         context: exercise.context,
-        question_id: question[:id],
+        question_id: question.id,
         question_index: ii,
-        content: question[:content],
-        is_in_multipart: questions.size > 1
+        content: question.content,
+        is_in_multipart: is_in_multipart
       )
 
       current_step.tasked.set_correct_answer_id
@@ -81,5 +81,4 @@ class TaskExercise
     # Task was already saved and we added more steps, so need to reload steps from DB
     task.task_steps.reset if task.persisted? && current_step != task_step
   end
-
 end

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -1,5 +1,4 @@
 class Content::Models::Exercise < IndestructibleRecord
-
   attr_accessor :pool_types, :is_excluded
 
   wrapped_by ::Content::Strategies::Direct::Exercise
@@ -66,32 +65,29 @@ class Content::Models::Exercise < IndestructibleRecord
     @content_hash ||= JSON.parse(content)
   end
 
-  def content_as_independent_questions
-    @content_as_independent_questions ||= begin
-      exercise_hash = content_hash
-      questions = exercise_hash['questions']
-      questions.map do |question|
-        content = exercise_hash.merge('questions' => [question]).to_json
-
-        { id: question['id'], content: content }
-      end
-    end
-  end
-
   def questions_hash
     content_hash['questions']
   end
 
-  def number_of_parts
+  def questions
+    @questions ||= begin
+      questions_hash.map do |question|
+        Content::Question.new(
+          id: question['id'], content_hash: content_hash.merge('questions' => [question])
+        )
+      end
+    end
+  end
+
+  def num_questions
     questions_hash.size
   end
 
   def is_multipart?
-    number_of_parts > 1
+    num_questions > 1
   end
 
   def feature_ids
     cnxfeatures.map(&:data)
   end
-
 end

--- a/app/subsystems/content/question.rb
+++ b/app/subsystems/content/question.rb
@@ -1,0 +1,15 @@
+Content::Question = Struct.new(:id, :content_hash, keyword_init: true) do
+  def question_hash
+    content_hash['questions'].first
+  end
+
+  delegate :[], to: :question_hash
+
+  def content
+    content_hash.to_json
+  end
+
+  def question_content
+    question_hash.to_json
+  end
+end

--- a/app/subsystems/content/routines/import_exercises.rb
+++ b/app/subsystems/content/routines/import_exercises.rb
@@ -61,19 +61,21 @@ class Content::Routines::ImportExercises
       tag_map = outputs.tags.index_by(&:value)
 
       exercises = wrapper_to_exercise_page_map.map do |wrapper, exercise_page|
-        exercise = Content::Models::Exercise.new(page: exercise_page,
-                                                 url: wrapper.url,
-                                                 uuid: wrapper.uuid,
-                                                 group_uuid: wrapper.group_uuid,
-                                                 number: wrapper.number,
-                                                 version: wrapper.version,
-                                                 nickname: wrapper.nickname,
-                                                 title: wrapper.title,
-                                                 preview: wrapper.preview,
-                                                 context: wrapper.context,
-                                                 content: wrapper.content,
-                                                 has_interactive: wrapper.has_interactive?,
-                                                 has_video: wrapper.has_video?)
+        exercise = Content::Models::Exercise.new(
+          page: exercise_page,
+          url: wrapper.url,
+          uuid: wrapper.uuid,
+          group_uuid: wrapper.group_uuid,
+          number: wrapper.number,
+          version: wrapper.version,
+          nickname: wrapper.nickname,
+          title: wrapper.title,
+          preview: wrapper.preview,
+          context: wrapper.context,
+          content: wrapper.content,
+          has_interactive: wrapper.has_interactive?,
+          has_video: wrapper.has_video?
+        )
 
         relevant_tags = wrapper.tags.map { |tag| tag_map[tag] }.compact
         run(:tag, exercise, relevant_tags, tagging_class: Content::Models::ExerciseTag, save: false)

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -70,7 +70,7 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
   protected
 
   def num_spaced_practice_exercises
-    exercises_count_dynamic = task_plan[:settings]['exercises_count_dynamic'].to_i
+    exercises_count_dynamic = task_plan.settings['exercises_count_dynamic'].to_i
     num_spaced_practice_exercises = [0, exercises_count_dynamic].max
     num_spaced_practice_exercises
   end

--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -1,17 +1,29 @@
 class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
-
   def self.schema
     '{
       "type": "object",
-      "required": [
-        "exercise_ids",
-        "exercises_count_dynamic"
-      ],
       "properties": {
-        "exercise_ids": {
+        "exercises": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "points": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "id",
+              "points"
+            ],
+            "additionalProperties": false
           },
           "minItems": 1,
           "uniqueItems": true
@@ -28,6 +40,10 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
           }
         }
       },
+      "required": [
+        "exercises",
+        "exercises_count_dynamic"
+      ],
       "additionalProperties": false
     }'
   end
@@ -35,10 +51,10 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
   def initialize(task_plan:, individualized_tasking_plans:)
     super
 
-    @exercise_ids = task_plan.settings['exercise_ids']
-    raise "No exercises selected" if @exercise_ids.blank?
+    @exercise_hashes = task_plan.settings['exercises']
+    raise "No exercises selected" if @exercise_hashes.blank?
 
-    @exercises = ecosystem.exercises_by_ids(@exercise_ids)
+    @exercises = ecosystem.exercises_by_ids(@exercise_hashes.map { |ex| ex['id'] })
 
     @core_page_ids = @exercises.map { |ex| ex.page.id }.uniq
   end
@@ -81,5 +97,4 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
 
     task
   end
-
 end

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -6,9 +6,6 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
   def self.schema
     '{
       "type": "object",
-      "required": [
-        "page_ids"
-      ],
       "properties": {
         "page_ids": {
           "type": "array",
@@ -19,6 +16,9 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
           "uniqueItems": true
         }
       },
+      "required": [
+        "page_ids"
+      ],
       "additionalProperties": false
     }'
   end

--- a/app/subsystems/tasks/populate_placeholder_steps.rb
+++ b/app/subsystems/tasks/populate_placeholder_steps.rb
@@ -138,10 +138,10 @@ class Tasks::PopulatePlaceholderSteps
         # Iterate through all the exercises and steps
         # Add/remove steps as needed
         [exercises.size, placeholder_steps.size].max.times do |index|
-          exercise = exercises[index]
+          exercise = exercises[index]&.to_model
           task_step = placeholder_steps[index]
 
-          if exercise.nil? || exercise.questions_hash.blank?
+          if exercise.nil? || exercise.num_questions == 0
             # Extra step: Remove it
             # We don't compact the task steps (gaps are ok) so we don't decrement num_added_steps
             task_step_ids_to_delete << task_step.id
@@ -159,7 +159,7 @@ class Tasks::PopulatePlaceholderSteps
                 labels: labels
               )
 
-              num_added_steps += exercise.number_of_parts
+              num_added_steps += exercise.num_questions
             else
               # Reuse a placeholder step
               tasked_placeholder_ids_to_delete << task_step.tasked_id
@@ -169,7 +169,7 @@ class Tasks::PopulatePlaceholderSteps
               task_step.number += num_added_steps
               task_step.changes_applied
 
-              num_added_steps += exercise.number_of_parts - 1
+              num_added_steps += exercise.num_questions - 1
             end
 
             # Detect PEs being used as SPEs and set the step type to :personalized_group

--- a/db/migrate/20160225203522_fix_content_exercise_answer_orders.rb
+++ b/db/migrate/20160225203522_fix_content_exercise_answer_orders.rb
@@ -2,7 +2,7 @@ class FixContentExerciseAnswerOrders < ActiveRecord::Migration[4.2]
   def up
     Content::Models::Exercise.find_each do |exercise|
       answers = exercise.questions_hash.first['answers']
-      exercise.questions_hash.first['answers'] = answers.sort_by{ |answer| answer['id'] }
+      exercise.questions_hash.first['answers'] = answers.sort_by { |answer| answer['id'] }
       exercise.update_attribute(:content, exercise.content_hash.to_json)
     end
   end

--- a/db/migrate/20200221163659_add_points_to_homework_task_plans.rb
+++ b/db/migrate/20200221163659_add_points_to_homework_task_plans.rb
@@ -1,0 +1,33 @@
+class AddPointsToHomeworkTaskPlans < ActiveRecord::Migration[5.2]
+  def up
+    Tasks::Models::TaskPlan.reset_column_information
+    Tasks::Models::TaskPlan.where(type: 'homework').find_in_batches do |task_plans|
+      task_plans.each do |task_plan|
+        task_plan.settings['exercises'] = task_plan.settings['exercise_ids'].map do |id|
+          { 'id' => id.to_s, 'points' => [ 1 ] }
+        end
+        task_plan.settings.delete 'exercise_ids'
+      end
+
+      Tasks::Models::TaskPlan.import task_plans, validate: false, on_duplicate_key_update: {
+        conflict_target: [ :id ], columns: [ :settings ]
+      }
+    end
+  end
+
+  def down
+    Tasks::Models::TaskPlan.reset_column_information
+    Tasks::Models::TaskPlan.where(type: 'homework').find_in_batches do |task_plans|
+      task_plans.each do |task_plan|
+        task_plan.settings['exercise_ids'] = task_plan.settings['exercises'].map do |exercise|
+          exercise['id']
+        end
+        task_plan.settings.delete 'exercises'
+      end
+
+      Tasks::Models::TaskPlan.import task_plans, validate: false, on_duplicate_key_update: {
+        conflict_target: [ :id ], columns: [ :settings ]
+      }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_04_192400) do
+ActiveRecord::Schema.define(version: 2020_02_21_163659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/lib/openstax/exercises/v1/fake_client.rb
+++ b/lib/openstax/exercises/v1/fake_client.rb
@@ -1,5 +1,4 @@
 class OpenStax::Exercises::V1::FakeClient
-
   attr_reader :store
 
   def initialize(exercises_configuration)

--- a/lib/openstax/exercises/v1/fake_client.rb
+++ b/lib/openstax/exercises/v1/fake_client.rb
@@ -71,7 +71,7 @@ class OpenStax::Exercises::V1::FakeClient
   end
 
   def self.new_exercise_hash(uuid: SecureRandom.uuid, group_uuid: SecureRandom.uuid,
-                             number: -1, version: 1, uid: nil, tags: nil, num_parts: 1)
+                             number: -1, version: 1, uid: nil, tags: nil, num_questions: 1)
     {
       uuid: uuid,
       group_uuid: group_uuid,
@@ -87,7 +87,7 @@ class OpenStax::Exercises::V1::FakeClient
           asset: "https://somewhere.com/something.png"
         }
       ],
-      questions: num_parts.times.map do |index|
+      questions: num_questions.times.map do |index|
         question_number = number + index
 
         {

--- a/spec/controllers/api/v1/task_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/task_plans_controller_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true,
 
       it 'returns an error message if the task_plan settings are invalid' do
         invalid_json_hash = valid_json_hash
-        invalid_json_hash['settings']['exercise_ids'] = [1, 2, 3]
+        invalid_json_hash['settings']['exercises'] = []
         invalid_json_hash['settings']['exercises_count_dynamic'] = 3
 
         controller.sign_in @teacher
@@ -374,7 +374,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true,
           .not_to change{ Tasks::Models::TaskPlan.count }
         expect(response).to have_http_status(:unprocessable_entity)
         error = response.body_as_hash[:errors].first
-        expect(error[:message]).to include "Settings - The property '#/' contains additional properties [\"exercise_ids\", \"exercises_count_dynamic\"] outside of the schema when none are allowed in schema"
+        expect(error[:message]).to include "Settings - The property '#/' contains additional properties [\"exercises\", \"exercises_count_dynamic\"] outside of the schema when none are allowed in schema"
       end
     end
 
@@ -610,7 +610,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true,
 
       it 'returns an error message if the task_plan settings are invalid' do
         invalid_json_hash = valid_json_hash
-        invalid_json_hash['settings']['exercise_ids'] = [1, 2, 3]
+        invalid_json_hash['settings']['exercises'] = []
         invalid_json_hash['settings']['exercises_count_dynamic'] = 3
 
         controller.sign_in @teacher
@@ -618,7 +618,7 @@ RSpec.describe Api::V1::TaskPlansController, type: :controller, api: true,
                               body: invalid_json_hash.to_json
         expect(response).to have_http_status(:unprocessable_entity)
         error = response.body_as_hash[:errors].first
-        expect(error[:message]).to include "Settings - The property '#/' contains additional properties [\"exercise_ids\", \"exercises_count_dynamic\"] outside of the schema when none are allowed in schema"
+        expect(error[:message]).to include "Settings - The property '#/' contains additional properties [\"exercises\", \"exercises_count_dynamic\"] outside of the schema when none are allowed in schema"
       end
 
       it 'returns an error message if the tasking_plans are invalid' do

--- a/spec/factories/content/exercises.rb
+++ b/spec/factories/content/exercises.rb
@@ -8,13 +8,15 @@ FactoryBot.define do
     transient         do
       uid             { nil }
       tags            { nil }
-      num_parts       { 1 }
+
+      num_questions   { 1 }
+
       wrapper         { OpenStax::Exercises::V1::Exercise.new(content: content) }
     end
 
     content           do
       OpenStax::Exercises::V1::FakeClient.new_exercise_hash(
-        number: number, version: version, uid: uid, tags: tags, num_parts: num_parts
+        number: number, version: version, uid: uid, tags: tags, num_questions: num_questions
       ).to_json
     end
 

--- a/spec/factories/tasks/tasked_exercises.rb
+++ b/spec/factories/tasks/tasked_exercises.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
 
     association :exercise, factory: :content_exercise
-    question_id    { exercise.content_as_independent_questions.first[:id] }
+    question_id    { exercise.questions.first.id }
     question_index { 0 }
     content        { exercise.content }
     url            { exercise.url }

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe CalculateTaskStats, type: :routine, vcr: VCR_OPTS, speed: :slow d
         task.exercise_steps.each do |exercise_step|
           tasked = exercise_step.tasked
           exercise = tasked.exercise
-          question_ids = exercise.questions_hash.map { |question| question['id'].to_s }
+          question_ids = exercise.questions.map(&:id).map(&:to_s)
           question_ids.each do |question_id|
             student_names_map[question_id] << student_names
             free_responses_map[question_id][student_names] << tasked.free_response

--- a/spec/routines/demo/assign_spec.rb
+++ b/spec/routines/demo/assign_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Demo::Assign, type: :routine do
         expect(settings['page_ids'].size).to eq matches[1].blank? ? 2 : 3
       when 'homework'
         expect(settings['page_ids'].size).to eq matches[1].blank? ? 2 : 3
-        expect(settings['exercise_ids'].size).to eq 4
+        expect(settings['exercises'].size).to eq 4
         expect(settings['exercises_count_dynamic']).to eq 2
       when 'external'
         expect(settings['external_url']).to eq 'https://example.com/External'

--- a/spec/routines/demo/export_spec.rb
+++ b/spec/routines/demo/export_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Demo::Export, type: :routine do
       target: course.periods.first,
       settings: {
         page_ids: reading_pages.map(&:id).map(&:to_s),
-        exercise_ids: reading_pages.first.exercises.first(5).map(&:id).map(&:to_s),
+        exercises: reading_pages.first.exercises.first(5).map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+        end,
         exercises_count_dynamic: 4
       }
     ).tap { |task_plan| DistributeTasks.call task_plan: task_plan }

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium do
-
   let(:course)    { FactoryBot.create :course_profile_course }
   let(:period)    { FactoryBot.create :course_membership_period, course: course }
   let!(:user)     do
@@ -34,14 +33,19 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
       owner: course,
       type: 'homework',
       ecosystem: @ecosystem.to_model,
-      settings: { exercise_ids: exercise_ids[0..5], exercises_count_dynamic: 3}
+      settings: {
+        exercises: exercises[0..5].map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.to_model.num_questions }
+        end,
+        exercises_count_dynamic: 3
+      }
     ).tap do |task_plan|
       task_plan.tasking_plans.first.target = period.to_model
       task_plan.save!
     end
   end
-  let(:core_pools)   { @ecosystem.homework_core_pools(pages: @pages) }
-  let(:exercise_ids) { core_pools.flat_map(&:exercises).map { |ex| ex.id.to_s } }
+  let(:core_pools) { @ecosystem.homework_core_pools(pages: @pages) }
+  let(:exercises)  { core_pools.flat_map(&:exercises) }
 
   context 'with no teacher_student roles' do
     context 'homework' do

--- a/spec/routines/export_and_upload_research_data_spec.rb
+++ b/spec/routines/export_and_upload_research_data_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe ExportAndUploadResearchData, type: :routine, speed: :medium do
             expect(data['Exercise JSON']).to eq json
 
             question_index = data['Question Number'].to_i - 1
-            question = exercise.questions_hash[question_index]
+            question = exercise.questions[question_index]
 
             solution = (question['collaborator_solutions'] || []).first
 

--- a/spec/routines/get_task_core_page_ids_spec.rb
+++ b/spec/routines/get_task_core_page_ids_spec.rb
@@ -18,13 +18,18 @@ RSpec.describe GetTaskCorePageIds, type: :routine do
     pages_1 = Content::Models::Page.where(id: @page_ids_1).to_a
     homework_exercises_1 = pages_1.flat_map(&:exercises).sort_by(&:uid).first(5)
     homework_plan_1 = FactoryBot.create(
-      :tasked_task_plan, owner: course,
-                         type: 'homework',
-                         assistant: homework_assistant,
-                         ecosystem: pages_1.first.ecosystem,
-                         number_of_students: 0,
-                         settings: { 'exercise_ids' => homework_exercises_1.map{ |ex| ex.id.to_s },
-                                     'exercises_count_dynamic' => 2 }
+      :tasked_task_plan,
+      owner: course,
+      type: 'homework',
+      assistant: homework_assistant,
+      ecosystem: pages_1.first.ecosystem,
+      number_of_students: 0,
+      settings: {
+        exercises: homework_exercises_1.map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+        end,
+        exercises_count_dynamic: 2
+      }
     )
 
     reading_plan_2 = FactoryBot.create(:tasked_task_plan, owner: course, number_of_students: 0)
@@ -32,13 +37,18 @@ RSpec.describe GetTaskCorePageIds, type: :routine do
     pages_2 = Content::Models::Page.where(id: @page_ids_2).to_a
     homework_exercises_2 = pages_2.flat_map(&:exercises).sort_by(&:uid).first(4)
     homework_plan_2 = FactoryBot.create(
-      :tasked_task_plan, owner: course,
-                         type: 'homework',
-                         assistant: homework_assistant,
-                         ecosystem: pages_2.first.ecosystem,
-                         number_of_students: 0,
-                         settings: { 'exercise_ids' => homework_exercises_2.map{ |ex| ex.id.to_s },
-                                     'exercises_count_dynamic' => 3 }
+      :tasked_task_plan,
+      owner: course,
+      type: 'homework',
+      assistant: homework_assistant,
+      ecosystem: pages_2.first.ecosystem,
+      number_of_students: 0,
+      settings: {
+        exercises: homework_exercises_2.map do |exercise|
+            { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+        end,
+        exercises_count_dynamic: 3
+      }
     )
 
     reading_plan_3 = FactoryBot.create(:tasked_task_plan, owner: course, number_of_students: 0)
@@ -46,13 +56,18 @@ RSpec.describe GetTaskCorePageIds, type: :routine do
     pages_3 = Content::Models::Page.where(id: @page_ids_3).to_a
     homework_exercises_3 = pages_3.flat_map(&:exercises).sort_by(&:uid).first(3)
     homework_plan_3 = FactoryBot.create(
-      :tasked_task_plan, owner: course,
-                         type: 'homework',
-                         assistant: homework_assistant,
-                         ecosystem: pages_3.first.ecosystem,
-                         number_of_students: 0,
-                         settings: { 'exercise_ids' => homework_exercises_3.map{ |ex| ex.id.to_s },
-                                     'exercises_count_dynamic' => 4 }
+      :tasked_task_plan,
+      owner: course,
+      type: 'homework',
+      assistant: homework_assistant,
+      ecosystem: pages_3.first.ecosystem,
+      number_of_students: 0,
+      settings: {
+        exercises: homework_exercises_3.map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+        end,
+        exercises_count_dynamic: 4
+      }
     )
 
     @reading_task_1 = reading_plan_1.tasks.joins(:taskings)

--- a/spec/routines/task_exercise_spec.rb
+++ b/spec/routines/task_exercise_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe TaskExercise, type: :routine do
   end
 
   let(:multipart_exercise)  do
-    content_exercise = FactoryBot.create(:content_exercise, num_parts: 2, context: 'Some context')
+    content_exercise = FactoryBot.create(
+      :content_exercise, num_questions: 2, context: 'Some context'
+    )
     strategy = Content::Strategies::Direct::Exercise.new(content_exercise)
     Content::Exercise.new(strategy: strategy)
   end
@@ -38,7 +40,7 @@ RSpec.describe TaskExercise, type: :routine do
 
     TaskExercise[exercise: multipart_exercise, task_step: task_step, task: task]
 
-    question_ids = multipart_exercise.content_as_independent_questions.map { |qq| qq[:id] }
+    question_ids = multipart_exercise.to_model.questions.map(&:id)
 
     expect(task.task_steps.length).to eq 2
 
@@ -70,7 +72,7 @@ RSpec.describe TaskExercise, type: :routine do
 
     TaskExercise[exercise: multipart_exercise, task_step: placeholder_step, task: task]
 
-    question_ids = multipart_exercise.content_as_independent_questions.map { |qq| qq[:id] }
+    question_ids = multipart_exercise.to_model.questions.map(&:id)
 
     expect(task.task_steps.length).to eq 4
     expect(task.task_steps[0]).to eq reading_step

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Content::Models::Exercise, type: :model do
   it { is_expected.to validate_presence_of(:version) }
 
   it 'splits parts' do
-    multipart = FactoryBot.create(:content_exercise, num_parts: 2)
-    separated = multipart.content_as_independent_questions
-    expect(separated.length).to eq 2
+    multipart = FactoryBot.create(:content_exercise, num_questions: 2)
+    questions = multipart.questions
+    expect(questions.length).to eq 2
 
-    expect(separated[0][:id]).to be_kind_of(String)
+    expect(questions.first.id).to be_kind_of(String)
 
-    first = JSON.parse(separated[0][:content])
-    second = JSON.parse(separated[1][:content])
+    first = JSON.parse(questions.first.content)
+    second = JSON.parse(questions.second.content)
 
     expect(first['questions']).to be_kind_of(Array)
 

--- a/spec/subsystems/content/routines/populate_exercise_pools_spec.rb
+++ b/spec/subsystems/content/routines/populate_exercise_pools_spec.rb
@@ -79,14 +79,26 @@ RSpec.describe Content::Routines::PopulateExercisePools, type: :routine, speed: 
 
   let(:concept_coach_exercise)    { FactoryBot.create :content_exercise, page: page }
 
-  let(:untagged_multi_exercise)   { FactoryBot.create :content_exercise, page: page, num_parts: 2 }
+  let(:untagged_multi_exercise)   do
+    FactoryBot.create :content_exercise, page: page, num_questions: 2
+  end
 
-  let(:conc_multi_exercise)       { FactoryBot.create :content_exercise, page: page, num_parts: 2 }
-  let(:recall_multi_exercise)     { FactoryBot.create :content_exercise, page: page, num_parts: 2 }
-  let(:c_or_r_multi_exercise)     { FactoryBot.create :content_exercise, page: page, num_parts: 2 }
-  let(:practice_multi_exercise)   { FactoryBot.create :content_exercise, page: page, num_parts: 2 }
+  let(:conc_multi_exercise)       do
+    FactoryBot.create :content_exercise, page: page, num_questions: 2
+  end
+  let(:recall_multi_exercise)     do
+    FactoryBot.create :content_exercise, page: page, num_questions: 2
+  end
+  let(:c_or_r_multi_exercise)     do
+    FactoryBot.create :content_exercise, page: page, num_questions: 2
+  end
+  let(:practice_multi_exercise)   do
+    FactoryBot.create :content_exercise, page: page, num_questions: 2
+  end
 
-  let(:cc_multi_exercise)         { FactoryBot.create :content_exercise, page: page, num_parts: 2 }
+  let(:cc_multi_exercise)         do
+    FactoryBot.create :content_exercise, page: page, num_questions: 2
+  end
 
   let(:exercise_tags) do
     {

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
 
   it { is_expected.to validate_presence_of(:title) }
 
-  it "requires at least one tasking_plan" do
+  it 'requires at least one tasking_plan' do
     expect(task_plan).to be_valid
 
     task_plan.tasking_plans.destroy_all
@@ -51,7 +51,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).to be_valid
   end
 
-  it "automatically infers the ecosystem from the settings or owner" do
+  it 'automatically infers the ecosystem from the settings or owner' do
     ecosystem = task_plan.ecosystem
     book = FactoryBot.create :content_book, ecosystem: ecosystem
     chapter = FactoryBot.create :content_chapter, book: book
@@ -74,7 +74,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).not_to be_valid
     expect(task_plan.ecosystem).to be_nil
 
-    task_plan.settings = { page_ids: [page.id.to_s] }
+    task_plan.settings = { page_ids: [ page.id.to_s ] }
     expect(task_plan).to be_valid
     expect(task_plan.ecosystem).to eq ecosystem
 

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     task_plan.assistant = FactoryBot.create(
       :tasks_assistant, code_class_name: '::Tasks::Assistants::IReadingAssistant'
     )
-    task_plan.settings = { exercise_ids: [exercise.id.to_s] }
+    task_plan.settings = {
+      exercises: [ { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions } ]
+    }
     expect(task_plan).not_to be_valid
 
     task_plan.settings = { page_ids: [] }
@@ -61,7 +63,9 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).not_to be_valid
     expect(task_plan.ecosystem).to be_nil
 
-    task_plan.settings = { exercise_ids: [exercise.id.to_s] }
+    task_plan.settings = {
+      exercises: [ { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions } ]
+    }
     expect(task_plan).to be_valid
     expect(task_plan.ecosystem).to eq ecosystem
 
@@ -84,7 +88,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan.ecosystem).to eq ecosystem
   end
 
-  it "requires that any exercise_ids or page_ids be in the task_plan's ecosystem" do
+  it "requires that any exercises or page_ids be in the task_plan's ecosystem" do
     book = FactoryBot.create :content_book, ecosystem: task_plan.ecosystem
     chapter = FactoryBot.create :content_chapter, book: book
     page = FactoryBot.create :content_page, chapter: chapter
@@ -95,22 +99,30 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
       :tasks_assistant, code_class_name: '::Tasks::Assistants::HomeworkAssistant'
     )
     task_plan.settings = {
-      page_ids: ['1', '2'], exercise_ids: ['1', '2'], exercises_count_dynamic: 2
+      page_ids: ['1', '2'], exercises: [
+        { id: '1', points: [ 1 ] }, { id: '2', points: [ 1 ] }
+      ], exercises_count_dynamic: 2
     }
     expect(task_plan).not_to be_valid
 
     task_plan.settings = {
-      page_ids: [page.id.to_s], exercise_ids: ['1', '2'], exercises_count_dynamic: 2
+      page_ids: [page.id.to_s], exercises: [
+        { id: '1', points: [ 1 ] }, { id: '2', points: [ 1 ] }
+      ], exercises_count_dynamic: 2
     }
     expect(task_plan).not_to be_valid
 
     task_plan.settings = {
-      page_ids: ['1', '2'], exercise_ids: [exercise.id.to_s], exercises_count_dynamic: 2
+      page_ids: ['1', '2'], exercises: [
+        { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+      ], exercises_count_dynamic: 2
     }
     expect(task_plan).not_to be_valid
 
     task_plan.settings = {
-      page_ids: [page.id.to_s], exercise_ids: [exercise.id.to_s], exercises_count_dynamic: 2
+      page_ids: [page.id.to_s], exercises: [
+        { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+      ], exercises_count_dynamic: 2
     }
     expect(task_plan).to be_valid
   end
@@ -122,7 +134,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).not_to be_valid
 
     task_plan.type = 'homework'
-    task_plan.settings['exercise_ids'] = ['1']
+    task_plan.settings['exercises'] = [ { 'id' => '1', 'points' => [ 1 ] } ]
     expect(task_plan).not_to be_valid
 
     task_plan.type = 'external'
@@ -241,12 +253,12 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     end
 
     it 'will not allow other fields to be updated after tasks are available to students' do
-      task_plan.reload.settings = { exercise_ids: [] }
+      task_plan.reload.settings = { exercises: [] }
       expect(task_plan).to be_valid
 
       student_task
 
-      task_plan.reload.settings = { exercise_ids: [] }
+      task_plan.reload.settings = { exercises: [] }
       expect(task_plan).not_to be_valid
     end
   end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -66,21 +66,21 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
     end
   end
 
-  it "requires non-nil due_at to be after opens_at" do
+  it 'requires non-nil due_at to be after opens_at' do
     expect(task).to be_valid
 
     task.due_at = Time.current - 1.week - 1.hour
     expect(task).to_not be_valid
   end
 
-  it "requires non-nil closes_at to be after due_at" do
+  it 'requires non-nil closes_at to be after due_at' do
     expect(task).to be_valid
 
     task.closes_at = Time.current - 2.days - 1.hour
     expect(task).to_not be_valid
   end
 
-  it "reports is_shared? correctly" do
+  it 'reports is_shared? correctly' do
     FactoryBot.create(:tasks_tasking, task: task)
     expect(task.is_shared?).to eq false
 
@@ -294,7 +294,7 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
     expect(task.correct_exercise_count).to eq 1
   end
 
-  context "update step counts" do
+  context 'update step counts' do
     let(:core_step_1) do
       FactoryBot.build(:tasks_tasked_reading).task_step.tap { |step| step.is_core = true }
     end
@@ -406,13 +406,13 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
       end.task_step.tap { |step| step.is_core = false }
     end
 
-    context "steps count" do
-      context "total" do
-        it "works with no steps" do
+    context 'steps count' do
+      context 'total' do
+        it 'works with no steps' do
           expect(task.steps_count).to eq(0)
         end
 
-        it "works with multiple steps" do
+        it 'works with multiple steps' do
           task.task_steps = [core_step_1, dynamic_step_1]
           task.save!
           task.reload
@@ -421,12 +421,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "completed steps count" do
-        it "works with no steps" do
+      context 'completed steps count' do
+        it 'works with no steps' do
           expect(task.completed_steps_count).to eq(0)
         end
 
-        it "works with multiple completed steps" do
+        it 'works with multiple completed steps' do
           task.task_steps = [completed_core_step_1, core_step_1, completed_dynamic_step_1]
           task.save!
           task.reload
@@ -435,12 +435,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "core steps count" do
-        it "works with no steps" do
+      context 'core steps count' do
+        it 'works with no steps' do
           expect(task.core_steps_count).to eq(0)
         end
 
-        it "works with multiple core steps" do
+        it 'works with multiple core steps' do
           task.task_steps = [core_step_1, dynamic_step_1, core_step_2]
           task.save!
           task.reload
@@ -449,12 +449,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "completed core steps count" do
-        it "works with no steps" do
+      context 'completed core steps count' do
+        it 'works with no steps' do
           expect(task.completed_core_steps_count).to eq(0)
         end
 
-        it "works with multiple completed core steps" do
+        it 'works with multiple completed core steps' do
           task.task_steps = [
             completed_core_step_1,
             dynamic_step_1,
@@ -468,12 +468,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "exercise steps count" do
-        it "works with no steps" do
+      context 'exercise steps count' do
+        it 'works with no steps' do
           expect(task.exercise_steps_count).to eq(0)
         end
 
-        it "works with multiple exercise steps" do
+        it 'works with multiple exercise steps' do
           task.task_steps = [exercise_step_1, core_step_1, exercise_step_2]
           task.save!
           task.reload
@@ -482,12 +482,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "completed exercise steps count" do
-        it "works with no steps" do
+      context 'completed exercise steps count' do
+        it 'works with no steps' do
           expect(task.completed_exercise_steps_count).to eq(0)
         end
 
-        it "works with multiple completed exercise steps" do
+        it 'works with multiple completed exercise steps' do
           task.task_steps = [
             completed_exercise_step_1, exercise_step_1, dynamic_step_1, completed_exercise_step_2
           ]
@@ -498,12 +498,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "correct exercise steps count" do
-        it "works with no steps" do
+      context 'correct exercise steps count' do
+        it 'works with no steps' do
           expect(task.correct_exercise_steps_count).to eq(0)
         end
 
-        it "works with multiple correct exercise steps" do
+        it 'works with multiple correct exercise steps' do
           task.task_steps = [
             correct_exercise_step_1, completed_exercise_step_1, correct_exercise_step_2
           ]
@@ -514,12 +514,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "placeholder steps count" do
-        it "works with no steps" do
+      context 'placeholder steps count' do
+        it 'works with no steps' do
           expect(task.placeholder_steps_count).to eq(0)
         end
 
-        it "works with multiple placeholder steps" do
+        it 'works with multiple placeholder steps' do
           task.task_steps = [core_placeholder_step, core_step_1, dynamic_placeholder_exercise_step]
           task.save!
           task.reload
@@ -528,12 +528,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "placeholder exercise steps count" do
-        it "works with no steps" do
+      context 'placeholder exercise steps count' do
+        it 'works with no steps' do
           expect(task.placeholder_exercise_steps_count).to eq(0)
         end
 
-        it "works with multiple placeholder exercise steps" do
+        it 'works with multiple placeholder exercise steps' do
           task.task_steps = [
             core_placeholder_exercise_step, core_placeholder_step, dynamic_placeholder_exercise_step
           ]
@@ -544,12 +544,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      context "core placeholder exercise steps count" do
-        it "works with no steps" do
+      context 'core placeholder exercise steps count' do
+        it 'works with no steps' do
           expect(task.core_placeholder_exercise_steps_count).to eq(0)
         end
 
-        it "works with multiple placeholder exercise steps" do
+        it 'works with multiple placeholder exercise steps' do
           task.task_steps = [
             dynamic_placeholder_step,
             core_placeholder_exercise_step,
@@ -562,7 +562,7 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         end
       end
 
-      it "updates on_time counts when the due date changes" do
+      it 'updates on_time counts when the due date changes' do
         task = FactoryBot.create(
           :tasks_task, opens_at: Time.current - 1.week,
                        due_at: Time.current - 1.day,
@@ -584,7 +584,7 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
         expect(task.correct_on_time_exercise_steps_count).to eq 1
       end
 
-      it "updates counts after any change to the task" do
+      it 'updates counts after any change to the task' do
         tasked_to = [ FactoryBot.create(:entity_role) ]
         task = FactoryBot.create :tasks_task, tasked_to: tasked_to, step_types: [
           :tasks_tasked_exercise,
@@ -679,158 +679,204 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
     it 'is hidden only if it has been hidden after being deleted for the last time' do
       expect(task).not_to be_hidden
 
-      task.task_plan.destroy!
+      task_plan.destroy!
       expect(task.reload).not_to be_hidden
 
       task.hide.save!
       expect(task).to be_hidden
 
-      task.task_plan.reload.restore!(recursive: true)
+      task_plan.reload.restore!(recursive: true)
       expect(task.reload).not_to be_hidden
 
-      task.task_plan.destroy!
+      task_plan.destroy!
       expect(task.reload).not_to be_hidden
 
       task.hide.save!
       expect(task).to be_hidden
     end
 
-    it 'calculates the score with lateness penalties' do
-      task = FactoryBot.create(
-        :tasks_task, step_types: [
-          :tasks_tasked_exercise, :tasks_tasked_exercise, :tasks_tasked_exercise
-        ]
-      )
-      task.grading_template.late_work_penalty_applied = :immediately
-      task.grading_template.late_work_penalty = 0.5
-      task.grading_template.save!
-
-      due_at = task.due_at
-
-      Timecop.freeze(due_at - 1.day) do
-        Preview::AnswerExercise[task_step: task.task_steps[0], is_correct: true]
-        task.reload
-
-        expect(task.correct_exercise_count).to eq 1
-        expect(task.completed_exercise_count).to eq 1
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 0
-        expect(task.completed_accepted_late_exercise_count).to eq 0
-        expect(task.completion).to eq 1/3.0
-        expect(task.correctness).to eq 1/3.0
-        expect(task.score).to eq 1/3.0
-      end
-
-      Timecop.freeze(due_at + 1.hour) do
-        Preview::AnswerExercise[task_step: task.task_steps[1], is_correct: true]
-        task.reload
-
-        expect(task.correct_exercise_count).to eq 2
-        expect(task.completed_exercise_count).to eq 2
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 0
-        expect(task.completed_accepted_late_exercise_count).to eq 0
-        expect(task.completion).to eq 2/3.0
-        expect(task.correctness).to eq 2/3.0
-        expect(task.score).to eq 1/3.0
-
-        task.accept_late_work
-        task.save!
-
-        expect(task.correct_exercise_count).to eq 2
-        expect(task.completed_exercise_count).to eq 2
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 2
-        expect(task.completed_accepted_late_exercise_count).to eq 2
-        expect(task.completion).to eq 2/3.0
-        expect(task.correctness).to eq 2/3.0
-        expect(task.score).to eq 2/3.0
-        expect(task.accepted_late_at).not_to be_nil
-      end
-
-      Timecop.freeze(due_at + 25.hours) do
-        Preview::AnswerExercise[task_step: task.task_steps[2], is_correct: true]
-        task.reload
-
-        expect(task.correct_exercise_count).to eq 3
-        expect(task.completed_exercise_count).to eq 3
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 2
-        expect(task.completed_accepted_late_exercise_count).to eq 2
-        expect(task.completion).to eq 1.0
-        expect(task.correctness).to eq 1.0
-        expect(task.score).to eq 0.5
-
-        task.grading_template.late_work_penalty_applied = :daily
-        task.grading_template.late_work_penalty = 0.3
+    context '#score' do
+      it 'calculates the score with lateness penalties' do
+        task = FactoryBot.create(
+          :tasks_task, step_types: [
+            :tasks_tasked_exercise, :tasks_tasked_exercise, :tasks_tasked_exercise
+          ]
+        )
+        task.grading_template.late_work_penalty_applied = :immediately
+        task.grading_template.late_work_penalty = 0.5
         task.grading_template.save!
 
-        expect(task.correct_exercise_count).to eq 3
-        expect(task.completed_exercise_count).to eq 3
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 2
-        expect(task.completed_accepted_late_exercise_count).to eq 2
-        expect(task.completion).to eq 1.0
-        expect(task.correctness).to eq 1.0
-        expect(task.score).to eq 0.7
+        due_at = task.due_at
 
-        task.accept_late_work
-        task.save!
+        Timecop.freeze(due_at - 1.day) do
+          Preview::AnswerExercise[task_step: task.task_steps.first, is_correct: true]
+          task.reload
 
-        expect(task.correct_exercise_count).to eq 3
-        expect(task.completed_exercise_count).to eq 3
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 3
-        expect(task.completed_accepted_late_exercise_count).to eq 3
-        expect(task.completion).to eq 1.0
-        expect(task.correctness).to eq 1.0
+          expect(task.correct_exercise_count).to eq 1
+          expect(task.completed_exercise_count).to eq 1
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 0
+          expect(task.completed_accepted_late_exercise_count).to eq 0
+          expect(task.completion).to eq 1/3.0
+          expect(task.correctness).to eq 1/3.0
+          expect(task.score).to eq 1/3.0
+        end
+
+        Timecop.freeze(due_at + 1.hour) do
+          Preview::AnswerExercise[task_step: task.task_steps.second, is_correct: true]
+          task.reload
+
+          expect(task.correct_exercise_count).to eq 2
+          expect(task.completed_exercise_count).to eq 2
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 0
+          expect(task.completed_accepted_late_exercise_count).to eq 0
+          expect(task.completion).to eq 2/3.0
+          expect(task.correctness).to eq 2/3.0
+          expect(task.score).to eq 1/3.0
+
+          task.accept_late_work
+          task.save!
+
+          expect(task.correct_exercise_count).to eq 2
+          expect(task.completed_exercise_count).to eq 2
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 2
+          expect(task.completed_accepted_late_exercise_count).to eq 2
+          expect(task.completion).to eq 2/3.0
+          expect(task.correctness).to eq 2/3.0
+          expect(task.score).to eq 2/3.0
+          expect(task.accepted_late_at).not_to be_nil
+        end
+
+        Timecop.freeze(due_at + 25.hours) do
+          Preview::AnswerExercise[task_step: task.task_steps.third, is_correct: true]
+          task.reload
+
+          expect(task.correct_exercise_count).to eq 3
+          expect(task.completed_exercise_count).to eq 3
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 2
+          expect(task.completed_accepted_late_exercise_count).to eq 2
+          expect(task.completion).to eq 1.0
+          expect(task.correctness).to eq 1.0
+          expect(task.score).to eq 0.5
+
+          task.grading_template.late_work_penalty_applied = :daily
+          task.grading_template.late_work_penalty = 0.3
+          task.grading_template.save!
+
+          expect(task.correct_exercise_count).to eq 3
+          expect(task.completed_exercise_count).to eq 3
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 2
+          expect(task.completed_accepted_late_exercise_count).to eq 2
+          expect(task.completion).to eq 1.0
+          expect(task.correctness).to eq 1.0
+          expect(task.score).to eq 0.7
+
+          task.accept_late_work
+          task.save!
+
+          expect(task.correct_exercise_count).to eq 3
+          expect(task.completed_exercise_count).to eq 3
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 3
+          expect(task.completed_accepted_late_exercise_count).to eq 3
+          expect(task.completion).to eq 1.0
+          expect(task.correctness).to eq 1.0
+          expect(task.score).to eq 1.0
+
+          task.due_at = due_at + 3.days
+          task.save!
+
+          expect(task.correct_exercise_count).to eq 3
+          expect(task.completed_exercise_count).to eq 3
+          expect(task.completed_on_time_exercise_count).to eq 3
+          expect(task.correct_on_time_exercise_count).to eq 3
+          expect(task.completed_accepted_late_exercise_count).to eq 3
+          expect(task.correct_accepted_late_exercise_count).to eq 3
+          expect(task.completion).to eq 1.0
+          expect(task.correctness).to eq 1.0
+          expect(task.score).to eq 1.0
+
+          task.due_at = due_at
+          task.save!
+
+          expect(task.correct_exercise_count).to eq 3
+          expect(task.completed_exercise_count).to eq 3
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.completed_accepted_late_exercise_count).to eq 3
+          expect(task.correct_accepted_late_exercise_count).to eq 3
+          expect(task.completion).to eq 1.0
+          expect(task.correctness).to eq 1.0
+          expect(task.score).to eq 1.0
+
+          task.reject_late_work
+          task.save!
+
+          expect(task.correct_exercise_count).to eq 3
+          expect(task.completed_exercise_count).to eq 3
+          expect(task.completed_on_time_exercise_count).to eq 1
+          expect(task.correct_on_time_exercise_count).to eq 1
+          expect(task.correct_accepted_late_exercise_count).to eq 0
+          expect(task.completed_accepted_late_exercise_count).to eq 0
+          expect(task.completion).to eq 1.0
+          expect(task.correctness).to eq 1.0
+          expect(task.score).to eq 0.4
+          expect(task.accepted_late_at).to be_nil
+        end
+      end
+
+      it 'uses teacher-chosen points for homework assignments' do
+        course = task_plan.owner
+        period = FactoryBot.create :course_membership_period, course: course
+        FactoryBot.create :course_membership_student, period: period
+
+        simple_exercise = FactoryBot.create :content_exercise
+        page = simple_exercise.page
+        multipart_exercise = FactoryBot.create :content_exercise, page: page, num_questions: 3
+
+        task_plan.grading_template.update_attribute :task_plan_type, 'homework'
+        task_plan.update_attributes!(
+          ecosystem: page.ecosystem,
+          type: 'homework',
+          assistant: FactoryBot.create(
+            :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
+          ),
+          settings: {
+            page_ids: [ page.id.to_s ],
+            exercises: [
+              { id: simple_exercise.id.to_s, points: [ 1 ] },
+              { id: multipart_exercise.id.to_s, points: [ 2, 3, 4 ] }
+            ],
+            exercises_count_dynamic: 0
+          }
+        )
+        task_plan.tasks.delete_all
+        DistributeTasks[task_plan: task_plan]
+
+        task = task_plan.tasks.first
+        expect(task.score).to eq 0.0
+
+        Preview::AnswerExercise[task_step: task.task_steps.first, is_correct: true]
+        expect(task.score).to eq 0.1
+
+        Preview::AnswerExercise[task_step: task.task_steps.second, is_correct: true]
+        expect(task.score).to eq 0.3
+
+        Preview::AnswerExercise[task_step: task.task_steps.third, is_correct: true]
+        expect(task.score).to eq 0.6
+
+        Preview::AnswerExercise[task_step: task.task_steps.fourth, is_correct: true]
         expect(task.score).to eq 1.0
-
-        task.due_at = due_at + 3.days
-        task.save!
-
-        expect(task.correct_exercise_count).to eq 3
-        expect(task.completed_exercise_count).to eq 3
-        expect(task.completed_on_time_exercise_count).to eq 3
-        expect(task.correct_on_time_exercise_count).to eq 3
-        expect(task.completed_accepted_late_exercise_count).to eq 3
-        expect(task.correct_accepted_late_exercise_count).to eq 3
-        expect(task.completion).to eq 1.0
-        expect(task.correctness).to eq 1.0
-        expect(task.score).to eq 1.0
-
-        task.due_at = due_at
-        task.save!
-
-        expect(task.correct_exercise_count).to eq 3
-        expect(task.completed_exercise_count).to eq 3
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.completed_accepted_late_exercise_count).to eq 3
-        expect(task.correct_accepted_late_exercise_count).to eq 3
-        expect(task.completion).to eq 1.0
-        expect(task.correctness).to eq 1.0
-        expect(task.score).to eq 1.0
-
-        task.reject_late_work
-        task.save!
-
-        expect(task.correct_exercise_count).to eq 3
-        expect(task.completed_exercise_count).to eq 3
-        expect(task.completed_on_time_exercise_count).to eq 1
-        expect(task.correct_on_time_exercise_count).to eq 1
-        expect(task.correct_accepted_late_exercise_count).to eq 0
-        expect(task.completed_accepted_late_exercise_count).to eq 0
-        expect(task.completion).to eq 1.0
-        expect(task.correctness).to eq 1.0
-        expect(task.score).to eq 0.4
-        expect(task.accepted_late_at).to be_nil
       end
     end
   end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -593,8 +593,11 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
           :tasks_tasked_exercise,
           :tasks_tasked_placeholder
         ]
-        exercise_ids = [task.tasked_exercises.first.content_exercise_id]
-        task.task_plan.update_attribute :settings, { 'exercise_ids' => exercise_ids }
+        exercise = task.tasked_exercises.first.exercise
+        exercises = [
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.num_questions }
+        ]
+        task.task_plan.update_attribute :settings, exercises: exercises
         task.task_steps.first(4).each { |ts| ts.update_attribute :is_core, true }
         task.task_steps.last.update_attribute :is_core, false
 

--- a/spec/support/create_student_history.rb
+++ b/spec/support/create_student_history.rb
@@ -128,7 +128,8 @@ class CreateStudentHistory
   end
 
   def create_homework_task_plan(ecosystem, course, periods, chapter, page, exercise)
-    exercise_ids = [ecosystem.chapters[chapter].pages[page].exercises[exercise].id.to_s]
+    ex = ecosystem.chapters[chapter].pages[page].exercises[exercise]
+    exercises = [ { id: ex.id.to_s, points: [ 1 ] * ex.to_model.num_questions } ]
 
     task_plan = FactoryBot.build(
       :tasks_task_plan,
@@ -138,7 +139,7 @@ class CreateStudentHistory
       title: 'Homework',
       type: 'homework',
       settings: {
-        exercise_ids: exercise_ids,
+        exercises: exercises,
         exercises_count_dynamic: 2
       },
       num_tasking_plans: 0

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -63,7 +63,7 @@ class SetupPerformanceReportData
     homework_assistant = get_assistant(course: course, task_plan_type: 'homework')
 
     page_ids = pages.map { |page| page.id.to_s }
-    exercise_ids = pages.flat_map { |page| page.exercises.map { |ex| ex.id.to_s } }
+    exercises = pages.flat_map(&:exercises)
 
     time_zone = course.time_zone.to_tz
 
@@ -100,7 +100,9 @@ class SetupPerformanceReportData
       assistant: homework_assistant,
       content_ecosystem_id: ecosystem.id,
       settings: {
-        exercise_ids: exercise_ids.first(5),
+        exercises: exercises.first(5).map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.to_model.num_questions }
+        end,
         exercises_count_dynamic: 2
       },
       num_tasking_plans: 0
@@ -127,7 +129,9 @@ class SetupPerformanceReportData
       assistant: homework_assistant,
       content_ecosystem_id: ecosystem.id,
       settings: {
-        exercise_ids: exercise_ids.last(2),
+        exercises: exercises.last(2).map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.to_model.num_questions }
+        end,
         exercises_count_dynamic: 2
       },
       num_tasking_plans: 0
@@ -154,7 +158,9 @@ class SetupPerformanceReportData
       assistant: homework_assistant,
       content_ecosystem_id: ecosystem.id,
       settings: {
-        exercise_ids: exercise_ids.first(5),
+        exercises: exercises.first(5).map do |exercise|
+          { id: exercise.id.to_s, points: [ 1 ] * exercise.to_model.num_questions }
+        end,
         exercises_count_dynamic: 2
       },
       num_tasking_plans: 0


### PR DESCRIPTION
So teachers can set points for each question in a homework assignment.

TODO:

- Make points affect task scores
- Modify scores API to return points for each question, lateness, points with lateness, scores with lateness, average score, average points, average points per question.
- Remove accept late work API/Add grant extension API