### PR TITLE
Restrict Travis builds to any pull_request + pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 # Copyright 2011-2019 Rice University. Licensed under the Affero General Public
 # License version 3 or later.  See the COPYRIGHT file for details.
 
-branches:
-  only:
-    - master
-    - alpha
-    - beta
-    - lms
-    - /^int-.*$/
-    - /^release-.*$/
+if: type = pull_request OR branch = master
 dist: xenial
 language: ruby
 addons:


### PR DESCRIPTION
This should allow us to build all PRs to any branch, plus build master after a PR is merged.