### PR TITLE
Remove unnecessary && true from bash commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ bundler_args: --without production --retry=6
 before_script:
   - bundle exec rake parallel:create parallel:load_schema parallel:seed --trace
 script:
-  - "[[ -n $LINT ]] && bundle exec rake lint:branch || [[ -z $LINT ]] && true"
-  - "[[ -n $ASSETS ]] && bundle exec rake assets:precompile || [[ -z $ASSETS ]] && true"
+  - "[[ -n $LINT ]] && bundle exec rake lint:branch || [[ -z $LINT ]]"
+  - "[[ -n $ASSETS ]] && bundle exec rake assets:precompile || [[ -z $ASSETS ]]"
   - >-
       [[ -n $TAG ]] && bundle exec parallel_rspec ./spec --test-options "--tag $TAG" ||
-      [[ -z $TAG ]] && true
+      [[ -z $TAG ]]


### PR DESCRIPTION
`&& true` commands are unnecessary, we can just return the value from the test that precedes them.