### PR TITLE
Do not restore teacher_students when an admin restores a teacher

### DIFF
--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -29,12 +29,7 @@ class Admin::TeachersController < Admin::BaseController
 
   def restore
     teacher = CourseMembership::Models::Teacher.find params[:id]
-    CourseMembership::Models::Teacher.transaction do
-      teacher.restore!
-      teacher.role.profile.roles.teacher_student.map(&:teacher_student).compact.select do |ts|
-        ts.course_profile_course_id == teacher.course_profile_course_id
-      end.select(&:deleted?).each(&:restore!)
-    end
+    teacher.restore!
     flash[:notice] = "Teacher \"#{teacher.role.name}\" readded to course."
     redirect_to edit_admin_course_path(teacher.course, anchor: 'teachers')
   end

--- a/spec/controllers/admin/teachers_controller_spec.rb
+++ b/spec/controllers/admin/teachers_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Admin::TeachersController, type: :controller do
       expect(response).to redirect_to edit_admin_course_path(course, anchor: 'teachers')
     end
 
-    it 'restores a teacher and all of their teacher_students' do
+    it 'restores a teacher but not their teacher_students' do
       teacher.destroy!
       expect(UserIsCourseTeacher[course: course, user: user_1]).to eq false
       expect(teacher.reload.deleted?).to eq true
@@ -63,7 +63,7 @@ RSpec.describe Admin::TeachersController, type: :controller do
         post :restore, params: { course_id: course.id, id: teacher.id }
       end.to  change     { UserIsCourseTeacher[course: course, user: user_1] }.to(true)
          .and change     { teacher.reload.deleted? }.to(false)
-         .and change     { teacher_student_1.reload.deleted? }.to(false)
+         .and not_change { teacher_student_1.reload.deleted? }
          .and not_change { teacher_student_2.reload.deleted? }
 
       expect(response).to redirect_to edit_admin_course_path(course, anchor: 'teachers')


### PR DESCRIPTION
I had changed the restore action to also restore teacher_students since I made the destroy action destroy them, but I just realized that restoring a teacher should not restore their teacher_students, since these are also automatically deleted by CreateOrResetTeacherStudent and you don't want multiples of them.