### PR TITLE
Reduced the Biglearn timeout to 3 minutes

### DIFF
--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -1,5 +1,5 @@
 module DashboardRoutineMethods
-  BIGLEARN_TIMEOUT = 10.minutes
+  BIGLEARN_TIMEOUT = 3.minutes
 
   def self.included(base)
     base.lev_routine


### PR DESCRIPTION
This is the timeout for when Biglearn fails completely.