### PR TITLE
allow points to be decimals divisible by 0.1

### DIFF
--- a/app/subsystems/tasks/assistants/homework_assistant.rb
+++ b/app/subsystems/tasks/assistants/homework_assistant.rb
@@ -14,7 +14,9 @@ class Tasks::Assistants::HomeworkAssistant < Tasks::Assistants::GenericAssistant
               "points": {
                 "type": "array",
                 "items": {
-                  "type": "integer"
+                  "type": "number",
+                  "multipleOf" : 0.1,
+                  "minimum": 0
                 },
                 "minItems": 1
               }


### PR DESCRIPTION
teachers can enter 0.1 or 0.5 but not 0.333333 or crazy stuff like that