### PR TITLE
changed class name

### DIFF
--- a/lib/openstax/biglearn/api/real_client.rb
+++ b/lib/openstax/biglearn/api/real_client.rb
@@ -339,7 +339,7 @@ class OpenStax::Biglearn::Api::RealClient < OpenStax::Biglearn::RealClient
       goal_num_tutor_assigned_pes = request[:goal_num_tutor_assigned_pes]
       if goal_num_tutor_assigned_pes.nil?
         if task.practice?
-          goal_num_tutor_assigned_pes = CreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES
+          goal_num_tutor_assigned_pes = FindOrCreatePracticeTaskRoutine::NUM_BIGLEARN_EXERCISES
         else
           p_steps = task.task_steps.personalized_group.to_a
           pe_steps = p_steps.select { |step| step.exercise? || step.placeholder? }


### PR DESCRIPTION
delayed task fails when it can't find the constant defined in this class.