### PR TITLE
Fix the migration that removes content from taskeds

### DIFF
--- a/app/subsystems/tasks/assistants/fragment_assistant.rb
+++ b/app/subsystems/tasks/assistants/fragment_assistant.rb
@@ -53,12 +53,7 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
           title: title
         )
       else
-        task_reading(
-          page: page,
-          step: build_task_step(task, page, fragment, index),
-          fragment_index: index,
-          title: title
-        )
+        task_reading(page: page, step: build_task_step(task, page, fragment, index), title: title)
       end
 
       # The page title applies only to the first step in the set of fragments given
@@ -66,12 +61,11 @@ class Tasks::Assistants::FragmentAssistant < Tasks::Assistants::GenericAssistant
     end
   end
 
-  def task_reading(page:, step:, fragment_index:, title: nil)
+  def task_reading(page:, step:, title: nil)
     Tasks::Models::TaskedReading.new(
       task_step: step,
       url: page.url,
       book_location: page.book_location,
-      fragment_index: fragment_index,
       title: title
     )
   end

--- a/app/subsystems/tasks/models/tasked_reading.rb
+++ b/app/subsystems/tasks/models/tasked_reading.rb
@@ -3,6 +3,8 @@ class Tasks::Models::TaskedReading < IndestructibleRecord
 
   json_serialize :book_location, Integer, array: true
 
+  delegate :fragment_index, to: :task_step
+
   validates :url, :fragment_index, presence: true
 
   def content

--- a/db/background_migrate/20200330145448_remove_duplicate_content_from_tasked_readings.rb
+++ b/db/background_migrate/20200330145448_remove_duplicate_content_from_tasked_readings.rb
@@ -1,0 +1,22 @@
+class RemoveDuplicateContentFromTaskedReadings < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    # Clear the content column for all TaskedReadings that have verbatim copies of the book content
+    Content::Models::Page.find_each do |page|
+      Tasks::Models::TaskedReading.transaction do
+        page.fragments.each_with_index do |fragment, index|
+          next unless fragment.respond_to? :to_html
+
+          Tasks::Models::TaskedReading.joins(:task_step).where(
+            task_step: { content_page_id: page.id, fragment_index: index },
+            content: fragment.to_html
+          ).update_all content: nil
+        end
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20200320203024_remove_content_from_taskeds.rb
+++ b/db/migrate/20200320203024_remove_content_from_taskeds.rb
@@ -1,40 +1,8 @@
 class RemoveContentFromTaskeds < ActiveRecord::Migration[5.2]
   def up
-    add_column :tasks_tasked_readings, :fragment_index, :integer
     change_column_null :tasks_tasked_readings, :content, true
 
-    # First set the fragment_index for all tasked_readings with content matching some page fragment
-    Content::Models::Page.find_each do |page|
-      page.fragments.each_with_index do |fragment, index|
-        next unless fragment.respond_to? :to_html
-
-        Tasks::Models::TaskedReading.joins(:task_step).where(
-          task_step: { content_page_id: page.id },
-          content: fragment.to_html
-        ).update_all fragment_index: index, content: nil
-      end
-    end
-
-    # If the content was modified, attempt to copy it from the previous step with the same page
-    Tasks::Models::TaskedReading.update_all(
-      <<~UPDATE_SQL
-        "fragment_index" = (
-          SELECT "previous_task_step"."fragment_index" + 1
-          FROM "tasks_task_steps" AS "previous_task_step"
-          WHERE "previous_task_step"."content_page_id" = "tasks_task_steps"."content_page_id"
-            AND "previous_task_step"."number" = "tasks_task_steps"."number" - 1
-        )
-        FROM "tasks_task_steps"
-        WHERE "tasks_tasked_readings"."fragment_index" IS NULL
-          AND "tasks_task_steps"."tasked_id" = "tasks_tasked_readings"."id"
-          AND "tasks_task_steps"."tasked_type" = 'Tasks::Models::TaskedReading'
-      UPDATE_SQL
-    )
-
-    # If no previous step with the same page, assume this is the first step in the page
-    Tasks::Models::TaskedReading.where(fragment_index: nil).update_all fragment_index: 0
-
-    change_column_null :tasks_tasked_readings, :fragment_index, false
+    BackgroundMigrate.perform_later 'up', 20200330145448
 
     # tasked_exercises don't have modified content at this time
     remove_column :tasks_tasked_exercises, :content

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_20_203024) do
+ActiveRecord::Schema.define(version: 2020_03_30_145448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -900,7 +900,6 @@ ActiveRecord::Schema.define(version: 2020_03_20_203024) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "book_location", default: "[]", null: false
-    t.integer "fragment_index", null: false
   end
 
   create_table "tasks_tasked_videos", id: :serial, force: :cascade do |t|

--- a/spec/factories/tasks/tasked_readings.rb
+++ b/spec/factories/tasks/tasked_readings.rb
@@ -1,17 +1,20 @@
 FactoryBot.define do
   factory :tasks_tasked_reading, class: '::Tasks::Models::TaskedReading' do
-    transient      { skip_task { false } }
+    transient      do
+      skip_task      { false }
+      fragment_index { task_step&.fragment_index || 0 }
+    end
 
     task_step      { nil }
     url            { Faker::Internet.url }
     title          { Faker::Lorem.sentence(3) }
     book_location  { [ [ rand(1..10), rand(1..10) ], [] ].sample }
-    fragment_index { 0 }
 
     after(:build) do |tasked_reading, evaluator|
       options = { tasked: tasked_reading, skip_task: evaluator.skip_task }
 
-      tasked_reading.task_step ||= FactoryBot.build(:tasks_task_step, options)
+      tasked_reading.task_step ||= FactoryBot.build :tasks_task_step, options
+      tasked_reading.task_step.fragment_index = evaluator.fragment_index
     end
   end
 end

--- a/spec/subsystems/tasks/models/tasked_interactive_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_interactive_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Tasks::Models::TaskedInteractive, type: :model do
+  subject(:tasked_interactive) do
+    FactoryBot.build(:tasks_tasked_interactive)
+  end
+
   it { is_expected.to validate_presence_of(:url) }
 
-  describe '#content_preview' do
-    subject(:tasked_interactive) do
-      FactoryBot.build(:tasks_tasked_interactive)
-    end
-
+  context '#content_preview' do
     let(:default_content_preview) { "External Interactive step ##{tasked_interactive.id}" }
 
     it "parses the content for the content preview" do

--- a/spec/subsystems/tasks/models/tasked_reading_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_reading_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Tasks::Models::TaskedReading, type: :model do
   end
 
   it { is_expected.to validate_presence_of(:url) }
-  it { is_expected.to validate_presence_of(:fragment_index) }
 
   context '#content_preview' do
     before do

--- a/spec/subsystems/tasks/models/tasked_video_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_video_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Tasks::Models::TaskedReading, type: :model do
+RSpec.describe Tasks::Models::TaskedVideo, type: :model do
+  subject(:tasked_video) { FactoryBot.build :tasks_tasked_video }
+
   it { is_expected.to validate_presence_of(:url) }
 
-  describe '#content_preview' do
-    subject(:tasked_video) do
-      FactoryBot.build(:tasks_tasked_video)
-    end
-
+  context '#content_preview' do
     let(:default_content_preview) { "External Reading step ##{tasked_video.id}" }
 
     it "parses the content for the content preview" do


### PR DESCRIPTION
Dropped the fragment_index column in TaskedReading (use the one in the task_step instead)