### PR TITLE
Removed temporary methods used for the content background migration

### DIFF
--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -38,10 +38,6 @@ class Content::Models::Exercise < IndestructibleRecord
     @parser ||= OpenStax::Exercises::V1::Exercise.new content: content
   end
 
-  def question_answer_ids
-    super || parser.question_answer_ids
-  end
-
   def units
     books.flat_map(&:units)
   end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -51,10 +51,6 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     @parser ||= OpenStax::Exercises::V1::Exercise.new(content: content)
   end
 
-  def answer_ids
-    super || parser.question_answer_ids.first
-  end
-
   def has_correctness?
     true
   end


### PR DESCRIPTION
These methods were used in a background migration and can be safely removed once it runs on all of our servers (the migration sets the columns to NOT NULL).

Merge ONLY after https://github.com/openstax/tutor/issues/913 passes.