### PR TITLE
Set course's is_college based on the creating user's school_type

### DIFF
--- a/app/routines/create_course.rb
+++ b/app/routines/create_course.rb
@@ -9,8 +9,6 @@ class CreateCourse
   uses_routine Tasks::CreateCourseAssistants, as: :create_course_assistants
 
   uses_routine AddEcosystemToCourse, as: :add_ecosystem
-  uses_routine CourseProfile::ClaimPreviewCourse, as: :claim_preview_course,
-                                                  translations: { outputs: { type: :verbatim } }
 
   def exec(name:, is_preview:, is_test:, is_college: nil, is_concept_coach: nil, term: nil,
            year: nil, num_sections: 1, catalog_offering: nil, appearance_code: nil, starts_at: nil,

--- a/app/routines/create_or_claim_course.rb
+++ b/app/routines/create_or_claim_course.rb
@@ -14,12 +14,17 @@ class CreateOrClaimCourse
 
   def exec(attributes)
     user = attributes[:teacher]
+    attributes[:is_college] ||= case user.school_type
+    when 'college'
+      true
+    when 'other_school_type'
+      false
+    else
+      nil
+    end
 
     if attributes[:is_preview]
-      run(:claim_preview_course, {
-            name: attributes[:name],
-            catalog_offering: attributes[:catalog_offering]
-      })
+      run(:claim_preview_course, attributes.slice(:catalog_offering, :name, :is_college))
     else
       run(:create_course, attributes.except(:teacher).merge(is_test: !!user.is_test))
     end

--- a/app/subsystems/course_profile/claim_preview_course.rb
+++ b/app/subsystems/course_profile/claim_preview_course.rb
@@ -1,10 +1,9 @@
 class CourseProfile::ClaimPreviewCourse
-
   lev_routine express_output: :course
 
   protected
 
-  def exec(catalog_offering:, name:, current_time: Time.current)
+  def exec(catalog_offering:, name:, is_college:, current_time: Time.current)
     course = CourseProfile::Models::Course
                .lock
                .joins(
@@ -52,7 +51,8 @@ class CourseProfile::ClaimPreviewCourse
       term: :preview,
       year: year,
       starts_at: term_year.starts_at,
-      ends_at: term_year.ends_at
+      ends_at: term_year.ends_at,
+      is_college: is_college
     )
 
     interval = "interval '#{(current_time - course.created_at).seconds.to_i} seconds'"
@@ -71,5 +71,4 @@ class CourseProfile::ClaimPreviewCourse
 
     outputs.course = course
   end
-
 end

--- a/spec/routines/create_or_claim_course_spec.rb
+++ b/spec/routines/create_or_claim_course_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe CreateOrClaimCourse, type: :routine do
     let(:is_preview) { true }
     let(:is_test)    { false }
 
-    it "claims an existing preview" do
+    it 'claims an existing preview' do
       expect_any_instance_of(CourseProfile::ClaimPreviewCourse)
-        .to receive(:call).with(catalog_offering: 123, name: 'TEST') do
+        .to receive(:call).with(catalog_offering: 123, name: 'TEST', is_college: nil) do
         Lev::Routine::Result.new(Lev::Outputs.new(course: mock_course), Lev::Errors.new)
       end
 
@@ -31,7 +31,7 @@ RSpec.describe CreateOrClaimCourse, type: :routine do
     let(:is_preview) { false }
     let(:is_test)    { true }
 
-    it "creates a new course" do
+    it 'creates a new course' do
 
       expect_any_instance_of(CreateCourse).to receive(:call) do
         Lev::Routine::Result.new(Lev::Outputs.new(course: mock_course), Lev::Errors.new)
@@ -47,5 +47,4 @@ RSpec.describe CreateOrClaimCourse, type: :routine do
       described_class.call(is_preview: false, teacher: user)
     end
   end
-
 end


### PR DESCRIPTION
Users are allowed to set it themselves, but the FE currently has no way to do this, which is fine.