### PR TITLE
add exercise and question ids to headings on scores api

### DIFF
--- a/app/representers/api/v1/task_plan/scores/question_heading_representer.rb
+++ b/app/representers/api/v1/task_plan/scores/question_heading_representer.rb
@@ -17,4 +17,14 @@ class Api::V1::TaskPlan::Scores::QuestionHeadingRepresenter < Roar::Decorator
            readable: true,
            writeable: false
 
+  property :exercise_id,
+           type: Integer,
+           readable: true,
+           writeable: false
+
+  property :question_id,
+           type: Integer,
+           readable: true,
+           writeable: false
+
 end

--- a/app/routines/calculate_task_plan_scores.rb
+++ b/app/routines/calculate_task_plan_scores.rb
@@ -57,8 +57,8 @@ class CalculateTaskPlanScores
          title: "Q#{index + 1}",
          points: available_points_per_question_index[index],
          type: step.is_core ? 'MCQ' : 'Tutor', # TODO: actually check if exercise is MCQ
-         question_id: step.is_core ? step.tasked.question_id : nil,
-         exercise_id: step.is_core ? step.tasked.content_exercise_id : nil,
+         question_id: step.exercise? && step.is_core? ? step.tasked.question_id : nil,
+         exercise_id: step.exercise? && step.is_core? ? step.tasked.content_exercise_id : nil,
         }
       end
       if task_plan.type == 'homework'

--- a/app/routines/calculate_task_plan_scores.rb
+++ b/app/routines/calculate_task_plan_scores.rb
@@ -55,8 +55,10 @@ class CalculateTaskPlanScores
       question_headings_array = exercise_steps.each_with_index.map do |step, index|
         {
          title: "Q#{index + 1}",
+         points: available_points_per_question_index[index],
          type: step.is_core ? 'MCQ' : 'Tutor', # TODO: actually check if exercise is MCQ
-         points: available_points_per_question_index[index]
+         question_id: step.is_core ? step.tasked.question_id : nil,
+         exercise_id: step.is_core ? step.tasked.content_exercise_id : nil,
         }
       end
       if task_plan.type == 'homework'

--- a/spec/representers/api/v1/task_plan/scores/representer_spec.rb
+++ b/spec/representers/api/v1/task_plan/scores/representer_spec.rb
@@ -62,8 +62,15 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
           {
             id: task_plan.owner.periods.first.id.to_s,
             name: '1st',
-            question_headings: 8.times.map do |index|
-              { title: "Q#{index + 1}", type: index < 5 ? 'MCQ' : 'Tutor', points: 1.0 }
+            question_headings: student_tasks.first.task_steps.each_with_index.map do |task_step, index|
+              {
+               title: "Q#{index + 1}",
+               points: 1.0,
+               type: task_step.is_core? ? 'MCQ' : 'Tutor',
+              }.merge(task_step.is_core? ?
+                      { question_id:  task_step.tasked.question_id.to_i,
+                       exercise_id: task_step.tasked.content_exercise_id.to_i } : {},
+            )
             end,
             late_work_fraction_penalty: late_work_penalty,
             num_questions_dropped: 0,
@@ -169,8 +176,15 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
           {
             id: task_plan.owner.periods.first.id.to_s,
             name: '1st',
-            question_headings: 8.times.map do |index|
-              { title: "Q#{index + 1}", type: index < 5 ? 'MCQ' : 'Tutor', points: 1.0 }
+            question_headings: student_tasks.first.task_steps.each_with_index.map do |task_step, index|
+              {
+               title: "Q#{index + 1}",
+               points: 1.0,
+               type: task_step.is_core? ? 'MCQ' : 'Tutor',
+              }.merge(task_step.is_core? ?
+                      { question_id:  task_step.tasked.question_id.to_i,
+                       exercise_id: task_step.tasked.content_exercise_id.to_i } : {},
+            )
             end,
             late_work_fraction_penalty: late_work_penalty,
             num_questions_dropped: 0,

--- a/spec/routines/calculate_task_plan_scores_spec.rb
+++ b/spec/routines/calculate_task_plan_scores_spec.rb
@@ -64,8 +64,14 @@ RSpec.describe CalculateTaskPlanScores, type: :routine, vcr: VCR_OPTS, speed: :s
         expect(period_output.id).to eq period.id
         expect(period_output.name).to eq period.name
         expect(period_output.question_headings.map(&:symbolize_keys)).to eq(
-          8.times.map do |index|
-            { title: "Q#{index + 1}", points: 1.0, type: index < 5 ? 'MCQ' : 'Tutor' }
+          tasks.first.task_steps.each_with_index.map do |task_step, index|
+            {
+             title: "Q#{index + 1}",
+             points: 1.0,
+             type: task_step.is_core? ? 'MCQ' : 'Tutor',
+             question_id: task_step.is_core? ? task_step.tasked.question_id : nil,
+             exercise_id: task_step.is_core? ? task_step.tasked.content_exercise_id : nil,
+            }
           end
         )
         expect(period_output.late_work_fraction_penalty).to eq late_work_penalty
@@ -126,8 +132,14 @@ RSpec.describe CalculateTaskPlanScores, type: :routine, vcr: VCR_OPTS, speed: :s
         expect(period_output.id).to eq period.id
         expect(period_output.name).to eq period.name
         expect(period_output.question_headings.map(&:symbolize_keys)).to eq(
-          8.times.map do |index|
-            { title: "Q#{index + 1}", points: 1.0, type: index < 5 ? 'MCQ' : 'Tutor' }
+          tasks.first.task_steps.each_with_index.map do |task_step, index|
+            {
+             title: "Q#{index + 1}",
+             points: 1.0,
+             type: task_step.is_core? ? 'MCQ' : 'Tutor',
+             question_id: task_step.is_core? ? task_step.tasked.question_id : nil,
+             exercise_id: task_step.is_core? ? task_step.tasked.content_exercise_id : nil,
+            }
           end
         )
         expect(period_output.late_work_fraction_penalty).to eq late_work_penalty
@@ -187,8 +199,14 @@ RSpec.describe CalculateTaskPlanScores, type: :routine, vcr: VCR_OPTS, speed: :s
         expect(period_output.id).to eq period.id
         expect(period_output.name).to eq period.name
         expect(period_output.question_headings.map(&:symbolize_keys)).to eq(
-          8.times.map do |index|
-            { title: "Q#{index + 1}", points: 1.0, type: index < 5 ? 'MCQ' : 'Tutor' }
+          tasks.first.task_steps.each_with_index.map do |task_step, index|
+            {
+             title: "Q#{index + 1}",
+             points: 1.0,
+             type: task_step.is_core? ? 'MCQ' : 'Tutor',
+             question_id: task_step.is_core? ? task_step.tasked.question_id : nil,
+             exercise_id: task_step.is_core? ? task_step.tasked.content_exercise_id : nil,
+            }
           end
         )
         expect(period_output.late_work_fraction_penalty).to eq late_work_penalty


### PR DESCRIPTION
Let's the FE display the question for core exercises easily