### PR TITLE
update scores api to return tasking_plans and work with all types

### DIFF
--- a/app/representers/api/v1/task_plan/scores/representer.rb
+++ b/app/representers/api/v1/task_plan/scores/representer.rb
@@ -22,6 +22,17 @@ class Api::V1::TaskPlan::Scores::Representer < ::Roar::Decorator
            readable: true,
            writeable: true
 
+  property :grading_template,
+           extend: Api::V1::GradingTemplateRepresenter,
+           readable: true,
+           writeable: false
+
+  collection :tasking_plans,
+             extend: Api::V1::TaskPlan::TaskingPlanRepresenter,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { tasking_plans }
+
   collection :periods,
              extend: Api::V1::TaskPlan::Scores::PeriodRepresenter,
              readable: true,

--- a/app/routines/calculate_task_plan_scores.rb
+++ b/app/routines/calculate_task_plan_scores.rb
@@ -126,7 +126,7 @@ class CalculateTaskPlanScores
         id: period.id,
         name: period.name,
         question_headings: question_headings_array,
-        late_work_fraction_penalty: task_plan.grading_template&.late_work_penalty,
+        late_work_fraction_penalty: task_plan.grading_template&.late_work_penalty || 0,
         num_questions_dropped: num_questions_dropped,
         points_dropped: points_dropped,
         students: students_array

--- a/app/routines/calculate_task_plan_scores.rb
+++ b/app/routines/calculate_task_plan_scores.rb
@@ -126,7 +126,7 @@ class CalculateTaskPlanScores
         id: period.id,
         name: period.name,
         question_headings: question_headings_array,
-        late_work_fraction_penalty: task_plan.grading_template.late_work_penalty,
+        late_work_fraction_penalty: task_plan.grading_template&.late_work_penalty,
         num_questions_dropped: num_questions_dropped,
         points_dropped: points_dropped,
         students: students_array


### PR DESCRIPTION
- Return tasking_plans and grading_template in the scores API.
- Safely navigate to late_work_penalty, as events, external, and old assignments don't use grading templates