### PR TITLE
LMS forward params to login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'whenever'
 gem 'omniauth-oauth2', '~> 1.3.1'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', '~> 9.0.2'
+gem 'openstax_accounts', '~> 9.1.0'
 gem 'action_interceptor'
 
 # Datetime parsing

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -19,6 +19,9 @@ OpenStax::Accounts.configure do |config|
   config.logout_redirect_url = ->(request) do
     LogoutRedirectChooser.new(request.url).choose(default: config.default_logout_redirect_url)
   end
+  config.forwardable_login_param_keys = [
+    :return_to, :sp,
+  ]
   config.return_to_url_approver = ->(url) do
     begin
       uri = Addressable::URI.parse(url)

--- a/config/initializers/openstax_accounts.rb
+++ b/config/initializers/openstax_accounts.rb
@@ -19,9 +19,6 @@ OpenStax::Accounts.configure do |config|
   config.logout_redirect_url = ->(request) do
     LogoutRedirectChooser.new(request.url).choose(default: config.default_logout_redirect_url)
   end
-  config.forwardable_login_param_keys = [
-    :return_to, :sp,
-  ]
   config.return_to_url_approver = ->(url) do
     begin
       uri = Addressable::URI.parse(url)


### PR DESCRIPTION
otherwise they seem to be stripped by this:
https://github.com/openstax/accounts-rails/blob/master/app/controllers/openstax/accounts/sessions_controller.rb#L13-L15

The mystery to me is how this ever worked.  The redirect here hasn't changed:
https://github.com/openstax/tutor-server/blob/master/app/controllers/lms_controller.rb#L113-L125