### PR TITLE
fix namespace reference in grading templates api create

### DIFF
--- a/app/controllers/api/v1/grading_templates_controller.rb
+++ b/app/controllers/api/v1/grading_templates_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::GradingTemplatesController < Api::V1::ApiController
     #{json_schema(Api::V1::GradingTemplateRepresenter, include: :writeable)}
   DESCRIPTION
   def create
-    standard_nested_create Tasks::Models::GradingTemplate.new,
+    standard_nested_create ::Tasks::Models::GradingTemplate.new,
                            :course,
                            course,
                            Api::V1::GradingTemplateRepresenter


### PR DESCRIPTION
Fixes looking under Api::V1::Tasks by looking at the top level.