### PR TITLE
Block cloned assignment creation unless the content is properly updated

### DIFF
--- a/app/routines/update_task_plan_ecosystem.rb
+++ b/app/routines/update_task_plan_ecosystem.rb
@@ -17,7 +17,7 @@ class UpdateTaskPlanEcosystem
     # No need to lock the plan because it should not be saved yet
     outputs.task_plan = task_plan
 
-    old_ecosystem = outputs.task_plan.set_ecosystem
+    old_ecosystem = outputs.task_plan.set_and_return_ecosystem
 
     return if old_ecosystem == ecosystem
 

--- a/app/routines/update_task_plan_ecosystem.rb
+++ b/app/routines/update_task_plan_ecosystem.rb
@@ -14,12 +14,10 @@ class UpdateTaskPlanEcosystem
   end
 
   def update_task_plan(task_plan:, ecosystem:)
-    # Lock the plan to prevent concurrent publication
-    outputs.task_plan = task_plan.lock!
+    # No need to lock the plan because it should not be saved yet
+    outputs.task_plan = task_plan
 
-    return unless outputs.task_plan.valid?
-
-    old_ecosystem = outputs.task_plan.ecosystem
+    old_ecosystem = outputs.task_plan.set_ecosystem
 
     return if old_ecosystem == ecosystem
 

--- a/app/subsystems/course_content/add_ecosystem_to_course.rb
+++ b/app/subsystems/course_content/add_ecosystem_to_course.rb
@@ -11,10 +11,10 @@ class CourseContent::AddEcosystemToCourse
       if course.lock!.ecosystem&.id == ecosystem.id
 
     course_ecosystem = CourseContent::Models::CourseEcosystem.new(
-      course: course, content_ecosystem_id: ecosystem.id
+      course: course, ecosystem: ecosystem
     )
     course.course_ecosystems << course_ecosystem
-    transfer_errors_from(course_ecosystem, {type: :verbatim}, true)
+    transfer_errors_from(course_ecosystem, { type: :verbatim }, true)
 
     # Create a mapping from the old course ecosystems to the new one and validate it
     outputs.ecosystem_map = ::Content::Map.find_or_create_by!(

--- a/app/subsystems/course_content/models/course_ecosystem.rb
+++ b/app/subsystems/course_content/models/course_ecosystem.rb
@@ -1,8 +1,6 @@
 class CourseContent::Models::CourseEcosystem < IndestructibleRecord
-
   belongs_to :course, subsystem: :course_profile
   belongs_to :ecosystem, subsystem: :content
 
-  default_scope -> { order(created_at: :desc) }
-
+  default_scope -> { order created_at: :desc }
 end

--- a/app/subsystems/course_content/models/excluded_exercise.rb
+++ b/app/subsystems/course_content/models/excluded_exercise.rb
@@ -1,7 +1,5 @@
 class CourseContent::Models::ExcludedExercise < ApplicationRecord
-
   belongs_to :course, subsystem: :course_profile
 
   validates :exercise_number, presence: true, uniqueness: { scope: :course_profile_course_id }
-
 end

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -1,5 +1,4 @@
 class CourseProfile::Models::Course < ApplicationRecord
-
   acts_as_paranoid without_default_scope: true
 
   include DefaultTimeValidations
@@ -65,14 +64,14 @@ class CourseProfile::Models::Course < ApplicationRecord
 
   def ecosystems
     # Keep the ecosystems in order
-    ce = course_ecosystems.to_a
-    ActiveRecord::Associations::Preloader.new.preload(ce, :ecosystem)
-    ce.map(&:ecosystem)
+    course_ecosystems.to_a.tap do |course_ecosystems|
+      ActiveRecord::Associations::Preloader.new.preload(course_ecosystems, :ecosystem)
+    end.map(&:ecosystem)
   end
 
   def ecosystem
     # Slightly more efficient than .ecosystems.first
-    course_ecosystems.first.try!(:ecosystem)
+    course_ecosystems.first&.ecosystem
   end
 
   def default_due_time
@@ -169,5 +168,4 @@ class CourseProfile::Models::Course < ApplicationRecord
     errors.add(:base, 'weights must add up to exactly 1')
     throw :abort
   end
-
 end

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -26,7 +26,7 @@ class Tasks::Models::TaskPlan < ApplicationRecord
 
   json_serialize :settings, Hash
 
-  before_validation :trim_text, :set_ecosystem
+  before_validation :trim_text, :set_and_return_ecosystem
 
   validates :title, presence: true
   validates :type, presence: true
@@ -76,7 +76,7 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     Jobba.find(publish_job_uuid) if publish_job_uuid.present?
   end
 
-  def set_ecosystem
+  def set_and_return_ecosystem
     self.ecosystem ||= cloned_from&.ecosystem ||
                        get_ecosystems_from_settings&.first ||
                        owner.try(:ecosystems)&.first

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -1,7 +1,6 @@
 require 'json-schema'
 
 class Tasks::Models::TaskPlan < ApplicationRecord
-
   acts_as_paranoid column: :withdrawn_at, without_default_scope: true
 
   UPDATEABLE_ATTRIBUTES_AFTER_OPEN = [
@@ -33,7 +32,11 @@ class Tasks::Models::TaskPlan < ApplicationRecord
   validates :type, presence: true
   validates :tasking_plans, presence: true
 
-  validate :valid_settings, :same_ecosystem, :changes_allowed, :not_past_due_when_publishing
+  validate :valid_settings,
+           :valid_ecosystem,
+           :ecosystem_matches,
+           :changes_allowed,
+           :not_past_due_when_publishing
 
   scope :tasked_to_period_id, ->(period_id) do
     joins(:tasking_plans).where(
@@ -73,6 +76,12 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     Jobba.find(publish_job_uuid) if publish_job_uuid.present?
   end
 
+  def set_ecosystem
+    self.ecosystem ||= cloned_from&.ecosystem ||
+                       get_ecosystems_from_settings&.first ||
+                       owner.try(:ecosystems)&.first
+  end
+
   protected
 
   def get_ecosystems_from_exercise_ids
@@ -95,12 +104,6 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     end
   end
 
-  def set_ecosystem
-    self.ecosystem ||= cloned_from&.ecosystem ||
-                       get_ecosystems_from_settings&.first ||
-                       owner.try(:ecosystems)&.first
-  end
-
   def valid_settings
     schema = assistant.try(:schema)
     return if schema.blank?
@@ -112,7 +115,16 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     throw :abort
   end
 
-  def same_ecosystem
+  def valid_ecosystem
+    valid_ecosystems = owner.try(:ecosystems)
+    # Remove nil check if we remove polymorphism.
+    return if valid_ecosystems.nil? || valid_ecosystems.include?(ecosystem)
+
+    errors.add(:ecosystem, 'is not valid for this course')
+    throw :abort
+  end
+
+  def ecosystem_matches
     return if ecosystem.nil?
 
     # Special checks for the page_ids and exercise_ids settings
@@ -147,5 +159,4 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     self.title&.strip!
     self.description&.strip!
   end
-
 end

--- a/db/migrate/20200427121628_fix_cloned_courses.rb
+++ b/db/migrate/20200427121628_fix_cloned_courses.rb
@@ -1,16 +1,24 @@
 class FixClonedCourses < ActiveRecord::Migration[5.2]
   def up
     CourseProfile::Models::Course.preload(:course_ecosystems).find_each do |course|
-      valid_ecosystem_ids = course.course_ecosystems.map(&:content_ecosystem_id)
+      existing_course_ecosystems = course.course_ecosystems.to_a
+      valid_ecosystem_ids = existing_course_ecosystems.map(&:content_ecosystem_id)
 
       missing_ecosystem_ids = Tasks::Models::TaskPlan.where(owner: course).where.not(
         content_ecosystem_id: valid_ecosystem_ids
-      ).distinct.pluck(:content_ecosystem_id)
+      ).distinct.pluck(:content_ecosystem_id).sort
+
+      next if missing_ecosystem_ids.empty?
 
       missing_ecosystem_ids.each do |ecosystem_id|
         CourseContent::Models::CourseEcosystem.create!(
           course: course, content_ecosystem_id: ecosystem_id
         )
+      end
+
+      # Ensure the ecosystem order is preserved
+      existing_course_ecosystems.each do |course_ecosystem|
+        course_ecosystem.update_attribute :created_at, Time.current
       end
     end
   end

--- a/db/migrate/20200427121628_fix_cloned_courses.rb
+++ b/db/migrate/20200427121628_fix_cloned_courses.rb
@@ -1,0 +1,20 @@
+class FixClonedCourses < ActiveRecord::Migration[5.2]
+  def up
+    CourseProfile::Models::Course.preload(:course_ecosystems).find_each do |course|
+      valid_ecosystem_ids = course.course_ecosystems.map(&:content_ecosystem_id)
+
+      missing_ecosystem_ids = Tasks::Models::TaskPlan.where(owner: course).where.not(
+        content_ecosystem_id: valid_ecosystem_ids
+      ).distinct.pluck(:content_ecosystem_id)
+
+      missing_ecosystem_ids.each do |ecosystem_id|
+        CourseContent::Models::CourseEcosystem.create!(
+          course: course, content_ecosystem_id: ecosystem_id
+        )
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_163436) do
+ActiveRecord::Schema.define(version: 2020_04_27_121628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:status]).to eq 422
         Api::V1::CoursesController::CREATE_REQUIRED_ATTRIBUTES.each do |required_attr|
           expect(response.body_as_hash[:errors]).to include(
-            {code: "missing_attribute", message: "The #{required_attr} attribute must be provided"}
+            {code: 'missing_attribute', message: "The #{required_attr} attribute must be provided"}
           )
         end
       end
@@ -463,8 +463,8 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         due_at = time_zone.now + 2.months
 
         # User time-zone-less strings to update the open/due dates
-        opens_at_str = opens_at.strftime "%Y-%m-%d %H:%M:%S"
-        due_at_str = due_at.strftime "%Y-%m-%d %H:%M:%S"
+        opens_at_str = opens_at.strftime '%Y-%m-%d %H:%M:%S'
+        due_at_str = due_at.strftime '%Y-%m-%d %H:%M:%S'
 
         task_plan = FactoryBot.build :tasks_task_plan, owner: @course, num_tasking_plans: 0
         tasking_plan = FactoryBot.create :tasks_tasking_plan, task_plan: task_plan,
@@ -649,7 +649,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:errors].first[:code]).to eq 'cc_course'
       end
 
-      it "works without a role specified" do
+      it 'works without a role specified' do
         Preview::AnswerExercise[task_step: @hw1_task.task_steps[0], is_correct: true]
         Preview::AnswerExercise[task_step: @hw1_task.task_steps[2], is_correct: false]
 
@@ -726,7 +726,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         )
       end
 
-      it "allows the start_at and end_at dates to be specified" do
+      it 'allows the start_at and end_at dates to be specified' do
         api_get :dashboard, @student_token, params: {
           id: @course.id, start_at: @time_zone.now + 1.day, end_at: @time_zone.now + 1.week
         }
@@ -734,7 +734,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:tasks].size).to eq 1
       end
 
-      it "allows the start_at date to be specified alone" do
+      it 'allows the start_at date to be specified alone' do
         api_get :dashboard, @student_token, params: {
           id: @course.id, start_at: @time_zone.now + 1.day
         }
@@ -742,7 +742,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:tasks].size).to eq 1
       end
 
-      it "allows the end_at date to be specified alone" do
+      it 'allows the end_at date to be specified alone' do
         api_get :dashboard, @student_token, params: {
           id: @course.id, end_at: @time_zone.now - 2.weeks
         }
@@ -759,7 +759,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:errors].first[:code]).to eq 'cc_course'
       end
 
-      it "works without a role specified" do
+      it 'works without a role specified' do
         api_get :dashboard, @teacher_token, params: { id: @course.id }
 
         expect(response.body_as_hash).to match(
@@ -802,7 +802,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         )
       end
 
-      it "allows the start_at and end_at dates to be specified" do
+      it 'allows the start_at and end_at dates to be specified' do
         api_get :dashboard, @teacher_token, params: {
           id: @course.id, start_at: @time_zone.now - 2.hours, end_at: @time_zone.now - 1.hour
         }
@@ -810,7 +810,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:plans]).to be_empty
       end
 
-      it "allows the start_at date to be specified alone" do
+      it 'allows the start_at date to be specified alone' do
         api_get :dashboard, @teacher_token, params: {
           id: @course.id, start_at: @time_zone.now - 2.hours
         }
@@ -818,7 +818,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         expect(response.body_as_hash[:plans].size).to eq 5
       end
 
-      it "allows the end_at date to be specified alone" do
+      it 'allows the end_at date to be specified alone' do
         api_get :dashboard, @teacher_token, params: {
           id: @course.id, end_at: @time_zone.now - 1.hours
         }

--- a/spec/factories/tasks/tasked_task_plan.rb
+++ b/spec/factories/tasks/tasked_task_plan.rb
@@ -1,5 +1,8 @@
 # To allow use in the development environment
-require_relative '../../support/fake_exercise_uuids'
+if Rails.env.development?
+  require_relative '../../vcr_helper'
+  require_relative '../../support/fake_exercise_uuids'
+end
 
 FactoryBot.define do
   factory :tasked_task_plan, parent: :tasks_task_plan do
@@ -58,19 +61,7 @@ FactoryBot.define do
 
     ecosystem do
       FactoryBot.create(:content_ecosystem).tap do |ecosystem|
-        if Rails.env.test?
-          require File.expand_path('../../../vcr_helper', __FILE__)
-
-          VCR.use_cassette('TaskedTaskPlan/with_inertia', VCR_OPTS) do
-            OpenStax::Cnx::V1.with_archive_url('https://archive-staging-tutor.cnx.org/contents/') do
-              Content::ImportBook[
-                cnx_book: cnx_book,
-                ecosystem: ecosystem,
-                reading_processing_instructions: reading_processing_instructions
-              ]
-            end
-          end
-        else
+        VCR.use_cassette('TaskedTaskPlan/with_inertia', VCR_OPTS) do
           OpenStax::Cnx::V1.with_archive_url('https://archive-staging-tutor.cnx.org/contents/') do
             Content::ImportBook[
               cnx_book: cnx_book,

--- a/spec/factories/tasks/tasks.rb
+++ b/spec/factories/tasks/tasks.rb
@@ -10,10 +10,12 @@ FactoryBot.define do
 
     task_type { :reading }
 
-    ecosystem { FactoryBot.create :content_ecosystem }
-
     after(:build) do |task, evaluator|
       tasked_to = [ evaluator.tasked_to ].flatten
+
+      period = tasked_to.first&.course_member&.period
+
+      task.ecosystem ||= period&.course&.ecosystem || FactoryBot.build(:content_ecosystem)
 
       task.task_plan ||= build(
         :tasks_task_plan,

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
         )
 
         generate_homework_test_exercise_content
+
+        AddEcosystemToCourse.call ecosystem: @ecosystem, course: course
       end
 
       it 'distributes the steps' do
@@ -81,6 +83,8 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
         )
 
         generate_homework_test_exercise_content
+
+        AddEcosystemToCourse.call ecosystem: @ecosystem, course: course
       end
 
       it 'creates a preview and distributes the steps' do

--- a/spec/routines/update_task_plan_ecosystem_spec.rb
+++ b/spec/routines/update_task_plan_ecosystem_spec.rb
@@ -5,26 +5,42 @@ RSpec.describe UpdateTaskPlanEcosystem, type: :routine do
     generate_homework_test_exercise_content
     @old_ecosystem = @ecosystem
     @old_pages = @pages
+
     generate_homework_test_exercise_content
+
+    @old_course = FactoryBot.create :course_profile_course
+    AddEcosystemToCourse.call ecosystem: @old_ecosystem, course: @old_course
+
+    @course = FactoryBot.create :course_profile_course
+    AddEcosystemToCourse.call ecosystem: @ecosystem, course: @course
   end
 
   context 'reading task plan' do
     let(:page_ids) { @old_pages[0..2].map(&:id) }
 
-    let(:reading_plan) do
-      FactoryBot.build(
+    let(:original_reading_plan) do
+      FactoryBot.create(
         :tasks_task_plan,
         type: 'reading',
         ecosystem: @old_ecosystem,
+        owner: @old_course,
         settings: { page_ids: page_ids }
       )
     end
 
     it 'can be updated to a newer ecosystem' do
-      expect(reading_plan.ecosystem).to eq @old_ecosystem
-      expect(reading_plan.settings['page_ids']).to eq page_ids
-      expect(reading_plan).to be_valid
-      updated_reading_plan = described_class[task_plan: reading_plan, ecosystem: @ecosystem]
+      expect(original_reading_plan).to be_valid
+
+      cloned_reading_plan = FactoryBot.build(
+        :tasks_task_plan,
+        type: 'reading',
+        ecosystem: @old_ecosystem,
+        owner: @course,
+        settings: { page_ids: page_ids }
+      )
+      expect(cloned_reading_plan).not_to be_valid
+
+      updated_reading_plan = described_class[task_plan: cloned_reading_plan, ecosystem: @ecosystem]
       expect(updated_reading_plan.ecosystem).to eq @ecosystem
       expect(updated_reading_plan.settings['page_ids'].length).to eq page_ids.length
       expect(updated_reading_plan.settings['page_ids']).not_to eq page_ids
@@ -38,21 +54,30 @@ RSpec.describe UpdateTaskPlanEcosystem, type: :routine do
   context 'homework task plan' do
     let(:exercise_ids)  { @old_pages.flat_map(&:homework_core_exercise_ids)[0..5].map(&:to_s) }
 
-    let(:homework_plan) do
-      FactoryBot.build(
+    let(:original_homework_plan) do
+      FactoryBot.create(
         :tasks_task_plan,
         type: 'homework',
         ecosystem: @old_ecosystem,
+        owner: @old_course,
         settings: { exercise_ids: exercise_ids, exercises_count_dynamic: 3 }
       )
     end
 
     it 'can be updated to a newer ecosystem' do
-      expect(homework_plan.ecosystem).to eq @old_ecosystem
-      expect(homework_plan.settings['exercise_ids']).to eq exercise_ids
-      expect(homework_plan).to be_valid
+      expect(original_homework_plan).to be_valid
+
+      cloned_homework_plan = FactoryBot.build(
+        :tasks_task_plan,
+        type: 'homework',
+        ecosystem: @old_ecosystem,
+        owner: @course,
+        settings: { exercise_ids: exercise_ids, exercises_count_dynamic: 3 }
+      )
+      expect(cloned_homework_plan).not_to be_valid
+
       updated_homework_plan = described_class[
-        task_plan: homework_plan, ecosystem: @ecosystem
+        task_plan: cloned_homework_plan, ecosystem: @ecosystem
       ]
       expect(updated_homework_plan.ecosystem).to eq @ecosystem
       expect(updated_homework_plan.settings['exercise_ids'].length).to eq exercise_ids.length
@@ -68,22 +93,29 @@ RSpec.describe UpdateTaskPlanEcosystem, type: :routine do
     let(:page_ids)     { @old_pages[0..2].map(&:id) }
     let(:snap_lab_ids) { page_ids.map{ |page_id| "#{page_id}:fs-id#{SecureRandom.hex}" } }
 
-    let(:extra_plan) do
-      FactoryBot.build(
+    let(:original_extra_plan) do
+      FactoryBot.create(
         :tasks_task_plan,
         type: 'extra',
         ecosystem: @old_ecosystem,
+        owner: @old_course,
         settings: { snap_lab_ids: snap_lab_ids }
       )
     end
 
     it 'can be updated to a newer ecosystem' do
-      expect(extra_plan.ecosystem).to eq @old_ecosystem
-      expect(extra_plan.settings['snap_lab_ids']).to eq snap_lab_ids
-      expect(extra_plan).to be_valid
-      updated_extra_plan = described_class[
-        task_plan: extra_plan, ecosystem: @ecosystem
-      ]
+      expect(original_extra_plan).to be_valid
+
+      cloned_extra_plan = FactoryBot.build(
+        :tasks_task_plan,
+        type: 'extra',
+        ecosystem: @old_ecosystem,
+        owner: @course,
+        settings: { snap_lab_ids: snap_lab_ids }
+      )
+      expect(cloned_extra_plan).not_to be_valid
+
+      updated_extra_plan = described_class[task_plan: cloned_extra_plan, ecosystem: @ecosystem]
       expect(updated_extra_plan.ecosystem).to eq @ecosystem
       expect(updated_extra_plan.settings['snap_lab_ids'].length).to eq snap_lab_ids.length
       expect(updated_extra_plan.settings['snap_lab_ids']).not_to eq snap_lab_ids
@@ -98,19 +130,28 @@ RSpec.describe UpdateTaskPlanEcosystem, type: :routine do
   end
 
   context 'external task plan' do
-    let(:external_plan) do
-      FactoryBot.build(
+    let(:original_external_plan) do
+      FactoryBot.create(
         :tasks_task_plan,
         type: 'external',
-        ecosystem: @old_ecosystem
+        ecosystem: @old_ecosystem,
+        owner: @old_course
       )
     end
 
     it 'can be updated to a newer ecosystem' do
-      expect(external_plan.ecosystem).to eq @old_ecosystem
-      expect(external_plan).to be_valid
+      expect(original_external_plan).to be_valid
+
+      cloned_external_plan = FactoryBot.build(
+        :tasks_task_plan,
+        type: 'external',
+        ecosystem: @old_ecosystem,
+        owner: @course
+      )
+      expect(cloned_external_plan).not_to be_valid
+
       updated_external_plan = described_class[
-        task_plan: external_plan, ecosystem: @ecosystem
+        task_plan: cloned_external_plan, ecosystem: @ecosystem
       ]
       expect(updated_external_plan.ecosystem).to eq @ecosystem
       expect(updated_external_plan).to be_valid

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant, vcr: VCR_
         num_tasking_plans: 0
       )
 
-      course = @task_plan.owner.tap do |course|
-        AddEcosystemToCourse[course: course, ecosystem: @ecosystem]
-      end
+      course = @task_plan.owner
 
       period = FactoryBot.create :course_membership_period, course: course
 

--- a/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/i_reading_assistant_spec.rb
@@ -91,11 +91,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant, vcr: VCR_
       )
     end
 
-    let(:course) do
-      task_plan.owner.tap do |course|
-        AddEcosystemToCourse[course: course, ecosystem: @ecosystem]
-      end
-    end
+    let(:course) { task_plan.owner }
 
     let(:period) { FactoryBot.create :course_membership_period, course: course }
 
@@ -295,11 +291,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant, vcr: VCR_
       )
     end
 
-    let(:course) do
-      task_plan.owner.tap do |course|
-        AddEcosystemToCourse[course: course, ecosystem: ecosystem]
-      end
-    end
+    let(:course) { task_plan.owner }
 
     let(:period) { FactoryBot.create :course_membership_period, course: course }
 
@@ -383,11 +375,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant, vcr: VCR_
       )
     end
 
-    let(:course) do
-      task_plan.owner.tap do |course|
-        AddEcosystemToCourse[course: course, ecosystem: ecosystem]
-      end
-    end
+    let(:course) { task_plan.owner }
 
     let(:period) { FactoryBot.create :course_membership_period, course: course }
 
@@ -566,9 +554,7 @@ RSpec.describe Tasks::Assistants::IReadingAssistant, type: :assistant, vcr: VCR_
       )
     end
 
-    let(:course) do
-      task_plan.owner.tap{ |course| AddEcosystemToCourse[course: course, ecosystem: ecosystem] }
-    end
+    let(:course) { task_plan.owner }
 
     let(:period) { FactoryBot.create :course_membership_period, course: course }
 

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
 
   it { is_expected.to validate_presence_of(:title) }
 
-  it "requires at least one tasking_plan" do
+  it 'requires at least one tasking_plan' do
     expect(task_plan).to be_valid
 
     task_plan.tasking_plans.destroy_all
@@ -41,7 +41,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan).to be_valid
   end
 
-  it "automatically infers the ecosystem from the settings or owner" do
+  it 'automatically infers the ecosystem from the settings or owner' do
     ecosystem = task_plan.ecosystem
     book = FactoryBot.create :content_book, ecosystem: ecosystem
     page = FactoryBot.create :content_page, book: book
@@ -53,7 +53,8 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan.ecosystem).to be_nil
 
     task_plan.settings = { exercise_ids: [exercise.id.to_s] }
-    expect(task_plan).to be_valid
+    # Not valid because the course does not have the ecosystem
+    expect(task_plan).not_to be_valid
     expect(task_plan.ecosystem).to eq ecosystem
 
     task_plan.settings = {}
@@ -62,7 +63,8 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     expect(task_plan.ecosystem).to be_nil
 
     task_plan.settings = { page_ids: [page.id.to_s] }
-    expect(task_plan).to be_valid
+    # Not valid because the course does not have the ecosystem
+    expect(task_plan).not_to be_valid
     expect(task_plan.ecosystem).to eq ecosystem
 
     task_plan.settings = {}
@@ -133,7 +135,9 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
   it "automatically sets its ecosystem to the original's if cloned_from is specified" do
     clone = FactoryBot.build :tasks_task_plan, cloned_from: task_plan
     clone.ecosystem = nil
-    expect(clone.valid?).to eq true
+
+    # Need to run UpdateTaskPlanEcosystem to be valid
+    expect(clone).not_to be_valid
     expect(clone.ecosystem).to eq task_plan.ecosystem
   end
 
@@ -143,7 +147,7 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     AddEcosystemToCourse[ecosystem: ecosystem, course: course]
     new_task_plan = FactoryBot.build :tasks_task_plan, owner: course
     new_task_plan.ecosystem = nil
-    expect(new_task_plan.valid?).to eq true
+    expect(new_task_plan).to be_valid
     expect(new_task_plan.ecosystem).to eq ecosystem
   end
 

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -21,7 +21,7 @@ VCR::Configuration.class_exec do
 
 
       # If the secret value is inside a URL, it will be URL encoded which means it
-      # may be different from value.  Handle this.
+      # may be different from value. Handle this.
       url_secret_value = CGI::escape(secret_value)
       if secret_value != url_secret_value
         filter_sensitive_data("<#{secret_name}_url>") { url_secret_value }
@@ -36,6 +36,8 @@ VCR.configure do |c|
   c.configure_rspec_metadata!
   c.allow_http_connections_when_no_cassette = false
   c.ignore_localhost = true
+  c.ignore_request { |request| Addressable::URI.parse(request.uri).path == '/oauth/token' } \
+    if Rails.env.development?
   c.preserve_exact_body_bytes { |http_message| !http_message.body.valid_encoding? }
 
   # Turn on debug logging, works in Travis too tho in full runs results
@@ -76,5 +78,5 @@ end
 VCR_OPTS = {
   # This should default to :none
   record: ENV.fetch('VCR_OPTS_RECORD', :none).to_sym,
-  allow_unused_http_interactions: false
+  allow_unused_http_interactions: Rails.env.development?
 }


### PR DESCRIPTION
Also adds old content to existing cloned courses to fix existing issues

Need to test this with the FE to see if cloned_from_id is being set properly for assignments.