### PR TITLE
fix namespace of tasks

### DIFF
--- a/app/controllers/api/v1/tasking_plans_controller.rb
+++ b/app/controllers/api/v1/tasking_plans_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::TaskingPlansController < Api::V1::ApiController
     #{json_schema(Api::V1::TaskPlan::TaskingPlanRepresenter, include: :readable)}
   EOS
   def grade
-    tasking_plan = Tasks::Models::TaskingPlan.find params[:id]
+    tasking_plan = ::Tasks::Models::TaskingPlan.find params[:id]
 
     OSU::AccessPolicy.require_action_allowed!(:grade, current_api_user, tasking_plan)
 


### PR DESCRIPTION
Found another one here, probably a side effect of load order from the Puma switch.