### PR TITLE
Fixed exercises that require context

### DIFF
--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -161,11 +161,8 @@ class Content::ImportBook
 
     # Transform links to point to the Tutor book etc
     ordered_pages = run(
-      :transform_and_cache_content, book: book, pages: ordered_pages, save: false
+      :transform_and_cache_content, book: book, pages: ordered_pages
     ).outputs.pages
-
-    # Pages are large enough that saving them individually seems faster than importing
-    ordered_pages.each(&:save!)
 
     outputs.book = book
     outputs.pages = ordered_pages

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -33,6 +33,13 @@ class Content::Models::Exercise < IndestructibleRecord
         ).arel.exists
     )
   end
+  scope :requires_context, -> do
+    where(
+      Content::Models::Tag.requires_context.joins(:exercise_tags).where(
+        '"content_exercise_tags"."content_exercise_id" = "content_exercises"."id"'
+      ).arel.exists
+    )
+  end
 
   def parser
     @parser ||= OpenStax::Exercises::V1::Exercise.new content: content

--- a/app/subsystems/content/models/tag.rb
+++ b/app/subsystems/content/models/tag.rb
@@ -19,7 +19,7 @@ class Content::Models::Tag < IndestructibleRecord
   validates :value, presence: true
   validates :tag_type, presence: true
 
-  before_save :update_tag_type_data_and_visible
+  before_validation :update_tag_type, :update_data_and_visible
 
   IMPORT_TAG_TYPES  = Set[ :lo, :aplo, :cnxmod ]
   MAPPING_TAG_TYPE = :lo
@@ -41,10 +41,11 @@ class Content::Models::Tag < IndestructibleRecord
     MAPPING_TAG_TYPE == tag_type.to_sym
   end
 
-  protected
-
-  def update_tag_type_data_and_visible
+  def update_tag_type
     self.tag_type = Tagger.get_type(value) if tag_type.nil? || generic?
+  end
+
+  def update_data_and_visible
     self.data = Tagger.get_data(tag_type, value) if data.nil?
     self.visible = VISIBLE_TAG_TYPES.include?(tag_type.to_sym) if visible.nil?
   end

--- a/app/subsystems/content/routines/import_exercises.rb
+++ b/app/subsystems/content/routines/import_exercises.rb
@@ -24,25 +24,6 @@ class Content::Routines::ImportExercises
         # This could happen, for example, if a manifest for a different environment is imported
         next if exercise_page.nil?
 
-        # Assign exercise context if required
-        if wrapper.requires_context?
-          feature_ids = wrapper.feature_ids(exercise_page.uuid)
-          wrapper.context = exercise_page.context_for_feature_ids(feature_ids)
-
-          if wrapper.context.blank?
-            if feature_ids.empty?
-              Rails.logger.warn do
-                "Exercise #{wrapper.uid} requires context but it has no feature ID tags"
-              end
-            else
-              Rails.logger.warn do
-                "Exercise #{wrapper.uid} requires context but its feature ID(s) [ #{
-                  feature_ids.join(', ')} ] could not be found on #{exercise_page.url}"
-              end
-            end
-          end
-        end
-
         wrapper_to_exercise_page_map[wrapper] = exercise_page
       end
 

--- a/app/subsystems/content/routines/tag_resource.rb
+++ b/app/subsystems/content/routines/tag_resource.rb
@@ -27,6 +27,7 @@ class Content::Routines::TagResource
       next if attrs.nil?
 
       tag.attributes = attrs.slice(:name, :description, :tag_type)
+      tag.update_tag_type
       tag
     end.compact
 
@@ -38,7 +39,10 @@ class Content::Routines::TagResource
     new_tags = new_attributes.map do |hash|
       Content::Models::Tag.new(
         hash.slice(:value, :name, :description, :tag_type).merge(ecosystem: ecosystem)
-      )
+      ).tap do |tag|
+        tag.update_tag_type
+        tag.update_data_and_visible
+      end
     end
 
     outputs.tags = existing_tags + new_tags

--- a/lib/openstax/exercises/v1/exercise.rb
+++ b/lib/openstax/exercises/v1/exercise.rb
@@ -99,12 +99,6 @@ class OpenStax::Exercises::V1::Exercise
     @import_tags ||= import_tag_hashes.map { |hash| hash[:value] }
   end
 
-  def feature_ids(page_uuid)
-    feature_tag_start = 'context-cnxfeature:'
-    feature_tags = cnxfeatures.select { |tag| tag.start_with? feature_tag_start }
-    feature_tags.map{ |tag| tag.sub(feature_tag_start, '') }
-  end
-
   def questions
     @questions ||= content_hash['questions']
   end

--- a/spec/routines/demo/assign_spec.rb
+++ b/spec/routines/demo/assign_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Demo::Assign, type: :routine do
 
       expected_num_steps = case task_plan.type
       when 'reading'
-        [ 15, 16 ]
+        [ 14, 15 ]
       when 'homework'
         [ 6 ]
       when 'external'

--- a/spec/subsystems/content/models/tag_spec.rb
+++ b/spec/subsystems/content/models/tag_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Content::Models::Tag, type: :model do
   it { is_expected.to have_many(:exercise_tags).dependent(:destroy) }
 
   it { is_expected.to validate_presence_of(:value) }
-  it { is_expected.to validate_presence_of(:tag_type) }
 
   it 'returns the book location information' do
     expect(tag.book_location).to eq([4, 1])

--- a/spec/subsystems/content/routines/transform_and_cache_page_content_spec.rb
+++ b/spec/subsystems/content/routines/transform_and_cache_page_content_spec.rb
@@ -2,313 +2,71 @@ require 'rails_helper'
 require 'vcr_helper'
 
 RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine do
-  before(:all) do
-    cnx_page_1 = OpenStax::Cnx::V1::Page.new(
-      id: '102e9604-daa7-4a09-9f9e-232251d1a4ee@7',
-      title: 'Physical Quantities and Units'
-    )
-    cnx_page_2 = OpenStax::Cnx::V1::Page.new(
-      id: '127f63f7-d67f-4710-8625-2b1d4128ef6b@2',
-      title: "Introduction to Electric Current, Resistance, and Ohm's Law"
-    )
+  context 'with real content' do
+    before(:all) do
+      cnx_page_1 = OpenStax::Cnx::V1::Page.new(
+        id: '102e9604-daa7-4a09-9f9e-232251d1a4ee@7',
+        title: 'Physical Quantities and Units'
+      )
+      cnx_page_2 = OpenStax::Cnx::V1::Page.new(
+        id: '127f63f7-d67f-4710-8625-2b1d4128ef6b@2',
+        title: "Introduction to Electric Current, Resistance, and Ohm's Law"
+      )
 
-    @book = FactoryBot.create :content_book
+      @book = FactoryBot.create :content_book
 
-    @pages = OpenStax::Cnx::V1.with_archive_url('https://archive.cnx.org/contents/') do
-      VCR.use_cassette("Content_Routines_TransformAndCachePageContent/with_book", VCR_OPTS) do
-        [
-          Content::Routines::ImportPage[cnx_page: cnx_page_1, book: @book, book_indices: [1, 2]],
-          Content::Routines::ImportPage[cnx_page: cnx_page_2, book: @book, book_indices: [20, 0]]
-        ]
+      @pages = OpenStax::Cnx::V1.with_archive_url('https://archive.cnx.org/contents/') do
+        VCR.use_cassette("Content_Routines_TransformAndCachePageContent/with_book", VCR_OPTS) do
+          [
+            Content::Routines::ImportPage[
+              cnx_page: cnx_page_1,
+              book: @book,
+              book_indices: [1, 2]
+            ],
+            Content::Routines::ImportPage[
+              cnx_page: cnx_page_2,
+              book: @book,
+              book_indices: [20, 0]
+            ]
+          ]
+        end
       end
+      @page_1 = @pages.first
+      @page_2 = @pages.second
     end
-    @page_1 = @pages.first
-    @page_2 = @pages.second
-  end
 
-  ORIGINAL_HREFS = [
-    'https://cnx.org/contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@2',
-    'https://cnx.org/contents/4bba6a1c-a0e6-45c0-988c-0d5c23425670@7',
-    'https://cnx.org/contents/aaf30a54-a356-4c5f-8c0d-2f55e4d20556@3'
-  ]
-
-  let(:link_text) do
-    [
-      "Introduction to Electric Current, Resistance, and Ohm's Law",
-      'Accuracy, Precision, and Significant Figures',
-      'Appendix A'
+    ORIGINAL_HREFS = [
+      'https://cnx.org/contents/127f63f7-d67f-4710-8625-2b1d4128ef6b@2',
+      'https://cnx.org/contents/4bba6a1c-a0e6-45c0-988c-0d5c23425670@7',
+      'https://cnx.org/contents/aaf30a54-a356-4c5f-8c0d-2f55e4d20556@3'
     ]
-  end
 
-  before { @page_1.reload }
+    let(:link_text) do
+      [
+        "Introduction to Electric Current, Resistance, and Ohm's Law",
+        'Accuracy, Precision, and Significant Figures',
+        'Appendix A'
+      ]
+    end
 
-  [
-    'http://cnx.org', 'http://archive.cnx.org', 'https://cnx.org', 'https://archive.cnx.org', ''
-  ].each do |link_prefix|
-    context "#{link_prefix.blank? ? 'no' : link_prefix} link prefix" do
-      before(:all) do
-        DatabaseCleaner.start
+    before { @page_1.reload }
 
-        @link_prefix_hrefs = ORIGINAL_HREFS.map do |original_href|
-          original_href.sub 'https://cnx.org', link_prefix
-        end
-        @pages.each do |page|
-          page.url.sub! 'https://cnx.org', link_prefix
-
-          ORIGINAL_HREFS.each_with_index do |original_href, index|
-            page.content.gsub! original_href, @link_prefix_hrefs[index]
-          end
-
-          page.save!
-        end
-      end
-      after(:all)  do
-        DatabaseCleaner.clean
-
-        @pages.each(&:reload)
-      end
-
-      context 'with simple ToC urls' do
-        context 'with versions' do
-          let(:before_hrefs)     { @link_prefix_hrefs }
-
-          let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}@#{@book.version}" }
-
-          context 'page links' do
-            context 'simple' do
-              let(:after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + before_hrefs[1..-1]
-              end
-
-              it 'updates page links in content to relative urls if the pages are in same book' do
-                doc = Nokogiri::HTML(@page_1.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq before_hrefs[index]
-                end
-
-                described_class.call(book: @book)
-                @pages.each(&:save!)
-
-                doc = Nokogiri::HTML(@page_1.reload.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq after_hrefs[index]
-                end
-              end
-            end
-
-            context 'composite' do
-              let(:composite_before_hrefs) do
-                before_hrefs.map do |href|
-                  href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
-                end
-              end
-
-              let(:composite_after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + composite_before_hrefs[1..-1]
-              end
-
-              before do
-                before_hrefs.each_with_index do |href, index|
-                  @page_1.content.gsub! href, composite_before_hrefs[index]
-                end
-
-                @page_1.save!
-              end
-
-              it 'updates page links in content to relative urls if the pages are in same book' do
-                doc = Nokogiri::HTML(@page_1.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_before_hrefs[index]
-                end
-
-                described_class.call(book: @book)
-                @pages.each(&:save!)
-
-                doc = Nokogiri::HTML(@page_1.reload.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_after_hrefs[index]
-                end
-              end
-            end
-          end
-
-          context 'book links' do
-            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
-
-            before do
-              before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
-
-              @page_1.save!
-            end
-
-            it 'updates links to the current book in content to relative urls' do
-              doc = Nokogiri::HTML(@page_1.content)
-
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_before_href
-              end
-
-              described_class.call(book: @book)
-              @pages.each(&:save!)
-
-              doc = Nokogiri::HTML(@page_1.reload.content)
-
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_after_href
-              end
-            end
-          end
-        end
-
-        context 'without versions' do
-          before(:all) do
-            DatabaseCleaner.start
-
-            @before_hrefs = @link_prefix_hrefs.map do |link_prefix_href|
-              link_prefix_href.split('@').first
-            end
-            @pages.each do |page|
-              page.reload
-
-              @link_prefix_hrefs.each_with_index do |link_prefix_href, index|
-                page.content.gsub! link_prefix_href, @before_hrefs[index]
-              end
-
-              page.save!
-            end
-          end
-          after(:all)  do
-            DatabaseCleaner.clean
-
-            @pages.each(&:reload)
-          end
-
-          let(:before_hrefs)     { @before_hrefs }
-
-          let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}" }
-
-          context 'page links' do
-            context 'simple' do
-              let(:after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + before_hrefs[1..-1]
-              end
-
-              it 'updates page links in content to relative urls if the pages are in same book' do
-                doc = Nokogiri::HTML(@page_1.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq before_hrefs[index]
-                end
-
-                described_class.call(book: @book)
-                @pages.each(&:save!)
-
-                doc = Nokogiri::HTML(@page_1.reload.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq after_hrefs[index]
-                end
-              end
-            end
-
-            context 'composite' do
-              let(:composite_before_hrefs) do
-                before_hrefs.map do |href|
-                  href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
-                end
-              end
-
-              let(:composite_after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + composite_before_hrefs[1..-1]
-              end
-
-              before do
-                before_hrefs.each_with_index do |href, index|
-                  @page_1.content.gsub! href, composite_before_hrefs[index]
-                end
-
-                @page_1.save!
-              end
-
-              it 'updates page links in content to relative urls if the pages are in same book' do
-                doc = Nokogiri::HTML(@page_1.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_before_hrefs[index]
-                end
-
-                described_class.call(book: @book)
-                @pages.each(&:save!)
-
-                doc = Nokogiri::HTML(@page_1.reload.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_after_hrefs[index]
-                end
-              end
-            end
-          end
-
-          context 'book links' do
-            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
-
-            before do
-              before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
-
-              @page_1.save!
-            end
-
-            it 'updates links to the current book in content to relative urls' do
-              doc = Nokogiri::HTML(@page_1.content)
-
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_before_href
-              end
-
-              described_class.call(book: @book)
-              @pages.each(&:save!)
-
-              doc = Nokogiri::HTML(@page_1.reload.content)
-
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_after_href
-              end
-            end
-          end
-        end
-      end
-
-      context 'with composite ToC urls' do
+    [
+      'http://cnx.org', 'http://archive.cnx.org', 'https://cnx.org', 'https://archive.cnx.org', ''
+    ].each do |link_prefix|
+      context "#{link_prefix.blank? ? 'no' : link_prefix} link prefix" do
         before(:all) do
           DatabaseCleaner.start
 
+          @link_prefix_hrefs = ORIGINAL_HREFS.map do |original_href|
+            original_href.sub 'https://cnx.org', link_prefix
+          end
           @pages.each do |page|
-            page.url.sub! "#{page.uuid}@#{page.version}",
-                          "#{@book.uuid}@#{@book.version}:#{page.uuid}@#{page.version}"
+            page.url.sub! 'https://cnx.org', link_prefix
+
+            ORIGINAL_HREFS.each_with_index do |original_href, index|
+              page.content.gsub! original_href, @link_prefix_hrefs[index]
+            end
 
             page.save!
           end
@@ -319,66 +77,97 @@ RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine d
           @pages.each(&:reload)
         end
 
-        context 'with versions' do
-          let(:before_hrefs)     { @link_prefix_hrefs }
+        context 'with simple ToC urls' do
+          context 'with versions' do
+            let(:before_hrefs)     { @link_prefix_hrefs }
 
-          let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}@#{@book.version}" }
+            let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}@#{@book.version}" }
 
-          context 'page links' do
-            context 'simple' do
-              let(:after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + before_hrefs[1..-1]
-              end
-
-              it 'updates page links in content to relative urls if the pages are in same book' do
-                doc = Nokogiri::HTML(@page_1.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq before_hrefs[index]
+            context 'page links' do
+              context 'simple' do
+                let(:after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + before_hrefs[1..-1]
                 end
 
-                described_class.call(book: @book)
-                @pages.each(&:save!)
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
 
-                doc = Nokogiri::HTML(@page_1.reload.content)
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq before_hrefs[index]
+                  end
 
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq after_hrefs[index]
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq after_hrefs[index]
+                  end
+                end
+              end
+
+              context 'composite' do
+                let(:composite_before_hrefs) do
+                  before_hrefs.map do |href|
+                    href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
+                  end
+                end
+
+                let(:composite_after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + composite_before_hrefs[1..-1]
+                end
+
+                before do
+                  before_hrefs.each_with_index do |href, index|
+                    @page_1.content.gsub! href, composite_before_hrefs[index]
+                  end
+
+                  @page_1.save!
+                end
+
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_before_hrefs[index]
+                  end
+
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_after_hrefs[index]
+                  end
                 end
               end
             end
 
-            context 'composite' do
-              let(:composite_before_hrefs) do
-                before_hrefs.map do |href|
-                  href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
-                end
-              end
-
-              let(:composite_after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + composite_before_hrefs[1..-1]
-              end
+            context 'book links' do
+              let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
 
               before do
-                before_hrefs.each_with_index do |href, index|
-                  @page_1.content.gsub! href, composite_before_hrefs[index]
-                end
+                before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
 
                 @page_1.save!
               end
 
-              it 'updates page links in content to relative urls if the pages are in same book' do
+              it 'updates links to the current book in content to relative urls' do
                 doc = Nokogiri::HTML(@page_1.content)
 
-                link_text.each_with_index do |value, index|
+                link_text.each do |value|
                   link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_before_hrefs[index]
+                  expect(link.attribute('href').value).to eq book_before_href
                 end
 
                 described_class.call(book: @book)
@@ -386,57 +175,149 @@ RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine d
 
                 doc = Nokogiri::HTML(@page_1.reload.content)
 
-                link_text.each_with_index do |value, index|
+                link_text.each do |value|
                   link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_after_hrefs[index]
+                  expect(link.attribute('href').value).to eq book_after_href
                 end
               end
             end
           end
 
-          context 'book links' do
-            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
+          context 'without versions' do
+            before(:all) do
+              DatabaseCleaner.start
 
-            before do
-              before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
+              @before_hrefs = @link_prefix_hrefs.map do |link_prefix_href|
+                link_prefix_href.split('@').first
+              end
+              @pages.each do |page|
+                page.reload
 
-              @page_1.save!
+                @link_prefix_hrefs.each_with_index do |link_prefix_href, index|
+                  page.content.gsub! link_prefix_href, @before_hrefs[index]
+                end
+
+                page.save!
+              end
+            end
+            after(:all)  do
+              DatabaseCleaner.clean
+
+              @pages.each(&:reload)
             end
 
-            it 'updates links to the current book in content to relative urls' do
-              doc = Nokogiri::HTML(@page_1.content)
+            let(:before_hrefs)     { @before_hrefs }
 
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_before_href
+            let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}" }
+
+            context 'page links' do
+              context 'simple' do
+                let(:after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + before_hrefs[1..-1]
+                end
+
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq before_hrefs[index]
+                  end
+
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq after_hrefs[index]
+                  end
+                end
               end
 
-              described_class.call(book: @book)
-              @pages.each(&:save!)
+              context 'composite' do
+                let(:composite_before_hrefs) do
+                  before_hrefs.map do |href|
+                    href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
+                  end
+                end
 
-              doc = Nokogiri::HTML(@page_1.reload.content)
+                let(:composite_after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + composite_before_hrefs[1..-1]
+                end
 
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_after_href
+                before do
+                  before_hrefs.each_with_index do |href, index|
+                    @page_1.content.gsub! href, composite_before_hrefs[index]
+                  end
+
+                  @page_1.save!
+                end
+
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_before_hrefs[index]
+                  end
+
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_after_hrefs[index]
+                  end
+                end
+              end
+            end
+
+            context 'book links' do
+              let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
+
+              before do
+                before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
+
+                @page_1.save!
+              end
+
+              it 'updates links to the current book in content to relative urls' do
+                doc = Nokogiri::HTML(@page_1.content)
+
+                link_text.each do |value|
+                  link = doc.xpath("//a[text()=\"#{value}\"]").first
+                  expect(link.attribute('href').value).to eq book_before_href
+                end
+
+                described_class.call(book: @book)
+                @pages.each(&:save!)
+
+                doc = Nokogiri::HTML(@page_1.reload.content)
+
+                link_text.each do |value|
+                  link = doc.xpath("//a[text()=\"#{value}\"]").first
+                  expect(link.attribute('href').value).to eq book_after_href
+                end
               end
             end
           end
         end
 
-        context 'without versions' do
+        context 'with composite ToC urls' do
           before(:all) do
             DatabaseCleaner.start
 
-            @before_hrefs = @link_prefix_hrefs.map do |link_prefix_href|
-              link_prefix_href.split('@').first
-            end
             @pages.each do |page|
-              page.reload
-
-              @link_prefix_hrefs.each_with_index do |link_prefix_href, index|
-                page.content.gsub! link_prefix_href, @before_hrefs[index]
-              end
+              page.url.sub! "#{page.uuid}@#{page.version}",
+                            "#{@book.uuid}@#{@book.version}:#{page.uuid}@#{page.version}"
 
               page.save!
             end
@@ -447,65 +328,96 @@ RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine d
             @pages.each(&:reload)
           end
 
-          let(:before_hrefs)     { @before_hrefs }
+          context 'with versions' do
+            let(:before_hrefs)     { @link_prefix_hrefs }
 
-          let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}" }
+            let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}@#{@book.version}" }
 
-          context 'page links' do
-            context 'simple' do
-              let(:after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + before_hrefs[1..-1]
-              end
-
-              it 'updates page links in content to relative urls if the pages are in same book' do
-                doc = Nokogiri::HTML(@page_1.content)
-
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq before_hrefs[index]
+            context 'page links' do
+              context 'simple' do
+                let(:after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + before_hrefs[1..-1]
                 end
 
-                described_class.call(book: @book)
-                @pages.each(&:save!)
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
 
-                doc = Nokogiri::HTML(@page_1.reload.content)
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq before_hrefs[index]
+                  end
 
-                link_text.each_with_index do |value, index|
-                  link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq after_hrefs[index]
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq after_hrefs[index]
+                  end
+                end
+              end
+
+              context 'composite' do
+                let(:composite_before_hrefs) do
+                  before_hrefs.map do |href|
+                    href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
+                  end
+                end
+
+                let(:composite_after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + composite_before_hrefs[1..-1]
+                end
+
+                before do
+                  before_hrefs.each_with_index do |href, index|
+                    @page_1.content.gsub! href, composite_before_hrefs[index]
+                  end
+
+                  @page_1.save!
+                end
+
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_before_hrefs[index]
+                  end
+
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_after_hrefs[index]
+                  end
                 end
               end
             end
 
-            context 'composite' do
-              let(:composite_before_hrefs) do
-                before_hrefs.map do |href|
-                  href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
-                end
-              end
-
-              let(:composite_after_hrefs) do
-                [
-                  "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
-                ] + composite_before_hrefs[1..-1]
-              end
+            context 'book links' do
+              let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
 
               before do
-                before_hrefs.each_with_index do |href, index|
-                  @page_1.content.gsub! href, composite_before_hrefs[index]
-                end
+                before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
 
                 @page_1.save!
               end
 
-              it 'updates page links in content to relative urls if the pages are in same book' do
+              it 'updates links to the current book in content to relative urls' do
                 doc = Nokogiri::HTML(@page_1.content)
 
-                link_text.each_with_index do |value, index|
+                link_text.each do |value|
                   link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_before_hrefs[index]
+                  expect(link.attribute('href').value).to eq book_before_href
                 end
 
                 described_class.call(book: @book)
@@ -513,42 +425,217 @@ RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine d
 
                 doc = Nokogiri::HTML(@page_1.reload.content)
 
-                link_text.each_with_index do |value, index|
+                link_text.each do |value|
                   link = doc.xpath("//a[text()=\"#{value}\"]").first
-                  expect(link.attribute('href').value).to eq composite_after_hrefs[index]
+                  expect(link.attribute('href').value).to eq book_after_href
                 end
               end
             end
           end
 
-          context 'book links' do
-            let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
+          context 'without versions' do
+            before(:all) do
+              DatabaseCleaner.start
 
-            before do
-              before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
+              @before_hrefs = @link_prefix_hrefs.map do |link_prefix_href|
+                link_prefix_href.split('@').first
+              end
+              @pages.each do |page|
+                page.reload
 
-              @page_1.save!
+                @link_prefix_hrefs.each_with_index do |link_prefix_href, index|
+                  page.content.gsub! link_prefix_href, @before_hrefs[index]
+                end
+
+                page.save!
+              end
+            end
+            after(:all)  do
+              DatabaseCleaner.clean
+
+              @pages.each(&:reload)
             end
 
-            it 'updates links to the current book in content to relative urls' do
-              doc = Nokogiri::HTML(@page_1.content)
+            let(:before_hrefs)     { @before_hrefs }
 
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_before_href
+            let(:book_before_href) { "#{link_prefix}/contents/#{@book.uuid}" }
+
+            context 'page links' do
+              context 'simple' do
+                let(:after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + before_hrefs[1..-1]
+                end
+
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq before_hrefs[index]
+                  end
+
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq after_hrefs[index]
+                  end
+                end
               end
 
-              described_class.call(book: @book)
-              @pages.each(&:save!)
+              context 'composite' do
+                let(:composite_before_hrefs) do
+                  before_hrefs.map do |href|
+                    href.sub "#{link_prefix}/contents/", "#{book_before_href}:"
+                  end
+                end
 
-              doc = Nokogiri::HTML(@page_1.reload.content)
+                let(:composite_after_hrefs) do
+                  [
+                    "/book/#{@book.ecosystem.id}/page/#{@page_2.id}"
+                  ] + composite_before_hrefs[1..-1]
+                end
 
-              link_text.each do |value|
-                link = doc.xpath("//a[text()=\"#{value}\"]").first
-                expect(link.attribute('href').value).to eq book_after_href
+                before do
+                  before_hrefs.each_with_index do |href, index|
+                    @page_1.content.gsub! href, composite_before_hrefs[index]
+                  end
+
+                  @page_1.save!
+                end
+
+                it 'updates page links in content to relative urls if the pages are in same book' do
+                  doc = Nokogiri::HTML(@page_1.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_before_hrefs[index]
+                  end
+
+                  described_class.call(book: @book)
+                  @pages.each(&:save!)
+
+                  doc = Nokogiri::HTML(@page_1.reload.content)
+
+                  link_text.each_with_index do |value, index|
+                    link = doc.xpath("//a[text()=\"#{value}\"]").first
+                    expect(link.attribute('href').value).to eq composite_after_hrefs[index]
+                  end
+                end
+              end
+            end
+
+            context 'book links' do
+              let(:book_after_href) { "/book/#{@book.ecosystem.id}" }
+
+              before do
+                before_hrefs.each { |href| @page_1.content.gsub! href, book_before_href }
+
+                @page_1.save!
+              end
+
+              it 'updates links to the current book in content to relative urls' do
+                doc = Nokogiri::HTML(@page_1.content)
+
+                link_text.each do |value|
+                  link = doc.xpath("//a[text()=\"#{value}\"]").first
+                  expect(link.attribute('href').value).to eq book_before_href
+                end
+
+                described_class.call(book: @book)
+                @pages.each(&:save!)
+
+                doc = Nokogiri::HTML(@page_1.reload.content)
+
+                link_text.each do |value|
+                  link = doc.xpath("//a[text()=\"#{value}\"]").first
+                  expect(link.attribute('href').value).to eq book_after_href
+                end
               end
             end
           end
+        end
+      end
+    end
+  end
+
+  context 'with custom tags' do
+    let(:exercise_tags_array) do
+      [
+        ['k12phys-ch03-s01-lo01', 'context-cnxmod:0e58aa87-2e09-40a7-8bf3-269b2fa16509'],
+        ['k12phys-ch03-s01-lo01', 'context-cnxmod:0e58aa87-2e09-40a7-8bf3-269b2fa16509',
+         'context-cnxfeature:fs-idp56122560'],
+        ['k12phys-ch03-s01-lo01', 'context-cnxmod:0e58aa87-2e09-40a7-8bf3-269b2fa16509',
+         'context-cnxfeature:fs-idp56122560', 'requires-context:y'],
+        ['k12phys-ch03-s01-lo02', 'context-cnxmod:0e58aa87-2e09-40a7-8bf3-269b2fa16509',
+         'context-cnxfeature:fs-idp42721584', 'requires-context:true'],
+      ]
+    end
+
+    let(:wrappers) do
+      exercise_tags_array.each_with_index.map do |exercise_tags, index|
+        options = { number: index + 1, version: 1, tags: exercise_tags }
+        content_hash = OpenStax::Exercises::V1::FakeClient.new_exercise_hash(options)
+
+        OpenStax::Exercises::V1::Exercise.new(content: content_hash.to_json)
+      end
+    end
+
+    let(:expected_context_node_ids) do
+      [nil, nil, 'fs-idp56122560', 'fs-idp42721584']
+    end
+
+    before(:all) do
+      @book = FactoryBot.create :content_book
+
+      @ecosystem = @book.ecosystem
+
+      cnx_page = OpenStax::Cnx::V1::Page.new(
+        id: '0e58aa87-2e09-40a7-8bf3-269b2fa16509', title: 'Acceleration'
+      )
+
+      @page = VCR.use_cassette('Content_Routines_ImportExercises/with_custom_tags', VCR_OPTS) do
+        Content::Routines::ImportPage[
+          cnx_page: cnx_page,
+          book: @book,
+          book_indices: [3, 1]
+        ]
+      end
+    end
+
+    before do
+      expect(OpenStax::Exercises::V1).to receive(:exercises).once do |_, &block|
+        block.call(wrappers)
+      end
+
+      Content::Routines::ImportExercises.call(
+        ecosystem: @ecosystem,
+        page: @page,
+        query_hash: { tag: ['k12phys-ch03-s01-lo01', 'k12phys-ch03-s01-lo02'] }
+      )
+
+      Content::Routines::PopulateExercisePools.call book: @book
+    end
+
+    it 'assigns context for exercises that require context' do
+      imported_exercises = @ecosystem.exercises.order(:number).to_a
+      imported_exercises.each { |ex| expect(ex.context).to be_nil }
+
+      expect { described_class.call book: @book }.not_to change { Content::Models::Exercise.count }
+
+      imported_exercises.map(&:reload).each_with_index do |exercise, index|
+        expected_context_node_id = expected_context_node_ids[index]
+
+        if expected_context_node_id.nil?
+          expect(exercise.context).to be_nil
+        else
+          context_node = Nokogiri::HTML.fragment(exercise.context).children.first
+          expect(context_node.attr('id')).to eq expected_context_node_id
         end
       end
     end


### PR DESCRIPTION
I had to move the context population to after page fragments are cached. Which has to happen after the exercise pools are populated.