### PR TITLE
add viewport scale meta tag

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -3,6 +3,7 @@
 <head>
   <title>OpenStax Tutor</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='https://c.la2-c2-dfw.salesforceliveagent.com/content/g/js/39.0/deployment.js'></script>
   <script type='text/javascript' src='<%= Tutor::Assets::Scripts[:tutor] %>' async></script>


### PR DESCRIPTION
 Is good practice to have them but these are needed to make media queries work correctly with the chrome mobile emulator. I wasted a lot of time debugging why `@media` never updated on https://github.com/openstax/tutor-js/pull/3007  


