### PR TITLE
Lock Rating records that are about to be upserted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - TAG=speed:slow
     - TAG=~speed:slow
     - ASSETS=true
-    - LINT=true
 rvm: 2.6.1
 cache: bundler
 before_install:
@@ -26,7 +25,6 @@ bundler_args: --without production --retry=6
 before_script:
   - bundle exec rake parallel:create parallel:load_schema parallel:seed --trace
 script:
-  - "[[ -n $LINT ]] && bundle exec rake lint:branch || [[ -z $LINT ]]"
   - "[[ -n $ASSETS ]] && bundle exec rake assets:precompile || [[ -z $ASSETS ]]"
   - >-
       [[ -n $TAG ]] && bundle exec parallel_rspec ./spec --test-options "--tag $TAG" ||

--- a/app/routines/ratings/update_period_book_parts.rb
+++ b/app/routines/ratings/update_period_book_parts.rb
@@ -67,7 +67,7 @@ class Ratings::UpdatePeriodBookParts
   end
 
   def update_period_book_part(period:, book_part_uuid:, tasked_exercises:, is_page:, current_time:)
-    period_book_part = Ratings::PeriodBookPart.find_or_initialize_by(
+    period_book_part = Ratings::PeriodBookPart.lock.find_or_initialize_by(
       period: period, book_part_uuid: book_part_uuid
     ) { |period_book_part| period_book_part.is_page = is_page }
 

--- a/app/routines/ratings/update_period_book_parts.rb
+++ b/app/routines/ratings/update_period_book_parts.rb
@@ -68,7 +68,7 @@ class Ratings::UpdatePeriodBookParts
 
   def update_period_book_part(period:, book_part_uuid:, tasked_exercises:, is_page:, current_time:)
     period_book_part = Ratings::PeriodBookPart
-      .lock('FOR NO KEY UPDATE NO WAIT')
+      .lock('FOR NO KEY UPDATE NOWAIT')
       .find_or_initialize_by(period: period, book_part_uuid: book_part_uuid) do |period_book_part|
       period_book_part.is_page = is_page
     end

--- a/app/routines/ratings/update_role_book_parts.rb
+++ b/app/routines/ratings/update_role_book_parts.rb
@@ -95,7 +95,7 @@ class Ratings::UpdateRoleBookParts
     update_exercises:,
     current_time:
   )
-    role_book_part = Ratings::RoleBookPart.find_or_initialize_by(
+    role_book_part = Ratings::RoleBookPart.lock.find_or_initialize_by(
       role: role, book_part_uuid: book_part_uuid
     ) { |role_book_part| role_book_part.is_page = is_page }
 
@@ -117,7 +117,9 @@ class Ratings::UpdateRoleBookParts
         .pluck(:group_uuid) + new_tasked_exercises.map(&:group_uuid)
     ).uniq
 
-    exercise_group_book_parts_by_group_uuid = Ratings::ExerciseGroupBookPart.where(
+    exercise_group_book_part_rel = Ratings::ExerciseGroupBookPart
+    exercise_group_book_part_rel = exercise_group_book_part_rel.lock if update_exercises
+    exercise_group_book_parts_by_group_uuid = exercise_group_book_part_rel.where(
       book_part_uuid: book_part_uuid
     ).index_by(&:exercise_group_uuid)
     exercise_group_uuids.each do |exercise_group_uuid|

--- a/app/routines/ratings/update_role_book_parts.rb
+++ b/app/routines/ratings/update_role_book_parts.rb
@@ -95,7 +95,7 @@ class Ratings::UpdateRoleBookParts
     update_exercises:,
     current_time:
   )
-    role_book_part = Ratings::RoleBookPart.lock('FOR NO KEY UPDATE NO WAIT').find_or_initialize_by(
+    role_book_part = Ratings::RoleBookPart.lock('FOR NO KEY UPDATE NOWAIT').find_or_initialize_by(
       role: role, book_part_uuid: book_part_uuid
     ) { |role_book_part| role_book_part.is_page = is_page }
 
@@ -119,7 +119,7 @@ class Ratings::UpdateRoleBookParts
 
     exercise_group_book_part_rel = Ratings::ExerciseGroupBookPart
     exercise_group_book_part_rel = exercise_group_book_part_rel.lock(
-      'FOR NO KEY UPDATE NO WAIT'
+      'FOR NO KEY UPDATE NOWAIT'
     ) if update_exercises
     exercise_group_book_parts_by_group_uuid = exercise_group_book_part_rel.where(
       book_part_uuid: book_part_uuid

--- a/db/background_migrate/20200515140524_initialize_glicko_ratings.rb
+++ b/db/background_migrate/20200515140524_initialize_glicko_ratings.rb
@@ -57,6 +57,7 @@ class InitializeGlickoRatings < ActiveRecord::Migration[5.2]
             task: task,
             role: role,
             period: period,
+            wait: true,
             current_time: current_time,
             queue: 'migration'
           )
@@ -98,6 +99,7 @@ class InitializeGlickoRatings < ActiveRecord::Migration[5.2]
             task: task,
             role: role,
             period: period,
+            wait: true,
             current_time: current_time,
             queue: 'migration'
           )


### PR DESCRIPTION
Block processes instead of doing useless work that ends in a transaction rollback.