### PR TITLE
filter exercise steps by can_be_auto_graded

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -364,10 +364,14 @@ class Tasks::Models::Task < ApplicationRecord
     end
   end
 
+  def manually_graded_steps
+    exercise_steps(preload_taskeds: true).reject {|step| step.tasked.can_be_auto_graded? }
+  end
+
   def manual_grading_feedback_available?
     case manual_grading_feedback_on
     when 'grade'
-      exercise_steps(preload_taskeds: true).any? do |task_step|
+      manually_graded_steps.any? do |task_step|
         task_step.tasked.was_manually_graded?
       end
     when 'publish'
@@ -380,11 +384,11 @@ class Tasks::Models::Task < ApplicationRecord
   def manual_grading_complete?
     case manual_grading_feedback_on
     when 'grade'
-      exercise_steps(preload_taskeds: true).all? do |task_step|
+      manually_graded_steps.all? do |task_step|
         task_step.tasked.was_manually_graded?
       end
     when 'publish'
-      exercise_steps(preload_taskeds: true).all? do |task_step|
+      manually_graded_steps.all? do |task_step|
         task_step.tasked.grade_published?
       end
     else


### PR DESCRIPTION
Filter exercise steps by the tasked's `can_be_auto_graded`. This fixes an issue with is_provisional returning true for non-WRM assignments.