### PR TITLE
Load extensions dynamically from the task_plan

### DIFF
--- a/app/routines/calculate_task_plan_scores.rb
+++ b/app/routines/calculate_task_plan_scores.rb
@@ -6,6 +6,9 @@ class CalculateTaskPlanScores
   def exec(task_plan:)
     current_time = Time.current
 
+    # Preload extensions
+    task_plan.extensions.load
+
     # Preload each task's student and period
     tasks = task_plan.tasks.preload(:time_zone, taskings: { role: :student })
 

--- a/app/routines/dashboard_routine_methods.rb
+++ b/app/routines/dashboard_routine_methods.rb
@@ -23,8 +23,11 @@ module DashboardRoutineMethods
   end
 
   def load_tasks(role, start_at_ntz = nil, end_at_ntz = nil, current_time = Time.current)
-    all_tasks = run(:get_tasks, roles: role, start_at_ntz: start_at_ntz, end_at_ntz: end_at_ntz)
-                  .outputs.tasks.preload(:time_zone, :task_plan, :task_steps).to_a
+    all_tasks = run(
+      :get_tasks, roles: role, start_at_ntz: start_at_ntz, end_at_ntz: end_at_ntz
+    ).outputs.tasks.preload(
+      :time_zone, :task_plan, :task_steps, taskings: { role: :extensions }
+    ).to_a
 
     visible_tasks = all_tasks.reject(&:hidden?)
 

--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -73,7 +73,6 @@ class DistributeTasks
       task.opens_at_ntz = tasking_plan.opens_at_ntz
       task.due_at_ntz = tasking_plan.due_at_ntz
       task.closes_at_ntz = tasking_plan.closes_at_ntz
-      task.extension = task_plan.extensions.to_a.find { |ex| ex.entity_role_id == role_id }
 
       updated_tasks << task if task.changed?
     end

--- a/app/subsystems/tasks/assistants/generic_assistant.rb
+++ b/app/subsystems/tasks/assistants/generic_assistant.rb
@@ -177,9 +177,6 @@ class Tasks::Assistants::GenericAssistant
       opens_at: individualized_tasking_plan.opens_at,
       due_at: individualized_tasking_plan.due_at,
       closes_at: individualized_tasking_plan.closes_at,
-      extension: individualized_tasking_plan.task_plan.extensions.to_a.find do |ex|
-        ex.entity_role_id == role.id
-      end,
       ecosystem: task_plan.ecosystem
     ).tap do |task|
       task.taskings << Tasks::Models::Tasking.new(

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -174,7 +174,7 @@ module Tasks
         .joins(task_plan: :tasking_plans)
         .where(task_type: task_types,task_plan: { withdrawn_at: nil })
         .where(tt[:opens_at_ntz].eq(nil).or tt[:opens_at_ntz].lteq(current_time_ntz))
-        .preload(task_plan: :tasking_plans)
+        .preload(task_plan: [ :tasking_plans, :extensions ])
         .reorder(nil).distinct
 
       if is_teacher

--- a/app/subsystems/tasks/models/extension.rb
+++ b/app/subsystems/tasks/models/extension.rb
@@ -4,8 +4,6 @@ class Tasks::Models::Extension < ApplicationRecord
 
   belongs_to_time_zone :due_at, :closes_at, suffix: :ntz
 
-  has_one :task, inverse_of: :extension
-
   before_validation :set_time_zone
 
   validates :role, uniqueness: { scope: :tasks_task_plan_id }

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -33,8 +33,6 @@ class Tasks::Models::Task < ApplicationRecord
 
   belongs_to :ecosystem, subsystem: :content, inverse_of: :tasks
 
-  belongs_to :extension, optional: true, inverse_of: :task
-
   sortable_has_many :task_steps, on: :number, inverse_of: :task do
     # Because we update task_step counts in the middle of the following methods,
     # we cause the task_steps to reload and these methods behave oddly (giving us duplicate records)
@@ -73,6 +71,33 @@ class Tasks::Models::Task < ApplicationRecord
   before_validation :update_cached_attributes
   after_create :update_caches_now
   after_touch :update_caches_later
+
+  def reload(*args)
+    @extension = nil
+
+    super
+  end
+
+  def extension
+    return @extension unless @extension.nil?
+
+    return if task_plan.nil?
+
+    tasking = taskings.first
+    return if tasking.nil?
+
+    @extension = if task_plan.extensions.loaded?
+      task_plan.extensions.detect do |extension|
+        extension.entity_role_id == tasking.entity_role_id
+      end
+    elsif tasking.association(:role).loaded? && tasking.role.extensions.loaded?
+      tasking.role.extensions.detect do |extension|
+        extension.tasks_task_plan_id == tasks_task_plan_id
+      end
+    else
+      task_plan.extensions.find_by entity_role_id: tasking.entity_role_id
+    end
+  end
 
   def preload_taskeds
     ActiveRecord::Associations::Preloader.new.preload task_steps.to_a, :tasked

--- a/db/migrate/20200324204502_create_tasks_extensions.rb
+++ b/db/migrate/20200324204502_create_tasks_extensions.rb
@@ -13,20 +13,17 @@ class CreateTasksExtensions < ActiveRecord::Migration[5.2]
 
     add_index :tasks_extensions, [ :tasks_task_plan_id, :entity_role_id ], unique: true
 
-    add_reference :tasks_tasks, :tasks_extension,
-                  foreign_key: { on_update: :cascade, on_delete: :nullify }
-
     Tasks::Models::Task.where.not(tasks_task_plan_id: nil)
                        .where.not(accepted_late_at: nil)
                        .where.not(time_zone_id: nil)
-                       .preload(:taskings, :time_zone)
+                       .preload(:task_plan, :time_zone, taskings: :role)
                        .find_in_batches do |tasks|
       extensions = tasks.map do |task|
         accepted_late_at_ntz = task.accepted_late_at.in_time_zone(task.time_zone.name)
 
         Tasks::Models::Extension.new(
-          tasks_task_plan_id: task.tasks_task_plan_id,
-          entity_role_id: task.taskings.first.entity_role_id,
+          task_plan: task.task_plan,
+          role: task.taskings.first.role,
           time_zone: task.time_zone,
           due_at_ntz: [ accepted_late_at_ntz, task.due_at_ntz ].compact.max,
           closes_at_ntz: [ accepted_late_at_ntz, task.closes_at_ntz ].compact.max
@@ -34,10 +31,6 @@ class CreateTasksExtensions < ActiveRecord::Migration[5.2]
       end
 
       Tasks::Models::Extension.import extensions, validate: false
-
-      Tasks::Models::Task.import tasks, validate: false, on_duplicate_key_update: {
-        conflict_target: [ :id ], columns: [ :tasks_extension_id ]
-      }
     end
 
     remove_column :tasks_tasks, :accepted_late_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1022,7 +1022,6 @@ ActiveRecord::Schema.define(version: 2020_05_29_235243) do
     t.datetime "closes_at_ntz"
     t.integer "core_page_ids", default: [], null: false, array: true
     t.datetime "student_history_at"
-    t.bigint "tasks_extension_id"
     t.datetime "grades_last_published_at"
     t.integer "ungraded_step_count", default: 0, null: false
     t.index ["content_ecosystem_id"], name: "index_tasks_tasks_on_content_ecosystem_id"
@@ -1031,7 +1030,6 @@ ActiveRecord::Schema.define(version: 2020_05_29_235243) do
     t.index ["last_worked_at"], name: "index_tasks_tasks_on_last_worked_at"
     t.index ["opens_at_ntz"], name: "index_tasks_tasks_on_opens_at_ntz"
     t.index ["task_type", "created_at"], name: "index_tasks_tasks_on_task_type_and_created_at"
-    t.index ["tasks_extension_id"], name: "index_tasks_tasks_on_tasks_extension_id"
     t.index ["tasks_task_plan_id"], name: "index_tasks_tasks_on_tasks_task_plan_id"
     t.index ["time_zone_id"], name: "index_tasks_tasks_on_time_zone_id"
     t.index ["uuid"], name: "index_tasks_tasks_on_uuid", unique: true
@@ -1180,7 +1178,6 @@ ActiveRecord::Schema.define(version: 2020_05_29_235243) do
   add_foreign_key "tasks_taskings", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_taskings", "tasks_tasks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_tasks", "content_ecosystems", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "tasks_tasks", "tasks_extensions", on_update: :cascade, on_delete: :nullify
   add_foreign_key "tasks_tasks", "tasks_task_plans", on_update: :cascade, on_delete: :cascade
   add_foreign_key "tasks_tasks", "time_zones", on_update: :cascade, on_delete: :nullify
   add_foreign_key "user_administrators", "user_profiles", on_update: :cascade, on_delete: :cascade

--- a/spec/factories/tasks/tasked_exercises.rb
+++ b/spec/factories/tasks/tasked_exercises.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
         task = tasked.task_step.task
         task_steps = task.task_steps
         task.task_steps = task_steps - [tasked.task_step]
-        create(:tasks_tasking, role: evaluator.tasked_to, task: task)
+        task.taskings << FactoryBot.build(:tasks_tasking, role: evaluator.tasked_to, task: task)
         task.task_steps = task_steps
       end
     end

--- a/spec/subsystems/tasks/models/extension_spec.rb
+++ b/spec/subsystems/tasks/models/extension_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Tasks::Models::Extension, type: :model do
   it { is_expected.to belong_to(:task_plan) }
   it { is_expected.to belong_to(:role) }
 
-  it { is_expected.to have_one(:task) }
-
   it { is_expected.to validate_uniqueness_of(:role).scoped_to(:tasks_task_plan_id) }
 
   it { is_expected.to validate_presence_of(:due_at_ntz) }

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -6,15 +6,17 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
       :tasks_task,
       opens_at: Time.current - 1.week,
       due_at: Time.current - 2.days,
-      closes_at: Time.current - 1.day
+      closes_at: Time.current - 1.day,
+      num_random_taskings: 1
     )
   end
 
+  let(:tasking)          { task.taskings.first }
+  let(:role)             { tasking.role }
   let(:task_plan)        { task.task_plan }
   let(:grading_template) { task_plan.grading_template }
 
   it { is_expected.to belong_to(:task_plan).optional }
-  it { is_expected.to belong_to(:extension).optional }
 
   it { is_expected.to belong_to(:time_zone).optional }
 
@@ -22,6 +24,12 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
   it { is_expected.to have_many(:taskings) }
 
   it { is_expected.to validate_presence_of(:title) }
+
+  it 'can find its own extension' do
+    extension = FactoryBot.create :tasks_extension, task_plan: task_plan, role: role
+
+    expect(task.extension).to eq extension
+  end
 
   it 'is late when last_worked_at is past due_at' do
     expect(task).not_to be_late
@@ -82,16 +90,14 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
   end
 
   it 'reports is_shared? correctly' do
-    FactoryBot.create(:tasks_tasking, task: task)
-    expect(task.is_shared?).to eq false
+    expect(task.reload.is_shared?).to eq false
 
     FactoryBot.create(:tasks_tasking, task: task)
-    expect(task.is_shared?).to eq true
+    expect(task.reload.is_shared?).to eq true
   end
 
   context 'with research cohort' do
-      let!(:tasking) { FactoryBot.create(:tasks_tasking, task: task) }
-      let(:student)  { tasking.role.student }
+      let(:student)  { role.student }
       let(:study)    { FactoryBot.create :research_study }
       let!(:cohort)  { FactoryBot.create :research_cohort, study: study }
       let!(:brain)   { FactoryBot.create :research_modified_tasked, study: study }
@@ -102,8 +108,7 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
 
       it 'has links to related models' do
         expect(task.taskings).to eq [tasking]
-        expect(task.roles).to eq [tasking.role]
-        expect(student).to eq tasking.role.student
+        expect(task.roles).to eq [role]
         expect(task.students).to eq [student]
         expect(task.research_cohorts).to eq [cohort]
         expect(task.research_study_brains).to eq [Research::Models::StudyBrain.find(brain.id)]
@@ -733,11 +738,11 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
 
       extension = Tasks::Models::Extension.new(
         entity_role_id: task.taskings.first.entity_role_id,
-        due_at: task.time_zone.to_tz.now,
-        closes_at: task.time_zone.to_tz.now
+        due_at: task.time_zone.to_tz.now + 1.minute,
+        closes_at: task.time_zone.to_tz.now + 1.minute
       )
       task.task_plan.extensions << extension
-      task.update_attribute :extension, extension
+      expect(task.extension).to eq extension
 
       expect(task.correct_exercise_count).to eq 2
       expect(task.completed_exercise_count).to eq 2


### PR DESCRIPTION
And try to preload them in places that use multiple tasks.

I think one day we should delete taskings and put the role ids in the tasks but maybe not today.