### PR TITLE
Separated can_be_updated and feedback_available logic for exercises

### DIFF
--- a/app/representers/api/v1/tasks/task_step_representer.rb
+++ b/app/representers/api/v1/tasks/task_step_representer.rb
@@ -61,6 +61,16 @@ module Api::V1::Tasks
                description: 'Whether or not this step is complete'
              }
 
+    property :can_be_updated,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { task_step.can_be_updated? },
+             schema_info: {
+               required: true,
+               type: 'boolean',
+               description: 'Whether or not this step can be updated'
+             }
+
     property :spy,
              type: Object,
              readable: true,

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -1,8 +1,8 @@
 module Api::V1::Tasks
   class TaskedExerciseRepresenter < TaskStepRepresenter
-    FEEDBACK_AVAILABLE = ->(*) { task_step.feedback_available? }
+    FEEDBACK_AVAILABLE = ->(*) { feedback_available? }
     INCLUDE_CONTENT_AND_FEEDBACK_AVAILABLE = ->(user_options:, **) do
-      user_options&.[](:include_content) && task_step.feedback_available?
+      user_options&.[](:include_content) && feedback_available?
     end
 
     property :title,
@@ -78,6 +78,16 @@ module Api::V1::Tasks
                description: "Content related to this step",
              },
              if: INCLUDE_CONTENT
+
+    property :feedback_available?,
+             as: :is_feedback_available,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: true,
+               type: 'boolean',
+               description: "Whether or not this exercise's feedback is available"
+             }
 
     property :solution,
              type: String,

--- a/app/routines/preview/work_task.rb
+++ b/app/routines/preview/work_task.rb
@@ -30,8 +30,8 @@ class Preview::WorkTask
 
       completed_at_value = completed_at.is_a?(Proc) ? completed_at.call(task_step, index) :
                                                       completed_at
-      # Can't rework steps after feedback date
-      next if task_step.completed? && task_step.feedback_available?(current_time: completed_at)
+      # Can't rework steps after feedback date or if manually graded
+      next unless task_step.can_be_updated?(current_time: completed_at)
 
       if task_step.exercise?
         is_correct_value = is_correct.is_a?(Proc) ? is_correct.call(task_step, index) : is_correct

--- a/app/subsystems/tasks/models/task_step.rb
+++ b/app/subsystems/tasks/models/task_step.rb
@@ -96,8 +96,18 @@ class Tasks::Models::TaskStep < ApplicationRecord
     !first_completed_at.nil?
   end
 
-  def feedback_available?(current_time: Time.current)
-    completed? && task.auto_grading_feedback_available?(current_time: current_time)
+  def can_be_updated?(current_time: Time.current)
+    return false if task.past_close?(current_time: current_time)
+
+    return false if exercise? && tasked.was_manually_graded?
+
+    return true unless completed?
+
+    return false if !exercise? || tasked.was_manually_graded?
+
+    !tasked.can_be_auto_graded? || !task.auto_grading_feedback_available?(
+      current_time: current_time
+    )
   end
 
   def group_name

--- a/lib/openstax/biglearn/api/fake_client.rb
+++ b/lib/openstax/biglearn/api/fake_client.rb
@@ -279,7 +279,7 @@ class OpenStax::Biglearn::Api::FakeClient < OpenStax::Biglearn::FakeClient
       unless ecosystem.nil?
         responses_by_page_id = Hash.new { |hash, key| hash[key] = [] }
         Tasks::Models::TaskedExercise.select(
-          :id, :answer_id, :correct_answer_id, :grader_points
+          :id, :answer_ids, :answer_id, :correct_answer_id, :grader_points
         ).joins(
           task_step: { task: :taskings }
         ).where(
@@ -287,7 +287,7 @@ class OpenStax::Biglearn::Api::FakeClient < OpenStax::Biglearn::FakeClient
             task: { ecosystem: ecosystem, taskings: { entity_role_id: role.id } }
           }
         ).preload(task_step: :task).filter do |tasked_exercise|
-          tasked_exercise.task_step.feedback_available? current_time: current_time
+          tasked_exercise.feedback_available? current_time: current_time
         end.each do |tasked_exercise|
           responses_by_page_id[tasked_exercise.task_step.content_page_id] <<
             tasked_exercise.is_correct?
@@ -489,13 +489,13 @@ class OpenStax::Biglearn::Api::FakeClient < OpenStax::Biglearn::FakeClient
     role_ids = students.map(&:entity_role_id)
     page_ids = [ pages ].flatten.map(&:id)
     responses = Tasks::Models::TaskedExercise.select(
-      :id, :answer_id, :correct_answer_id, :grader_points
+      :id, :answer_ids, :answer_id, :correct_answer_id, :grader_points
     ).joins(
       task_step: { task: :taskings }
     ).where(
       task_step: { content_page_id: page_ids, task: { taskings: { entity_role_id: role_ids } } }
     ).preload(task_step: :task).filter do |tasked_exercise|
-      tasked_exercise.task_step.feedback_available? current_time: current_time
+      tasked_exercise.feedback_available? current_time: current_time
     end.map(&:is_correct?)
 
     calculate_clue responses: responses, ecosystem: ecosystem

--- a/spec/representers/api/v1/task_step_representer_spec.rb
+++ b/spec/representers/api/v1/task_step_representer_spec.rb
@@ -11,4 +11,15 @@ RSpec.describe Api::V1::TaskStepRepresenter, type: :representer do
 
     expect(representation).to include('is_completed' => true)
   end
+
+  it 'includes the can_be_updated field' do
+    last_time = Time.current
+    first_time = last_time - 1.week
+    task_step = FactoryBot.create(:tasks_task_step, first_completed_at: first_time,
+                                                    last_completed_at: last_time)
+
+    representation = described_class.prepare(task_step).to_hash
+
+    expect(representation).to include('can_be_updated' => false)
+  end
 end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       allow(step).to receive(:group_name).and_return('Some group')
       allow(step).to receive(:is_core).and_return(true)
       allow(step).to receive(:completed?).and_return(false)
-      allow(step).to receive(:feedback_available?).and_return(false)
+      allow(step).to receive(:can_be_updated?).and_return(true)
       allow(step).to receive(:labels).and_return([])
       allow(step).to receive(:related_content).and_return('RelatedContent')
       allow(step).to receive(:spy_with_response_validation).and_return(
@@ -38,6 +38,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       allow(exercise).to receive(:answer_id).and_return(nil)
       allow(exercise).to receive(:last_completed_at).and_return(Time.current)
       allow(exercise).to receive(:first_completed_at).and_return(Time.current - 1.week)
+      allow(exercise).to receive(:feedback_available?).and_return(false)
       allow(exercise).to receive(:question_id).and_return('questionID')
       allow(exercise).to receive(:is_in_multipart).and_return(false)
       allow(exercise).to receive(:response_validation).and_return({ valid: false })
@@ -94,6 +95,10 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       expect(representation).to include('is_core' => true)
     end
 
+    it "has the correct 'can_be_updated'" do
+      expect(representation).to include('can_be_updated' => true)
+    end
+
     it "has 'labels'" do
       allow(task_step).to receive(:labels).and_return([])
       expect(complete_representation).to include('labels')
@@ -139,9 +144,13 @@ RSpec.shared_examples 'a tasked_exercise representer' do
     end
 
     context 'feedback available' do
-      before { allow(task_step).to receive(:feedback_available?).and_return(true) }
+      before { allow(tasked_exercise).to receive(:feedback_available?).and_return(true) }
 
       it_behaves_like 'a good exercise representation should'
+
+      it "has the correct 'is_feedback_available'" do
+        expect(representation).to include('is_feedback_available' => true)
+      end
 
       it "has correct 'solution'" do
         expect(complete_representation).to include('solution' => 'Some solution')
@@ -159,8 +168,20 @@ RSpec.shared_examples 'a tasked_exercise representer' do
     context 'feedback unavailable' do
       it_behaves_like 'a good exercise representation should'
 
+      it "has the correct 'is_feedback_available'" do
+        expect(representation).to include('is_feedback_available' => false)
+      end
+
+      it "'solution' is not included" do
+        expect(complete_representation).not_to include('solution')
+      end
+
       it "'feedback_html' is not included" do
         expect(representation).to_not include('feedback_html')
+      end
+
+      it "'correct_answer_id' is not included" do
+        expect(representation).not_to include('correct_answer_id')
       end
     end
   end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::Tasks::TaskedExerciseRepresenter, type: :representer do
     end
 
     context 'feedback available' do
-      before { allow(task_step).to receive(:feedback_available?).and_return(true) }
+      before { allow(tasked_exercise).to receive(:feedback_available?).and_return(true) }
 
       it "'grader_points is included'" do
         expect(representation).to include('grader_points' => 0.5)

--- a/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
+++ b/spec/representers/api/v1/tasks/tasked_placeholder_representer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::V1::Tasks::TaskedPlaceholderRepresenter, type: :representer 
       allow(step).to receive(:group_name).and_return('Some group')
       allow(step).to receive(:is_core).and_return(false)
       allow(step).to receive(:completed?).and_return(false)
+      allow(step).to receive(:can_be_updated?).and_return(true)
 
       allow(step).to receive(:spy_with_response_validation).and_return({})
     end

--- a/spec/subsystems/research/models/study_brain_spec.rb
+++ b/spec/subsystems/research/models/study_brain_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Research::Models::StudyBrain, type: :model do
         study: cohort.study, code: code
       )
     end
-    let(:task_step) { FactoryBot.build(:tasks_tasked_exercise, skip_task: true).task_step }
+    let(:task_step) { FactoryBot.build(:tasks_tasked_exercise).task_step }
 
     it 'can be recorded from a brain and returns original value' do
       expect do

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -94,22 +94,21 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     expect(tasked_exercise).to be_valid
   end
 
-  it 'cannot be answered after due and graded' do
+  it 'cannot be answered after graded' do
     tasked_exercise.answer_id = tasked_exercise.answer_ids.first
     tasked_exercise.free_response = 'abc'
+    expect(tasked_exercise.was_manually_graded?).to eq false
+    expect(tasked_exercise.task_step.can_be_updated?).to eq true
     tasked_exercise.save!
 
     tasked_exercise.last_graded_at = Time.current
     tasked_exercise.grader_points = 0.0
+    expect(tasked_exercise.was_manually_graded?).to eq true
+    expect(tasked_exercise.task_step.can_be_updated?).to eq false
     tasked_exercise.save!
 
     tasked_exercise.answer_id = tasked_exercise.answer_ids.last
     tasked_exercise.free_response = 'def'
-
-    expect(tasked_exercise).to be_valid
-
-    tasked_exercise.task_step.task.update_attribute :due_at_ntz, Time.current - 1.day
-
     expect(tasked_exercise).not_to be_valid
   end
 


### PR DESCRIPTION
Added the new fields to the step representers in case the FE needs them.

To be used to determine the state of each step:
1. Editable
2. Non-editable but no feedback yet
3. Feedback available