### PR TITLE
change :never to :not_accepted to clarify 100 percent deduction case

### DIFF
--- a/app/subsystems/tasks/models/grading_template.rb
+++ b/app/subsystems/tasks/models/grading_template.rb
@@ -12,7 +12,7 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
   enum task_plan_type:             [ :reading, :homework ]
   enum auto_grading_feedback_on:   [ :answer, :due, :publish ], _prefix: true
   enum manual_grading_feedback_on: [ :grade, :publish ], _prefix: true
-  enum late_work_penalty_applied:  [ :never, :immediately, :daily ]
+  enum late_work_penalty_applied:  [ :not_accepted, :immediately, :daily ]
 
   validates :task_plan_type,
             :name,

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -174,7 +174,7 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def late_work_penalty_applied
-    grading_template&.late_work_penalty_applied || 'never'
+    grading_template&.late_work_penalty_applied || 'not_accepted'
   end
 
   def late_work_penalty_per_period

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -256,6 +256,8 @@ class Tasks::Models::Task < ApplicationRecord
       late_work_penalty_per_period
     when 'daily'
       ((task_step.last_completed_at - due_at)/1.day).ceil * late_work_penalty_per_period
+    when 'not_accepted'
+      1.0
     else
       0.0
     end

--- a/spec/factories/tasks/grading_templates.rb
+++ b/spec/factories/tasks/grading_templates.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     correctness_weight             { (1 - completion_weight).round(1) }
     auto_grading_feedback_on       { [ :answer, :due, :publish ].sample }
     manual_grading_feedback_on     { [ :grade, :publish ].sample }
-    late_work_penalty_applied      { [ :never, :immediately, :daily ].sample }
+    late_work_penalty_applied      { [ :not_accepted, :immediately, :daily ].sample }
     late_work_penalty              { rand.round(1) }
     default_open_time              { '07:00:00' }
     default_due_time               { '21:00:00' }

--- a/spec/representers/api/v1/grading_template_representer_spec.rb
+++ b/spec/representers/api/v1/grading_template_representer_spec.rb
@@ -113,7 +113,9 @@ RSpec.describe Api::V1::GradingTemplateRepresenter, type: :representer do
     end
 
     it 'can be written' do
-      val = ([ 'never', 'immediately', 'daily' ] - [ represented.late_work_penalty_applied ]).sample
+      val = (
+        [ 'not_accepted', 'immediately', 'daily' ] - [ represented.late_work_penalty_applied ]
+      ).sample
       expect do
         representer.from_hash('late_work_penalty_applied' => val)
       end.to change { represented.late_work_penalty_applied }.to(val)

--- a/spec/representers/api/v1/task_representer_spec.rb
+++ b/spec/representers/api/v1/task_representer_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Api::V1::TaskRepresenter, type: :representer do
   end
 
   it 'includes late_work_penalty_applied' do
-    task.task_plan.grading_template.late_work_penalty_applied = :never
-    expect(described_class.new(task).to_hash['late_work_penalty_applied']).to eq 'never'
+    task.task_plan.grading_template.late_work_penalty_applied = :not_accepted
+    expect(described_class.new(task).to_hash['late_work_penalty_applied']).to eq 'not_accepted'
 
     task.task_plan.grading_template.late_work_penalty_applied = :immediately
     expect(described_class.new(task).to_hash['late_work_penalty_applied']).to eq 'immediately'


### PR DESCRIPTION
This is a simple change that should make "don't accept late work" always return 100% deduction for late work. We could technically send up :immediately + 100% from the front end, but this helps the UX and skips changing some front end code... plus is probably more future proof in case we need to redefine what "not accepted" means.