### PR TITLE
Fix exercises that require context from collated sections

### DIFF
--- a/app/routines/import_ecosystem_manifest.rb
+++ b/app/routines/import_ecosystem_manifest.rb
@@ -1,5 +1,4 @@
 class ImportEcosystemManifest
-
   lev_routine express_output: :ecosystem,
               active_job_enqueue_options: { queue: :maintenance },
               use_jobba: true
@@ -35,5 +34,4 @@ class ImportEcosystemManifest
         exercise_uids: book.exercise_ids,
         comments: comments)
   end
-
 end

--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -116,16 +116,8 @@ class Content::Models::Page < IndestructibleRecord
     @context_for_feature_ids ||= {}
     return @context_for_feature_ids[feature_ids] if @context_for_feature_ids.has_key?(feature_ids)
 
-    feature_node = nil
-    fragments.each do |fragment|
-      next unless fragment.respond_to?(:to_html)
-
-      fragment_node = Nokogiri::HTML.fragment(fragment.to_html)
-      feature_node = parser_class.feature_node(fragment_node, feature_ids)
-
-      break unless feature_node.nil?
-    end
-
+    doc = Nokogiri::HTML(content)
+    feature_node = parser_class.feature_node(doc, feature_ids)
     @context_for_feature_ids[feature_ids] = feature_node.try(:to_html)
   end
 

--- a/app/subsystems/lms/send_course_scores.rb
+++ b/app/subsystems/lms/send_course_scores.rb
@@ -13,7 +13,6 @@ require 'oauth'
 #   https://andyfmiller.com/2016/03/26/ims-lti-outcomes-1-0-versus-2-0/
 
 class Lms::SendCourseScores
-
   lev_routine transaction: :no_transaction, use_jobba: true
 
   def exec(course:)
@@ -168,5 +167,4 @@ class Lms::SendCourseScores
 
     builder.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
   end
-
 end

--- a/spec/fixtures/manifests/Section Summary Context Exercise.yml
+++ b/spec/fixtures/manifests/Section Summary Context Exercise.yml
@@ -1,0 +1,32 @@
+---
+title: 'College Physics (405335a3-7cff-4df2-a9ad-29062a4af261)'
+books:
+- archive_url: https://archive.cnx.org
+  cnx_id: 405335a3-7cff-4df2-a9ad-29062a4af261
+  reading_processing_instructions:
+  - css: .conceptual-questions, .problems-exercises, [data-element-type="conceptual-questions"],
+      [data-element-type="problems-exercises"], [data-element-type="check-understanding"],
+      [data-type="glossary"]
+    fragments: []
+  - css: '[data-type="footnote-refs"]'
+    fragments:
+    - media
+  - css: .phet-explorations-embedded
+    fragments:
+    - interactive
+    - exercise
+    labels:
+    - phet-explorations
+  - css: .watch-physics
+    fragments:
+    - video
+    - exercise
+    labels:
+    - watch-physics
+  - css: .example-video, [data-type="example"]
+    fragments:
+    - reading
+    labels:
+    - example
+  exercise_ids:
+    - 19874@2

--- a/spec/subsystems/content/routines/transform_and_cache_page_content_spec.rb
+++ b/spec/subsystems/content/routines/transform_and_cache_page_content_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'vcr_helper'
 
-RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine do
+RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine, vcr: VCR_OPTS do
   context 'with real content' do
     before(:all) do
       cnx_page_1 = OpenStax::Cnx::V1::Page.new(
@@ -638,6 +638,17 @@ RSpec.describe Content::Routines::TransformAndCachePageContent, type: :routine d
           expect(context_node.attr('id')).to eq expected_context_node_id
         end
       end
+    end
+  end
+
+  context 'with an exercise that requires context from a Section Summary' do
+    let(:manifest_path)   { 'spec/fixtures/manifests/Section Summary Context Exercise.yml' }
+    let(:manifest_string) { File.read manifest_path }
+
+    it "sets the exercise's context from the Section Summary"  do
+      ecosystem = ImportEcosystemManifest[manifest: manifest_string]
+      exercise = ecosystem.exercises.first
+      expect(exercise.context).not_to be_blank
     end
   end
 end


### PR DESCRIPTION
2 changes:

- Exercises with context now look at pages that come after the current one if a tag with the given id does not exist in the current page (because of collation).
- Exercises with context now use the content pre-reading-processing-instructions (so they still work if the reading processing instructions exclude the content containing the chosen tag).