### PR TITLE
don't allow any fields to be updated if template has task_plans

### DIFF
--- a/app/subsystems/tasks/models/grading_template.rb
+++ b/app/subsystems/tasks/models/grading_template.rb
@@ -123,7 +123,7 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
     return unless has_open_task_plans?
 
     errors.add :base,
-               'cannot be changed because this template is assigned to one or more task_plans'
+               'cannot be changed because this template is assigned to one or more open task_plans'
     throw :abort
   end
 

--- a/app/subsystems/tasks/models/grading_template.rb
+++ b/app/subsystems/tasks/models/grading_template.rb
@@ -34,7 +34,7 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
 
   validate :weights_add_up, :default_times_have_good_values
 
-  before_update  :no_task_plans_when_changing_task_plan_type
+  before_update  :no_open_task_plans_on_update, :no_task_plans_when_changing_task_plan_type
   before_destroy :no_task_plans_on_destroy, :not_last_template
 
   DEFAULT_ATTRIBUTES = [
@@ -76,6 +76,10 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
     !task_plans.reject(&:withdrawn?).empty?
   end
 
+  def has_open_task_plans?
+    task_plans.reject(&:withdrawn?).any?(&:out_to_students?)
+  end
+
   protected
 
   def weights_add_up
@@ -111,6 +115,14 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
     return unless task_plan_type_changed? && has_task_plans?
 
     errors.add :task_plan_type,
+               'cannot be changed because this template is assigned to one or more task_plans'
+    throw :abort
+  end
+
+  def no_open_task_plans_on_update
+    return unless has_open_task_plans?
+
+    errors.add :base,
                'cannot be changed because this template is assigned to one or more task_plans'
     throw :abort
   end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe Api::V1::CoursesController, type: :controller, api: true,
         Preview::AnswerExercise[task_step: @hw2_task.task_steps[0], is_correct: true]
         Preview::AnswerExercise[task_step: @hw2_task.task_steps[1], is_correct: true]
         Preview::AnswerExercise[task_step: @hw2_task.task_steps[2], is_correct: false]
-        @hw2_task.task_plan.grading_template.update_attribute :auto_grading_feedback_on, :answer
+        @hw2_task.task_plan.grading_template.update_column :auto_grading_feedback_on, :answer
 
         Preview::AnswerExercise[task_step: @hw3_task.task_steps[0], is_correct: false]
         Preview::AnswerExercise[task_step: @hw3_task.task_steps[1], is_correct: false]

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       end
 
       context "manual_grading_feedback_on == 'grade'" do
-        before { task_plan.grading_template.manual_grading_feedback_on_grade! }
+        before { task_plan.grading_template.update_column :manual_grading_feedback_on, :grade }
 
         it 'updates the grader fields, published fields and gradable step counts' do
           expect do
@@ -347,7 +347,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       end
 
       context "manual_grading_feedback_on == 'publish'" do
-        before { task_plan.grading_template.manual_grading_feedback_on_publish! }
+        before { task_plan.grading_template.update_column :manual_grading_feedback_on, :publish }
 
         it 'updates the grader fields and gradable step counts' do
           expect do

--- a/spec/controllers/api/v1/task_steps_controller_spec.rb
+++ b/spec/controllers/api/v1/task_steps_controller_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :controller, api: true, versi
       task_step.complete! completed_at: completed_at
       expect(task_step.first_completed_at).to eq completed_at
       expect(task_step.last_completed_at).to eq completed_at
-      task_step.task.task_plan.grading_template.update_attribute :auto_grading_feedback_on, :due
+      task_step.task.task_plan.grading_template.update_column :auto_grading_feedback_on, :due
 
       expect do
         api_put :update, @user_1_token,

--- a/spec/controllers/api/v1/tasking_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/tasking_plans_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::TaskingPlansController, type: :controller, api: true, ve
       assistant: get_assistant(course: @course, task_plan_type: 'reading'),
       published_at: Time.current
     )
-    @task_plan.grading_template.manual_grading_feedback_on_publish!
+    @task_plan.grading_template.update_column :manual_grading_feedback_on, :publish
     @tasking_plan = @task_plan.tasking_plans.first
     @tasking_plan.update_attribute :due_at_ntz, Time.current - 1.day
     @not_due_tasking_plan = FactoryBot.create(

--- a/spec/representers/api/v1/task_plan/scores/representer_spec.rb
+++ b/spec/representers/api/v1/task_plan/scores/representer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
         exercises_count_dynamic: 3
       }
     ).tap do |task_plan|
-      task_plan.grading_template.update_attribute :late_work_penalty_applied, :immediately
+      task_plan.grading_template.update_column :late_work_penalty_applied, :immediately
     end
   end
   let(:tasking_plan)         { task_plan.tasking_plans.first }

--- a/spec/requests/api/v1/exercise_update_progression_spec.rb
+++ b/spec/requests/api/v1/exercise_update_progression_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Exercise update progression', type: :request, api: true, version
 
   let(:step_route_base) { "/api/steps/#{tasked.task_step.id}" }
 
-  before { grading_template.update_attribute :auto_grading_feedback_on, :due }
+  before { grading_template.update_column :auto_grading_feedback_on, :due }
 
   it "only shows feedback and correct answer id after completed and feedback available" do
     api_get(step_route_base, user_1_token)
@@ -59,7 +59,7 @@ RSpec.describe 'Exercise update progression', type: :request, api: true, version
     expect(response.body_as_hash).not_to have_key(:correct_answer_id)
 
     # Get it again after feedback is available
-    grading_template.update_attribute :auto_grading_feedback_on, :answer
+    grading_template.update_column :auto_grading_feedback_on, :answer
 
     api_get(step_route_base, user_1_token)
 
@@ -94,7 +94,7 @@ RSpec.describe 'Exercise update progression', type: :request, api: true, version
     expect(response).to have_http_status(:success)
 
     # Feedback is now available
-    grading_template.update_attribute :auto_grading_feedback_on, :answer
+    grading_template.update_column :auto_grading_feedback_on, :answer
 
     # Free response cannot be changed
     api_put("#{step_route_base}", user_1_token,

--- a/spec/routines/find_or_create_practice_worst_topics_task_spec.rb
+++ b/spec/routines/find_or_create_practice_worst_topics_task_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FindOrCreatePracticeWorstTopicsTask, type: :routine, speed: :medi
     worked_pages.each do |page|
       is_correct = !@worst_pages.include?(page)
       task = FactoryBot.create :tasks_task, ecosystem: @ecosystem, tasked_to: @role
-      task.grading_template.update_attribute :auto_grading_feedback_on, :answer
+      task.grading_template.update_column :auto_grading_feedback_on, :answer
 
       OpenStax::Biglearn::Api::FakeClient::CLUE_MIN_NUM_RESPONSES.times do
         exercise = FactoryBot.create :content_exercise, page: page

--- a/spec/subsystems/tasks/get_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_performance_report_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       it 'returns the proper numbers' do
         tasks = Tasks::Models::Task.where(title: 'Homework task plan')
         tasks.each do |task|
-          task.task_plan.grading_template.update_attribute :auto_grading_feedback_on, :answer
+          task.task_plan.grading_template.update_column :auto_grading_feedback_on, :answer
         end
 
         expect(first_period_report.overall_homework_score).to be_within(1e-6).of(9/14.0)
@@ -340,7 +340,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       it 'returns the proper numbers' do
         tasks = Tasks::Models::Task.where(title: 'Homework task plan')
         tasks.each do |task|
-          task.task_plan.grading_template.update_attribute :auto_grading_feedback_on, :due
+          task.task_plan.grading_template.update_column :auto_grading_feedback_on, :due
         end
 
         expect(first_period_report.overall_homework_score).to be_within(1e-6).of(9/14.0)
@@ -505,7 +505,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       it 'returns the proper numbers' do
         tasks = Tasks::Models::Task.where(title: 'Homework task plan')
         tasks.each do |task|
-          task.task_plan.grading_template.update_attribute :auto_grading_feedback_on, :publish
+          task.task_plan.grading_template.update_column :auto_grading_feedback_on, :publish
         end
 
         # A single past-due unpublished task makes the homework score and the course average 0.0
@@ -846,7 +846,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
         taskings: { entity_role_id: @student_1.roles.first.id },
         title: 'Homework task plan'
       )
-      task.task_plan.grading_template.update_attribute :auto_grading_feedback_on, :publish
+      task.task_plan.grading_template.update_column :auto_grading_feedback_on, :publish
 
       expect(report.data_headings.size).to eq expected_tasks
 

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -769,9 +769,10 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
       ]
     )
     task.taskings << FactoryBot.build(:tasks_tasking)
-    task.grading_template.late_work_penalty_applied = :immediately
-    task.grading_template.late_work_penalty = 0.5
-    task.grading_template.save!
+    task.grading_template.update_columns(
+      late_work_penalty_applied: :immediately,
+      late_work_penalty: 0.5
+    )
 
     due_at = task.due_at
 
@@ -837,9 +838,10 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
       expect(task.score_without_lateness).to eq 1.0
       expect(task.score).to eq 2.5/3.0
 
-      task.grading_template.late_work_penalty_applied = :daily
-      task.grading_template.late_work_penalty = 0.3
-      task.grading_template.save!
+      task.grading_template.update_columns(
+        late_work_penalty_applied: :daily,
+        late_work_penalty: 0.3
+      )
 
       expect(task.correct_exercise_count).to eq 3
       expect(task.completed_exercise_count).to eq 3

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -908,7 +908,7 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
     ecosystem = page.ecosystem
     AddEcosystemToCourse.call ecosystem: ecosystem, course: course
 
-    task_plan.grading_template.update_attribute :task_plan_type, 'homework'
+    task_plan.grading_template.update_column :task_plan_type, 'homework'
     task_plan.update_attributes!(
       ecosystem: ecosystem,
       type: 'homework',

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
 
   it 'cannot have answer or free response updated after feedback is available' do
     grading_template = tasked_exercise.task_step.task.task_plan.grading_template
-    grading_template.update_attribute :auto_grading_feedback_on, :answer
+    grading_template.update_column :auto_grading_feedback_on, :answer
 
     tasked_exercise.free_response = 'abc'
     tasked_exercise.answer_id = tasked_exercise.answer_ids.first
@@ -83,7 +83,7 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     tasked_exercise.free_response = 'some new thing'
     expect(tasked_exercise).not_to be_valid
 
-    grading_template.update_attribute :auto_grading_feedback_on, :due
+    grading_template.update_column :auto_grading_feedback_on, :due
 
     expect(tasked_exercise.reload).to be_valid
     tasked_exercise.answer_id = tasked_exercise.answer_ids.last


### PR DESCRIPTION
As requested 1048, don't allow any fields to be changed if there are task_plans.