### PR TITLE
Preload all the things when fetching tasks

### DIFF
--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -209,7 +209,12 @@ module Tasks
         .joins(task_plan: :tasking_plans)
         .where(task_type: task_types,task_plan: { withdrawn_at: nil })
         .where(tt[:opens_at_ntz].eq(nil).or tt[:opens_at_ntz].lteq(current_time_ntz))
-        .preload(task_plan: [ :tasking_plans, :extensions ])
+        .preload(:course, :taskings, :time_zone,
+         task_plan: [ :tasking_plans, :dropped_questions,
+                      :grading_template, :extensions],
+         task_steps: :tasked)
+        .reorder(nil).distinct
+
         .reorder(nil).distinct
 
       if is_teacher


### PR DESCRIPTION
An attempt to speed up the gradebook (performance forecast, in the backend) by fixing N+1 queries.