### PR TITLE
Discard grading templates when cloning pre-WRM courses

### DIFF
--- a/app/routines/clone_course.rb
+++ b/app/routines/clone_course.rb
@@ -14,6 +14,11 @@ class CloneCourse
   def exec(course:, teacher_user:, copy_question_library:,
            name: nil, is_college: nil, term: nil, year: nil, num_sections: nil,
            time_zone: nil, estimated_student_count: nil)
+    grading_templates = course.pre_wrm_scores? ?
+      Tasks::Models::GradingTemplate.default :
+      course.grading_templates.without_deleted.map do |grading_template|
+        grading_template.dup.tap { |clone| clone.cloned_from = grading_template }
+      end
     attrs = {
       name: name || course.name,
       is_college: is_college.nil? ? course.is_college : is_college,
@@ -34,9 +39,7 @@ class CloneCourse
       is_preview: false,
       reading_weight: course.reading_weight,
       homework_weight: course.homework_weight,
-      grading_templates: course.grading_templates.map do |grading_template|
-        grading_template.dup.tap { |clone| clone.cloned_from = grading_template }
-      end,
+      grading_templates: grading_templates,
       past_due_unattempted_ungraded_wrq_are_zero: course.past_due_unattempted_ungraded_wrq_are_zero
     }
 

--- a/spec/routines/clone_course_spec.rb
+++ b/spec/routines/clone_course_spec.rb
@@ -4,19 +4,18 @@ RSpec.describe CloneCourse, type: :routine do
   let(:course) { FactoryBot.create :course_profile_course }
   let(:user)   { FactoryBot.create :user_profile }
 
-  it 'creates a copy of a course' do
+  let!(:grading_template) { FactoryBot.create :tasks_grading_template, course: course }
 
+  it 'creates a copy of a course' do
     result = described_class.call(
       course: course,
       teacher_user: user,
       copy_question_library: false,
       estimated_student_count: 100
     )
-
     expect(result.errors).to be_empty
 
     clone = result.outputs.course
-
     expect(clone).to be_a CourseProfile::Models::Course
     expect(clone.cloned_from).to eq course
     expect(clone.estimated_student_count).to eq 100
@@ -28,15 +27,12 @@ RSpec.describe CloneCourse, type: :routine do
   end
 
   it "copies the course's question library if requested" do
-
     10.times{ FactoryBot.create :course_content_excluded_exercise, course: course }
 
     result = described_class.call(course: course, teacher_user: user, copy_question_library: true)
-
     expect(result.errors).to be_empty
 
     clone = result.outputs.course
-
     expect(clone).to be_a CourseProfile::Models::Course
     expect(clone.cloned_from).to eq course
     expect(clone.course_assistants.count).to eq 4
@@ -44,5 +40,72 @@ RSpec.describe CloneCourse, type: :routine do
     expect(clone.excluded_exercises.map(&:exercise_number)).to(
       match_array(course.excluded_exercises.map(&:exercise_number))
     )
+  end
+
+  context 'pre-wrm course' do
+    before { course.update_attribute :ends_at, DateTime.new(2020, 6, 30) }
+
+    it 'assigns default grading templates to the cloned course' do
+      result = described_class.call(
+        course: course,
+        teacher_user: user,
+        copy_question_library: false,
+        estimated_student_count: 100
+      )
+      expect(result.errors).to be_empty
+
+      clone = result.outputs.course
+      expected_attributes = Tasks::Models::GradingTemplate::DEFAULT_ATTRIBUTES.dup
+      expected_attributes.each do |grading_template_attributes|
+        grading_template_attributes.each do |key, value|
+          grading_template_attributes[key] = value.to_s if value.is_a?(Symbol)
+        end
+      end
+      expect(
+        clone.grading_templates.map do |grading_template|
+          grading_template.attributes.symbolize_keys.except(
+            :id, :course_profile_course_id, :cloned_from_id, :created_at, :updated_at, :deleted_at
+          )
+        end
+      ).to eq expected_attributes
+
+      clone.grading_templates.each do |grading_template|
+        expect(grading_template.cloned_from_id).to be_nil
+      end
+    end
+  end
+
+  context 'wrm course' do
+    before { course.update_attribute :ends_at, DateTime.new(2020, 7, 2) }
+
+    it "copies the course's grading templates if not pre-wrm" do
+      result = described_class.call(
+        course: course,
+        teacher_user: user,
+        copy_question_library: false,
+        estimated_student_count: 100
+      )
+      expect(result.errors).to be_empty
+
+      clone = result.outputs.course
+      expect(
+        clone.grading_templates.map do |grading_template|
+          grading_template.attributes.symbolize_keys.except(
+            :id, :course_profile_course_id, :cloned_from_id, :created_at, :updated_at, :deleted_at
+          )
+        end
+      ).to eq(
+        course.grading_templates.without_deleted.map do |grading_template|
+          grading_template.attributes.symbolize_keys.except(
+            :id, :course_profile_course_id, :cloned_from_id, :created_at, :updated_at, :deleted_at
+          )
+        end
+      )
+
+      original_grading_template_ids = course.grading_templates.without_deleted.map(&:id)
+      clone.grading_templates.each do |grading_template|
+        expect(grading_template.cloned_from_id).to be_in original_grading_template_ids
+      end
+    end
   end
 end


### PR DESCRIPTION
We want the courses to get the new defaults when they are cloned.