### PR TITLE
Fixed the task caches when steps have nil page_ids (spaced practice placeholder steps)

### DIFF
--- a/app/subsystems/tasks/update_task_caches.rb
+++ b/app/subsystems/tasks/update_task_caches.rb
@@ -254,7 +254,7 @@ class Tasks::UpdateTaskCaches
           task_steps = task_steps_by_page_id[page.id]
           next if task_steps.empty?
 
-          unmapped_page_ids = task_steps.map(&:content_page_id).uniq
+          unmapped_page_ids = task_steps.map(&:content_page_id).compact.uniq
           unmapped_page_tutor_uuids = unmapped_page_tutor_uuid_by_id.values_at(*unmapped_page_ids)
           unmapped_page_tutor_uuids = (
             unmapped_page_tutor_uuids + [ page.tutor_uuid ]


### PR DESCRIPTION
Not sure why this started being a problem.
Task caches for the affected course will have to be manually reset.