### PR TITLE
add drop question info in student task step

### DIFF
--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -175,8 +175,8 @@ module Api::V1::Tasks
              writeable: false,
              if: FEEDBACK_AVAILABLE
 
-    property :dropped,
-            type: Object,
+    property :dropped_method,
+            type: String,
             readable: true,
             writeable: false
   end

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -175,7 +175,7 @@ module Api::V1::Tasks
              writeable: false,
              if: FEEDBACK_AVAILABLE
 
-    property :drop_question,
+    property :dropped,
             type: Object,
             readable: true,
             writeable: false

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -174,5 +174,10 @@ module Api::V1::Tasks
              readable: true,
              writeable: false,
              if: FEEDBACK_AVAILABLE
+
+    property :drop_question,
+            type: Object,
+            readable: true,
+            writeable: false
   end
 end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -280,8 +280,9 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     end
   end
 
-  def drop_question
-    task_step.task&.task_plan&.dropped_questions&.find { |q| q.question_id == question_id }
+  def dropped
+    dropped_question = task_step.task&.task_plan&.dropped_questions&.find { |q| q.question_id == question_id }
+    dropped_question&.drop_method
   end
 
   def was_manually_graded?

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -157,7 +157,6 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     full_credit_question_ids = Set.new(
       task_step.task&.task_plan&.dropped_questions&.filter(&:full_credit?)&.map(&:question_id) || []
     )
-
     full_credit_question_ids.include? question_id
   end
 
@@ -279,6 +278,10 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     else
       nil
     end
+  end
+
+  def drop_question
+    task_step.task&.task_plan&.dropped_questions&.find { |q| q.question_id == question_id }
   end
 
   def was_manually_graded?

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -280,7 +280,7 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     end
   end
 
-  def dropped
+  def dropped_method
     dropped_question = task_step.task&.task_plan&.dropped_questions&.find { |q| q.question_id == question_id }
     dropped_question&.drop_method
   end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
@@ -47,7 +47,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       allow(exercise).to receive(:published_late_work_point_penalty).and_return(0.25)
       allow(exercise).to receive(:published_points).and_return(0.5)
       allow(exercise).to receive(:published_comments).and_return('Hi')
-      allow(exercise).to receive(:dropped).and_return(nil)
+      allow(exercise).to receive(:dropped_method).and_return(nil)
       allow(exercise).to receive(:cache_key).and_return('tasks/models/tasked_exercises/42')
       allow(exercise).to receive(:cache_version).and_return('test')
     end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
@@ -47,6 +47,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       allow(exercise).to receive(:published_late_work_point_penalty).and_return(0.25)
       allow(exercise).to receive(:published_points).and_return(0.5)
       allow(exercise).to receive(:published_comments).and_return('Hi')
+      allow(exercise).to receive(:dropped).and_return(nil)
       allow(exercise).to receive(:cache_key).and_return('tasks/models/tasked_exercises/42')
       allow(exercise).to receive(:cache_version).and_return('test')
     end


### PR DESCRIPTION
Adds a drop_question object in the student task step if the question was dropped.