### PR TITLE
List only past-due tasks in the gradebook (/api/performance)

### DIFF
--- a/spec/subsystems/tasks/export_performance_report_spec.rb
+++ b/spec/subsystems/tasks/export_performance_report_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine do
       :tasks_tasking_plan,
       target: @course,
       task_plan: draft_task_plan,
-      opens_at: @course.time_zone.now,
-      due_at: @course.time_zone.now + 1.week,
-      closes_at: @course.time_zone.now + 2.weeks
+      opens_at: @course.time_zone.now - 1.week,
+      due_at: @course.time_zone.now,
+      closes_at: @course.time_zone.now + 1.week
     )
 
     draft_task_plan.save!

--- a/spec/subsystems/tasks/get_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_performance_report_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       :tasks_tasking_plan,
       target: @course,
       task_plan: external_task_plan,
-      opens_at: @course.time_zone.now - 4.weeks,
-      due_at: @course.time_zone.now - 3.weeks,
-      closes_at: @course.time_zone.now - 2.weeks
+      opens_at: @course.time_zone.now - 5.weeks,
+      due_at: @course.time_zone.now - 4.weeks,
+      closes_at: @course.time_zone.now - 3.weeks
     )
 
     external_task_plan.save!
@@ -78,9 +78,9 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       :tasks_tasking_plan,
       target: @course,
       task_plan: event_task_plan,
-      opens_at: @course.time_zone.now - 1.week,
-      due_at: @course.time_zone.now,
-      closes_at: @course.time_zone.now + 1.week
+      opens_at: @course.time_zone.now - 2.weeks,
+      due_at: @course.time_zone.now - 1.week,
+      closes_at: @course.time_zone.now
     )
 
     event_task_plan.save!
@@ -107,9 +107,9 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       :tasks_tasking_plan,
       target: @course,
       task_plan: draft_task_plan,
-      opens_at: @course.time_zone.now,
-      due_at: @course.time_zone.now + 1.week,
-      closes_at: @course.time_zone.now + 2.weeks
+      opens_at: @course.time_zone.now - 1.week,
+      due_at: @course.time_zone.now,
+      closes_at: @course.time_zone.now + 1.week
     )
 
     draft_task_plan.save!
@@ -169,51 +169,65 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
     end
 
     context "auto_grading_feedback_on == 'answer'" do
-      it 'returns the proper numbers' do
-        tasks = Tasks::Models::Task.where(title: 'Homework task plan')
-        tasks.each do |task|
-          task.task_plan.grading_template.update_column :auto_grading_feedback_on, :answer
+      before do
+        Tasks::Models::GradingTemplate.find_each do |grading_template|
+          grading_template.update_columns auto_grading_feedback_on: :answer, late_work_penalty: 0.0
         end
+        Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+          task.update_cached_attributes.save validate: false
+        end
+      end
 
-        expect(first_period_report.overall_homework_score).to be_within(1e-6).of(9/14.0)
-        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(11/14.0)
-        expect(first_period_report.overall_reading_score).to be_nil
-        expect(first_period_report.overall_reading_progress).to be_nil
-        expect(first_period_report.overall_course_average).to be_within(1e-6).of(9/14.0)
+      it 'returns the proper numbers' do
+        expect(first_period_report.overall_homework_score).to be_within(1e-6).of(
+          ((1.0 + 0.75)/2 + (2.0/7.0 + 0.25)/2)/2
+        )
+        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(
+          (1.0 + (4.0/7.0 + 0.25)/2)/2
+        )
+        expect(first_period_report.overall_reading_score).to be_within(1e-6).of(0.45)
+        expect(first_period_report.overall_reading_progress).to be_within(1e-6).of(
+          (1.0 + 1.0/11.0)/2
+        )
+        expect(first_period_report.overall_course_average).to eq(
+          first_period_report.overall_homework_score
+        )
 
-        expect(second_period_report.overall_homework_score).to eq 0.5
-        expect(second_period_report.overall_homework_progress).to eq 0.5
-        expect(second_period_report.overall_reading_score).to be_nil
-        expect(second_period_report.overall_reading_progress).to be_nil
-        expect(second_period_report.overall_course_average).to eq 0.5
+        expect(second_period_report.overall_homework_score).to eq 0.25
+        expect(second_period_report.overall_homework_progress).to eq 0.25
+        expect(second_period_report.overall_reading_score).to eq 0.0
+        expect(second_period_report.overall_reading_progress).to eq 0.0
+        expect(second_period_report.overall_course_average).to eq 0.25
 
         expect(first_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
         expect(first_period_report.data_headings[0].plan_id).to be_a Integer
         expect(first_period_report.data_headings[0].type).to eq 'homework'
         expect(first_period_report.data_headings[0].due_at).to be_a Time
-        expect(first_period_report.data_headings[0].average_score).to be_nil
-        expect(first_period_report.data_headings[0].average_progress).to be_nil
+        expect(first_period_report.data_headings[0].average_score).to eq 0.5
+        expect(first_period_report.data_headings[0].average_progress).to eq 0.625
 
         expect(second_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
         expect(second_period_report.data_headings[0].plan_id).to be_a Integer
         expect(second_period_report.data_headings[0].type).to eq 'homework'
         expect(second_period_report.data_headings[0].due_at).to be_a Time
-        expect(second_period_report.data_headings[0].average_score).to be_nil
-        expect(second_period_report.data_headings[0].average_progress).to be_nil
+        expect(second_period_report.data_headings[0].average_score).to eq 0.0
+        expect(second_period_report.data_headings[0].average_progress).to eq 0.0
 
         expect(first_period_report.data_headings[1].title).to eq 'Reading task plan'
         expect(first_period_report.data_headings[1].plan_id).to be_a Integer
         expect(first_period_report.data_headings[1].type).to eq 'reading'
         expect(first_period_report.data_headings[1].due_at).to be_a Time
-        expect(first_period_report.data_headings[1].average_score).to be_nil
-        expect(first_period_report.data_headings[1].average_progress).to be_nil
+        expect(first_period_report.data_headings[1].average_score).to be_within(1e-6).of(0.45)
+        expect(first_period_report.data_headings[1].average_progress).to(
+          be_within(1e-6).of((1.0 + 1.0/11.0)/2)
+        )
 
         expect(second_period_report.data_headings[1].title).to eq 'Reading task plan'
         expect(second_period_report.data_headings[1].plan_id).to be_a Integer
         expect(second_period_report.data_headings[1].type).to eq 'reading'
         expect(second_period_report.data_headings[1].due_at).to be_a Time
-        expect(second_period_report.data_headings[1].average_score).to be_nil
-        expect(second_period_report.data_headings[1].average_progress).to be_nil
+        expect(second_period_report.data_headings[1].average_score).to eq 0.0
+        expect(second_period_report.data_headings[1].average_progress).to eq 0.0
 
         expect(first_period_report.data_headings[2].title).to eq 'Homework task plan'
         expect(first_period_report.data_headings[2].plan_id).to be_a Integer
@@ -261,20 +275,20 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           @student_2.roles.first.student.student_identifier
         ]
         expect(first_period_students.map(&:homework_score)).to match_array [
-          1.0, be_within(1e-6).of(2/7.0)
+          be_within(1e-6).of((1.0 + 0.75)/2), be_within(1e-6).of((2.0/7.0 + 0.25)/2)
         ]
         expect(first_period_students.map(&:homework_progress)).to match_array [
-          1.0, be_within(1e-6).of(4/7.0)
+          1.0, be_within(1e-6).of((4.0/7.0 + 0.25)/2)
         ]
         expect(first_period_students.map(&:reading_score)).to match_array [
-          nil, nil
+          be_within(1e-6).of(0.9), 0.0
         ]
         expect(first_period_students.map(&:reading_progress)).to match_array [
-          nil, nil
+          1.0, be_within(1e-6).of(1.0/11.0)
         ]
-        expect(first_period_students.map(&:course_average)).to match_array [
-          1.0, be_within(1e-6).of(2/7.0)
-        ]
+        expect(first_period_students.map(&:course_average)).to eq(
+          first_period_students.map(&:homework_score)
+        )
 
         second_period_students = second_period_report.students
         expect(second_period_students.map(&:name)).to match_array [
@@ -293,11 +307,13 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           @student_3.roles.first.student.student_identifier,
           @student_4.roles.first.student.student_identifier
         ]
-        expect(second_period_students.map(&:homework_score)).to match_array [ 1.0, 0.0 ]
-        expect(second_period_students.map(&:homework_progress)).to match_array [ 1.0, 0.0 ]
-        expect(second_period_students.map(&:reading_score)).to match_array [ nil, nil ]
-        expect(second_period_students.map(&:reading_progress)).to match_array [ nil, nil ]
-        expect(second_period_students.map(&:course_average)).to match_array [ 1.0, 0.0 ]
+        expect(second_period_students.map(&:homework_score)).to match_array [ 0.5, 0.0 ]
+        expect(second_period_students.map(&:homework_progress)).to match_array [ 0.5, 0.0 ]
+        expect(second_period_students.map(&:reading_score)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:reading_progress)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:course_average)).to eq(
+          second_period_students.map(&:homework_score)
+        )
 
         (first_period_students + second_period_students).each do |student|
           expect(student.is_dropped).to eq false
@@ -331,54 +347,116 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           end
         end
       end
+
+      it 'works after a student has moved to a different period' do
+        MoveStudent.call(period: second_period, student: @student_1.roles.first.student)
+
+        # No need to retest the entire response, just spot check some things that
+        # should change when the student moves
+        expect(first_period_report.overall_homework_score).to be_within(1e-6).of((2/7.0 + 0.25)/2)
+        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(
+          (4.0/7.0 + 0.25)/2
+        )
+        expect(first_period_report.overall_reading_score).to eq 0.0
+        expect(first_period_report.overall_reading_progress).to be_within(1e-6).of(1.0/11.0)
+        expect(first_period_report.overall_course_average).to eq(
+          first_period_report.overall_homework_score
+        )
+        expect(first_period_report.data_headings[0].average_score).to eq 0.25
+
+        expect(second_period_report.overall_homework_score).to be_within(1e-6).of(
+          ((1.0 + 0.75)/2 + 0.5)/3
+        )
+        expect(second_period_report.overall_homework_progress).to eq 0.5
+        expect(second_period_report.overall_reading_score).to eq 0.3
+        expect(second_period_report.overall_reading_progress).to be_within(1e-6).of(1.0/3.0)
+        expect(second_period_report.overall_course_average).to eq(
+          second_period_report.overall_homework_score
+        )
+        expect(second_period_report.data_headings[2].average_score).to be_within(1e-6).of(2/3.0)
+
+        # There should now be 1 student in period 1 and 3 students in period 2
+        # whereas before there were 2 in each
+        expect(first_period_report.students.length).to eq 1
+        expect(second_period_report.students.length).to eq 3
+      end
+
+      it 'marks dropped students and excludes them from averages' do
+        CourseMembership::InactivateStudent.call(student: @student_2.roles.first.student)
+
+        expect(first_period_report.overall_homework_score).to be_within(1e-6).of((1.0 + 0.75)/2)
+        expect(first_period_report.overall_homework_progress).to eq 1.0
+        expect(first_period_report.overall_reading_score).to be_within(1e-6).of(0.9)
+        expect(first_period_report.overall_reading_progress).to eq 1.0
+        expect(first_period_report.overall_course_average).to eq(
+          first_period_report.overall_homework_score
+        )
+        expect(first_period_report.students.any? do |student|
+          student.name == @student_2.name && student.is_dropped
+        end).to eq true
+      end
     end
 
     context "auto_grading_feedback_on == 'due'" do
-      it 'returns the proper numbers' do
-        tasks = Tasks::Models::Task.where(title: 'Homework task plan')
-        tasks.each do |task|
-          task.task_plan.grading_template.update_column :auto_grading_feedback_on, :due
+      before do
+        Tasks::Models::GradingTemplate.find_each do |grading_template|
+          grading_template.update_columns auto_grading_feedback_on: :due, late_work_penalty: 0.0
         end
+        Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+          task.update_cached_attributes.save validate: false
+        end
+      end
 
-        expect(first_period_report.overall_homework_score).to be_within(1e-6).of(9/14.0)
-        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(11/14.0)
-        expect(first_period_report.overall_reading_score).to be_nil
-        expect(first_period_report.overall_reading_progress).to be_nil
-        expect(first_period_report.overall_course_average).to be_within(1e-6).of(9/14.0)
+      it 'returns the proper numbers' do
+        expect(first_period_report.overall_homework_score).to be_within(1e-6).of(
+          ((1.0 + 0.75)/2 + (2.0/7.0 + 0.25)/2)/2
+        )
+        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(
+          (1.0 + (4.0/7.0 + 0.25)/2)/2
+        )
+        expect(first_period_report.overall_reading_score).to be_within(1e-6).of(0.45)
+        expect(first_period_report.overall_reading_progress).to be_within(1e-6).of(
+          (1.0 + 1.0/11.0)/2
+        )
+        expect(first_period_report.overall_course_average).to eq(
+          first_period_report.overall_homework_score
+        )
 
-        expect(second_period_report.overall_homework_score).to eq 0.5
-        expect(second_period_report.overall_homework_progress).to eq 0.5
-        expect(second_period_report.overall_reading_score).to be_nil
-        expect(second_period_report.overall_reading_progress).to be_nil
-        expect(second_period_report.overall_course_average).to eq 0.5
+        expect(second_period_report.overall_homework_score).to eq 0.25
+        expect(second_period_report.overall_homework_progress).to eq 0.25
+        expect(second_period_report.overall_reading_score).to eq 0.0
+        expect(second_period_report.overall_reading_progress).to eq 0.0
+        expect(second_period_report.overall_course_average).to eq 0.25
 
         expect(first_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
         expect(first_period_report.data_headings[0].plan_id).to be_a Integer
         expect(first_period_report.data_headings[0].type).to eq 'homework'
         expect(first_period_report.data_headings[0].due_at).to be_a Time
-        expect(first_period_report.data_headings[0].average_score).to be_nil
-        expect(first_period_report.data_headings[0].average_progress).to be_nil
+        expect(first_period_report.data_headings[0].average_score).to eq 0.5
+        expect(first_period_report.data_headings[0].average_progress).to eq 0.625
 
         expect(second_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
         expect(second_period_report.data_headings[0].plan_id).to be_a Integer
         expect(second_period_report.data_headings[0].type).to eq 'homework'
         expect(second_period_report.data_headings[0].due_at).to be_a Time
-        expect(second_period_report.data_headings[0].average_score).to be_nil
-        expect(second_period_report.data_headings[0].average_progress).to be_nil
+        expect(second_period_report.data_headings[0].average_score).to eq 0.0
+        expect(second_period_report.data_headings[0].average_progress).to eq 0.0
 
         expect(first_period_report.data_headings[1].title).to eq 'Reading task plan'
         expect(first_period_report.data_headings[1].plan_id).to be_a Integer
         expect(first_period_report.data_headings[1].type).to eq 'reading'
         expect(first_period_report.data_headings[1].due_at).to be_a Time
-        expect(first_period_report.data_headings[1].average_score).to be_nil
-        expect(first_period_report.data_headings[1].average_progress).to be_nil
+        expect(first_period_report.data_headings[1].average_score).to be_within(1e-6).of(0.45)
+        expect(first_period_report.data_headings[1].average_progress).to(
+          be_within(1e-6).of((1.0 + 1.0/11.0)/2)
+        )
 
         expect(second_period_report.data_headings[1].title).to eq 'Reading task plan'
         expect(second_period_report.data_headings[1].plan_id).to be_a Integer
         expect(second_period_report.data_headings[1].type).to eq 'reading'
         expect(second_period_report.data_headings[1].due_at).to be_a Time
-        expect(second_period_report.data_headings[1].average_score).to be_nil
-        expect(second_period_report.data_headings[1].average_progress).to be_nil
+        expect(second_period_report.data_headings[1].average_score).to eq 0.0
+        expect(second_period_report.data_headings[1].average_progress).to eq 0.0
 
         expect(first_period_report.data_headings[2].title).to eq 'Homework task plan'
         expect(first_period_report.data_headings[2].plan_id).to be_a Integer
@@ -426,20 +504,20 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           @student_2.roles.first.student.student_identifier
         ]
         expect(first_period_students.map(&:homework_score)).to match_array [
-          1.0, be_within(1e-6).of(2/7.0)
+          be_within(1e-6).of((1.0 + 0.75)/2), be_within(1e-6).of((2.0/7.0 + 0.25)/2)
         ]
         expect(first_period_students.map(&:homework_progress)).to match_array [
-          1.0, be_within(1e-6).of(4/7.0)
+          1.0, be_within(1e-6).of((4.0/7.0 + 0.25)/2)
         ]
         expect(first_period_students.map(&:reading_score)).to match_array [
-          nil, nil
+          be_within(1e-6).of(0.9), 0.0
         ]
         expect(first_period_students.map(&:reading_progress)).to match_array [
-          nil, nil
+          1.0, be_within(1e-6).of(1.0/11.0)
         ]
-        expect(first_period_students.map(&:course_average)).to match_array [
-          1.0, be_within(1e-6).of(2/7.0)
-        ]
+        expect(first_period_students.map(&:course_average)).to eq(
+          first_period_students.map(&:homework_score)
+        )
 
         second_period_students = second_period_report.students
         expect(second_period_students.map(&:name)).to match_array [
@@ -458,11 +536,13 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           @student_3.roles.first.student.student_identifier,
           @student_4.roles.first.student.student_identifier
         ]
-        expect(second_period_students.map(&:homework_score)).to match_array [ 1.0, 0.0 ]
-        expect(second_period_students.map(&:homework_progress)).to match_array [ 1.0, 0.0 ]
-        expect(second_period_students.map(&:reading_score)).to match_array [ nil, nil ]
-        expect(second_period_students.map(&:reading_progress)).to match_array [ nil, nil ]
-        expect(second_period_students.map(&:course_average)).to match_array [ 1.0, 0.0 ]
+        expect(second_period_students.map(&:homework_score)).to match_array [ 0.5, 0.0 ]
+        expect(second_period_students.map(&:homework_progress)).to match_array [ 0.5, 0.0 ]
+        expect(second_period_students.map(&:reading_score)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:reading_progress)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:course_average)).to eq(
+          second_period_students.map(&:homework_score)
+        )
 
         (first_period_students + second_period_students).each do |student|
           expect(student.is_dropped).to eq false
@@ -499,51 +579,63 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
     end
 
     context "auto_grading_feedback_on == 'publish'" do
-      it 'returns the proper numbers' do
-        tasks = Tasks::Models::Task.where(title: 'Homework task plan')
-        grading_templates = tasks.map(&:task_plan).uniq.map(&:grading_template).uniq
-        grading_templates.each { |gt| gt.update_column :auto_grading_feedback_on, :publish }
-        tasks.each { |task| task.update_caches_now update_cached_attributes: true }
+      before do
+        Tasks::Models::GradingTemplate.find_each do |grading_template|
+          grading_template.update_columns auto_grading_feedback_on: :publish, late_work_penalty: 0.0
+        end
+        Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+          task.update_cached_attributes.save validate: false
+        end
+      end
 
-        expect(first_period_report.overall_homework_score).to be_nil
-        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(11/14.0)
-        expect(first_period_report.overall_reading_score).to be_nil
-        expect(first_period_report.overall_reading_progress).to be_nil
-        expect(first_period_report.overall_course_average).to be_nil
+      it 'returns the proper numbers' do
+        expect(first_period_report.overall_homework_score).to eq 0.0
+        expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(
+          (1.0 + (4.0/7.0 + 0.25)/2)/2
+        )
+        expect(first_period_report.overall_reading_score).to eq 0.0
+        expect(first_period_report.overall_reading_progress).to be_within(1e-6).of(
+          (1.0 + 1.0/11.0)/2
+        )
+        expect(first_period_report.overall_course_average).to eq(
+          first_period_report.overall_homework_score
+        )
 
         expect(second_period_report.overall_homework_score).to eq 0.0
-        expect(second_period_report.overall_homework_progress).to eq 0.5
-        expect(second_period_report.overall_reading_score).to be_nil
-        expect(second_period_report.overall_reading_progress).to be_nil
+        expect(second_period_report.overall_homework_progress).to eq 0.25
+        expect(second_period_report.overall_reading_score).to eq 0.0
+        expect(second_period_report.overall_reading_progress).to eq 0.0
         expect(second_period_report.overall_course_average).to eq 0.0
 
         expect(first_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
         expect(first_period_report.data_headings[0].plan_id).to be_a Integer
         expect(first_period_report.data_headings[0].type).to eq 'homework'
         expect(first_period_report.data_headings[0].due_at).to be_a Time
-        expect(first_period_report.data_headings[0].average_score).to be_nil
-        expect(first_period_report.data_headings[0].average_progress).to be_nil
+        expect(first_period_report.data_headings[0].average_score).to eq 0.0
+        expect(first_period_report.data_headings[0].average_progress).to eq 0.625
 
         expect(second_period_report.data_headings[0].title).to eq 'Homework 2 task plan'
         expect(second_period_report.data_headings[0].plan_id).to be_a Integer
         expect(second_period_report.data_headings[0].type).to eq 'homework'
         expect(second_period_report.data_headings[0].due_at).to be_a Time
-        expect(second_period_report.data_headings[0].average_score).to be_nil
-        expect(second_period_report.data_headings[0].average_progress).to be_nil
+        expect(second_period_report.data_headings[0].average_score).to eq 0.0
+        expect(second_period_report.data_headings[0].average_progress).to eq 0.0
 
         expect(first_period_report.data_headings[1].title).to eq 'Reading task plan'
         expect(first_period_report.data_headings[1].plan_id).to be_a Integer
         expect(first_period_report.data_headings[1].type).to eq 'reading'
         expect(first_period_report.data_headings[1].due_at).to be_a Time
-        expect(first_period_report.data_headings[1].average_score).to be_nil
-        expect(first_period_report.data_headings[1].average_progress).to be_nil
+        expect(first_period_report.data_headings[1].average_score).to eq 0.0
+        expect(first_period_report.data_headings[1].average_progress).to(
+          be_within(1e-6).of((1.0 + 1.0/11.0)/2)
+        )
 
         expect(second_period_report.data_headings[1].title).to eq 'Reading task plan'
         expect(second_period_report.data_headings[1].plan_id).to be_a Integer
         expect(second_period_report.data_headings[1].type).to eq 'reading'
         expect(second_period_report.data_headings[1].due_at).to be_a Time
-        expect(second_period_report.data_headings[1].average_score).to be_nil
-        expect(second_period_report.data_headings[1].average_progress).to be_nil
+        expect(second_period_report.data_headings[1].average_score).to eq 0.0
+        expect(second_period_report.data_headings[1].average_progress).to eq 0.0
 
         expect(first_period_report.data_headings[2].title).to eq 'Homework task plan'
         expect(first_period_report.data_headings[2].plan_id).to be_a Integer
@@ -591,20 +683,20 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           @student_2.roles.first.student.student_identifier
         ]
         expect(first_period_students.map(&:homework_score)).to match_array [
-          nil, nil
+          0.0, nil
         ]
         expect(first_period_students.map(&:homework_progress)).to match_array [
-          1.0, be_within(1e-6).of(4/7.0)
+          1.0, be_within(1e-6).of((4.0/7.0 + 0.25)/2)
         ]
         expect(first_period_students.map(&:reading_score)).to match_array [
-          nil, nil
+          0.0, nil
         ]
         expect(first_period_students.map(&:reading_progress)).to match_array [
-          nil, nil
+          1.0, be_within(1e-6).of(1.0/11.0)
         ]
-        expect(first_period_students.map(&:course_average)).to match_array [
-          nil, nil
-        ]
+        expect(first_period_students.map(&:course_average)).to eq(
+          first_period_students.map(&:homework_score)
+        )
 
         second_period_students = second_period_report.students
         expect(second_period_students.map(&:name)).to match_array [
@@ -623,11 +715,13 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           @student_3.roles.first.student.student_identifier,
           @student_4.roles.first.student.student_identifier
         ]
-        expect(second_period_students.map(&:homework_score)).to match_array [ 0.0, nil ]
-        expect(second_period_students.map(&:homework_progress)).to match_array [ 1.0, 0.0 ]
-        expect(second_period_students.map(&:reading_score)).to match_array [ nil, nil ]
-        expect(second_period_students.map(&:reading_progress)).to match_array [ nil, nil ]
-        expect(second_period_students.map(&:course_average)).to match_array [ 0.0, nil ]
+        expect(second_period_students.map(&:homework_score)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:homework_progress)).to match_array [ 0.5, 0.0 ]
+        expect(second_period_students.map(&:reading_score)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:reading_progress)).to match_array [ 0.0, 0.0 ]
+        expect(second_period_students.map(&:course_average)).to eq(
+          second_period_students.map(&:homework_score)
+        )
 
         (first_period_students + second_period_students).each do |student|
           expect(student.is_dropped).to eq false
@@ -663,34 +757,6 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       end
     end
 
-    it 'works after a student has moved to a different period' do
-      MoveStudent.call(period: second_period, student: @student_1.roles.first.student)
-
-      # No need to retest the entire response, just spot check some things that
-      # should change when the student moves
-
-      # period 1 no longer has an average score in the data headings (complete tasks moved
-      # to period 2; on the other hand, period 2 now has average scores where it didn't before)
-      expect(first_period_report.overall_homework_score).to be_within(1e-6).of(2/7.0)
-      expect(first_period_report.overall_homework_progress).to be_within(1e-6).of(4/7.0)
-      expect(first_period_report.overall_reading_score).to be_nil
-      expect(first_period_report.overall_reading_progress).to be_nil
-      expect(first_period_report.overall_course_average).to be_within(1e-6).of(2/7.0)
-      expect(first_period_report.data_headings[0].average_score).to be_nil
-
-      expect(second_period_report.overall_homework_score).to be_within(1e-6).of(2/3.0)
-      expect(second_period_report.overall_homework_progress).to be_within(1e-6).of(2/3.0)
-      expect(second_period_report.overall_reading_score).to be_nil
-      expect(second_period_report.overall_reading_progress).to be_nil
-      expect(second_period_report.overall_course_average).to be_within(1e-6).of(2/3.0)
-      expect(second_period_report.data_headings[2].average_score).to be_within(1e-6).of(2/3.0)
-
-      # There should now be 1 student in period 1 and 3 students in period 2
-      # whereas before there were 2 in each
-      expect(first_period_report.students.length).to eq 1
-      expect(second_period_report.students.length).to eq 3
-    end
-
     it 'returns nil when a student did not work a particular task' do
       first_student_of_first_period.role.taskings.first.task.really_destroy!
       expect(first_period_report.students.first.data).to include nil
@@ -716,19 +782,6 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
     it 'works when a student has no last_name' do
       first_student_of_first_period.role.profile.account.update_attribute(:last_name, nil)
       expect { reports }.not_to raise_error
-    end
-
-    it 'marks dropped students and excludes them from averages' do
-      CourseMembership::InactivateStudent.call(student: @student_2.roles.first.student)
-
-      expect(first_period_report.overall_homework_score).to eq 1.0
-      expect(first_period_report.overall_homework_progress).to eq 1.0
-      expect(first_period_report.overall_reading_score).to be_nil
-      expect(first_period_report.overall_reading_progress).to be_nil
-      expect(first_period_report.overall_course_average).to eq 1.0
-      expect(first_period_report.students.any? do |student|
-        student.name == @student_2.name && student.is_dropped
-      end).to eq true
     end
   end
 
@@ -758,169 +811,185 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
       expect(data_types).to eq expected_task_types
     end
 
-    it 'returns the proper numbers' do
-      expect(report.overall_homework_score).to eq 1.0
-      expect(report.overall_homework_progress).to eq 1.0
-      expect(report.overall_reading_score).to be_nil
-      expect(report.overall_reading_progress).to be_nil
-      expect(report.overall_course_average).to eq 1.0
+    context "auto_grading_feedback_on == 'answer'" do
+      before do
+        Tasks::Models::GradingTemplate.find_each do |grading_template|
+          grading_template.update_columns auto_grading_feedback_on: :answer, late_work_penalty: 0.0
+        end
+        Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+          task.update_cached_attributes.save validate: false
+        end
+      end
 
-      expect(report.data_headings[0].title).to eq 'Homework 2 task plan'
-      expect(report.data_headings[0].plan_id).to be_a Integer
-      expect(report.data_headings[0].type).to eq 'homework'
-      expect(report.data_headings[0].due_at).to be_a Time
-      expect(report.data_headings[0].average_score).to be_nil
-      expect(report.data_headings[0].average_progress).to be_nil
+      it 'returns the proper numbers' do
+        expect(report.overall_homework_score).to be_within(1e-6).of((1.0 + 0.75)/2)
+        expect(report.overall_homework_progress).to eq 1.0
+        expect(report.overall_reading_score).to be_within(1e-6).of(0.9)
+        expect(report.overall_reading_progress).to eq 1.0
+        expect(report.overall_course_average).to eq report.overall_homework_score
 
-      expect(report.data_headings[1].title).to eq 'Reading task plan'
-      expect(report.data_headings[1].plan_id).to be_a Integer
-      expect(report.data_headings[1].type).to eq 'reading'
-      expect(report.data_headings[1].due_at).to be_a Time
-      expect(report.data_headings[1].average_score).to be_nil
-      expect(report.data_headings[1].average_progress).to be_nil
+        expect(report.data_headings[0].title).to eq 'Homework 2 task plan'
+        expect(report.data_headings[0].plan_id).to be_a Integer
+        expect(report.data_headings[0].type).to eq 'homework'
+        expect(report.data_headings[0].due_at).to be_a Time
+        expect(report.data_headings[0].average_score).to eq 0.75
+        expect(report.data_headings[0].average_progress).to eq 1.0
 
-      expect(report.data_headings[2].title).to eq 'Homework task plan'
-      expect(report.data_headings[2].plan_id).to be_a Integer
-      expect(report.data_headings[2].type).to eq 'homework'
-      expect(report.data_headings[2].due_at).to be_a Time
-      expect(report.data_headings[2].average_score).to eq 1.0
-      expect(report.data_headings[2].average_progress).to eq 1.0
+        expect(report.data_headings[1].title).to eq 'Reading task plan'
+        expect(report.data_headings[1].plan_id).to be_a Integer
+        expect(report.data_headings[1].type).to eq 'reading'
+        expect(report.data_headings[1].due_at).to be_a Time
+        expect(report.data_headings[1].average_score).to be_within(1e-6).of(0.9)
+        expect(report.data_headings[1].average_progress).to eq 1.0
 
-      expect(report.data_headings[3].title).to eq 'External assignment'
-      expect(report.data_headings[3].plan_id).to be_a Integer
-      expect(report.data_headings[3].type).to eq 'external'
-      expect(report.data_headings[3].due_at).to be_a Time
-      expect(report.data_headings[3].average_score).to be_nil
-      expect(report.data_headings[3].average_progress).to eq 0.0
+        expect(report.data_headings[2].title).to eq 'Homework task plan'
+        expect(report.data_headings[2].plan_id).to be_a Integer
+        expect(report.data_headings[2].type).to eq 'homework'
+        expect(report.data_headings[2].due_at).to be_a Time
+        expect(report.data_headings[2].average_score).to eq 1.0
+        expect(report.data_headings[2].average_progress).to eq 1.0
 
-      expect(student.name).to eq @student_1.name
-      expect(student.first_name).to eq @student_1.first_name
-      expect(student.last_name).to eq @student_1.last_name
-      expect(student.role).to eq @student_1.roles.first.id
-      expect(student.student_identifier).to(
-        eq @student_1.roles.first.student.student_identifier
-      )
-      expect(student.homework_score).to eq 1.0
-      expect(student.homework_progress).to eq 1.0
-      expect(student.reading_score).to be_nil
-      expect(student.reading_progress).to be_nil
-      expect(student.course_average).to eq 1.0
+        expect(report.data_headings[3].title).to eq 'External assignment'
+        expect(report.data_headings[3].plan_id).to be_a Integer
+        expect(report.data_headings[3].type).to eq 'external'
+        expect(report.data_headings[3].due_at).to be_a Time
+        expect(report.data_headings[3].average_score).to be_nil
+        expect(report.data_headings[3].average_progress).to eq 0.0
 
-      expect(student.is_dropped).to eq false
+        expect(student.name).to eq @student_1.name
+        expect(student.first_name).to eq @student_1.first_name
+        expect(student.last_name).to eq @student_1.last_name
+        expect(student.role).to eq @student_1.roles.first.id
+        expect(student.student_identifier).to(
+          eq @student_1.roles.first.student.student_identifier
+        )
+        expect(student.homework_score).to be_within(1e-6).of((1.0 + 0.75)/2)
+        expect(student.homework_progress).to eq 1.0
+        expect(student.reading_score).to be_within(1e-6).of(0.9)
+        expect(student.reading_progress).to eq 1.0
+        expect(student.course_average).to eq student.homework_score
 
-      data = student.data
-      expect(data.size).to eq expected_tasks
-      expect(data.map(&:type)).to eq expected_task_types
+        expect(student.is_dropped).to eq false
 
-      data.each do |data|
-        expect(data.id).to be_a Integer
-        expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
-        expect(data.due_at).to be_a Time
-        expect(data.last_worked_at).to be_nil.or(be_a Time)
-        expect(data.is_extended).to be_in [true, false]
-        expect(data.is_past_due).to be_in [true, false]
-        expect(data.step_count).to be_a Integer
-        expect(data.completed_step_count).to be_a Integer
-        expect(data.completed_on_time_steps_count).to be_a Integer
-        expect(data.actual_and_placeholder_exercise_count).to be_a Integer
-        expect(data.completed_exercise_count).to be_a Integer
-        expect(data.completed_on_time_exercise_steps_count).to be_a Integer
-        expect(data.recovered_exercise_count).to be_a Integer
-        expect(data.gradable_step_count).to be_a Integer
-        expect(data.ungraded_step_count).to be_a Integer
-        expect(data.is_included_in_averages).to be_in [true, false]
-        expect(data.progress).to be_a Float
-        # Some assignments might not have feedback available
-        # so they might get a nil here even though points/score have been assigned
-        expect(data.published_points.class).to be_in([NilClass, Float])
-        expect(data.published_score.class).to be_in([NilClass, Float])
+        data = student.data
+        expect(data.size).to eq expected_tasks
+        expect(data.map(&:type)).to eq expected_task_types
+
+        data.each do |data|
+          expect(data.id).to be_a Integer
+          expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
+          expect(data.due_at).to be_a Time
+          expect(data.last_worked_at).to be_nil.or(be_a Time)
+          expect(data.is_extended).to be_in [true, false]
+          expect(data.is_past_due).to be_in [true, false]
+          expect(data.step_count).to be_a Integer
+          expect(data.completed_step_count).to be_a Integer
+          expect(data.completed_on_time_steps_count).to be_a Integer
+          expect(data.actual_and_placeholder_exercise_count).to be_a Integer
+          expect(data.completed_exercise_count).to be_a Integer
+          expect(data.completed_on_time_exercise_steps_count).to be_a Integer
+          expect(data.recovered_exercise_count).to be_a Integer
+          expect(data.gradable_step_count).to be_a Integer
+          expect(data.ungraded_step_count).to be_a Integer
+          expect(data.is_included_in_averages).to be_in [true, false]
+          expect(data.progress).to be_a Float
+          # Some assignments might not have feedback available
+          # so they might get a nil here even though points/score have been assigned
+          expect(data.published_points.class).to be_in([NilClass, Float])
+          expect(data.published_score.class).to be_in([NilClass, Float])
+        end
       end
     end
 
-    it 'does not include correctness and score for tasks with no feedback available' do
-      task = Tasks::Models::Task.joins(:taskings).find_by(
-        taskings: { entity_role_id: @student_1.roles.first.id },
-        title: 'Homework task plan'
-      )
-      task.task_plan.grading_template.update_column :auto_grading_feedback_on, :publish
+    context "auto_grading_feedback_on == 'publish'" do
+      before do
+        Tasks::Models::GradingTemplate.find_each do |grading_template|
+          grading_template.update_columns auto_grading_feedback_on: :publish, late_work_penalty: 0.0
+        end
+        Tasks::Models::Task.preload(task_steps: :tasked).find_each do |task|
+          task.update_cached_attributes.save validate: false
+        end
+      end
 
-      expect(report.data_headings.size).to eq expected_tasks
+      it 'does not include correctness and score for tasks with no feedback available' do
+        expect(report.data_headings.size).to eq expected_tasks
 
-      expect(report.overall_homework_score).to be_nil
-      expect(report.overall_homework_progress).to eq 1.0
-      expect(report.overall_reading_score).to be_nil
-      expect(report.overall_reading_progress).to be_nil
-      expect(report.overall_course_average).to be_nil
+        expect(report.overall_homework_score).to be_nil
+        expect(report.overall_homework_progress).to eq 1.0
+        expect(report.overall_reading_score).to be_nil
+        expect(report.overall_reading_progress).to eq 1.0
+        expect(report.overall_course_average).to be_nil
 
-      expect(report.data_headings[0].title).to eq 'Homework 2 task plan'
-      expect(report.data_headings[0].plan_id).to be_a Integer
-      expect(report.data_headings[0].type).to eq 'homework'
-      expect(report.data_headings[0].due_at).to be_a Time
-      expect(report.data_headings[0].average_score).to be_nil
-      expect(report.data_headings[0].average_progress).to be_nil
+        expect(report.data_headings[0].title).to eq 'Homework 2 task plan'
+        expect(report.data_headings[0].plan_id).to be_a Integer
+        expect(report.data_headings[0].type).to eq 'homework'
+        expect(report.data_headings[0].due_at).to be_a Time
+        expect(report.data_headings[0].average_score).to be_nil
+        expect(report.data_headings[0].average_progress).to eq 1.0
 
-      expect(report.data_headings[1].title).to eq 'Reading task plan'
-      expect(report.data_headings[1].plan_id).to be_a Integer
-      expect(report.data_headings[1].type).to eq 'reading'
-      expect(report.data_headings[1].due_at).to be_a Time
-      expect(report.data_headings[1].average_score).to be_nil
-      expect(report.data_headings[1].average_progress).to be_nil
+        expect(report.data_headings[1].title).to eq 'Reading task plan'
+        expect(report.data_headings[1].plan_id).to be_a Integer
+        expect(report.data_headings[1].type).to eq 'reading'
+        expect(report.data_headings[1].due_at).to be_a Time
+        expect(report.data_headings[1].average_score).to be_nil
+        expect(report.data_headings[1].average_progress).to eq 1.0
 
-      expect(report.data_headings[2].title).to eq 'Homework task plan'
-      expect(report.data_headings[2].plan_id).to be_a Integer
-      expect(report.data_headings[2].type).to eq 'homework'
-      expect(report.data_headings[2].due_at).to be_a Time
-      expect(report.data_headings[2].average_score).to be_nil
-      expect(report.data_headings[2].average_progress).to eq 1.0
+        expect(report.data_headings[2].title).to eq 'Homework task plan'
+        expect(report.data_headings[2].plan_id).to be_a Integer
+        expect(report.data_headings[2].type).to eq 'homework'
+        expect(report.data_headings[2].due_at).to be_a Time
+        expect(report.data_headings[2].average_score).to be_nil
+        expect(report.data_headings[2].average_progress).to eq 1.0
 
-      expect(report.data_headings[3].title).to eq 'External assignment'
-      expect(report.data_headings[3].plan_id).to be_a Integer
-      expect(report.data_headings[3].type).to eq 'external'
-      expect(report.data_headings[3].due_at).to be_a Time
-      expect(report.data_headings[3].average_score).to be_nil
-      expect(report.data_headings[3].average_progress).to eq 0.0
+        expect(report.data_headings[3].title).to eq 'External assignment'
+        expect(report.data_headings[3].plan_id).to be_a Integer
+        expect(report.data_headings[3].type).to eq 'external'
+        expect(report.data_headings[3].due_at).to be_a Time
+        expect(report.data_headings[3].average_score).to be_nil
+        expect(report.data_headings[3].average_progress).to eq 0.0
 
-      expect(student.name).to eq @student_1.name
-      expect(student.first_name).to eq @student_1.first_name
-      expect(student.last_name).to eq @student_1.last_name
-      expect(student.role).to eq @student_1.roles.first.id
-      expect(student.student_identifier).to(
-        eq @student_1.roles.first.student.student_identifier
-      )
-      expect(student.homework_score).to be_nil
-      expect(student.homework_progress).to eq 1.0
-      expect(student.reading_score).to be_nil
-      expect(student.reading_progress).to be_nil
-      expect(student.course_average).to be_nil
+        expect(student.name).to eq @student_1.name
+        expect(student.first_name).to eq @student_1.first_name
+        expect(student.last_name).to eq @student_1.last_name
+        expect(student.role).to eq @student_1.roles.first.id
+        expect(student.student_identifier).to(
+          eq @student_1.roles.first.student.student_identifier
+        )
+        expect(student.homework_score).to be_nil
+        expect(student.homework_progress).to eq 1.0
+        expect(student.reading_score).to be_nil
+        expect(student.reading_progress).to eq 1.0
+        expect(student.course_average).to be_nil
 
-      expect(student.is_dropped).to eq false
+        expect(student.is_dropped).to eq false
 
-      data = student.data
-      expect(data.size).to eq expected_tasks
-      expect(data.map(&:type)).to eq expected_task_types
+        data = student.data
+        expect(data.size).to eq expected_tasks
+        expect(data.map(&:type)).to eq expected_task_types
 
-      data.each do |data|
-        expect(data.id).to be_a Integer
-        expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
-        expect(data.due_at).to be_a Time
-        expect(data.last_worked_at).to be_nil.or(be_a Time)
-        expect(data.is_extended).to be_in [true, false]
-        expect(data.is_past_due).to be_in [true, false]
-        expect(data.step_count).to be_a Integer
-        expect(data.completed_step_count).to be_a Integer
-        expect(data.completed_on_time_steps_count).to be_a Integer
-        expect(data.actual_and_placeholder_exercise_count).to be_a Integer
-        expect(data.completed_exercise_count).to be_a Integer
-        expect(data.completed_on_time_exercise_steps_count).to be_a Integer
-        expect(data.recovered_exercise_count).to be_a Integer
-        expect(data.gradable_step_count).to be_a Integer
-        expect(data.ungraded_step_count).to be_a Integer
-        expect(data.is_included_in_averages).to be_in [true, false]
-        expect(data.progress).to be_a Float
-        # Some assignments might not have feedback available
-        # so they might get a nil here even though points/score have been assigned
-        expect(data.published_points.class).to be_in([NilClass, Float])
-        expect(data.published_score.class).to be_in([NilClass, Float])
+        data.each do |data|
+          expect(data.id).to be_a Integer
+          expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
+          expect(data.due_at).to be_a Time
+          expect(data.last_worked_at).to be_nil.or(be_a Time)
+          expect(data.is_extended).to be_in [true, false]
+          expect(data.is_past_due).to be_in [true, false]
+          expect(data.step_count).to be_a Integer
+          expect(data.completed_step_count).to be_a Integer
+          expect(data.completed_on_time_steps_count).to be_a Integer
+          expect(data.actual_and_placeholder_exercise_count).to be_a Integer
+          expect(data.completed_exercise_count).to be_a Integer
+          expect(data.completed_on_time_exercise_steps_count).to be_a Integer
+          expect(data.recovered_exercise_count).to be_a Integer
+          expect(data.gradable_step_count).to be_a Integer
+          expect(data.ungraded_step_count).to be_a Integer
+          expect(data.is_included_in_averages).to be_in [true, false]
+          expect(data.progress).to be_a Float
+          # Some assignments might not have feedback available
+          # so they might get a nil here even though points/score have been assigned
+          expect(data.published_points.class).to be_in([NilClass, Float])
+          expect(data.published_score.class).to be_in([NilClass, Float])
+        end
       end
     end
   end

--- a/spec/support/setup_performance_report_data.rb
+++ b/spec/support/setup_performance_report_data.rb
@@ -33,8 +33,7 @@ class SetupPerformanceReportData
       roles << CreateOrResetTeacherStudent[user: teacher_student, period: period_1]
     end
 
-    student_tasks = course.is_concept_coach ? setup_cc_tasks(roles, pages) :
-                                              setup_tasks(course, ecosystem, roles, pages)
+    student_tasks = setup_tasks(course, ecosystem, roles, pages)
 
     answer_tasks(student_tasks)
   end
@@ -83,9 +82,9 @@ class SetupPerformanceReportData
       :tasks_tasking_plan,
       target: course,
       task_plan: reading_taskplan,
-      opens_at: time_zone.now,
-      due_at: time_zone.now + 1.week,
-      closes_at: time_zone.now + 2.weeks
+      opens_at: time_zone.now - 1.week,
+      due_at: time_zone.now.yesterday,
+      closes_at: time_zone.now + 6.days
     )
 
     reading_taskplan.save!
@@ -101,7 +100,7 @@ class SetupPerformanceReportData
       content_ecosystem_id: ecosystem.id,
       settings: {
         exercises: exercises.first(5).map do |exercise|
-          { id: exercise.id.to_s, points: [ 1 ] * exercise.number_of_questions }
+          { id: exercise.id.to_s, points: [ 1.0 ] * exercise.number_of_questions }
         end,
         exercises_count_dynamic: 2
       },
@@ -110,10 +109,11 @@ class SetupPerformanceReportData
 
     homework_taskplan.tasking_plans << FactoryBot.build(
       :tasks_tasking_plan,
-      target: course, task_plan: homework_taskplan,
-      opens_at: time_zone.now,
-      due_at: time_zone.now.tomorrow,
-      closes_at: time_zone.now.tomorrow + 1.day
+      target: course,
+      task_plan: homework_taskplan,
+      opens_at: time_zone.now.yesterday - 2.days,
+      due_at: time_zone.now.yesterday - 1.day,
+      closes_at: time_zone.now + 5.days
     )
 
     homework_taskplan.save!
@@ -129,7 +129,7 @@ class SetupPerformanceReportData
       content_ecosystem_id: ecosystem.id,
       settings: {
         exercises: exercises.last(2).map do |exercise|
-          { id: exercise.id.to_s, points: [ 1 ] * exercise.number_of_questions }
+          { id: exercise.id.to_s, points: [ 1.0 ] * exercise.number_of_questions }
         end,
         exercises_count_dynamic: 2
       },
@@ -138,10 +138,11 @@ class SetupPerformanceReportData
 
     homework2_taskplan.tasking_plans << FactoryBot.build(
       :tasks_tasking_plan,
-      target: course, task_plan: homework2_taskplan,
-      opens_at: time_zone.now,
-      due_at: time_zone.now + 2.weeks,
-      closes_at: time_zone.now + 4.weeks
+      target: course,
+      task_plan: homework2_taskplan,
+      opens_at: time_zone.now - 2.weeks,
+      due_at: time_zone.now,
+      closes_at: time_zone.now + 1.week
     )
 
     homework2_taskplan.save!
@@ -157,7 +158,7 @@ class SetupPerformanceReportData
       content_ecosystem_id: ecosystem.id,
       settings: {
         exercises: exercises.first(5).map do |exercise|
-          { id: exercise.id.to_s, points: [ 1 ] * exercise.number_of_questions }
+          { id: exercise.id.to_s, points: [ 1.0 ] * exercise.number_of_questions }
         end,
         exercises_count_dynamic: 2
       },
@@ -191,7 +192,7 @@ class SetupPerformanceReportData
     # User 1 answered 2 correct core, 1 correct spaced practice
     # and 1 incorrect personalized exercise (in an SPE slot) in 2nd homework
     is_completed = ->(task_step, index) { true }
-    is_correct   = ->(task_step, index) { index < task_step.task.task_steps.size }
+    is_correct   = ->(task_step, index) { index < task_step.task.task_steps.size - 1 }
     Preview::WorkTask[task: student_1_tasks[2], is_completed: is_completed, is_correct: is_correct]
 
     # User 2 answered 2 questions correctly and 2 incorrectly in homework


### PR DESCRIPTION
Previously the gradebook was showing any task that was open.