### PR TITLE
Invalidate task score caches on course timezone updates

### DIFF
--- a/app/subsystems/course_profile/update_course.rb
+++ b/app/subsystems/course_profile/update_course.rb
@@ -7,10 +7,13 @@ class CourseProfile::UpdateCourse
     course = CourseProfile::Models::Course.find_by(id: id)
     course.update_attributes(course_params)
 
-    transfer_errors_from course, {type: :verbatim}, true
+    transfer_errors_from course, { type: :verbatim }, true
+
+    Tasks::Models::Task.where(course: course).find_each(&:update_caches_later) \
+      if course.previous_changes['timezone'] ||
+         course.previous_changes['past_due_unattempted_ungraded_wrq_are_zero']
 
     OpenStax::Biglearn::Api.update_rosters course: course
     OpenStax::Biglearn::Api.update_course_active_dates course: course
   end
-
 end


### PR DESCRIPTION
Changing the timezone can change the scores due to late work.