### PR TITLE
Freeze old scores

### DIFF
--- a/app/representers/api/v1/performance_report/period_representer.rb
+++ b/app/representers/api/v1/performance_report/period_representer.rb
@@ -6,7 +6,7 @@ module Api::V1::PerformanceReport
              type: String,
              readable: true,
              writeable: false,
-             getter: ->(*) { period.id.to_s }
+             getter: ->(*) { respond_to?(:period_id) ? period_id : period.id.to_s }
 
     property :overall_course_average,
              type: Float,

--- a/app/representers/api/v1/performance_report/student/data/representer.rb
+++ b/app/representers/api/v1/performance_report/student/data/representer.rb
@@ -32,11 +32,14 @@ module Api::V1::PerformanceReport::Student::Data
              readable: true,
              writeable: false
 
-    property :actual_and_placeholder_exercise_count,
-             as: :exercise_count,
+    property :exercise_count,
              type: Integer,
              readable: true,
-             writeable: false
+             writeable: false,
+             getter: ->(*) do
+               respond_to?(:exercise_count) ? exercise_count :
+                                              actual_and_placeholder_exercise_count
+             end
 
     property :completed_exercise_count,
              type: Integer,

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -122,6 +122,10 @@ class CourseProfile::Models::Course < ApplicationRecord
     !is_preview && ended?(DateTime.new(2020, 7))
   end
 
+  def frozen_scores?(current_time = Time.current)
+    ended?(current_time) && !teacher_performance_report.nil?
+  end
+
   protected
 
   def set_starts_at_and_ends_at

--- a/app/subsystems/tasks/freeze_ended_course_teacher_performance_reports.rb
+++ b/app/subsystems/tasks/freeze_ended_course_teacher_performance_reports.rb
@@ -6,14 +6,32 @@ class Tasks::FreezeEndedCourseTeacherPerformanceReports
   def exec(current_time: Time.current)
     loop do
       courses = CourseProfile::Models::Course.transaction do
-        courses = CourseProfile::Models::Course.lock.where(
-          CourseProfile::Models::Course.arel_table[:ends_at].lteq current_time
-        ).where(teacher_performance_report: nil).order(ends_at: :desc).first(BATCH_SIZE)
+        courses = CourseProfile::Models::Course
+          .lock
+          .where(CourseProfile::Models::Course.arel_table[:ends_at].lteq current_time)
+          .where(teacher_performance_report: nil)
+          .order(ends_at: :desc)
+          .preload(teachers: :role)
+          .first(BATCH_SIZE)
 
         courses.each do |course|
+          performance_report = Tasks::GetPerformanceReport[
+            course: course,
+            is_teacher: true,
+            is_frozen: false
+          ]
+
           course.teacher_performance_report = Api::V1::PerformanceReport::Representer.new(
-            Tasks::GetPerformanceReport[course: course, is_teacher: true]
+            performance_report
           ).to_hash
+
+          course.teachers.each do |teacher|
+            Tasks::ExportPerformanceReport.call(
+              course: course,
+              role: teacher.role,
+              performance_report: performance_report
+            )
+          end
         end
 
         CourseProfile::Models::Course.import courses, validate: false, on_duplicate_key_update: {

--- a/app/subsystems/tasks/freeze_ended_course_teacher_performance_reports.rb
+++ b/app/subsystems/tasks/freeze_ended_course_teacher_performance_reports.rb
@@ -1,0 +1,29 @@
+class Tasks::FreezeEndedCourseTeacherPerformanceReports
+  BATCH_SIZE = 1000
+
+  lev_routine transaction: :no_transaction
+
+  def exec(current_time: Time.current)
+    loop do
+      courses = CourseProfile::Models::Course.transaction do
+        courses = CourseProfile::Models::Course.lock.where(
+          CourseProfile::Models::Course.arel_table[:ends_at].lteq current_time
+        ).where(teacher_performance_report: nil).order(ends_at: :desc).first(BATCH_SIZE)
+
+        courses.each do |course|
+          course.teacher_performance_report = Api::V1::PerformanceReport::Representer.new(
+            Tasks::GetPerformanceReport[course: course, is_teacher: true]
+          ).to_hash
+        end
+
+        CourseProfile::Models::Course.import courses, validate: false, on_duplicate_key_update: {
+          conflict_target: [ :id ], columns: [ :teacher_performance_report ]
+        }
+
+        courses
+      end
+
+      break if courses.size < BATCH_SIZE
+    end
+  end
+end

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -6,12 +6,18 @@ module Tasks
 
     protected
 
-    def exec(course:, role: nil, is_teacher: nil)
+    def exec(course:, role: nil, is_teacher: nil, current_time: Time.current)
       raise ArgumentError, 'you must supply the role when is_teacher is not true' \
         if role.nil? && !is_teacher
 
       is_teacher = CourseMembership::IsCourseTeacher[course: course, roles: [role]] \
         if is_teacher.nil?
+
+      if is_teacher && course.ends_at <= current_time && !course.teacher_performance_report.nil?
+        outputs.performance_report = course.teacher_performance_report
+
+        return
+      end
 
       periods = []
       if is_teacher
@@ -157,7 +163,7 @@ module Tasks
             end
           end
 
-          OpenStruct.new(
+          Hashie::Mash.new(
             name: name,
             first_name: first_task.first_name,
             last_name: first_task.last_name,
@@ -175,7 +181,7 @@ module Tasks
         end
 
         overall_students = student_data.reject(&:is_dropped)
-        OpenStruct.new(
+        Hashie::Mash.new(
           period: period,
           overall_homework_score: average(array: overall_students.map(&:homework_score)),
           overall_homework_progress: average(array: overall_students.map(&:homework_progress)),
@@ -272,7 +278,7 @@ module Tasks
         tasks = task_plan_id_to_task_map[task_plan_id]
         longest_task = tasks.max_by(&:actual_and_placeholder_exercise_count)
 
-        OpenStruct.new(
+        Hashie::Mash.new(
           plan_id: task_plan_id,
           title: task_plan.title,
           type: task_plan.type,

--- a/app/subsystems/tasks/models/performance_report_export.rb
+++ b/app/subsystems/tasks/models/performance_report_export.rb
@@ -2,7 +2,7 @@ module Tasks::Models
   class PerformanceReportExport < IndestructibleRecord
     mount_uploader :export, ExportUploader
 
-    default_scope { order(created_at: :desc) }
+    default_scope { order created_at: :desc }
 
     belongs_to :course, subsystem: :course_profile
     belongs_to :role,   subsystem: :entity

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -35,5 +35,10 @@ every 1.hour do
 end
 
 every 1.week do
-  runner "Stats::Generate.call(start_at: 1.week.ago.beginning_of_week)"
+  runner "OpenStax::RescueFrom.this { Stats::Generate.call start_at: 1.week.ago.beginning_of_week }"
+end
+
+# On the 1st of every odd month (normal courses only end on January, March, July, September)
+every 2.month do
+  runner 'OpenStax::RescueFrom.this { Tasks::FreezeEndedCourseTeacherPerformanceReports.call }'
 end

--- a/db/migrate/20200713140652_add_teacher_performance_report_to_courses.rb
+++ b/db/migrate/20200713140652_add_teacher_performance_report_to_courses.rb
@@ -1,0 +1,7 @@
+class AddTeacherPerformanceReportToCourses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_profile_courses, :teacher_performance_report, :jsonb, array: true
+
+    Tasks::FreezeEndedCourseTeacherPerformanceReports.set(queue: :migration).perform_later
+  end
+end

--- a/db/migrate/20200713140652_add_teacher_performance_report_to_courses.rb
+++ b/db/migrate/20200713140652_add_teacher_performance_report_to_courses.rb
@@ -2,6 +2,10 @@ class AddTeacherPerformanceReportToCourses < ActiveRecord::Migration[5.2]
   def change
     add_column :course_profile_courses, :teacher_performance_report, :jsonb, array: true
 
-    Tasks::FreezeEndedCourseTeacherPerformanceReports.set(queue: :migration).perform_later
+    reversible do |dir|
+      dir.up do
+        Tasks::FreezeEndedCourseTeacherPerformanceReports.set(queue: :migration).perform_later
+      end
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_142820) do
+ActiveRecord::Schema.define(version: 2020_07_13_140652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -343,6 +343,7 @@ ActiveRecord::Schema.define(version: 2020_06_17_142820) do
     t.float "reading_weight", default: 0.5, null: false
     t.string "timezone", null: false
     t.boolean "past_due_unattempted_ungraded_wrq_are_zero", default: true, null: false
+    t.jsonb "teacher_performance_report", array: true
     t.index ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id"
     t.index ["cloned_from_id"], name: "index_course_profile_courses_on_cloned_from_id"
     t.index ["is_lms_enabling_allowed"], name: "index_course_profile_courses_on_is_lms_enabling_allowed"

--- a/lib/date_time_utilities.rb
+++ b/lib/date_time_utilities.rb
@@ -3,7 +3,7 @@ Time::DATE_FORMATS[:w3cz] = ->(time) { time.utc.strftime("%Y-%m-%dT%H:%M:%S.%LZ"
 module DateTimeUtilities
   # Convert the given DateTime to a W3CZ formatted string
   def self.to_api_s(date_time)
-    date_time.try(:to_formatted_s, :w3cz)
+    date_time.is_a?(String) ? date_time : date_time.try(:to_formatted_s, :w3cz)
   end
 
   # Parse a string representing a DateTime

--- a/spec/subsystems/tasks/freeze_ended_course_teacher_performance_reports_spec.rb
+++ b/spec/subsystems/tasks/freeze_ended_course_teacher_performance_reports_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+require 'vcr_helper'
+
+RSpec.describe Tasks::FreezeEndedCourseTeacherPerformanceReports, type: :routine do
+  before(:all) do
+    VCR.use_cassette("Tasks_GetPerformanceReport/with_book", VCR_OPTS) do
+      @ecosystem = FetchAndImportBookAndCreateEcosystem[
+        book_cnx_id: '93e2b09d-261c-4007-a987-0b3062fe154b'
+      ]
+    end
+    @course = FactoryBot.create(
+      :course_profile_course, :with_assistants, :with_grading_templates,
+                              reading_weight: 0, homework_weight: 1
+    )
+    CourseContent::AddEcosystemToCourse.call(course: @course, ecosystem: @ecosystem)
+
+    @teacher = FactoryBot.create(:user_profile)
+    @student_1 = FactoryBot.create(:user_profile)
+    @student_2 = FactoryBot.create(:user_profile)
+    @student_3 = FactoryBot.create(:user_profile)
+    @student_4 = FactoryBot.create(:user_profile)
+
+    @teacher_student = FactoryBot.create(:user_profile)
+
+    SetupPerformanceReportData[
+      course: @course,
+      teacher: @teacher,
+      students: [@student_1, @student_2, @student_3, @student_4],
+      teacher_students: [@teacher_student],
+      ecosystem: @ecosystem
+    ]
+
+    # External assignment
+    external_assistant = @course.course_assistants
+                                .find_by(tasks_task_plan_type: 'external')
+                                .assistant
+
+    external_task_plan = FactoryBot.build(
+      :tasks_task_plan,
+      title: 'External assignment',
+      course: @course,
+      type: 'external',
+      assistant: external_assistant,
+      content_ecosystem_id: @ecosystem.id,
+      settings: { external_url: 'https://www.example.com' },
+      num_tasking_plans: 0
+    )
+
+    external_task_plan.tasking_plans << FactoryBot.build(
+      :tasks_tasking_plan,
+      target: @course,
+      task_plan: external_task_plan,
+      opens_at: @course.time_zone.now - 5.weeks,
+      due_at: @course.time_zone.now - 4.weeks,
+      closes_at: @course.time_zone.now - 3.weeks
+    )
+
+    external_task_plan.save!
+
+    DistributeTasks.call(task_plan: external_task_plan)
+
+    # Event
+    event_assistant = @course.course_assistants
+                             .find_by(tasks_task_plan_type: 'event')
+                             .assistant
+
+    event_task_plan = FactoryBot.build(
+      :tasks_task_plan,
+      title: 'Event',
+      course: @course,
+      type: 'event',
+      assistant: event_assistant,
+      content_ecosystem_id: @ecosystem.id,
+      num_tasking_plans: 0
+    )
+
+    event_task_plan.tasking_plans << FactoryBot.build(
+      :tasks_tasking_plan,
+      target: @course,
+      task_plan: event_task_plan,
+      opens_at: @course.time_zone.now - 2.weeks,
+      due_at: @course.time_zone.now - 1.week,
+      closes_at: @course.time_zone.now
+    )
+
+    event_task_plan.save!
+
+    DistributeTasks.call(task_plan: event_task_plan)
+
+    # Draft assignment, not included in the scores
+    reading_assistant = @course.course_assistants
+                               .find_by(tasks_task_plan_type: 'reading')
+                               .assistant
+
+    draft_task_plan = FactoryBot.build(
+      :tasks_task_plan,
+      title: 'Draft task plan',
+      course: @course,
+      type: 'reading',
+      assistant: reading_assistant,
+      content_ecosystem_id: @ecosystem.id,
+      settings: { page_ids: @ecosystem.pages.first(2).map(&:id).map(&:to_s) },
+      num_tasking_plans: 0
+    )
+
+    draft_task_plan.tasking_plans << FactoryBot.build(
+      :tasks_tasking_plan,
+      target: @course,
+      task_plan: draft_task_plan,
+      opens_at: @course.time_zone.now - 1.week,
+      due_at: @course.time_zone.now,
+      closes_at: @course.time_zone.now + 1.week
+    )
+
+    draft_task_plan.save!
+
+    # Create the preview task, which might interfere with the scores
+    DistributeTasks.call(task_plan: draft_task_plan, preview: true)
+  end
+
+  before { @course.reload }
+
+  context 'course has not ended yet' do
+    it 'does nothing' do
+      expect(@course.teacher_performance_report).to be_nil
+
+      expect do
+        described_class.call
+      end.not_to change { @course.reload.teacher_performance_report }
+    end
+  end
+
+  context 'course has ended' do
+    before { @course.update_attribute :ends_at, Time.current }
+
+    it "freezes the course's teacher performance report" do
+      reports = Tasks::GetPerformanceReport[course: @course, is_teacher: true]
+
+      expect do
+        described_class.call
+      end.to change { @course.reload.teacher_performance_report }.from(nil)
+
+      # Some objects like AR models don't serialize/deserialize entirely the same
+      # But the overall representation should match
+      expect(
+        Api::V1::PerformanceReport::Representer.new(
+          Tasks::GetPerformanceReport[course: @course, is_teacher: true]
+        ).to_hash
+      ).to eq Api::V1::PerformanceReport::Representer.new(reports).to_hash
+    end
+  end
+end

--- a/spec/subsystems/tasks/get_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_performance_report_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
   end
 
   before do
+    @course.reload
     @student_1.reload
     @student_2.reload
   end
@@ -165,6 +166,18 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           data_types = student.data.map(&:type)
           expect(data_types).to eq expected_task_types
         end
+      end
+    end
+
+    context 'ended course with a frozen performance report' do
+      before do
+        @course.ends_at = Time.current
+        @course.teacher_performance_report = [ { is_frozen: true } ]
+        @course.save validate: false
+      end
+
+      it 'returns the frozen performance report instead' do
+        expect(reports.first.is_frozen).to eq true
       end
     end
 


### PR DESCRIPTION
Every odd month:
- Freeze the performance report for courses that ended
- Freeze these courses' exports