### PR TITLE
strip os-part-text from titles

### DIFF
--- a/lib/openstax/cnx/v1/title.rb
+++ b/lib/openstax/cnx/v1/title.rb
@@ -5,16 +5,13 @@ class OpenStax::Cnx::V1::Title
     return nil if title.nil?
 
     part = Nokogiri::HTML.fragment(title)
-    text_node = part.css('.os-text')
-    if text_node.present? && (number = part.at_css('.os-number'))
-      number.css('.os-part-text').each(&:remove)      
-      @book_location = number.text.split('.').map do |number|
+    number_node = part.css('.os-number')
+    if number_node.present?
+      @book_location = number_node.text.gsub(/[^\.\d]/, '').split('.').map do |number|
         Integer(number) rescue nil
       end.compact
-      @text = text_node.inner_html
-    else
-      @book_location = []
-      @text = part.text.strip
     end
+    @book_location = [] if @book_location.nil?
+    @text = title
   end
 end

--- a/lib/openstax/cnx/v1/title.rb
+++ b/lib/openstax/cnx/v1/title.rb
@@ -6,14 +6,15 @@ class OpenStax::Cnx::V1::Title
 
     part = Nokogiri::HTML.fragment(title)
     text_node = part.css('.os-text')
-    if text_node.present?
-      @book_location = part.css('.os-number').text.split('.').map do |number|
+    if text_node.present? && (number = part.at_css('.os-number'))
+      number.css('.os-part-text').each(&:remove)      
+      @book_location = number.text.split('.').map do |number|
         Integer(number) rescue nil
       end.compact
       @text = text_node.inner_html
     else
       @book_location = []
-      @text = title
+      @text = part.text.strip
     end
   end
 end

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -194,11 +194,11 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
       expect(page.title).to eq 'Atoms, Isotopes, Ions, and Molecules: The Building Blocks'
     end
 
-    it 'retains HTML tags inside title' do
+    it 'removes part-text but retains other HTML tags' do
       page = OpenStax::Cnx::V1::Page.new(
-        id: '123', hash: { 'title' => '<span class="os-text"><i>The Florentine Codex</i>, c. 1585</span>' }
+        id: '123', hash: { 'title' => '<span class="os-number"><span class="os-part-text">Unit </span>1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text"><i>The Florentine Codex</i>, c. 1585</span>' }
       )
-      expect(page.book_location).to eq []
+      expect(page.book_location).to eq [1]
       expect(page.title).to eq '<i>The Florentine Codex</i>, c. 1585'
     end
 

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -185,21 +185,13 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
   end
 
   context 'parsing html titles' do
-    it 'parses parts' do
+    it 'extracts os-number and retains all HTML' do
+      html = '<span class="os-number"><span class="os-part-text">Unit </span>1.42</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text"><i>The Florentine Codex</i>, c. 1585</span>'
       page = OpenStax::Cnx::V1::Page.new(
-        id: '123',
-        hash: { 'title' => '<span class="os-number">2.1</span><span class="os-divider"> </span><span class="os-text">Atoms, Isotopes, Ions, and Molecules: The Building Blocks</span>' }
+        id: '123', hash: { 'title' => html }
       )
-      expect(page.book_location).to eq [ 2, 1 ]
-      expect(page.title).to eq 'Atoms, Isotopes, Ions, and Molecules: The Building Blocks'
-    end
-
-    it 'removes part-text but retains other HTML tags' do
-      page = OpenStax::Cnx::V1::Page.new(
-        id: '123', hash: { 'title' => '<span class="os-number"><span class="os-part-text">Unit </span>1</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text"><i>The Florentine Codex</i>, c. 1585</span>' }
-      )
-      expect(page.book_location).to eq [1]
-      expect(page.title).to eq '<i>The Florentine Codex</i>, c. 1585'
+      expect(page.book_location).to eq [1, 42]
+      expect(page.title).to eq html
     end
 
     it 'leaves book_location blank if not present' do
@@ -207,7 +199,6 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
         id: '123', hash: { 'title' => '<span class="os-text">Review Questions</span>' }
       )
       expect(page.book_location).to eq []
-      expect(page.title).to eq 'Review Questions'
     end
 
     it 'continues to function for plain text titles' do

--- a/spec/representers/api/v1/task_plan/stats/detailed_representer_spec.rb
+++ b/spec/representers/api/v1/task_plan/stats/detailed_representer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::TaskPlan::Stats::DetailedRepresenter, type: :representer
           partially_complete_count: 2,
           current_pages: a_collection_containing_exactly(
             id: task_plan.core_page_ids.first.to_s,
-            title: "Newton's First Law of Motion: Inertia",
+            title: a_string_matching("Newton's First Law of Motion: Inertia"),
             student_count: 2,
             correct_count: 1,
             incorrect_count: 1,

--- a/spec/representers/api/v1/task_plan/stats/representer_spec.rb
+++ b/spec/representers/api/v1/task_plan/stats/representer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::TaskPlan::Stats::Representer, type: :representer do
           current_pages: a_collection_containing_exactly(
             a_hash_including(
               id: task_plan.core_page_ids.first.to_s,
-              title: "Newton's First Law of Motion: Inertia",
+              title: a_string_matching("Newton's First Law of Motion: Inertia"),
               student_count: 0,
               correct_count: 0,
               incorrect_count: 0,

--- a/spec/requests/api/v1/ecosystems_controller_spec.rb
+++ b/spec/requests/api/v1/ecosystems_controller_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
                   version: book.as_toc.pages.first.version,
                   cnx_id: book.as_toc.pages.first.cnx_id,
                   short_id: book.as_toc.pages.first.short_id,
-                  title: 'Preface',
+                  title: a_string_matching('Preface'),
                   chapter_section: [],
                   type: 'page'
                 },
@@ -295,7 +295,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
                   {
                     uuid: unit.uuid,
                     cnx_id: unit.uuid,
-                    title: "Unit #{unit_index + 1}",
+                    title: a_string_matching("Unit #{unit_index + 1}"),
                     type: 'unit',
                     chapter_section: [],
                     children: unit.chapters.each.map do |chapter|
@@ -333,7 +333,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
                     version: page.version,
                     cnx_id: page.cnx_id,
                     short_id: page.short_id,
-                    title: title,
+                    title: a_string_matching(title),
                     chapter_section: [],
                     type: 'page'
                   }

--- a/spec/routines/calculate_task_stats_spec.rb
+++ b/spec/routines/calculate_task_stats_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe CalculateTaskStats, type: :routine, vcr: VCR_OPTS, speed: :slow d
       expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
-      expect(page['title']).to eq "Newton's First Law of Motion: Inertia"
+      expect(page['title']).to match "Newton's First Law of Motion: Inertia"
       expect(page['student_count']).to eq 1 # num students with completed task steps
       expect(page['correct_count']).to eq student_tasks[0].exercise_steps.size
       expect(page['incorrect_count']).to eq 0
@@ -162,7 +162,7 @@ RSpec.describe CalculateTaskStats, type: :routine, vcr: VCR_OPTS, speed: :slow d
       expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
-      expect(page['title']).to eq "Newton's First Law of Motion: Inertia"
+      expect(page['title']).to match "Newton's First Law of Motion: Inertia"
       expect(page['student_count']).to eq 2
       expect(page['correct_count']).to eq student_tasks[0].exercise_steps.size
       expect(page['incorrect_count']).to eq student_tasks[1].exercise_steps.size
@@ -179,7 +179,7 @@ RSpec.describe CalculateTaskStats, type: :routine, vcr: VCR_OPTS, speed: :slow d
       expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
-      expect(page['title']).to eq "Newton's First Law of Motion: Inertia"
+      expect(page['title']).to match "Newton's First Law of Motion: Inertia"
       expect(page['student_count']).to eq 3
       expect(page['correct_count']).to eq(
         student_tasks[0].exercise_steps.size +
@@ -199,7 +199,7 @@ RSpec.describe CalculateTaskStats, type: :routine, vcr: VCR_OPTS, speed: :slow d
       expect(stats.first.trouble).to eq false
 
       page = stats.first.current_pages.first
-      expect(page['title']).to eq "Newton's First Law of Motion: Inertia"
+      expect(page['title']).to match "Newton's First Law of Motion: Inertia"
       expect(page['student_count']).to eq 4
       expect(page['correct_count']).to eq(
         student_tasks[0].exercise_steps.size +

--- a/spec/routines/demo/import_spec.rb
+++ b/spec/routines/demo/import_spec.rb
@@ -46,17 +46,17 @@ RSpec.describe Demo::Import, type: :routine, vcr: VCR_OPTS do
     end
 
     chapter = book.chapters.first
-    expect(chapter.title).to eq 'Chapter 1'
+    expect(chapter.title).to match 'Chapter 1'
     expect(chapter.book_location).to eq [1]
 
     pages = chapter.pages
-    expect(pages.map(&:title)).to eq [
+    expect(pages.map(&:title)).to match([
       'Introduction',
       'Douglass struggles toward literacy',
       "Douglass struggles against slavery’s injustice",
       'Douglass promotes dignity',
       'Confrontation seeking righteousness'
-    ]
+    ].map{ |title| a_string_matching(title)})
     expect(pages.map(&:book_location)).to eq [[], [1, 1], [1, 2], [1, 3], [1, 4]]
   end
 end

--- a/spec/routines/get_student_guide_spec.rb
+++ b/spec/routines/get_student_guide_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
 
           chapter_2 = chapters.first
           expect(chapter_2).to match(
-            title: "Force and Newton's Laws of Motion",
+            title: a_string_matching("Force and Newton's Laws of Motion"),
             book_location: [],
             student_count: 1,
             questions_answered_count: 5,
@@ -135,7 +135,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
           chapter_2_pages = chapters.first[:children]
           expect(chapter_2_pages).to match [
             {
-              title: "Newton's First Law of Motion: Inertia",
+              title: a_string_matching("Newton's First Law of Motion: Inertia"),
               book_location: [],
               student_count: 1,
               questions_answered_count: 5,
@@ -175,7 +175,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
           chapter_1_pages = chapters.first[:children]
           expect(chapter_1_pages).to match [
             {
-              title: 'The Science of Biology',
+              title: '<span class="os-number">1.1</span><span class="os-divider"> </span><span class="os-text">The Science of Biology</span>',
               book_location: [1, 1],
               student_count: 1,
               questions_answered_count: 0,
@@ -185,7 +185,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Themes and Concepts of Biology',
+              title: '<span class="os-number">1.2</span><span class="os-divider"> </span><span class="os-text">Themes and Concepts of Biology</span>',
               book_location: [1, 2],
               student_count: 1,
               questions_answered_count: 0,
@@ -199,7 +199,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
           chapter_2_pages = chapters.second[:children]
           expect(chapter_2_pages).to match [
             {
-              title: 'Atoms, Isotopes, Ions, and Molecules: The Building Blocks',
+              title: a_string_matching('Atoms, Isotopes, Ions, and Molecules: The Building Blocks'),
               book_location: [2, 1],
               student_count: 1,
               questions_answered_count: 0,
@@ -209,7 +209,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Water',
+              title: a_string_matching('Water'),
               book_location: [2, 2],
               student_count: 1,
               questions_answered_count: 0,
@@ -219,7 +219,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Carbon',
+              title: a_string_matching('Carbon'),
               book_location: [2, 3],
               student_count: 1,
               questions_answered_count: 0,
@@ -234,7 +234,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
           chapter_3_pages = chapters.third[:children]
           expect(chapter_3_pages).to match [
             {
-              title: 'Synthesis of Biological Macromolecules',
+              title: a_string_matching('Synthesis of Biological Macromolecules'),
               book_location: [3, 1],
               student_count: 1,
               questions_answered_count: 1,
@@ -244,7 +244,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: kind_of(Time)
             },
             {
-              title: 'Carbohydrates',
+              title: a_string_matching('Carbohydrates'),
               book_location: [3, 2],
               student_count: 1,
               questions_answered_count: 0,
@@ -254,7 +254,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Lipids',
+              title: a_string_matching('Lipids'),
               book_location: [3, 3],
               student_count: 1,
               questions_answered_count: 0,
@@ -264,7 +264,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Proteins',
+              title: a_string_matching('Proteins'),
               book_location: [3, 4],
               student_count: 1,
               questions_answered_count: 0,
@@ -274,7 +274,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Nucleic Acids',
+              title: a_string_matching('Nucleic Acids'),
               book_location: [3, 5],
               student_count: 1,
               questions_answered_count: 0,
@@ -289,7 +289,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
           chapter_4_pages = chapters.fourth[:children]
           expect(chapter_4_pages).to match [
             {
-              title: 'Studying Cells',
+              title: a_string_matching('Studying Cells'),
               book_location: [4, 1],
               student_count: 1,
               questions_answered_count: 0,
@@ -299,7 +299,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Prokaryotic Cells',
+              title: a_string_matching('Prokaryotic Cells'),
               book_location: [4, 2],
               student_count: 1,
               questions_answered_count: 5,
@@ -309,7 +309,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: kind_of(Time)
             },
             {
-              title: 'Eukaryotic Cells',
+              title: a_string_matching('Eukaryotic Cells'),
               book_location: [4, 3],
               student_count: 1,
               questions_answered_count: 0,
@@ -319,7 +319,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'The Endomembrane System and Proteins',
+              title: a_string_matching('The Endomembrane System and Proteins'),
               book_location: [4, 4],
               student_count: 1,
               questions_answered_count: 0,
@@ -329,7 +329,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Cytoskeleton',
+              title: a_string_matching('Cytoskeleton'),
               book_location: [4, 5],
               student_count: 1,
               questions_answered_count: 0,
@@ -339,7 +339,7 @@ RSpec.describe GetStudentGuide, type: :routine, speed: :slow do
               last_worked_at: nil
             },
             {
-              title: 'Connections between Cells and Cellular Activities',
+              title: a_string_matching('Connections between Cells and Cellular Activities'),
               book_location: [4, 6],
               student_count: 1,
               questions_answered_count: 0,

--- a/spec/routines/get_teacher_guide_spec.rb
+++ b/spec/routines/get_teacher_guide_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_1_chapter_1_pages = period_1_chapters.first[:children]
       expect(period_1_chapter_1_pages).to match [
         {
-          title: 'The Science of Biology',
+          title: a_string_matching('The Science of Biology'),
           book_location: [1, 1],
           student_count: 0,
           questions_answered_count: 0,
@@ -361,7 +361,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Themes and Concepts of Biology',
+          title: a_string_matching('Themes and Concepts of Biology'),
           book_location: [1, 2],
           student_count: 0,
           questions_answered_count: 0,
@@ -375,7 +375,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_1_chapter_2_pages = period_1_chapters.second[:children]
       expect(period_1_chapter_2_pages).to match [
         {
-          title: 'Atoms, Isotopes, Ions, and Molecules: The Building Blocks',
+          title: a_string_matching('Atoms, Isotopes, Ions, and Molecules: The Building Blocks'),
           book_location: [2, 1],
           student_count: 0,
           questions_answered_count: 0,
@@ -385,7 +385,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Water',
+          title: a_string_matching('Water'),
           book_location: [2, 2],
           student_count: 0,
           questions_answered_count: 0,
@@ -395,7 +395,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Carbon',
+          title: a_string_matching('Carbon'),
           book_location: [2, 3],
           student_count: 0,
           questions_answered_count: 0,
@@ -410,7 +410,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_1_chapter_3_pages = period_1_chapters.third[:children]
       expect(period_1_chapter_3_pages).to match [
         {
-          title: 'Synthesis of Biological Macromolecules',
+          title: a_string_matching('Synthesis of Biological Macromolecules'),
           book_location: [3, 1],
           student_count: 1,
           questions_answered_count: 1,
@@ -420,7 +420,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: kind_of(Time)
         },
         {
-          title: 'Carbohydrates',
+          title: a_string_matching('Carbohydrates'),
           book_location: [3, 2],
           student_count: 0,
           questions_answered_count: 0,
@@ -430,7 +430,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Lipids',
+          title: a_string_matching('Lipids'),
           book_location: [3, 3],
           student_count: 0,
           questions_answered_count: 0,
@@ -440,7 +440,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Proteins',
+          title: a_string_matching('Proteins'),
           book_location: [3, 4],
           student_count: 0,
           questions_answered_count: 0,
@@ -450,7 +450,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Nucleic Acids',
+          title: a_string_matching('Nucleic Acids'),
           book_location: [3, 5],
           student_count: 0,
           questions_answered_count: 0,
@@ -465,7 +465,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_1_chapter_4_pages = period_1_chapters.fourth[:children]
       expect(period_1_chapter_4_pages).to match [
         {
-          title: 'Studying Cells',
+          title: a_string_matching('Studying Cells'),
           book_location: [4, 1],
           student_count: 0,
           questions_answered_count: 0,
@@ -475,7 +475,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Prokaryotic Cells',
+          title: a_string_matching('Prokaryotic Cells'),
           book_location: [4, 2],
           student_count: 1,
           questions_answered_count: 5,
@@ -485,7 +485,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: kind_of(Time)
         },
         {
-          title: 'Eukaryotic Cells',
+          title: a_string_matching('Eukaryotic Cells'),
           book_location: [4, 3],
           student_count: 0,
           questions_answered_count: 0,
@@ -495,7 +495,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'The Endomembrane System and Proteins',
+          title: a_string_matching('The Endomembrane System and Proteins'),
           book_location: [4, 4],
           student_count: 0,
           questions_answered_count: 0,
@@ -505,7 +505,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Cytoskeleton',
+          title: a_string_matching('Cytoskeleton'),
           book_location: [4, 5],
           student_count: 0,
           questions_answered_count: 0,
@@ -515,7 +515,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Connections between Cells and Cellular Activities',
+          title: a_string_matching('Connections between Cells and Cellular Activities'),
           book_location: [4, 6],
           student_count: 0,
           questions_answered_count: 0,
@@ -529,7 +529,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_2_chapter_1_pages = period_2_chapters.first[:children]
       expect(period_2_chapter_1_pages).to match [
         {
-          title: 'The Science of Biology',
+          title: a_string_matching('The Science of Biology'),
           book_location: [1, 1],
           student_count: 0,
           questions_answered_count: 0,
@@ -539,7 +539,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Themes and Concepts of Biology',
+          title: a_string_matching('Themes and Concepts of Biology'),
           book_location: [1, 2],
           student_count: 0,
           questions_answered_count: 0,
@@ -553,7 +553,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_2_chapter_2_pages = period_2_chapters.second[:children]
       expect(period_2_chapter_2_pages).to match [
         {
-          title: 'Atoms, Isotopes, Ions, and Molecules: The Building Blocks',
+          title: a_string_matching('Atoms, Isotopes, Ions, and Molecules: The Building Blocks'),
           book_location: [2, 1],
           student_count: 0,
           questions_answered_count: 0,
@@ -563,7 +563,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Water',
+          title: a_string_matching('Water'),
           book_location: [2, 2],
           student_count: 0,
           questions_answered_count: 0,
@@ -573,7 +573,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Carbon',
+          title: a_string_matching('Carbon'),
           book_location: [2, 3],
           student_count: 0,
           questions_answered_count: 0,
@@ -588,7 +588,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_2_chapter_3_pages = period_2_chapters.third[:children]
       expect(period_2_chapter_3_pages).to match [
         {
-          title: 'Synthesis of Biological Macromolecules',
+          title: a_string_matching('Synthesis of Biological Macromolecules'),
           book_location: [3, 1],
           student_count: 1,
           questions_answered_count: 1,
@@ -598,7 +598,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: kind_of(Time)
         },
         {
-          title: 'Carbohydrates',
+          title: a_string_matching('Carbohydrates'),
           book_location: [3, 2],
           student_count: 0,
           questions_answered_count: 0,
@@ -608,7 +608,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Lipids',
+          title: a_string_matching('Lipids'),
           book_location: [3, 3],
           student_count: 0,
           questions_answered_count: 0,
@@ -618,7 +618,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Proteins',
+          title: a_string_matching('Proteins'),
           book_location: [3, 4],
           student_count: 0,
           questions_answered_count: 0,
@@ -628,7 +628,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Nucleic Acids',
+          title: a_string_matching('Nucleic Acids'),
           book_location: [3, 5],
           student_count: 0,
           questions_answered_count: 0,
@@ -643,7 +643,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
       period_2_chapter_4_pages = period_2_chapters.fourth[:children]
       expect(period_2_chapter_4_pages).to match [
         {
-          title: 'Studying Cells',
+          title: a_string_matching('Studying Cells'),
           book_location: [4, 1],
           student_count: 0,
           questions_answered_count: 0,
@@ -653,7 +653,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Prokaryotic Cells',
+          title: a_string_matching('Prokaryotic Cells'),
           book_location: [4, 2],
           student_count: 1,
           questions_answered_count: 5,
@@ -663,7 +663,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: kind_of(Time)
         },
         {
-          title: 'Eukaryotic Cells',
+          title: a_string_matching('Eukaryotic Cells'),
           book_location: [4, 3],
           student_count: 0,
           questions_answered_count: 0,
@@ -673,7 +673,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'The Endomembrane System and Proteins',
+          title: a_string_matching('The Endomembrane System and Proteins'),
           book_location: [4, 4],
           student_count: 0,
           questions_answered_count: 0,
@@ -683,7 +683,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Cytoskeleton',
+          title: a_string_matching('Cytoskeleton'),
           book_location: [4, 5],
           student_count: 0,
           questions_answered_count: 0,
@@ -693,7 +693,7 @@ RSpec.describe GetTeacherGuide, type: :routine, speed: :slow do
           last_worked_at: nil
         },
         {
-          title: 'Connections between Cells and Cellular Activities',
+          title: a_string_matching('Connections between Cells and Cellular Activities'),
           book_location: [4, 6],
           student_count: 0,
           questions_answered_count: 0,

--- a/spec/subsystems/content/import_book_spec.rb
+++ b/spec/subsystems/content/import_book_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Content::ImportBook, type: :routine, vcr: VCR_OPTS, speed: :slow 
         'Douglass promotes dignity',
         'Confrontation seeking righteousness'
       ]
-      book.pages.each_with_index do |page, index|
+      book.as_toc.pages.each_with_index do |page, index|
         expect(page.title).to match titles[index]
       end
     end

--- a/spec/subsystems/content/import_book_spec.rb
+++ b/spec/subsystems/content/import_book_spec.rb
@@ -71,28 +71,28 @@ RSpec.describe Content::ImportBook, type: :routine, vcr: VCR_OPTS, speed: :slow 
 
       chapter = book.chapters.first
       expect(book.units.first.chapters.first).to eq chapter
-      expect(chapter.title).to eq 'The Study of Life'
+      expect(chapter.title).to match 'The Study of Life'
       expect(chapter.book_location).to eq [1]
 
       page = book.chapters.first.pages.first
-      expect(page.title).to eq 'Introduction'
+      expect(page.title).to match 'Introduction'
       expect(page.book_location).to eq []
 
       # Jump to 3rd chapter
       chapter = book.chapters.third
       expect(book.units.first.chapters.third).to eq chapter
-      expect(chapter.title).to eq 'Biological Macromolecules'
+      expect(chapter.title).to match 'Biological Macromolecules'
       expect(chapter.book_location).to eq [3]
 
       # The second page of that chapter
       page = chapter.pages.second
-      expect(page.title).to eq 'Synthesis of Biological Macromolecules'
+      expect(page.title).to match 'Synthesis of Biological Macromolecules'
       expect(page.book_location).to eq [3, 1]
 
       # Jump to 6th chapter (getting us into 2nd unit)
       chapter = book.chapters[5]
       expect(book.units.second.chapters.third).to eq chapter
-      expect(chapter.title).to eq 'Metabolism'
+      expect(chapter.title).to match 'Metabolism'
       expect(chapter.book_location).to eq [6]
     end
 
@@ -126,16 +126,19 @@ RSpec.describe Content::ImportBook, type: :routine, vcr: VCR_OPTS, speed: :slow 
 
     it 'handles baked book_locations' do
       expect(book.chapters.size).to eq 1
-      expect(book.chapters.first.title).to eq 'Chapter 1'
+      expect(book.chapters.first.title).to match 'Chapter 1'
 
       expect(book.as_toc.pages.map(&:book_location)).to eq [ [], [1, 1], [1, 2], [1, 3], [1, 4] ]
-      expect(book.as_toc.pages.map(&:title)).to eq [
+      titles = [
         'Introduction',
         'Douglass struggles toward literacy',
         'Douglass struggles against slavery’s injustice',
         'Douglass promotes dignity',
         'Confrontation seeking righteousness'
       ]
+      book.pages.each_with_index do |page, index|
+        expect(page.title).to match titles[index]
+      end
     end
 
     it 'converts CNX links' do


### PR DESCRIPTION
it's unused and causes duplication with the existing labels