### PR TITLE
Removed lev transaction for 2 Glicko routines that only work with in-memory objects

### DIFF
--- a/app/routines/ratings/calculate_g_and_e.rb
+++ b/app/routines/ratings/calculate_g_and_e.rb
@@ -1,6 +1,6 @@
 # http://www.glicko.net/glicko/glicko2.pdf
 class Ratings::CalculateGAndE
-  lev_routine
+  lev_routine transaction: :no_transaction
 
   def exec(record:, opponents:)
     outputs.g_array = opponents.map do |opponent|

--- a/app/routines/ratings/update_glicko.rb
+++ b/app/routines/ratings/update_glicko.rb
@@ -9,7 +9,7 @@ class Ratings::UpdateGlicko
   # Glicko convergence tolerance
   EPSILON = 1e-6
 
-  lev_routine
+  lev_routine transaction: :no_transaction
 
   uses_routine Ratings::CalculateGAndE, as: :calculate_g_and_e
 


### PR DESCRIPTION
They don't access the DB, so no transaction isolation level needed.
The transaction isolation level is potentially causing deadlocks during the migration process.