### PR TITLE
Run UpdateTaskCaches when tasks become due

### DIFF
--- a/app/routines/ratings/concerns/rating_jobs.rb
+++ b/app/routines/ratings/concerns/rating_jobs.rb
@@ -84,7 +84,7 @@ module Ratings::Concerns::RatingJobs
             period: period, task: task, run_at_due: true, queue: queue.to_s, wait: wait
           )
 
-          task.period_book_part_job_id = job&.provider_job_id
+          task.period_book_part_job_id = job.provider_job_id
         else
           job.update_attribute :run_at, task.due_at
         end
@@ -108,7 +108,7 @@ module Ratings::Concerns::RatingJobs
           role: role, task: task, run_at_due: true, queue: queue.to_s, wait: wait
         )
 
-        task.role_book_part_job_id = job&.provider_job_id
+        task.role_book_part_job_id = job.provider_job_id
       else
         job.update_attribute :run_at, task.due_at
       end

--- a/app/subsystems/tasks/update_task_plan_caches.rb
+++ b/app/subsystems/tasks/update_task_plan_caches.rb
@@ -1,6 +1,8 @@
 # Updates the TaskPlan cache fields (step counts), used by the Teacher dashboard NEW flag
 class Tasks::UpdateTaskPlanCaches
-  lev_routine active_job_enqueue_options: { queue: :dashboard }, transaction: :read_committed
+  lev_routine active_job_enqueue_options: { queue: :dashboard },
+              transaction: :read_committed,
+              job_class: LevJobReturningJob
 
   protected
 

--- a/db/migrate/20200722150727_add_task_cache_job_id_to_tasks.rb
+++ b/db/migrate/20200722150727_add_task_cache_job_id_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddTaskCacheJobIdToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks_tasks, :task_cache_job_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_155313) do
+ActiveRecord::Schema.define(version: 2020_07_22_150727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1030,6 +1030,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_155313) do
     t.float "published_points_after_due", default: ::Float::NAN, null: false
     t.boolean "is_provisional_score_before_due", default: false, null: false
     t.boolean "is_provisional_score_after_due", default: false, null: false
+    t.integer "task_cache_job_id"
     t.index ["content_ecosystem_id"], name: "index_tasks_tasks_on_content_ecosystem_id"
     t.index ["course_profile_course_id"], name: "index_tasks_tasks_on_course_profile_course_id"
     t.index ["due_at_ntz", "opens_at_ntz"], name: "index_tasks_tasks_on_due_at_ntz_and_opens_at_ntz"

--- a/spec/requests/api/v1/task_steps_controller_spec.rb
+++ b/spec/requests/api/v1/task_steps_controller_spec.rb
@@ -315,6 +315,9 @@ RSpec.describe Api::V1::TaskStepsController, type: :request, api: true, version:
 
     before do
       tasking_plan.update_attribute :target, @period
+      task.opens_at = Time.current - 1.day
+      task.due_at = Time.current - 1.day
+      task.save!
 
       tasked.answer_ids = []
       tasked.free_response = 'A sentence explaining all the things!'
@@ -330,6 +333,12 @@ RSpec.describe Api::V1::TaskStepsController, type: :request, api: true, version:
     end
 
     context 'task not yet due' do
+      before do
+        task.opens_at_ntz = Time.current + 1.day
+        task.due_at_ntz = Time.current + 1.day
+        task.save!
+      end
+
       it 'raises SecurityTransgression' do
         expect do
           api_put grade_api_step_url(task_step.id), @teacher_user_token,
@@ -350,12 +359,6 @@ RSpec.describe Api::V1::TaskStepsController, type: :request, api: true, version:
     end
 
     context 'task past-due' do
-      before do
-        task.opens_at_ntz = Time.current - 1.day
-        task.due_at_ntz = Time.current - 1.day
-        task.save!
-      end
-
       context "manual_grading_feedback_on == 'grade'" do
         before { task_plan.grading_template.update_column :manual_grading_feedback_on, :grade }
 

--- a/spec/routines/mark_task_step_completed_spec.rb
+++ b/spec/routines/mark_task_step_completed_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe MarkTaskStepCompleted, type: :routine do
-  let(:tasked_reading)  { FactoryBot.create(:tasks_tasked_reading) }
-  let(:tasked_exercise) { FactoryBot.create(:tasks_tasked_exercise) }
+  let(:tasked_reading)  { FactoryBot.create :tasks_tasked_reading }
+  let(:tasked_exercise) { FactoryBot.create :tasks_tasked_exercise }
 
   it 'can mark a reading step as completed' do
-    result = MarkTaskStepCompleted.call(task_step: tasked_reading.task_step)
+    result = described_class.call task_step: tasked_reading.task_step
     expect(result.errors).to be_empty
     expect(tasked_reading.task_step).to be_completed
   end
@@ -16,7 +16,7 @@ RSpec.describe MarkTaskStepCompleted, type: :routine do
     expect_any_instance_of(tasked_exercise.class).to receive(:valid?)
     expect_any_instance_of(tasked_exercise.class).to receive(:before_completion)
 
-    result = MarkTaskStepCompleted.call(task_step: tasked_exercise.task_step)
+    result = described_class.call task_step: tasked_exercise.task_step
     expect(result.errors).to be_empty
     expect(tasked_exercise.task_step).to be_completed
   end
@@ -32,17 +32,37 @@ RSpec.describe MarkTaskStepCompleted, type: :routine do
     expect_any_instance_of(Tasks::Models::Task).to receive(:update_caches_later).and_call_original
 
     expect do
-      result = MarkTaskStepCompleted.call(task_step: task_step)
+      result = described_class.call task_step: task_step
       expect(result.errors).to be_empty
     end.to change { task.reload.completed_steps_count }.from(0).to(1)
   end
 
   it 'returns an error if the answer_id is missing for an exercise' do
-    result = MarkTaskStepCompleted.call(task_step: tasked_exercise.task_step)
+    result = described_class.call task_step: tasked_exercise.task_step
     expect(result.errors).not_to be_empty
     expect(result.errors).to have_offending_input :tasked
     expect(result.errors.map(&:code)).to eq [ :'Answer is required' ]
 
     expect(tasked_exercise.reload.task_step).not_to be_completed
+  end
+
+  it "queues one Tasks::UpdateTaskCaches job to run on the task's due date" do
+    task_step = tasked_exercise.task_step.reload
+    task = task_step.task
+    FactoryBot.create :tasks_tasking, task: task
+    task_step_2 = FactoryBot.create :tasks_task_step, task: task
+    task.update_attribute :due_at, Time.current + 1.month
+
+    expect do
+      Delayed::Worker.with_delay_jobs(true) do
+        Preview::AnswerExercise.call task_step: task_step, is_correct: [ true, false ].sample
+      end
+    end.to change { task.reload.task_cache_job_id }
+
+    expect do
+      Delayed::Worker.with_delay_jobs(true) do
+        MarkTaskStepCompleted.call task_step: task_step_2
+      end
+    end.to not_change { task.reload.task_cache_job_id }
   end
 end

--- a/spec/routines/ratings/update_period_book_parts_spec.rb
+++ b/spec/routines/ratings/update_period_book_parts_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Ratings::UpdatePeriodBookParts, type: :routine do
       Delayed::Worker.with_delay_jobs(true) do
         described_class.call period: period, task: task, run_at_due: true
       end
-    end.to change { Delayed::Job.count }.by(1)
+    end.to  change { Delayed::Job.count }.by(1)
+       .and change { task.reload.period_book_part_job_id }
   end
 end

--- a/spec/routines/ratings/update_role_book_parts_spec.rb
+++ b/spec/routines/ratings/update_role_book_parts_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe Ratings::UpdateRoleBookParts, type: :routine do
         Delayed::Worker.with_delay_jobs(true) do
           described_class.call role: role, task: task, run_at_due: true
         end
-      end.to change { Delayed::Job.count }.by(1)
+      end.to  change { Delayed::Job.count }.by(1)
+         .and change { task.reload.role_book_part_job_id }
     end
   end
 
@@ -133,7 +134,8 @@ RSpec.describe Ratings::UpdateRoleBookParts, type: :routine do
         Delayed::Worker.with_delay_jobs(true) do
           described_class.call role: role, task: task, run_at_due: true
         end
-      end.to change { Delayed::Job.count }.by(1)
+      end.to  change { Delayed::Job.count }.by(1)
+         .and change { task.reload.role_book_part_job_id }
     end
   end
 end

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -298,29 +298,34 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
     end
 
     it 'aggregates wrq step counts from undropped unarchived student tasks only' do
-      tasking_plan = task_plan.tasking_plans.first
+      tasking_plan = task_plan.reload.tasking_plans.first
       tasking_plan.update_attribute :target, period
-      student_task.update_attribute :gradable_step_count, 42
-      student_task.update_attribute :ungraded_step_count, 21
-      teacher_student_task.update_attribute :gradable_step_count, 84
-      teacher_student_task.update_attribute :ungraded_step_count, 84
+      student_task.gradable_step_count = 42
+      student_task.ungraded_step_count = 21
+      teacher_student_task.gradable_step_count = 84
+      teacher_student_task.ungraded_step_count = 84
+      [ student_task, teacher_student_task ].each do |task|
+        task.opens_at = Time.current - 1.day
+        task.due_at = Time.current - 1.day
+        task.save validate: false
+      end
 
       task_plan.update_gradable_step_counts!
-      expect(tasking_plan.gradable_step_count).to eq 42
+      expect(tasking_plan.reload.gradable_step_count).to eq 42
       expect(tasking_plan.ungraded_step_count).to eq 21
       expect(task_plan.gradable_step_count).to eq 42
       expect(task_plan.ungraded_step_count).to eq 21
 
       period.destroy!
       task_plan.reload.update_gradable_step_counts!
-      expect(tasking_plan.gradable_step_count).to eq 42
+      expect(tasking_plan.reload.gradable_step_count).to eq 42
       expect(tasking_plan.ungraded_step_count).to eq 21
       expect(task_plan.gradable_step_count).to eq 0
       expect(task_plan.ungraded_step_count).to eq 0
 
       period.restore!
       task_plan.reload.update_gradable_step_counts!
-      expect(tasking_plan.gradable_step_count).to eq 42
+      expect(tasking_plan.reload.gradable_step_count).to eq 42
       expect(tasking_plan.ungraded_step_count).to eq 21
       expect(task_plan.gradable_step_count).to eq 42
       expect(task_plan.ungraded_step_count).to eq 21


### PR DESCRIPTION
This PR sets up UpdateTaskCaches to run when tasks become due mainly so we can update the NEW flag counts...

Please test extensively.