### PR TITLE
add due_at_without_extension to student in performance report

### DIFF
--- a/app/representers/api/v1/performance_report/student/data/representer.rb
+++ b/app/representers/api/v1/performance_report/student/data/representer.rb
@@ -77,6 +77,12 @@ module Api::V1::PerformanceReport::Student::Data
              writeable: false,
              getter: ->(*) { DateTimeUtilities.to_api_s(due_at) }
 
+    property :due_at_without_extension,
+             type: String,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { DateTimeUtilities.to_api_s(due_at_without_extension) }
+
     property :last_worked_at,
              type: String,
              readable: true,

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -393,6 +393,7 @@ module Tasks
           type:                                   type,
           id:                                     tt.id,
           due_at:                                 tt.due_at,
+          due_at_without_extension:               tt.due_at_without_extension,
           last_worked_at:                         tt.last_worked_at&.in_time_zone(tz),
           is_extended:                            tt.extended?,
           is_past_due:                            tt.past_due?,

--- a/spec/subsystems/tasks/get_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_performance_report_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
             expect(data.id).to be_a Integer
             expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
             expect(data.due_at).to be_a Time
+            expect(data.due_at_without_extension).to be_a Time
             expect(data.last_worked_at).to be_nil.or(be_a Time)
             expect(data.is_extended).to be_in [true, false]
             expect(data.is_past_due).to be_in [true, false]
@@ -568,6 +569,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
             expect(data.id).to be_a Integer
             expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
             expect(data.due_at).to be_a Time
+            expect(data.due_at_without_extension).to be_a Time
             expect(data.last_worked_at).to be_nil.or(be_a Time)
             expect(data.is_extended).to be_in [true, false]
             expect(data.is_past_due).to be_in [true, false]
@@ -747,6 +749,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
             expect(data.id).to be_a Integer
             expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
             expect(data.due_at).to be_a Time
+            expect(data.due_at_without_extension).to be_a Time
             expect(data.last_worked_at).to be_nil.or(be_a Time)
             expect(data.is_extended).to be_in [true, false]
             expect(data.is_past_due).to be_in [true, false]
@@ -892,6 +895,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           expect(data.id).to be_a Integer
           expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
           expect(data.due_at).to be_a Time
+          expect(data.due_at_without_extension).to be_a Time
           expect(data.last_worked_at).to be_nil.or(be_a Time)
           expect(data.is_extended).to be_in [true, false]
           expect(data.is_past_due).to be_in [true, false]
@@ -984,6 +988,7 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
           expect(data.id).to be_a Integer
           expect(data.status).to be_in ['completed', 'in_progress', 'not_started']
           expect(data.due_at).to be_a Time
+          expect(data.due_at_without_extension).to be_a Time
           expect(data.last_worked_at).to be_nil.or(be_a Time)
           expect(data.is_extended).to be_in [true, false]
           expect(data.is_past_due).to be_in [true, false]


### PR DESCRIPTION
Need this field on the front end to accurately line up grade book student data with the task heading due_at.