### PR TITLE
Fix Glicko Performance Forecast on ecosystem update

### DIFF
--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -20,13 +20,17 @@ class GetStudentGuide
         WHERE_SQL
       )
     ).pluck(:core_page_ids).flatten.uniq
-    chapter_uuid_page_uuids = Content::Models::Page
+
+    chapter_uuids_by_page_uuid = Hash.new { |hash, key| hash[key] = [] }
+    Content::Models::Page
       .with_exercises
       .where(id: core_page_ids)
-      .pluck(:parent_book_part_uuid, :uuid)
-    chapter_uuids, page_uuids = chapter_uuid_page_uuids.transpose
-    chapter_uuids = Set.new chapter_uuids
-    page_uuids = Set.new page_uuids
+      .pluck(:uuid, :parent_book_part_uuid)
+      .each do |page_uuid, chapter_uuid|
+      chapter_uuids_by_page_uuid[page_uuid] << chapter_uuid
+    end
+    page_uuids = Set.new chapter_uuids_by_page_uuid.keys
+    chapter_uuids = Set.new chapter_uuids_by_page_uuid.values.flatten
 
     role_book_parts_by_book_part_uuid = Ratings::RoleBookPart.where(
       role: role, book_part_uuid: (chapter_uuids + page_uuids).to_a
@@ -55,22 +59,44 @@ class GetStudentGuide
       end.compact
       next if page_guides.empty?
 
-      chapter_role_book_part = role_book_parts_by_book_part_uuid[chapter.uuid] ||
-                               Ratings::RoleBookPart.new(
-        role: role,
-        book_part_uuid: chapter.uuid,
-        is_page: false
-      )
+      chapter_uuids = (
+        [ chapter.uuid ] + chapter_uuids_by_page_uuid.values_at(*chapter.pages.map(&:uuid)).flatten
+      ).uniq
+
+      chapter_role_book_parts = role_book_parts_by_book_part_uuid.values_at(*chapter_uuids).compact
+
+      real_clue_book_parts = chapter_role_book_parts.select do |chapter_role_book_part|
+        chapter_role_book_part.clue['is_real']
+      end
+      if real_clue_book_parts.empty?
+        clue = {
+          minimum: 0.0,
+          most_likely: 0.5,
+          maximum: 1.0,
+          is_real: false
+        }
+      else
+        most_likely = real_clue_book_parts.sum(0.0) do |chapter_role_book_part|
+          chapter_role_book_part.clue['most_likely'] * chapter_role_book_part.num_results
+        end/real_clue_book_parts.sum(0, &:num_results)
+
+        clue = {
+          minimum: 0.0,
+          most_likely: most_likely,
+          maximum: 1.0,
+          is_real: true
+        }
+      end
 
       {
         title: chapter.title,
         book_location: chapter.book_location,
         student_count: 1,
-        questions_answered_count: chapter_role_book_part.num_results,
-        clue: chapter_role_book_part.clue,
+        questions_answered_count: chapter_role_book_parts.sum(0, &:num_results),
+        clue: clue,
         page_ids: page_guides.map { |guide| guide[:page_ids] }.reduce([], :+),
-        first_worked_at: chapter_role_book_part.created_at,
-        last_worked_at: chapter_role_book_part.updated_at,
+        first_worked_at: chapter_role_book_parts.map(&:created_at).min,
+        last_worked_at: chapter_role_book_parts.map(&:updated_at).max,
         children: page_guides
       }
     end.compact

--- a/app/routines/get_student_guide.rb
+++ b/app/routines/get_student_guide.rb
@@ -33,14 +33,6 @@ class GetStudentGuide
     ).index_by(&:book_part_uuid)
 
     chapter_guides = book.chapters.map do |chapter|
-      next unless chapter_uuids.include? chapter.uuid
-      chapter_role_book_part = role_book_parts_by_book_part_uuid[chapter.uuid] ||
-                               Ratings::RoleBookPart.new(
-        role: role,
-        book_part_uuid: chapter.uuid,
-        is_page: false
-      )
-
       page_guides = chapter.pages.map do |page|
         next unless page_uuids.include? page.uuid
         page_role_book_part = role_book_parts_by_book_part_uuid[page.uuid] ||
@@ -61,6 +53,14 @@ class GetStudentGuide
           last_worked_at: page_role_book_part.updated_at
         }
       end.compact
+      next if page_guides.empty?
+
+      chapter_role_book_part = role_book_parts_by_book_part_uuid[chapter.uuid] ||
+                               Ratings::RoleBookPart.new(
+        role: role,
+        book_part_uuid: chapter.uuid,
+        is_page: false
+      )
 
       {
         title: chapter.title,

--- a/app/routines/get_teacher_guide.rb
+++ b/app/routines/get_teacher_guide.rb
@@ -13,13 +13,17 @@ class GetTeacherGuide
       .select(:settings)
       .where(course: course)
       .flat_map(&:core_page_ids)
-    chapter_uuid_page_uuids = Content::Models::Page
+
+    chapter_uuids_by_page_uuid = Hash.new { |hash, key| hash[key] = [] }
+    Content::Models::Page
       .with_exercises
       .where(id: core_page_ids)
-      .pluck(:parent_book_part_uuid, :uuid)
-    chapter_uuids, page_uuids = chapter_uuid_page_uuids.transpose
-    chapter_uuids = Set.new chapter_uuids
-    page_uuids = Set.new page_uuids
+      .pluck(:uuid, :parent_book_part_uuid)
+      .each do |page_uuid, chapter_uuid|
+      chapter_uuids_by_page_uuid[page_uuid] << chapter_uuid
+    end
+    page_uuids = Set.new chapter_uuids_by_page_uuid.keys
+    chapter_uuids = Set.new chapter_uuids_by_page_uuid.values.flatten
 
     period_book_parts_by_period_id = Ratings::PeriodBookPart.where(
       period: periods, book_part_uuid: (chapter_uuids + page_uuids).to_a
@@ -52,22 +56,49 @@ class GetTeacherGuide
         end.compact
         next if page_guides.empty?
 
-        chapter_period_book_part = period_book_parts_by_book_part_uuid[chapter.uuid] ||
-                                   Ratings::PeriodBookPart.new(
-          period: period,
-          book_part_uuid: chapter.uuid,
-          is_page: false
-        )
+        chapter_uuids = (
+          [ chapter.uuid ] +
+          chapter_uuids_by_page_uuid.values_at(*chapter.pages.map(&:uuid)).flatten
+        ).uniq
+
+        chapter_period_book_parts = period_book_parts_by_book_part_uuid.values_at(
+          *chapter_uuids
+        ).compact
+
+        real_clue_book_parts = chapter_period_book_parts.select do |chapter_period_book_part|
+          chapter_period_book_part.clue['is_real']
+        end
+        if real_clue_book_parts.empty?
+          questions_answered_count = 0
+
+          clue = {
+            minimum: 0.0,
+            most_likely: 0.5,
+            maximum: 1.0,
+            is_real: false
+          }
+        else
+          most_likely = real_clue_book_parts.sum(0.0) do |chapter_period_book_part|
+            chapter_period_book_part.clue['most_likely'] * chapter_period_book_part.num_results
+          end/real_clue_book_parts.sum(0, &:num_results)
+
+          clue = {
+            minimum: 0.0,
+            most_likely: most_likely,
+            maximum: 1.0,
+            is_real: true
+          }
+        end
 
         {
           title: chapter.title,
           book_location: chapter.book_location,
-          student_count: chapter_period_book_part.num_students,
-          questions_answered_count: chapter_period_book_part.num_results,
-          clue: chapter_period_book_part.clue,
+          student_count: chapter_period_book_parts.sum(0, &:num_students),
+          questions_answered_count: chapter_period_book_parts.sum(0, &:num_results),
+          clue: clue,
           page_ids: page_guides.map { |guide| guide[:page_ids] }.reduce([], :+),
-          first_worked_at: chapter_period_book_part.created_at,
-          last_worked_at: chapter_period_book_part.updated_at,
+          first_worked_at: chapter_period_book_parts.map(&:created_at).min,
+          last_worked_at: chapter_period_book_parts.map(&:updated_at).max,
           children: page_guides
         }
       end.compact


### PR DESCRIPTION
Display PF even if the chapter CLUe is missing

Attempt to combine chapter CLUes across ecosystem updates