### PR TITLE
add submitted_late and late_work_point_penalty to scores api

### DIFF
--- a/app/representers/api/v1/task_plan/scores/student_question_representer.rb
+++ b/app/representers/api/v1/task_plan/scores/student_question_representer.rb
@@ -22,6 +22,11 @@ class Api::V1::TaskPlan::Scores::StudentQuestionRepresenter < Roar::Decorator
            readable: true,
            writeable: false
 
+  property :late_work_point_penalty,
+           type: Float,
+           readable: true,
+           writeable: false
+
   property :is_completed,
            readable: true,
            writeable: false,
@@ -53,6 +58,11 @@ class Api::V1::TaskPlan::Scores::StudentQuestionRepresenter < Roar::Decorator
            writeable: false
 
   property :needs_grading,
+           readable: true,
+           writeable: false,
+           schema_info: { type: 'boolean' }
+
+  property :submitted_late,
            readable: true,
            writeable: false,
            schema_info: { type: 'boolean' }

--- a/app/routines/calculate_task_plan_scores.rb
+++ b/app/routines/calculate_task_plan_scores.rb
@@ -126,10 +126,12 @@ class CalculateTaskPlanScores
               is_correct: tasked.is_correct?,
               selected_answer_id: tasked.answer_id,
               points: points,
+              late_work_point_penalty: tasked.late_work_point_penalty,
               free_response: tasked.free_response,
               grader_points: tasked.grader_points,
               grader_comments: tasked.grader_comments,
-              needs_grading: tasked.needs_grading?
+              needs_grading: tasked.needs_grading?,
+              submitted_late: tasked.submitted_late?
             }
           else
             {

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -168,6 +168,10 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     full_credit_question_ids.include? question_id
   end
 
+  def submitted_late?
+    task_step.completed? && task_step.last_completed_at >= task_step.task.due_at
+  end
+
   # Used directly only when grading
   def grader_points
     gp = super

--- a/spec/representers/api/v1/task_plan/scores/representer_spec.rb
+++ b/spec/representers/api/v1/task_plan/scores/representer_spec.rb
@@ -115,7 +115,9 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     free_response: 'a sentence explaining all the things',
                     selected_answer_id: kind_of(String),
                     points: 1.0,
-                    needs_grading: false
+                    late_work_point_penalty: 0.0,
+                    needs_grading: false,
+                    submitted_late: false
                   }
                 ] + [
                   {
@@ -124,10 +126,16 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     question_id: kind_of(String),
                     is_completed: false,
                     is_correct: false,
-                    needs_grading: false
+                    needs_grading: false,
+                    submitted_late: false,
+                    late_work_point_penalty: 0.0
                   }
                 ] * 4 + [
-                  { task_step_id: kind_of(String), is_completed: false, needs_grading: false }
+                  {
+                    task_step_id: kind_of(String),
+                    is_completed: false,
+                    needs_grading: false
+                  }
                 ] * 3,
                 grades_need_publishing: false
               },
@@ -152,7 +160,9 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     free_response: 'a sentence not explaining anything',
                     selected_answer_id: kind_of(String),
                     points: student_tasks.second.completion_weight,
-                    needs_grading: false
+                    late_work_point_penalty: 0.0,
+                    needs_grading: false,
+                    submitted_late: false
                   }
                 ] + [
                   {
@@ -161,10 +171,16 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     question_id: kind_of(String),
                     is_completed: false,
                     is_correct: false,
-                    needs_grading: false
+                    needs_grading: false,
+                    submitted_late: false,
+                    late_work_point_penalty: 0.0
                   }
                 ] * 4 + [
-                  { task_step_id: kind_of(String), is_completed: false, needs_grading: false }
+                  {
+                    task_step_id: kind_of(String),
+                    is_completed: false,
+                    needs_grading: false,
+                  }
                 ] * 3,
                 grades_need_publishing: false
               }
@@ -257,7 +273,9 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     free_response: 'a sentence explaining all the things',
                     selected_answer_id: kind_of(String),
                     points: 1.0,
-                    needs_grading: false
+                    late_work_point_penalty: 0.2,
+                    needs_grading: false,
+                    submitted_late: true
                   }
                 ] + [
                   {
@@ -267,14 +285,16 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     is_completed: false,
                     is_correct: false,
                     points: 0.0,
-                    needs_grading: false
+                    late_work_point_penalty: 0.0,
+                    needs_grading: false,
+                    submitted_late: false,
                   }
                 ] * 4 + [
                   {
                     task_step_id: kind_of(String),
                     is_completed: false,
                     points: 0.0,
-                    needs_grading: false
+                    needs_grading: false,
                   }
                 ] * 3,
                 grades_need_publishing: false
@@ -300,7 +320,10 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     free_response: 'a sentence not explaining anything',
                     selected_answer_id: kind_of(String),
                     points: student_tasks.second.completion_weight,
-                    needs_grading: false
+                    late_work_point_penalty: student_tasks.second.completion_weight *
+                                             student_tasks.second.grading_template.late_work_penalty,
+                    needs_grading: false,
+                    submitted_late: true
                   }
                 ] + [
                   {
@@ -310,7 +333,9 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     is_completed: false,
                     is_correct: false,
                     points: 0.0,
-                    needs_grading: false
+                    late_work_point_penalty: 0.0,
+                    needs_grading: false,
+                    submitted_late: false
                   }
                 ] * 4 + [
                   {

--- a/spec/representers/api/v1/task_plan/scores/representer_spec.rb
+++ b/spec/representers/api/v1/task_plan/scores/representer_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Api::V1::TaskPlan::Scores::Representer, type: :representer do
                     free_response: 'a sentence explaining all the things',
                     selected_answer_id: kind_of(String),
                     points: 1.0,
-                    late_work_point_penalty: 0.2,
+                    late_work_point_penalty: 1.0 * late_work_penalty,
                     needs_grading: false,
                     submitted_late: true
                   }

--- a/spec/routines/calculate_task_plan_scores_spec.rb
+++ b/spec/routines/calculate_task_plan_scores_spec.rb
@@ -146,10 +146,12 @@ RSpec.describe CalculateTaskPlanScores, type: :routine, vcr: VCR_OPTS, speed: :s
                       is_correct: false,
                       selected_answer_id: tasked.answer_id,
                       points: ts.completed? || task.past_due? ? 0.0 : nil,
+                      late_work_point_penalty: 0.0,
                       free_response: nil,
                       grader_points: nil,
                       grader_comments: nil,
-                      needs_grading: false
+                      needs_grading: false,
+                      submitted_late: false
                     }
                   else
                     {
@@ -249,10 +251,12 @@ RSpec.describe CalculateTaskPlanScores, type: :routine, vcr: VCR_OPTS, speed: :s
                       is_correct: ts.is_correct?,
                       selected_answer_id: tasked.answer_id,
                       points: ts.completed? ? task.completion_weight : (task.past_due? ? 0.0 : nil),
+                      late_work_point_penalty: 0.0,
                       free_response: tasked.free_response,
                       grader_points: nil,
                       grader_comments: nil,
-                      needs_grading: false
+                      needs_grading: false,
+                      submitted_late: false
                     }
                   else
                     {
@@ -357,10 +361,12 @@ RSpec.describe CalculateTaskPlanScores, type: :routine, vcr: VCR_OPTS, speed: :s
                       is_correct: is_correct,
                       selected_answer_id: tasked.answer_id,
                       points: points,
+                      late_work_point_penalty: 0.0,
                       free_response: tasked.free_response,
                       grader_points: nil,
                       grader_comments: nil,
-                      needs_grading: false
+                      needs_grading: false,
+                      submitted_late: false
                     }
                   else
                     {


### PR DESCRIPTION
Adds `submitted_late` and `late_work_point_penalty` to the student questions, so the scores table can show a late work icon and penalty per question:

<img width="226" alt="image" src="https://user-images.githubusercontent.com/34174/88873306-3a9d9f80-d1d1-11ea-8791-a56821fb4f4b.png">

