### PR TITLE
Separate the frozen score cache into its own table

### DIFF
--- a/app/subsystems/course_profile/models/cache.rb
+++ b/app/subsystems/course_profile/models/cache.rb
@@ -1,0 +1,3 @@
+class CourseProfile::Models::Cache < ApplicationRecord
+  belongs_to :course, inverse_of: :cache
+end

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -15,6 +15,8 @@ class CourseProfile::Models::Course < ApplicationRecord
 
   acts_as_paranoid without_default_scope: true
 
+  has_one :cache, inverse_of: :course
+
   belongs_to :cloned_from, foreign_key: 'cloned_from_id',
                            class_name: 'CourseProfile::Models::Course',
                            optional: true
@@ -138,7 +140,7 @@ class CourseProfile::Models::Course < ApplicationRecord
   end
 
   def frozen_scores?(current_time = Time.current)
-    ended?(current_time) && !teacher_performance_report.nil?
+    ended?(current_time) && !cache&.teacher_performance_report.nil?
   end
 
   protected

--- a/app/subsystems/tasks/get_performance_report.rb
+++ b/app/subsystems/tasks/get_performance_report.rb
@@ -16,7 +16,7 @@ module Tasks
       is_frozen = is_teacher && course.frozen_scores?(current_time) if is_frozen.nil?
 
       if is_frozen
-        outputs.performance_report = course.teacher_performance_report.map do |report|
+        outputs.performance_report = course.cache.teacher_performance_report.map do |report|
           Hashie::Mash.new report
         end
 

--- a/db/migrate/20200713140652_add_teacher_performance_report_to_courses.rb
+++ b/db/migrate/20200713140652_add_teacher_performance_report_to_courses.rb
@@ -1,11 +1,5 @@
 class AddTeacherPerformanceReportToCourses < ActiveRecord::Migration[5.2]
   def change
     add_column :course_profile_courses, :teacher_performance_report, :jsonb, array: true
-
-    reversible do |dir|
-      dir.up do
-        Tasks::FreezeEndedCourseTeacherPerformanceReports.set(queue: :migration).perform_later
-      end
-    end
   end
 end

--- a/db/migrate/20200730181511_create_course_profile_caches.rb
+++ b/db/migrate/20200730181511_create_course_profile_caches.rb
@@ -1,0 +1,34 @@
+class CreateCourseProfileCaches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :course_profile_caches do |t|
+      t.references :course_profile_course, null: false,
+                                           foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.jsonb :teacher_performance_report, array: true, null: false
+
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        CourseProfile::Models::Course.where.not(
+          teacher_performance_report: nil
+        ).find_each do |course|
+          CourseProfile::Models::Cache.create!(
+            course: course,
+            teacher_performance_report: course.read_attribute(:teacher_performance_report)
+          )
+        end
+      end
+
+      dir.down do
+        CourseProfile::Models::Cache.preload(:course).find_each do |cache|
+          cache.course.update_attribute(
+            :teacher_performance_report, cache.teacher_performance_report
+          )
+        end
+      end
+    end
+
+    remove_column :course_profile_courses, :teacher_performance_report, :jsonb, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -303,6 +303,14 @@ ActiveRecord::Schema.define(version: 2020_07_31_211543) do
     t.index ["entity_role_id"], name: "index_course_membership_teachers_on_entity_role_id", unique: true
   end
 
+  create_table "course_profile_caches", force: :cascade do |t|
+    t.bigint "course_profile_course_id", null: false
+    t.jsonb "teacher_performance_report", null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_profile_course_id"], name: "index_course_profile_caches_on_course_profile_course_id"
+  end
+
   create_table "course_profile_courses", id: :serial, force: :cascade do |t|
     t.integer "school_district_school_id"
     t.string "name", null: false
@@ -343,7 +351,6 @@ ActiveRecord::Schema.define(version: 2020_07_31_211543) do
     t.float "reading_weight", default: 0.5, null: false
     t.string "timezone", null: false
     t.boolean "past_due_unattempted_ungraded_wrq_are_zero", default: true, null: false
-    t.jsonb "teacher_performance_report", array: true
     t.index ["catalog_offering_id"], name: "index_course_profile_courses_on_catalog_offering_id"
     t.index ["cloned_from_id"], name: "index_course_profile_courses_on_cloned_from_id"
     t.index ["is_lms_enabling_allowed"], name: "index_course_profile_courses_on_is_lms_enabling_allowed"
@@ -1175,6 +1182,7 @@ ActiveRecord::Schema.define(version: 2020_07_31_211543) do
   add_foreign_key "course_membership_teacher_students", "entity_roles", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_membership_teachers", "course_profile_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_membership_teachers", "entity_roles", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "course_profile_caches", "course_profile_courses", on_update: :cascade, on_delete: :cascade
   add_foreign_key "course_profile_courses", "catalog_offerings", on_update: :cascade, on_delete: :nullify
   add_foreign_key "course_profile_courses", "course_profile_courses", column: "cloned_from_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "course_profile_courses", "school_district_schools", on_update: :cascade, on_delete: :nullify

--- a/spec/factories/course_profile/caches.rb
+++ b/spec/factories/course_profile/caches.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :course_profile_cache, class: '::CourseProfile::Models::Cache' do
+    association :course, factory: :course_profile_course
+
+    teacher_performance_report { [] }
+  end
+end

--- a/spec/subsystems/course_profile/models/cache_spec.rb
+++ b/spec/subsystems/course_profile/models/cache_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CourseProfile::Models::Cache, type: :model do
+  subject(:cache) { FactoryBot.create :course_profile_cache }
+
+  it { is_expected.to belong_to(:course) }
+end

--- a/spec/subsystems/course_profile/models/course_spec.rb
+++ b/spec/subsystems/course_profile/models/course_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe CourseProfile::Models::Course, type: :model do
   subject(:course) { FactoryBot.create :course_profile_course }
 
+  it { is_expected.to have_one(:cache) }
+
   it { is_expected.to belong_to(:school).optional }
   it { is_expected.to belong_to(:offering).optional }
 
@@ -189,5 +191,18 @@ RSpec.describe CourseProfile::Models::Course, type: :model do
 
     course.ends_at = DateTime.new(2020, 6, 30)
     expect(course.pre_wrm_scores?).to eq true
+  end
+
+  it 'knows if scores are frozen' do
+    expect(course.frozen_scores?).to eq false
+
+    cache = FactoryBot.create :course_profile_cache, course: course
+    expect(course.frozen_scores?).to eq false
+
+    course.ends_at = Time.current
+    expect(course.frozen_scores?).to eq true
+
+    cache.destroy!
+    expect(course.reload.frozen_scores?).to eq false
   end
 end

--- a/spec/subsystems/tasks/export_performance_report_spec.rb
+++ b/spec/subsystems/tasks/export_performance_report_spec.rb
@@ -94,9 +94,13 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine do
 
     context 'cached' do
       it 'does not blow up with a cached performance report' do
-        @course.teacher_performance_report = Api::V1::PerformanceReport::Representer.new(
-          Tasks::GetPerformanceReport[role: @role, course: @course]
-        ).to_hash
+        FactoryBot.create(
+          :course_profile_cache,
+          course: @course,
+          teacher_performance_report: Api::V1::PerformanceReport::Representer.new(
+            Tasks::GetPerformanceReport[role: @role, course: @course]
+          ).to_hash
+        )
         @course.ends_at = Time.current
         @course.save validate: false
 
@@ -108,9 +112,13 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine do
       it 'uses the last performance export, if available' do
         @output_filename = described_class[role: @role, course: @course]
 
-        @course.teacher_performance_report = Api::V1::PerformanceReport::Representer.new(
-          Tasks::GetPerformanceReport[role: @role, course: @course]
-        ).to_hash
+        FactoryBot.create(
+          :course_profile_cache,
+          course: @course,
+          teacher_performance_report: Api::V1::PerformanceReport::Representer.new(
+            Tasks::GetPerformanceReport[role: @role, course: @course]
+          ).to_hash
+        )
         @course.ends_at = Time.current
         @course.save validate: false
 
@@ -167,10 +175,12 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine do
 
     context 'cached' do
       it 'does not blow up with a cached performance report' do
-        @course.update_attribute :teacher_performance_report,
-                                 Api::V1::PerformanceReport::Representer.new(
-                                   Tasks::GetPerformanceReport[role: @role, course: @course]
-                                 ).to_hash
+        FactoryBot.create(
+          :course_profile_cache,
+          course: @course, teacher_performance_report: Api::V1::PerformanceReport::Representer.new(
+            Tasks::GetPerformanceReport[role: @role, course: @course]
+          ).to_hash
+        )
 
         expect do
           @output_filename = described_class[role: @role, course: @course]
@@ -180,10 +190,12 @@ RSpec.describe Tasks::ExportPerformanceReport, type: :routine do
       it 'uses the last performance export, if available' do
         @output_filename = described_class[role: @role, course: @course]
 
-        @course.update_attribute :teacher_performance_report,
-                                 Api::V1::PerformanceReport::Representer.new(
-                                   Tasks::GetPerformanceReport[role: @role, course: @course]
-                                 ).to_hash
+        FactoryBot.create(
+          :course_profile_cache,
+          course: @course, teacher_performance_report: Api::V1::PerformanceReport::Representer.new(
+            Tasks::GetPerformanceReport[role: @role, course: @course]
+          ).to_hash
+        )
 
         expect do
           expect(described_class[role: @role, course: @course]).to eq @output_filename

--- a/spec/subsystems/tasks/freeze_ended_course_teacher_performance_reports_spec.rb
+++ b/spec/subsystems/tasks/freeze_ended_course_teacher_performance_reports_spec.rb
@@ -127,9 +127,7 @@ RSpec.describe Tasks::FreezeEndedCourseTeacherPerformanceReports, type: :routine
       expect do
         described_class.call
       end.to  not_change { @course.reload.frozen_scores? }.from(false)
-         .and not_change { @course.teacher_performance_report }.from(nil)
-
-      expect(@course.teacher_performance_report).to be_nil
+         .and not_change { @course.cache }.from(nil)
     end
   end
 
@@ -144,7 +142,7 @@ RSpec.describe Tasks::FreezeEndedCourseTeacherPerformanceReports, type: :routine
       expect do
         described_class.call
       end.to  change { @course.reload.frozen_scores? }.from(false).to(true)
-         .and change { @course.teacher_performance_report }.from(nil)
+         .and change { @course.cache }.from(nil)
 
       # Some objects like AR models don't serialize/deserialize entirely the same,
       # so we save the representation instead.

--- a/spec/subsystems/tasks/get_performance_report_spec.rb
+++ b/spec/subsystems/tasks/get_performance_report_spec.rb
@@ -171,8 +171,12 @@ RSpec.describe Tasks::GetPerformanceReport, type: :routine do
 
     context 'ended course with a frozen performance report' do
       before do
+        FactoryBot.create(
+          :course_profile_cache,
+          course: @course,
+          teacher_performance_report: [ { is_frozen: true } ]
+        )
         @course.ends_at = Time.current
-        @course.teacher_performance_report = [ { is_frozen: true } ]
         @course.save validate: false
       end
 


### PR DESCRIPTION
The field can be pretty big so we don't want to load it all the time for performance reasons.
In Rails it's easier to put the field in a separate table.
default_scope works most of the time, but interferes with `.count` etc