### PR TITLE
don't validate due_at is in future

### DIFF
--- a/app/subsystems/tasks/models/tasking_plan.rb
+++ b/app/subsystems/tasks/models/tasking_plan.rb
@@ -11,7 +11,7 @@ class Tasks::Models::TaskingPlan < ApplicationRecord
 
   validates :opens_at_ntz, :due_at_ntz, :closes_at_ntz, presence: true, timeliness: { type: :date }
 
-  validate :due_at_in_the_future, :due_at_on_or_after_opens_at, :closes_at_on_or_after_due_at,
+  validate :due_at_on_or_after_opens_at, :closes_at_on_or_after_due_at,
            :opens_after_course_starts, :closes_before_course_ends, :course_can_task_target
 
   def past_open?(current_time: Time.current)
@@ -27,17 +27,6 @@ class Tasks::Models::TaskingPlan < ApplicationRecord
   end
 
   protected
-
-  def due_at_in_the_future
-    return if task_plan&.course.nil? ||
-              task_plan.is_draft? ||
-              !due_at_ntz_changed? ||
-              due_at.nil? ||
-              due_at > Time.current
-
-    errors.add(:due_at, 'cannot be set into the past')
-    throw :abort
-  end
 
   def due_at_on_or_after_opens_at
     return if task_plan&.course.nil? || due_at.nil? || opens_at.nil? || due_at >= opens_at

--- a/spec/subsystems/tasks/models/tasking_plan_spec.rb
+++ b/spec/subsystems/tasks/models/tasking_plan_spec.rb
@@ -14,15 +14,6 @@ RSpec.describe Tasks::Models::TaskingPlan, type: :model do
   it { is_expected.to validate_presence_of(:due_at_ntz) }
   it { is_expected.to validate_presence_of(:closes_at_ntz) }
 
-  it "requires due_at to be in the future when changed after the task_plan is published" do
-    publish_time = Time.current
-    task_plan.first_published_at = publish_time
-    task_plan.last_published_at = publish_time
-    expect(tasking_plan).to be_valid
-    tasking_plan.due_at = tasking_plan.time_zone.now
-    expect(tasking_plan).not_to be_valid
-  end
-
   it "requires due_at to be greater than or equal to opens_at" do
     expect(tasking_plan).to be_valid
     tasking_plan.opens_at = tasking_plan.due_at


### PR DESCRIPTION
Doing so prevents editing old task plans to extend only their closes_at in order to provide a extension to students

Branch is based off of `v39.1.1` and will be released as hotfix.  Will rebase to `master` after it's tagged and released
