### PR TITLE
Added a migration to fix the task caches of existing manually-graded tasks

### DIFF
--- a/db/migrate/20200807211136_fix_existing_task_caches.rb
+++ b/db/migrate/20200807211136_fix_existing_task_caches.rb
@@ -1,0 +1,8 @@
+class FixExistingTaskCaches < ActiveRecord::Migration[5.2]
+  def up
+    Tasks::Models::Task.where(is_provisional_score_after_due: true).find_each(&:update_caches_later)
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_211543) do
+ActiveRecord::Schema.define(version: 2020_08_07_211136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"


### PR DESCRIPTION
There are ~15,000 tasks with is_provisional_score_after_due: true in prod so this should run in about a minute.