### PR TITLE
set session cookie options iframe compatibility

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_tutor_session'
+# MUST use secure: true, same_site: :none
+# otherwise cookies will not be set inside iframes and break launching from lms in lms/launch_authenticate
+if Rails.env.production?
+  Rails.application.config.session_store :cookie_store, key: '_tutor_session', secure: true, same_site: :none
+else
+  Rails.application.config.session_store :cookie_store, key: '_tutor_session'
+end


### PR DESCRIPTION
Needed for LMS launch inside iframe

Chrome 84+ will default to "None" unless it's set explicitly and that will not be sent inside iframes.

https://blog.heroku.com/chrome-changes-samesite-cookie