### PR TITLE
Admin edit styles

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -87,14 +87,24 @@ $(document).ready(function() {
     window.location.search = $.param(paramsObject);
   });
 
+  //========== Hides and shows the preview message box when is_preview selected ==========//
+  function onIsPreviewChange() {
+    const previewFG = $('#offering_preview_message').closest('.form-group');
+    if ($('#offering_is_preview_available').is(":checked")) {
+      previewFG.show();
+    } else {
+      previewFG.hide();
+    }
+  }
+  $('#offering_is_preview_available').change(onIsPreviewChange);
+  onIsPreviewChange();
+
+  
   //========== Changes the course form when a course offering is selected ==========//
   function updateCourseForm() {
     var offering = $('#course_catalog_offering_id option:selected').first();
     if (offering.prop('value')) {
       $('#course_appearance_code').prop('placeholder', offering.attr('data-appearance_code'));
-      $('#course_is_concept_coach').prop('disabled', true);
-      $('#course_is_concept_coach').prop('checked',
-                                         offering.attr('data-is_concept_coach') == '1');
     }
     else {
       $('#course_appearance_code').prop('placeholder', '');

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -108,7 +108,6 @@ $(document).ready(function() {
     }
     else {
       $('#course_appearance_code').prop('placeholder', '');
-      $('#course_is_concept_coach').prop('disabled', false);
     }
   }
   $('#course_catalog_offering_id').change(updateCourseForm);

--- a/app/assets/stylesheets/manager.scss
+++ b/app/assets/stylesheets/manager.scss
@@ -86,3 +86,13 @@ nav.navbar.production {
     overflow: hidden;
   }
 }
+
+input[type="radio"],
+input[type="checkbox"] {
+  &.form-control {
+    display: inline;
+    width: inherit;
+    height: inherit;
+  }
+
+}

--- a/app/handlers/admin/courses_create.rb
+++ b/app/handlers/admin/courses_create.rb
@@ -13,10 +13,9 @@ class Admin::CoursesCreate
     attribute :catalog_offering_id, type: Integer
     attribute :is_test, type: ActiveAttr::Typecasting::Boolean
     attribute :is_preview, type: ActiveAttr::Typecasting::Boolean
-    attribute :is_concept_coach, type: ActiveAttr::Typecasting::Boolean
     attribute :is_college, type: ActiveAttr::Typecasting::Boolean
     validates :name, :term, :year, :num_sections, presence: true
-    validates :is_test, :is_preview, :is_concept_coach, :is_college, inclusion: [true, false]
+    validates :is_test, :is_preview, :is_college, inclusion: [true, false]
   end
 
   uses_routine CreateCourse, translations: { outputs: { type: :verbatim } }
@@ -41,7 +40,6 @@ class Admin::CoursesCreate
                         ends_at: course_params.ends_at,
                         is_test: course_params.is_test,
                         is_preview: course_params.is_preview,
-                        is_concept_coach: course_params.is_concept_coach,
                         is_college: course_params.is_college,
                         catalog_offering: offering,
                         appearance_code: course_params.appearance_code,

--- a/app/views/admin/catalog_offerings/_edit_row.html.erb
+++ b/app/views/admin/catalog_offerings/_edit_row.html.erb
@@ -1,10 +1,3 @@
-<style type='text/css'>
-  .checkbox-label {
-    display: inline-block;
-    margin: 11px 0 0 10px;
-  }
-</style>
-
 <div id='offering_<%= offering.id %>' class='underlined-spaced-row'>
   <div class="form-group">
     <%= form.label :number %>
@@ -36,6 +29,14 @@
     <%= form.text_field :default_course_name, class: 'form-control' %>
   </div>
   <div class="form-group">
+    <%= form.label :pdf_url %>
+    <%= form.text_field :pdf_url, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= form.label :webview_url %>
+    <%= form.text_field :webview_url, class: 'form-control' %>
+  </div>
+  <div class="form-group">
     <%= form.label "Ecosystem" %>
     <%= form.collection_select :content_ecosystem_id,
        @ecosystems, :id, :unique_title, { include_blank: true }, class: 'form-control' %>
@@ -52,8 +53,8 @@
   </div>
   <div class="checkbox">
     <label>
-      <%= form.check_box :is_preview_available, class: 'form-control' %>
-      <span class="checkbox-label">Available for preview courses?</span>
+      <%= form.check_box :does_cost, class: 'form-control' %>
+      <span class="checkbox-label">Costs students?</span>
     </label>
   </div>
   <div class="checkbox">
@@ -62,38 +63,31 @@
       <span class="checkbox-label">Available for real courses?</span>
     </label>
   </div>
+  <div class="checkbox">
+    <label>
+      <%= form.check_box :is_preview_available, class: 'form-control' %>
+      <span class="checkbox-label">Available for preview courses?</span>
+    </label>
+  </div>
   <div class="form-group">
     <%= form.label :preview_message, 'Message displayed when a preview course is created' %>
     <%= form.text_field :preview_message, class: 'form-control' %>
-  </div>
-  <div class="checkbox">
-    <label>
-      <%= form.check_box :does_cost, class: 'form-control' %>
-      <span class="checkbox-label">Costs students?</span>
-    </label>
-  </div>
-  <div class="checkbox">
-    <label>
-      <%= form.check_box :is_tutor, class: 'form-control' %>
-      <span class="checkbox-label">Works for full Tutor?</span>
-    </label>
-  </div>
-  <div class="checkbox">
-    <label style="vertical-align:middle">
-      <%= form.check_box :is_concept_coach, class: 'form-control' %>
-      <span class="checkbox-label">Works for Concept Coach?</span>
-    </label>
-  </div>
-  <div class="form-group">
-    <%= form.label :pdf_url %>
-    <%= form.text_field :pdf_url, class: 'form-control' %>
-  </div>
-  <div class="form-group">
-    <%= form.label :webview_url %>
-    <%= form.text_field :webview_url, class: 'form-control' %>
   </div>
 
   <%= form.submit class: 'btn btn-primary', value: 'Save' %>
 
   <%= link_to 'Cancel', admin_catalog_offerings_path, class: 'btn' %>
 </div>
+<script>
+  function onPreviewChange() {
+    const previewFG = $('#offering_preview_message').closest('.form-group');
+    if ($('#offering_is_preview_available').is(":checked")) {
+      previewFG.show();
+    } else {
+      previewFG.hide();
+    }
+  }
+  $('#offering_is_preview_available').change(onPreviewChange);
+  onPreviewChange();
+
+</script>

--- a/app/views/admin/catalog_offerings/_edit_row.html.erb
+++ b/app/views/admin/catalog_offerings/_edit_row.html.erb
@@ -78,16 +78,3 @@
 
   <%= link_to 'Cancel', admin_catalog_offerings_path, class: 'btn' %>
 </div>
-<script>
-  function onPreviewChange() {
-    const previewFG = $('#offering_preview_message').closest('.form-group');
-    if ($('#offering_is_preview_available').is(":checked")) {
-      previewFG.show();
-    } else {
-      previewFG.hide();
-    }
-  }
-  $('#offering_is_preview_available').change(onPreviewChange);
-  onPreviewChange();
-
-</script>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -83,11 +83,6 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :is_concept_coach %>
-    <%= f.check_box :is_concept_coach, class: 'form-control' %>
-  </div>
-
-  <div class="form-group">
     <%= f.label :is_college %>
     <br>
     <%= f.select :is_college, [[ "Unknown", nil ], [ "Yes", true ], [ "No", false ]],

--- a/spec/features/admin/assign_teachers_spec.rb
+++ b/spec/features/admin/assign_teachers_spec.rb
@@ -13,12 +13,13 @@ RSpec.feature 'Administration', js: true do
       :user_profile, username: 'imateacher', first_name: 'Ima',
       last_name: 'Teacher', full_name: 'Ima Teacher'
     )
-
+    offering = FactoryBot.create :catalog_offering
     # Create a course
     visit admin_courses_path(query: '')
     click_link 'Add Course'
 
     fill_in 'Name', with: 'A Course'
+    select offering.salesforce_book_name, from: 'Catalog Offering'
 
     click_button 'Save'
     # Edit the course

--- a/spec/features/admin/create_blank_course_spec.rb
+++ b/spec/features/admin/create_blank_course_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Administration' do
+  let!(:catalog_offering){catalog_offering = FactoryBot.create :catalog_offering}
   before do
     admin = FactoryBot.create(:user_profile, :administrator)
     stub_current_user(admin)
@@ -11,6 +12,7 @@ RSpec.feature 'Administration' do
     click_link 'Add Course'
 
     fill_in 'Name', with: 'Hello hi ciao Hey World'
+    select catalog_offering.salesforce_book_name, from: 'Catalog Offering'
     click_button 'Save'
 
     expect(current_path).to eq(admin_courses_path)
@@ -19,7 +21,6 @@ RSpec.feature 'Administration' do
   end
 
   scenario 'create a blank course with a catalog_offering' do
-    catalog_offering = FactoryBot.create :catalog_offering
 
     visit admin_courses_path(query: '')
     click_link 'Add Course'

--- a/spec/features/admin/district_terms_work_spec.rb
+++ b/spec/features/admin/district_terms_work_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'DistrictTermsWork' do
   scenario 'normal creation, no deletion or editing' do
     admin = FactoryBot.create(:user_profile, :administrator)
+    offering = FactoryBot.create :catalog_offering
     stub_current_user(admin)
 
     visit admin_districts_path
@@ -22,6 +23,7 @@ RSpec.feature 'DistrictTermsWork' do
     click_link 'Add Course'
 
     fill_in 'Name', with: 'Hello World'
+    select offering.salesforce_book_name, from: 'Catalog Offering'
     select 'JFK', from: 'School'
     click_button 'Save'
 


### PR DESCRIPTION
Fixes huge checkboxes and re-arranges admin fields a bit 
before:
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/79566/90290169-feaa4180-de42-11ea-87fc-ca9b787bb88a.png">


after:
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/79566/90290134-f225e900-de42-11ea-88da-69b9b8ba36f2.png">
