### PR TITLE
Don't report LockWaitTimeout to Sentry

### DIFF
--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -73,6 +73,12 @@ OpenStax::RescueFrom.register_exception(
   notify: false
 )
 
+OpenStax::RescueFrom.register_exception(
+  'ActiveRecord::LockWaitTimeout',
+  status: :locked,
+  notify: false
+)
+
 # Exceptions in controllers are not automatically reraised in production-like environments
 ActionController::Base.use_openstax_exception_rescue
 


### PR DESCRIPTION
We just want these to retry silently later, so don't log them to Sentry.