### PR TITLE
Fix 403 when ONLY grant tutor access was checked

### DIFF
--- a/app/access_policies/offering_access_policy.rb
+++ b/app/access_policies/offering_access_policy.rb
@@ -2,14 +2,7 @@ class OfferingAccessPolicy
   def self.action_allowed?(action, requestor, offering)
     return false if requestor.is_anonymous? ||
                     !requestor.is_human? ||
-                    !requestor.account.confirmed_faculty? ||
-                    requestor.account.foreign_school? ||
-                    !(
-                      requestor.account.college? ||
-                      requestor.account.high_school? ||
-                      requestor.account.k12_school? ||
-                      requestor.account.home_school?
-                    )
+                    !requestor.can_create_courses?
 
     case action.to_sym
     when :index, :read

--- a/spec/access_policies/offering_access_policy_spec.rb
+++ b/spec/access_policies/offering_access_policy_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe OfferingAccessPolicy, type: :access_policy do
     end
   end
 
+  context 'explicitly marked as grant_tutor_access' do
+    let(:requestor) { FactoryBot.create(:user_profile).tap{ |user| user.account.update_attributes(grant_tutor_access: true) } }
+
+    [:index, :read, :create_course].each do |test_action|
+      context test_action.to_s do
+        let(:action) { test_action }
+
+        it { should eq true }
+      end
+    end
+  end
+
   context 'verified faculty' do
     let(:requestor) { faculty }
 


### PR DESCRIPTION
use can_create_courses? for access It also incorporates the "grant_tutor_access" flag that the access policy check was missing.  