### PR TITLE
rename manifest.json to assets.json

### DIFF
--- a/lib/tutor/assets/manifest.rb
+++ b/lib/tutor/assets/manifest.rb
@@ -24,7 +24,7 @@ module Tutor
         end
 
         def url
-          Tutor::Assets.url_for 'manifest.json'
+          Tutor::Assets.url_for 'assets.json'
         end
 
         def assets

--- a/spec/cassettes/OpenStax_Payments_Api_RealClient/_refund/raises_an_error_for_non-existent_product_instances.yml
+++ b/spec/cassettes/OpenStax_Payments_Api_RealClient/_refund/raises_an_error_for_non-existent_product_instances.yml
@@ -1153,7 +1153,7 @@ http_interactions:
         \         <td class=\"code\"><pre>False</pre></td>\n        </tr>\n      \n
         \       <tr>\n          <td>WEBPACK_LOADER</td>\n          <td class=\"code\"><pre>{&#39;DEFAULT&#39;:
         {&#39;BUNDLE_DIR_NAME&#39;: &#39;bundles/&#39;,\n             &#39;STATS_FILE&#39;:
-        &#39;/Users/jps/dev/openstax/ospayments/static/bundles/assets.json&#39;}}</pre></td>\n
+        &#39;/Users/jps/dev/openstax/ospayments/static/bundles/manifest.json&#39;}}</pre></td>\n
         \       </tr>\n      \n        <tr>\n          <td>WSGI_APPLICATION</td>\n
         \         <td class=\"code\"><pre>&#39;wsgi.application&#39;</pre></td>\n
         \       </tr>\n      \n        <tr>\n          <td>X_FRAME_OPTIONS</td>\n

--- a/spec/cassettes/OpenStax_Payments_Api_RealClient/_refund/raises_an_error_for_non-existent_product_instances.yml
+++ b/spec/cassettes/OpenStax_Payments_Api_RealClient/_refund/raises_an_error_for_non-existent_product_instances.yml
@@ -1153,7 +1153,7 @@ http_interactions:
         \         <td class=\"code\"><pre>False</pre></td>\n        </tr>\n      \n
         \       <tr>\n          <td>WEBPACK_LOADER</td>\n          <td class=\"code\"><pre>{&#39;DEFAULT&#39;:
         {&#39;BUNDLE_DIR_NAME&#39;: &#39;bundles/&#39;,\n             &#39;STATS_FILE&#39;:
-        &#39;/Users/jps/dev/openstax/ospayments/static/bundles/manifest.json&#39;}}</pre></td>\n
+        &#39;/Users/jps/dev/openstax/ospayments/static/bundles/assets.json&#39;}}</pre></td>\n
         \       </tr>\n      \n        <tr>\n          <td>WSGI_APPLICATION</td>\n
         \         <td class=\"code\"><pre>&#39;wsgi.application&#39;</pre></td>\n
         \       </tr>\n      \n        <tr>\n          <td>X_FRAME_OPTIONS</td>\n

--- a/spec/cassettes/Tutor_Assets/loading_remote_manifest/uses_remote_json.yml
+++ b/spec/cassettes/Tutor_Assets/loading_remote_manifest/uses_remote_json.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://tutor-dev.openstax.org/assets/manifest.json
+    uri: https://tutor-dev.openstax.org/assets/assets.json
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Rails sprockets gem will remove a manifest.json file

Goes along with https://github.com/openstax/tutor-js/pull/3293