### PR TITLE
log error when LMS doesn't return xml

### DIFF
--- a/app/subsystems/lms/outcome_response.rb
+++ b/app/subsystems/lms/outcome_response.rb
@@ -6,11 +6,11 @@ module Lms
     end
 
     def code_major
-      @code_major ||= @xml.at_css('imsx_POXHeader imsx_statusInfo imsx_codeMajor').content
+      @code_major ||= @xml.at_css('imsx_POXHeader imsx_statusInfo imsx_codeMajor')&.content || 'failure'
     end
 
     def description
-      @description ||= @xml.at_css('imsx_POXHeader imsx_statusInfo imsx_description').content
+      @description ||= @xml.at_css('imsx_POXHeader imsx_statusInfo imsx_description')&.content
     end
 
   end

--- a/app/subsystems/lms/send_course_scores.rb
+++ b/app/subsystems/lms/send_course_scores.rb
@@ -87,27 +87,17 @@ class Lms::SendCourseScores
         callback.outcome_url, request_xml, {'Content-Type' => 'application/xml'}
       )
 
-      Rails.logger.debug { response.body }
-
       outcome_response = Lms::OutcomeResponse.new(response)
-
-      if 'failure' == outcome_response.code_major
-        error!(
-          message: outcome_response.description,
-          course: @course.id,
-          score: score_data[:course_average],
-          student_name: score_data[:name],
-          student_identifier: score_data[:student_identifier]
-        )
-      end
-    rescue StandardError => ee
+      raise 'lms returned failure' if outcome_response.code_major == 'failure'
+    rescue StandardError => e
       error!(
-        exception: ee,
-        message: ee.message,
+        exception: e,
+        message: e.message,
         course: @course.id,
         score: score_data[:course_average],
         student_name: score_data[:name],
-        student_identifier: score_data[:student_identifier]
+        student_identifier: score_data[:student_identifier],
+        response: response&.body
       )
     end
   end


### PR DESCRIPTION
Canvas will return JSON in some situations 😭   It's tempting to attempt to parse that out so we could log the message but it's probably going to be futile for anything other than this narrow case

https://sentry.cnx.org/openstax/tutor/issues/578420/events/2953909/ 
```{"errors":[{"field":"grade","message":"cannot be changed at this time: This assignment is still unpublished","error_code":null}],"error_report_id":705708}```