### PR TITLE
import ecosystems from cloudfront

### DIFF
--- a/app/routines/fetch_and_import_book_and_create_ecosystem.rb
+++ b/app/routines/fetch_and_import_book_and_create_ecosystem.rb
@@ -8,6 +8,7 @@ class FetchAndImportBookAndCreateEcosystem
   # Returns a Content::Models::Ecosystem containing a book obtained from the given CNX id
   def exec(book_cnx_id:, archive_url: nil,
            reading_processing_instructions: nil, exercise_uids: nil, comments: nil)
+
     OpenStax::Cnx::V1.with_archive_url(archive_url || OpenStax::Cnx::V1.archive_url_base) do
       cnx_book = OpenStax::Cnx::V1.book(id: book_cnx_id)
 

--- a/app/routines/import_ecosystem_manifest.rb
+++ b/app/routines/import_ecosystem_manifest.rb
@@ -26,7 +26,6 @@ class ImportEcosystemManifest
     fatal_error(code: :multiple_books) if manifest.books.size > 1
 
     book = manifest.books.first
-
     run(:fetch_and_import,
         archive_url: book.archive_url,
         book_cnx_id: book.cnx_id,

--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -4,7 +4,7 @@ require 'open-uri'
 require_relative './v1/configuration'
 
 require_relative './v1/custom_css'
-
+require_relative '../../url_path'
 require_relative './v1/fragment'
 require_relative './v1/fragment/html'
 require_relative './v1/fragment/embedded'
@@ -58,21 +58,22 @@ module OpenStax::Cnx::V1
       end
     end
 
-    # Archive url for the given path
-    # Forces /contents/ to be prepended to the path, unless the path begins with /
+
     def archive_url_for(path)
-      Addressable::URI.join(configuration.archive_url_base, '/contents/', path).to_s
+      UrlPath.join(configuration.archive_url_base, '/contents/', path.to_s)
     end
 
     # Webview url for the given path
     # Forces /contents/ to be prepended to the path, unless the path begins with /
     def webview_url_for(path)
-      Addressable::URI.join(configuration.webview_url_base, '/contents/', path).to_s
+      UrlPath.join(configuration.webview_url_base, '/contents/', path.to_s)
     end
+ 
+    def fetch(path, format: 'json')
+      url = "#{path}.#{format}"
 
-    def fetch(url)
       begin
-        Rails.logger.debug { "Fetching #{url}" }
+        Rails.logger.debug { "Fetching #{url}.json" }
         JSON.parse open(url, 'ACCEPT' => 'text/json').read
       rescue OpenURI::HTTPError => exception
         raise OpenStax::HTTPError, "#{exception.message} for URL #{url}"

--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -46,7 +46,7 @@ module OpenStax::Cnx::V1
     end
 
     def url
-      @url ||= url_for(id)
+      @url ||= url_for(uuid)
     end
 
     def parsed_title
@@ -66,7 +66,7 @@ module OpenStax::Cnx::V1
     end
 
     def uuid
-      @uuid ||= full_hash.fetch('id')
+      id.gsub(%r{@(\d|\.)+$}, '')
     end
 
     def short_id
@@ -74,11 +74,11 @@ module OpenStax::Cnx::V1
     end
 
     def version
-      @version ||= full_hash.fetch('version')
+      id.split('@').last
     end
 
     def canonical_url
-      @canonical_url ||= url_for("#{uuid}@#{version}")
+      @canonical_url ||= url_for("#{uuid}")
     end
 
     def content

--- a/lib/url_path.rb
+++ b/lib/url_path.rb
@@ -1,0 +1,31 @@
+# https://stackoverflow.com/a/34620369
+module UrlPath
+
+  def self.join(*paths, separator: '/')
+    paths = paths.compact.reject(&:empty?)
+    last = paths.length - 1
+    paths.each_with_index.reduce([]) { |parts, (path, index)|
+      # remove url part above when ../ is encountered
+      path.gsub!(%r{\.\.\/}) do |_|
+        parts.pop
+        index -= 1
+        last -= 1
+        ''
+      end
+
+      parts << _expand(path, index, last, separator)
+      parts
+    }.join
+  end
+
+  def self._expand(path, current, last, separator)
+    if path.start_with?(separator) && current != 0
+      path = path[1..-1]
+    end
+
+    unless path.end_with?(separator) || current == last
+      path = [path, separator]
+    end
+    path
+  end
+end


### PR DESCRIPTION
Needs tests written and to discuss if we want to add a new field for the code version.

This uses urls like in this format for books:
https://openstax.org/apps/archive/20200827.155539/contents/02040312-72c8-441e-a685-20e9333f3e1d@14.4.json

The ecosystem yaml needs to be updated with the archive url including
the code version like so:

- archive_url: https://openstax.org/apps/archive/20200827.155539/