### PR TITLE
ignore requests to republish task plans

### DIFF
--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -312,7 +312,7 @@ class Tasks::Models::TaskPlan < ApplicationRecord
   end
 
   def not_past_due_when_publishing
-    return if !is_publish_requested || tasking_plans.none?(&:past_due?)
+    return if is_published? || !is_publish_requested || tasking_plans.none?(&:past_due?)
 
     errors.add :due_at, 'cannot be in the past when publishing'
     throw :abort

--- a/spec/subsystems/tasks/models/task_plan_spec.rb
+++ b/spec/subsystems/tasks/models/task_plan_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe Tasks::Models::TaskPlan, type: :model do
 
     task_plan.tasking_plans.first.due_at = Time.current.yesterday
     expect(task_plan).to_not be_valid
+    # it shouldn't have error when it's already published
+    task_plan.first_published_at = Time.current
+    expect(task_plan).to be_valid
+
   end
 
   it 'trims title and description fields' do


### PR DESCRIPTION
No reason to raise an error when assignment was already published