### PR TITLE
Distribute tasks in background job

### DIFF
--- a/app/routines/distribute_tasks.rb
+++ b/app/routines/distribute_tasks.rb
@@ -11,6 +11,9 @@ class DistributeTasks
     # Lock the plan to prevent concurrent publication
     task_plan.lock!
 
+    # when ran in background job, publish_time will be iso date string
+    publish_time = Time.parse(publish_time) if publish_time.is_a?(String)
+
     # Abort if it seems like someone already published this plan
     fatal_error(code: :publish_last_requested_at_must_be_in_the_past) \
       if task_plan.publish_last_requested_at.present? &&

--- a/app/routines/reassign_published_period_task_plans.rb
+++ b/app/routines/reassign_published_period_task_plans.rb
@@ -2,8 +2,6 @@ class ReassignPublishedPeriodTaskPlans
 
   lev_routine
 
-  uses_routine DistributeTasks, as: :distribute
-
   protected
 
   def exec(period:, protect_unopened_tasks: true)
@@ -17,9 +15,11 @@ class ReassignPublishedPeriodTaskPlans
 
     published_task_plans.each_with_index do |tp, ii|
       status.set_progress(ii, published_task_plans.size)
-      run(:distribute, task_plan: tp,
-                       publish_time: Time.current,
-                       protect_unopened_tasks: protect_unopened_tasks)
+      DistributeTasks.perform_later(
+        task_plan: tp,
+        publish_time: Time.current.iso8601,
+        protect_unopened_tasks: protect_unopened_tasks
+      )
     end
   end
 


### PR DESCRIPTION
Split up the long jobs so they can finish faster