### PR TITLE
refactor exercise filter to check each tasked

### DIFF
--- a/app/routines/find_or_create_practice_saved_task.rb
+++ b/app/routines/find_or_create_practice_saved_task.rb
@@ -7,24 +7,17 @@ class FindOrCreatePracticeSavedTask
   protected
 
   def setup(**args)
-    @exercise_ids = available_questions(args[:question_ids]).pluck(:content_exercise_id)
+    @exercise_ids = questions(args[:question_ids]).pluck(:content_exercise_id)
     @task_type = :practice_saved
     @ecosystem = run(:get_course_ecosystem, course: @course).outputs.ecosystem
   end
 
-  def available_questions(question_ids)
-    @role.practice_questions.where(id: question_ids).select(&:available?)
+  def questions(question_ids)
+    @role.practice_questions.where(id: question_ids)
   end
 
   def add_task_steps
     exercises = Content::Models::Exercise.where(id: @exercise_ids)
-
-    fatal_error(
-      code: :no_exercises,
-      message: "No exercises available to build the Saved Practice." +
-               " [Course: #{@course.id} - Role: #{@role.id}" +
-               " - Task Type: #{@task_type} - Ecosystem: #{@ecosystem.title}]"
-    ) if exercises.empty?
 
     exercises = FilterExcludedExercises.call(
       exercises: exercises,
@@ -32,6 +25,13 @@ class FindOrCreatePracticeSavedTask
       additional_excluded_numbers: [],
       current_time: Time.current
     ).outputs.exercises
+
+    fatal_error(
+      code: :no_exercises,
+      message: "No exercises available to build the Saved Practice." +
+               " [Course: #{@course.id} - Role: #{@role.id}" +
+               " - Task Type: #{@task_type} - Ecosystem: #{@ecosystem.title}]"
+    ) if exercises.empty?
 
     # Add the exercises as task steps
     exercises.each do |exercise|

--- a/app/subsystems/tasks/models/practice_question.rb
+++ b/app/subsystems/tasks/models/practice_question.rb
@@ -9,13 +9,6 @@ class Tasks::Models::PracticeQuestion < ApplicationRecord
                                   uniqueness: { scope: [:content_exercise_id, :entity_role_id] }
 
   def available?
-    parts.all?(&:feedback_available?)
-  end
-
-  def parts
-    return [tasked_exercise] unless tasked_exercise.is_in_multipart?
-
-    task = tasked_exercise.task_step.task
-    task.task_steps.exercises.preload(:tasked).map(&:tasked).select{|tasked| tasked.content_exercise_id == content_exercise_id }
+    tasked_exercise.parts.all?(&:feedback_available?)
   end
 end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -339,6 +339,13 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     )
   end
 
+  def parts
+    return [self] unless is_in_multipart?
+
+    task = task_step.task
+    task.task_steps.exercises.preload(:tasked).map(&:tasked).select{|tasked| tasked.content_exercise_id == content_exercise_id }
+  end
+
   protected
 
   def free_response_required_before_answer_id

--- a/spec/requests/api/v1/practices_controller_spec.rb
+++ b/spec/requests/api/v1/practices_controller_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Api::V1::PracticesController, type: :request, api: true, version:
       let(:num_practice_exercises) { 5 }
 
       before do
-        allow_any_instance_of(FindOrCreatePracticeSavedTask).to receive(:available_questions).and_return(
+        allow_any_instance_of(FindOrCreatePracticeSavedTask).to receive(:questions).and_return(
           num_practice_exercises.times.map { FactoryBot.create(:tasks_practice_question) }
         )
       end
@@ -260,7 +260,7 @@ RSpec.describe Api::V1::PracticesController, type: :request, api: true, version:
     context 'with no practice exercises' do
       before do
         expect_any_instance_of(
-          allow_any_instance_of(FindOrCreatePracticeSavedTask).to receive(:available_questions).and_return([])
+          allow_any_instance_of(FindOrCreatePracticeSavedTask).to receive(:questions).and_return([])
         )
       end
 


### PR DESCRIPTION
This moves the PracticeQuestion logic into the exercises filter, which needs to check for feedback on the tasked exercise itself. MPQs should be covered here, as the number will be added for exclusion if _any_ of the parts are unavailable.

While this logic is simpler/faster, it does have an edge case. If a completed question is assigned again in a second assignment, it will be unavailable despite the student having seen answers. This also prevents allowing the Save to Practice button inside of a practice assignment (like Practice Worst.)

If we want to support that in the future, we could do something like this:

```ruby
exercise_numbers_with_status = Hash.new {|hash, key| hash[key] = [] }
taskeds.map {|t|
  exercise_numbers_with_status[t.exercise.number] << t.parts.all?(&:feedback_available?)
}
exercise_numbers_with_status.select {|k, v| v.all?(false) }.keys
```

(To address that edge case, you have to treat the feedback availability of all the MPQ steps of a tasked as a single unit, then only exclude instances where all are unavailable. Completing an MPQ (all steps) would allow availability for all steps somewhere else.)