### PR TITLE
add basic author setup to exercises

### DIFF
--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -266,6 +266,10 @@ module Api::V1
                writeable: false,
                if: ->(*) { respond_to?(:roles) }
 
+    property :related_teacher_profile_ids,
+             readable: true,
+             writeable: false
+
     property :spy_info,
              type: Object,
              readable: true,

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -180,6 +180,11 @@ module Api::V1::Courses
                writeable: false,
                type: String
 
+      property :profile_id,
+               readable: true,
+               writeable: false,
+               type: String
+
       property :first_name,
                readable: true,
                writeable: false,

--- a/app/representers/api/v1/courses/dashboard_representer.rb
+++ b/app/representers/api/v1/courses/dashboard_representer.rb
@@ -180,11 +180,6 @@ module Api::V1::Courses
                writeable: false,
                type: String
 
-      property :profile_id,
-               readable: true,
-               writeable: false,
-               type: String
-
       property :first_name,
                readable: true,
                writeable: false,

--- a/app/representers/api/v1/exercise_author_representer.rb
+++ b/app/representers/api/v1/exercise_author_representer.rb
@@ -1,0 +1,19 @@
+module Api::V1
+  class ExerciseAuthorRepresenter < Roar::Decorator
+    include Roar::JSON
+    include Representable::Coercion
+
+    property :id,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: { required: true }
+
+    property :name,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: { required: true }
+
+  end
+end

--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -87,5 +87,8 @@ module Api::V1
              writeable: false,
              getter: ->(*) { respond_to?(:page_uuid) ? page_uuid : page.try(:uuid) },
              schema_info: { required: true }
+
+    property :author,
+             extend: Api::V1::ExerciseAuthorRepresenter
   end
 end

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -79,6 +79,11 @@ module Api::V1
                ).to_s
              end
 
+    property :profile_id,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { id }
+
     property :viewed_tour_stats
 
   end

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -59,6 +59,7 @@ class CollectCourseInfo
         periods: periods,
         students: students,
         roles: roles,
+        related_teacher_profile_ids: course.related_teacher_profile_ids,
         spy_info: course.spy_info
       )
     end

--- a/app/routines/filter_excluded_exercises.rb
+++ b/app/routines/filter_excluded_exercises.rb
@@ -7,7 +7,8 @@ class FilterExcludedExercises
     role: nil,
     course: nil,
     additional_excluded_numbers: [],
-    current_time: Time.current
+    current_time: Time.current,
+    profile_ids: []
   )
     # Assumes tasks only have 1 tasking
     role ||= task&.taskings&.first&.role
@@ -23,10 +24,9 @@ class FilterExcludedExercises
     course_excluded_numbers = course.nil? ? [] : course.excluded_exercises.map(&:exercise_number)
 
     # Exclude exercises that aren't created by OS or course teacher(s)
-    profile_ids = [User::Models::OpenStaxProfile::ID]
-    profile_ids = profile_ids + course.related_teacher_profile_ids unless course.nil?
+    profile_ids << User::Models::OpenStaxProfile::ID
     no_ownership_excluded_numbers = exercises.map do |exercise|
-      exercise.number unless exercise.user_profile_id.in?(profile_ids)
+      exercise.number unless exercise.user_profile_id.in?(profile_ids.concat.uniq)
     end
 
     # Get exercises excluded due to anti-cheating rules

--- a/app/routines/filter_excluded_exercises.rb
+++ b/app/routines/filter_excluded_exercises.rb
@@ -24,9 +24,9 @@ class FilterExcludedExercises
 
     # Exclude exercises that aren't created by OS or course teacher(s)
     profile_ids = [User::Models::OpenStaxProfile::ID]
-    profile_ids = profile_ids + course.related_teacher_profiles.map(&:id) unless course.nil?
+    profile_ids = profile_ids + course.related_teacher_profile_ids unless course.nil?
     no_ownership_excluded_numbers = exercises.map do |exercise|
-      exercise.number unless exercise.author_id.in?(profile_ids)
+      exercise.number unless exercise.user_profile_id.in?(profile_ids)
     end
 
     # Get exercises excluded due to anti-cheating rules

--- a/app/routines/find_or_create_practice_saved_task.rb
+++ b/app/routines/find_or_create_practice_saved_task.rb
@@ -30,7 +30,8 @@ class FindOrCreatePracticeSavedTask
       exercises: exercises,
       role: @role,
       additional_excluded_numbers: [],
-      current_time: Time.current
+      current_time: Time.current,
+      profile_ids: @course.related_teacher_profile_ids
     ).outputs.exercises
 
     # Add the exercises as task steps

--- a/app/routines/get_course_teachers.rb
+++ b/app/routines/get_course_teachers.rb
@@ -13,6 +13,7 @@ class GetCourseTeachers
       {
         id: teacher.id.to_s,
         role_id: teacher.entity_role_id.to_s,
+        profile_id: teacher.role.profile.id.to_s,
         deleted_at: teacher.deleted_at,
         first_name: teacher.first_name,
         last_name: teacher.last_name

--- a/app/routines/get_exercises.rb
+++ b/app/routines/get_exercises.rb
@@ -44,9 +44,14 @@ class GetExercises
 
     # Build map of exercise uids to representations, with pool type
     hash = {}
+
     exercise_ids_by_pool_type.each do |pool_type, exercise_ids|
       pool_exercises = exercises_by_id.values_at(*exercise_ids).compact
-      pool_exercises = run(:filter, exercises: pool_exercises, course: course).outputs.exercises if filter_exercises
+
+      if filter_exercises
+        pool_exercises = run(:filter, exercises: pool_exercises,
+                                      profile_ids: profile_ids).outputs.exercises
+      end
 
       pool_exercises.each do |exercise|
         unless hash.has_key?(exercise.uid)

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -105,4 +105,12 @@ class Content::Models::Exercise < IndestructibleRecord
   def feature_ids
     cnxfeatures.map(&:data)
   end
+
+  def author
+    if author_id == User::Models::OpenStaxProfile::ID
+      User::Models::OpenStaxProfile
+    else
+      User::Models::Profile.find(author_id)
+    end
+  end
 end

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -17,6 +17,7 @@ class Content::Models::Exercise < IndestructibleRecord
   validates :group_uuid, presence: true
   validates :number, presence: true
   validates :version, presence: true
+  validates :user_profile_id, presence: true
 
   # http://stackoverflow.com/a/7745635
   scope :latest, ->(scope = unscoped) do
@@ -107,10 +108,10 @@ class Content::Models::Exercise < IndestructibleRecord
   end
 
   def author
-    if author_id == User::Models::OpenStaxProfile::ID
+    if user_profile_id == User::Models::OpenStaxProfile::ID
       User::Models::OpenStaxProfile
     else
-      User::Models::Profile.find(author_id)
+      User::Models::Profile.find(user_profile_id)
     end
   end
 end

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -163,6 +163,10 @@ class CourseProfile::Models::Course < ApplicationRecord
     profiles.flatten.uniq
   end
 
+  def related_teacher_profile_ids
+    related_teacher_profiles.map(&:id)
+  end
+
   protected
 
   def set_starts_at_and_ends_at

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -150,6 +150,19 @@ class CourseProfile::Models::Course < ApplicationRecord
     ended?(current_time) && !cache&.teacher_performance_report.nil?
   end
 
+  def related_teacher_profiles
+    profiles = []
+    courses = [self]
+
+    courses.each do |c|
+      next unless c.present?
+      profiles << c.teachers.map {|t| t.role.profile }
+      courses << c.cloned_from
+    end
+
+    profiles.flatten.uniq
+  end
+
   protected
 
   def set_starts_at_and_ends_at

--- a/app/subsystems/user/models/openstax_profile.rb
+++ b/app/subsystems/user/models/openstax_profile.rb
@@ -1,0 +1,15 @@
+module User
+  module Models
+    class OpenStaxProfile
+      ID = 0
+
+      def self.id
+        ID
+      end
+
+      def self.name
+        'OpenStax Tutor'
+      end
+    end
+  end
+end

--- a/db/migrate/20201105003758_add_author_to_content_exercises.rb
+++ b/db/migrate/20201105003758_add_author_to_content_exercises.rb
@@ -1,0 +1,9 @@
+class AddAuthorToContentExercises < ActiveRecord::Migration[5.2]
+  def change
+    add_column :content_exercises,
+               :author_id,
+               :integer,
+               null: false,
+               default: User::Models::OpenStaxProfile::ID
+  end
+end

--- a/db/migrate/20201105003758_add_author_to_content_exercises.rb
+++ b/db/migrate/20201105003758_add_author_to_content_exercises.rb
@@ -1,9 +1,10 @@
 class AddAuthorToContentExercises < ActiveRecord::Migration[5.2]
   def change
     add_column :content_exercises,
-               :author_id,
+               :user_profile_id,
                :integer,
                null: false,
                default: User::Models::OpenStaxProfile::ID
+    add_index :content_exercises, :user_profile_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -123,12 +123,13 @@ ActiveRecord::Schema.define(version: 2020_11_05_003758) do
     t.string "nickname"
     t.jsonb "question_answer_ids", null: false
     t.integer "number_of_questions", null: false
-    t.integer "author_id", default: 0, null: false
+    t.integer "user_profile_id", default: 0, null: false
     t.index ["content_page_id"], name: "index_content_exercises_on_content_page_id"
     t.index ["group_uuid", "version"], name: "index_content_exercises_on_group_uuid_and_version"
     t.index ["number", "version"], name: "index_content_exercises_on_number_and_version"
     t.index ["title"], name: "index_content_exercises_on_title"
     t.index ["url"], name: "index_content_exercises_on_url"
+    t.index ["user_profile_id"], name: "index_content_exercises_on_user_profile_id"
     t.index ["uuid"], name: "index_content_exercises_on_uuid"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_182152) do
+ActiveRecord::Schema.define(version: 2020_11_05_003758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2020_10_28_182152) do
     t.string "nickname"
     t.jsonb "question_answer_ids", null: false
     t.integer "number_of_questions", null: false
+    t.integer "author_id", default: 0, null: false
     t.index ["content_page_id"], name: "index_content_exercises_on_content_page_id"
     t.index ["group_uuid", "version"], name: "index_content_exercises_on_group_uuid_and_version"
     t.index ["number", "version"], name: "index_content_exercises_on_number_and_version"

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -27,6 +27,6 @@ RSpec.describe Content::Models::Exercise, type: :model do
   it 'defaults the author to OpenStax' do
     exercise = FactoryBot.create(:content_exercise)
 
-    expect(exercise.author_id).to eq User::Models::OpenStaxProfile::ID
+    expect(exercise.user_profile_id).to eq User::Models::OpenStaxProfile::ID
   end
 end

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe Content::Models::Exercise, type: :model do
     expect(first['questions'].first['stem_html']).to match('(0)')
     expect(second['questions'].first['stem_html']).to match('(1)')
   end
+
+  it 'defaults the author to OpenStax' do
+    exercise = FactoryBot.create(:content_exercise)
+
+    expect(exercise.author_id).to eq User::Models::OpenStaxProfile::ID
+  end
 end


### PR DESCRIPTION
Adds authorship information so that a teacher can create their own exercises.

- Get and filter exercises authored by the current teacher and co-teachers
- Track by user_profile_id. A default of `0` means OpenStax
- Send profile ids down in the representers
- If the course was cloned, include exercises and profile ids from teachers in the original course
