### PR TITLE
bump version number by looking at max version and generate uuids

### DIFF
--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -15,7 +15,6 @@ class CreateTeacherExercise
     exercise = Content::Models::Exercise.new(
       content: wrapper.content,
       page: page,
-      number: derived_from&.number,
       user_profile_id: profile.id,
       nickname: wrapper.nickname,
       title: wrapper.title,

--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -11,13 +11,11 @@ class CreateTeacherExercise
 
     wrapper = OpenStax::Exercises::V1::Exercise.new(content: content.to_json)
     derived_from = derived_from_id && find_derivable_exercise(course, derived_from_id)
-    version = (derived_from&.version || 0) + 1
 
     exercise = Content::Models::Exercise.new(
       content: wrapper.content,
       page: page,
       number: derived_from&.number,
-      version: version,
       user_profile_id: profile.id,
       nickname: wrapper.nickname,
       title: wrapper.title,
@@ -32,13 +30,7 @@ class CreateTeacherExercise
       is_copyable: copyable || true
     )
     exercise.images.attach(images) if images
-
-    if save
-      exercise.set_teacher_exercise_number
-      exercise.content_hash[:uid] = exercise.uid
-      exercise.content = exercise.content_hash.to_json
-      exercise.save
-    end
+    exercise.save if save
 
     run(
       :tag,

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -132,14 +132,20 @@ class Content::Models::Exercise < IndestructibleRecord
     if derived_from && derived_from.user_profile_id == user_profile_id
       self.number = derived_from.number
       self.version = (Content::Models::Exercise.where(number: number).maximum(:version) || 0) + 1
+      self.group_uuid = derived_from.group_uuid
     else
       self.number = generate_next_teacher_exercise_number
       self.version = 1
+      self.group_uuid = SecureRandom.uuid
     end
+
+    self.uuid = SecureRandom.uuid
 
     content_hash[:number] = number
     content_hash[:version] = version
     content_hash[:uid] = uid
+    content_hash[:uuid] = uuid
+    content_hash[:group_uuid] = group_uuid
     self.content = content_hash.to_json
   end
 

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -129,7 +129,8 @@ class Content::Models::Exercise < IndestructibleRecord
   def set_teacher_exercise_number_and_version
     return unless authored_by_teacher?
 
-    if number?
+    if derived_from && derived_from.user_profile_id == user_profile_id
+      self.number = derived_from.number
       self.version = (Content::Models::Exercise.where(number: number).maximum(:version) || 0) + 1
     else
       self.number = generate_next_teacher_exercise_number

--- a/lib/openstax/exercises/v1/fake_client.rb
+++ b/lib/openstax/exercises/v1/fake_client.rb
@@ -63,7 +63,7 @@ class OpenStax::Exercises::V1::FakeClient
         }
       ],
       questions: num_questions.times.map do |index|
-        question_number = number + index
+        question_number = (number || -1) + index
 
         {
           id: "#{question_number}",

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -31,17 +31,29 @@ RSpec.describe Content::Models::Exercise, type: :model do
   end
 
   it 'generates a number if the exercise was created by a teacher' do
-    allow_any_instance_of(ActiveRecord::Base.connection).to receive(:select_value).and_return(1000001)
+    allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
+    exercise = FactoryBot.create(:content_exercise, user_profile_id: 1, number: nil)
 
-    exercise = FactoryBot.create(:content_exercise, user_profile_id: 1)
+    expect(exercise.number).to eq(1000001)
+    expect(exercise.version).to eq(1)
+  end
 
-    expect(exercise.number).to_eq 1000001
+  it 'bumps version number if the exercise is derived' do
+    allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
+
+    derivable = FactoryBot.create(:content_exercise, version: 5)
+    exercise  = FactoryBot.create(
+      :content_exercise, user_profile_id: 1, number: derivable.number, derived_from_id: derivable.id
+    )
+
+    expect(exercise.number).to eq(derivable.number)
+    expect(exercise.version).to eq(6)
   end
 
   it 'does not generate a number if the exercise was created by OpenStax' do
-    allow_any_instance_of(ActiveRecord::Base.connection).to receive(:select_value).and_return(1000001)
+    allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
     exercise = FactoryBot.create(:content_exercise, user_profile_id: 0)
 
-    expect(exercise.number).not_to_eq 1000001
+    expect(exercise.number).not_to eq(1000001)
   end
 end


### PR DESCRIPTION
The version generation needs to consider that the given derivable exercise might not be the original, and bump the latest version it can find globally rather than from the derivable.