### PR TITLE
Track coauthor profile ids

### DIFF
--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -15,7 +15,6 @@ class CreateTeacherExercise
     exercise = Content::Models::Exercise.new(
       content: wrapper.content,
       page: page,
-      number: derived_from&.number,
       user_profile_id: profile.id,
       nickname: wrapper.nickname,
       title: wrapper.title,

--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -11,13 +11,11 @@ class CreateTeacherExercise
 
     wrapper = OpenStax::Exercises::V1::Exercise.new(content: content.to_json)
     derived_from = derived_from_id && find_derivable_exercise(course, derived_from_id)
-    version = (derived_from&.version || 0) + 1
 
     exercise = Content::Models::Exercise.new(
       content: wrapper.content,
       page: page,
       number: derived_from&.number,
-      version: version,
       user_profile_id: profile.id,
       nickname: wrapper.nickname,
       title: wrapper.title,
@@ -32,13 +30,7 @@ class CreateTeacherExercise
       is_copyable: copyable || true
     )
     exercise.images.attach(images) if images
-
-    if save
-      exercise.set_teacher_exercise_number
-      exercise.content_hash[:uid] = exercise.uid
-      exercise.content = exercise.content_hash.to_json
-      exercise.save
-    end
+    exercise.save if save
 
     run(
       :tag,

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -132,14 +132,20 @@ class Content::Models::Exercise < IndestructibleRecord
     if derived_from && derived_from.user_profile_id == user_profile_id
       self.number = derived_from.number
       self.version = (Content::Models::Exercise.where(number: number).maximum(:version) || 0) + 1
+      self.group_uuid = derived_from.group_uuid
     else
       self.number = generate_next_teacher_exercise_number
       self.version = 1
+      self.group_uuid = SecureRandom.uuid
     end
+
+    self.uuid = SecureRandom.uuid
 
     content_hash[:number] = number
     content_hash[:version] = version
     content_hash[:uid] = uid
+    content_hash[:uuid] = uuid
+    content_hash[:group_uuid] = group_uuid
     self.content = content_hash.to_json
   end
 

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -129,7 +129,8 @@ class Content::Models::Exercise < IndestructibleRecord
   def set_teacher_exercise_number_and_version
     return unless authored_by_teacher?
 
-    if number?
+    if derived_from && derived_from.user_profile_id == user_profile_id
+      self.number = derived_from.number
       self.version = (Content::Models::Exercise.where(number: number).maximum(:version) || 0) + 1
     else
       self.number = generate_next_teacher_exercise_number

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -22,7 +22,8 @@ class Content::Models::Exercise < IndestructibleRecord
   validates :version, presence: true
   validates :user_profile_id, presence: true
 
-  before_validation :set_teacher_exercise_number_and_version, on: :create
+  before_validation :set_teacher_exercise_identities, on: :create
+  before_validation :set_teacher_exercise_coauthors, on: :create
 
   # http://stackoverflow.com/a/7745635
   scope :latest, ->(scope = unscoped) do
@@ -122,14 +123,34 @@ class Content::Models::Exercise < IndestructibleRecord
     end
   end
 
+  def coauthors
+    real_ids = coauthor_profile_ids.reject {|id| id.in?(abstract_profile_ids) }
+
+    profiles = [
+      User::Models::AnonymousAuthorProfile,
+      User::Models::OpenStaxProfile,
+      *User::Models::Profile.find(real_ids)
+    ].index_by(&:id)
+
+    coauthor_profile_ids.map {|id| profiles[id] }
+  end
+
   def authored_by_teacher?
     user_profile_id != User::Models::OpenStaxProfile::ID
   end
 
-  def set_teacher_exercise_number_and_version
+  def derived_from_same_profile?
+    derived_from && derived_from.user_profile_id == user_profile_id
+  end
+
+  def abstract_profile_ids
+    [User::Models::AnonymousAuthorProfile::ID, User::Models::OpenStaxProfile::ID]
+  end
+
+  def set_teacher_exercise_identities
     return unless authored_by_teacher?
 
-    if derived_from && derived_from.user_profile_id == user_profile_id
+    if derived_from_same_profile?
       self.number = derived_from.number
       self.version = (Content::Models::Exercise.where(number: number).maximum(:version) || 0) + 1
       self.group_uuid = derived_from.group_uuid
@@ -147,6 +168,21 @@ class Content::Models::Exercise < IndestructibleRecord
     content_hash[:uuid] = uuid
     content_hash[:group_uuid] = group_uuid
     self.content = content_hash.to_json
+
+    self
+  end
+
+  def set_teacher_exercise_coauthors
+    return unless authored_by_teacher? && derived_from
+    return if derived_from.coauthor_profile_ids.empty? && derived_from_same_profile?
+
+    coauthor_ids = derived_from.coauthor_profile_ids.dup
+
+    [derived_from.author.id, author.id].each do |id|
+      coauthor_ids << id unless !id.in?(abstract_profile_ids) && id.in?(coauthor_ids)
+    end
+
+    self.coauthor_profile_ids = coauthor_ids
   end
 
   def generate_next_teacher_exercise_number

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -123,7 +123,7 @@ class Content::Models::Exercise < IndestructibleRecord
   end
 
   def authored_by_teacher?
-    user_profile_id.present? && user_profile_id != User::Models::OpenStaxProfile::ID
+    user_profile_id != User::Models::OpenStaxProfile::ID
   end
 
   def set_teacher_exercise_number_and_version

--- a/app/subsystems/user/models/anonymous_author_profile.rb
+++ b/app/subsystems/user/models/anonymous_author_profile.rb
@@ -8,7 +8,7 @@ module User
       end
 
       def self.name
-        'OpenStax Community'
+        'OpenStax user'
       end
     end
   end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,8 +8,7 @@ test:
 
 amazon:
   service: S3
-  access_key_id: ""
-  secret_access_key: ""
-  bucket: ""
-  region: "" # e.g. 'us-east-1'
-  public: true
+  access_key_id: <%= ENV['AWS_S3_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_S3_SECRET_ACCESS_KEY'] %>
+  bucket: <%= ENV['AWS_S3_BUCKET_NAME'] %>
+  region: <%= ENV['AWS_S3_REGION'] %>

--- a/db/migrate/20201204011000_add_coauthor_profile_ids_to_content_exercises.rb
+++ b/db/migrate/20201204011000_add_coauthor_profile_ids_to_content_exercises.rb
@@ -1,0 +1,7 @@
+class AddCoauthorProfileIdsToContentExercises < ActiveRecord::Migration[5.2]
+  def change
+    add_column :content_exercises, :coauthor_profile_ids, :integer,
+               array: true, default: []
+    change_column_null :tasks_tasked_exercises, :url, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_23_223824) do
+ActiveRecord::Schema.define(version: 2020_12_04_011000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2020_11_23_223824) do
     t.boolean "is_copyable", default: true, null: false
     t.boolean "anonymize_author", default: false, null: false
     t.bigint "derived_from_id"
+    t.integer "coauthor_profile_ids", default: [], array: true
     t.index ["content_page_id"], name: "index_content_exercises_on_content_page_id"
     t.index ["derived_from_id"], name: "index_content_exercises_on_derived_from_id"
     t.index ["group_uuid", "version"], name: "index_content_exercises_on_group_uuid_and_version"
@@ -943,7 +944,7 @@ ActiveRecord::Schema.define(version: 2020_11_23_223824) do
 
   create_table "tasks_tasked_exercises", id: :serial, force: :cascade do |t|
     t.integer "content_exercise_id", null: false
-    t.string "url", null: false
+    t.string "url"
     t.string "title"
     t.text "free_response"
     t.string "answer_id"

--- a/lib/openstax/exercises/v1/fake_client.rb
+++ b/lib/openstax/exercises/v1/fake_client.rb
@@ -63,7 +63,7 @@ class OpenStax::Exercises::V1::FakeClient
         }
       ],
       questions: num_questions.times.map do |index|
-        question_number = number + index
+        question_number = (number || -1) + index
 
         {
           id: "#{question_number}",

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -40,9 +40,12 @@ RSpec.describe Content::Models::Exercise, type: :model do
   end
 
   context 'authored by a teacher' do
+    let(:profile_one) { FactoryBot.create(:user_profile) }
+    let(:profile_two) { FactoryBot.create(:user_profile) }
+
     it 'generates a number and uuid' do
       allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
-      exercise = FactoryBot.create(:content_exercise, user_profile_id: 1, number: nil)
+      exercise = FactoryBot.create(:content_exercise, user_profile_id: profile_one.id, number: nil)
 
       expect(exercise.number).to eq(1000001)
       expect(exercise.uuid).not_to be_nil
@@ -50,10 +53,11 @@ RSpec.describe Content::Models::Exercise, type: :model do
     end
 
     it 'generates a number and resets version if the derivable does not belong to the teacher (other teachers or OpenStax)' do
-      derivable = FactoryBot.create(:content_exercise, version: 5, user_profile_id: 2)
+      allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000000)
+      derivable = FactoryBot.create(:content_exercise, version: 5, user_profile_id: profile_two.id)
       allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
       exercise  = FactoryBot.create(
-        :content_exercise, user_profile_id: 1, number: derivable.number, derived_from_id: derivable.id
+        :content_exercise, user_profile_id: profile_one.id, number: derivable.number, derived_from_id: derivable.id
       )
 
       expect(exercise.number).to eq(1000001)
@@ -64,15 +68,39 @@ RSpec.describe Content::Models::Exercise, type: :model do
     it 'uses derivable number and group_uuid, and bumps version if the derivable belongs to the teacher' do
       allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
 
-      derivable = FactoryBot.create(:content_exercise, user_profile_id: 1)
+      derivable = FactoryBot.create(:content_exercise, user_profile_id: profile_one.id)
       derivable.update_attributes(version: 5)
       exercise  = FactoryBot.create(
-        :content_exercise, user_profile_id: 1, derived_from_id: derivable.id
+        :content_exercise, user_profile_id: profile_one.id, derived_from_id: derivable.id
       )
 
       expect(exercise.number).to eq(derivable.number)
       expect(exercise.group_uuid).to eq(derivable.group_uuid)
       expect(exercise.version).to eq(6)
+    end
+
+    context 'setting coauthors' do
+      it 'saves normally' do
+        allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
+        os_exercise = FactoryBot.create(:content_exercise)
+        derivable   = FactoryBot.create(:content_exercise, user_profile_id: profile_one.id, derived_from: os_exercise)
+        exercise    = FactoryBot.create(
+          :content_exercise, user_profile_id: profile_two.id, number: derivable.number, derived_from: derivable
+        )
+
+        expect(exercise.coauthor_profile_ids).to eq([User::Models::OpenStaxProfile::ID, profile_one.id, profile_two.id])
+      end
+
+      it 'saves anonymously and avoids adding real id duplicates' do
+        allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
+        anon_exercise = FactoryBot.create(:content_exercise, user_profile_id: profile_two.id, anonymize_author: true)
+        derivable = FactoryBot.create(:content_exercise, user_profile_id: profile_one.id, derived_from: anon_exercise)
+        exercise  = FactoryBot.create(
+          :content_exercise, user_profile_id: profile_one.id, number: derivable.number, derived_from: derivable
+        )
+
+        expect(exercise.coauthor_profile_ids).to eq([User::Models::AnonymousAuthorProfile::ID, profile_one.id])
+      end
     end
   end
 end

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -31,17 +31,29 @@ RSpec.describe Content::Models::Exercise, type: :model do
   end
 
   it 'generates a number if the exercise was created by a teacher' do
-    allow_any_instance_of(ActiveRecord::Base.connection).to receive(:select_value).and_return(1000001)
+    allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
+    exercise = FactoryBot.create(:content_exercise, user_profile_id: 1, number: nil)
 
-    exercise = FactoryBot.create(:content_exercise, user_profile_id: 1)
+    expect(exercise.number).to eq(1000001)
+    expect(exercise.version).to eq(1)
+  end
 
-    expect(exercise.number).to_eq 1000001
+  it 'bumps version number if the exercise is derived' do
+    allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
+
+    derivable = FactoryBot.create(:content_exercise, version: 5)
+    exercise  = FactoryBot.create(
+      :content_exercise, user_profile_id: 1, number: derivable.number, derived_from_id: derivable.id
+    )
+
+    expect(exercise.number).to eq(derivable.number)
+    expect(exercise.version).to eq(6)
   end
 
   it 'does not generate a number if the exercise was created by OpenStax' do
-    allow_any_instance_of(ActiveRecord::Base.connection).to receive(:select_value).and_return(1000001)
+    allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1000001)
     exercise = FactoryBot.create(:content_exercise, user_profile_id: 0)
 
-    expect(exercise.number).not_to_eq 1000001
+    expect(exercise.number).not_to eq(1000001)
   end
 end


### PR DESCRIPTION
(Diff is off from being based off https://github.com/openstax/tutor-server/pull/2225)

Generally, this:

- Adds a `coauthor_profile_ids` array field
- When copying an exercise owned by the current profile, when no other authors have been involved, keep it empty (so that copying questions only you created won't display a coauthors dropdown on the FE.)
- When copying an exercise that already had coauthors, or came from another author (another teacher, OpenStax), add those ids to the field

Some additional notes:

- Creating anonymously is preserved, if you need to find the real names you can via `derived_from_id`, but will require some chained querying
- Multiple anonymous coauthors are not uniqued/collapsed, as we decided it was better to track and display each contribution
- Non-anonymous, real profile ids are only added once, as I was worried about a case where a coauthor continually copies, and their id gets added several times. Happy to change this though if I'm overthinking it.