### PR TITLE
Include editing terms of use

### DIFF
--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -70,7 +70,7 @@ module Api::V1
     property :available_terms,
               readable: true,
               writeable: false,
-              getter: ->(*) { GetUserTermsInfos[self].map{|i| i.slice('id', 'name', 'title', 'signed', 'is_proxy_signed') } }
+              getter: ->(*) { GetUserTermsInfos[self].map{|i| i.slice('id', 'name', 'title', 'is_signed', 'is_proxy_signed') } }
 
     property :profile_url,
              getter: ->(*) do

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -67,10 +67,10 @@ module Api::V1
              writeable: false,
              readable: true
 
-    property :terms_signatures_needed,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { GetUserTermsInfos[self].any?{|info| !info.is_signed} }
+    property :available_terms,
+              readable: true,
+              writeable: false,
+              getter: ->(*) { GetUserTermsInfos[self].map{|i| i.slice('id', 'name', 'title', 'signed', 'is_proxy_signed') } }
 
     property :profile_url,
              getter: ->(*) do

--- a/app/routines/get_user_terms_infos.rb
+++ b/app/routines/get_user_terms_infos.rb
@@ -4,7 +4,9 @@ class GetUserTermsInfos
   uses_routine GetUserCourses, translations: { outputs: { type: :verbatim } }
   uses_routine Legal::GetContractNames, translations: { outputs: { type: :verbatim } }
 
-  CONTRACT_NAMES_SIGNED_BY_EVERYONE = [:general_terms_of_use, :privacy_policy]
+  # even though exercise_editing is a teacher-only activity, we include it in the terms
+  # so the front-end can make decisions about when to show the prompt for it
+  CONTRACT_NAMES_SIGNED_BY_EVERYONE = [:general_terms_of_use, :privacy_policy, :exercise_editing]
 
   def exec(user)
     # Get contracts that apply to the user's current courses; some of these

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -127,12 +127,13 @@ class Content::Models::Exercise < IndestructibleRecord
   end
 
   def set_teacher_exercise_number
+    puts 'valid set e'
     return unless authored_by_teacher?
 
-    self.number = generate_next_teacher_exercise_number
+    self.number = Content::Models::Exercise.generate_next_teacher_exercise_number
   end
 
-  def generate_next_teacher_exercise_number
+  def self.generate_next_teacher_exercise_number
     ActiveRecord::Base.connection.select_value("SELECT nextval('teacher_exercise_number')")
   end
 end

--- a/app/subsystems/course_profile/models/course.rb
+++ b/app/subsystems/course_profile/models/course.rb
@@ -32,6 +32,9 @@ class CourseProfile::Models::Course < ApplicationRecord
   has_many :periods, subsystem: :course_membership, inverse_of: :course
 
   has_many :teachers, subsystem: :course_membership, inverse_of: :course
+  has_many :teacher_roles, through: :teachers, source: :role, class_name: 'Entity::Role'
+  has_many :teacher_profiles, through: :teacher_roles, source: :profile, class_name: 'User::Models::Profile'
+
   has_many :students, subsystem: :course_membership, inverse_of: :course
   has_many :teacher_students, subsystem: :course_membership, inverse_of: :course
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,7 +79,7 @@ module Tutor
     )
 
     config.middleware.use Rack::Attack
-    config.railties_order = [:all, :main_app]
+
     config.after_initialize do
       require 'rack-attack-settings'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -422,6 +422,7 @@ Rails.application.routes.draw do
   end
 
   mount FinePrint::Engine => :fine_print
+  mount ActiveStorage::Engine, at: '/rails/active_storage'
 
   # API docs
   apipie
@@ -436,6 +437,10 @@ Rails.application.routes.draw do
     end
   end
 
-  # Catch-all frontend route
-  get :'*other', controller: :webview, action: :index
+  # Catch-all frontend route, excluding active_storage
+  # the constraint shouldn't be needed once upgraded to rails 6
+  get :'*other', controller: :webview, action: :index, constraints: ->(req) do
+    req.path.exclude? 'rails/active_storage'
+  end
+
 end

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -30,13 +30,18 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
   it 'flags terms as needing signing' do
     user # force let to fire before create contract
 
-    FinePrint::Contract.create! do |contract|
+    contract = FinePrint::Contract.create! do |contract|
       contract.name    = 'general_terms_of_use'
       contract.version = 1
       contract.title   = 'Terms of Use'
       contract.content = 'Placeholder for general terms of use, required for new installations to function'
-    end
 
-    expect(representation).to include('available_terms' => true)
+    end
+    expect(representation['available_terms']).to eq [
+      contract.as_json(only: ['id', 'name', 'title', "is_signed", "is_proxy_signed"]).merge(
+        'is_proxy_signed' => false,
+        'is_signed' => false,
+      )
+    ]
   end
 end

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
     expect(representation['faculty_status']).to eq user.faculty_status
     expect(representation['can_create_courses']).to eq user.can_create_courses?
     expect(representation['viewed_tour_stats']).to eq []
-    expect(representation['terms_signatures_needed']).to eq false
+    expect(representation['available_terms']).to eq []
     expect(representation['profile_url']).to eq Addressable::URI.join(
       OpenStax::Accounts.configuration.openstax_accounts_url, '/profile'
     ).to_s
@@ -37,6 +37,6 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
       contract.content = 'Placeholder for general terms of use, required for new installations to function'
     end
 
-    expect(representation).to include('terms_signatures_needed' => true)
+    expect(representation).to include('available_terms' => true)
   end
 end

--- a/spec/requests/api/v1/course_exercises_controller_spec.rb
+++ b/spec/requests/api/v1/course_exercises_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::V1::CourseExercisesController, type: :request, api: true,
           selectedChapterSection: page.id,
           questionText: 'Test'
         }
-
+        expect(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return 10000
         expect do
           api_post api_course_exercises_url(course.id), user_1_token,
                      params: params.to_json

--- a/spec/routines/create_teacher_exercise_spec.rb
+++ b/spec/routines/create_teacher_exercise_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CreateTeacherExercise, type: :routine do
 
   context 'creating a teacher exercise' do
     it 'works with valid data' do
-      allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1)
+      allow(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1)
 
       expect do
         @result = described_class.call(
@@ -30,7 +30,7 @@ RSpec.describe CreateTeacherExercise, type: :routine do
     end
 
     it 'works with an owned source' do
-      allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1)
+      allow(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1)
 
       expect do
         @result = described_class.call(
@@ -47,7 +47,7 @@ RSpec.describe CreateTeacherExercise, type: :routine do
     end
 
     it 'does not work with an unowned source' do
-      allow_any_instance_of(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1)
+      allow(Content::Models::Exercise).to receive(:generate_next_teacher_exercise_number).and_return(1)
 
       expect do
         @result = described_class.call(

--- a/spec/subsystems/content/models/exercise_spec.rb
+++ b/spec/subsystems/content/models/exercise_spec.rb
@@ -26,22 +26,16 @@ RSpec.describe Content::Models::Exercise, type: :model do
 
   it 'defaults the author to OpenStax' do
     exercise = FactoryBot.create(:content_exercise)
-
     expect(exercise.user_profile_id).to eq User::Models::OpenStaxProfile::ID
   end
 
   it 'generates a number if the exercise was created by a teacher' do
-    allow_any_instance_of(ActiveRecord::Base.connection).to receive(:select_value).and_return(1000001)
-
     exercise = FactoryBot.create(:content_exercise, user_profile_id: 1)
-
-    expect(exercise.number).to_eq 1000001
+    expect(exercise.number).to_be > 1000000
   end
 
   it 'does not generate a number if the exercise was created by OpenStax' do
-    allow_any_instance_of(ActiveRecord::Base.connection).to receive(:select_value).and_return(1000001)
     exercise = FactoryBot.create(:content_exercise, user_profile_id: 0)
-
-    expect(exercise.number).not_to_eq 1000001
+    expect(exercise.number).to_be < 100
   end
 end


### PR DESCRIPTION
Send all the terms and their status to the FE so it can pick when they should be displayed

Also reverts the change to Railtie order and filters the routes