### PR TITLE
remove url from presence validation

### DIFF
--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -9,7 +9,7 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
 
   before_validation :set_correct_answer_id, on: :create, if: :has_answers?
 
-  validates :url, :question_id, :question_index, :content, presence: true
+  validates :question_id, :question_index, :content, presence: true
   validates :correct_answer_id, presence: true, if: :has_answers?
   validates :free_response, length: { maximum: 10000 }
   validates :grader_points, numericality: { greater_than_or_equal_to: 0.0, allow_nil: true }

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     FactoryBot.create :tasks_tasked_exercise, exercise: content_exercise
   end
 
-  it { is_expected.to validate_presence_of(:url) }
   it { is_expected.to validate_presence_of(:question_id) }
   it { is_expected.to validate_presence_of(:question_index) }
   it { is_expected.to validate_presence_of(:correct_answer_id) }


### PR DESCRIPTION
URL is no longer required because of Teacher-created exercises.