### PR TITLE
Update tasks with new teacher exercise version

### DIFF
--- a/app/controllers/api/v1/course_exercises_controller.rb
+++ b/app/controllers/api/v1/course_exercises_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::CourseExercisesController < Api::V1::ApiController
 
     page    = @course.ecosystem.pages.find(params[:selectedChapterSection])
     content = BuildTeacherExerciseContentHash[data: params]
-    profile = @course.teachers.map{|t| t.role.profile }.find{|p| p.id == params[:authorId] } || current_human_user
+    profile = @course.teacher_profiles.find {|p| p.id == params[:authorId] } || current_human_user
     params.permit(:images)
 
     exercise = CreateTeacherExercise[

--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -50,7 +50,7 @@ class CreateTeacherExercise
       save: save
     )
 
-    if save && version > 1
+    if save && exercise.version > 1
       run(
         :update_assigned_exercise_version,
         number: exercise.number,

--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -3,6 +3,7 @@ class CreateTeacherExercise
 
   uses_routine Content::Routines::TagResource, as: :tag
   uses_routine Content::Routines::PopulateExercisePools, as: :populate_exercise_pools
+  uses_routine UpdateAssignedExerciseVersion, as: :update_assigned_exercise_version
 
   protected
 
@@ -48,6 +49,14 @@ class CreateTeacherExercise
       pages: [page],
       save: save
     )
+
+    if save && version > 1
+      run(
+        :update_assigned_exercise_version,
+        number: exercise.number,
+        profile: profile
+      )
+    end
 
     outputs.exercise = exercise
   end

--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -53,8 +53,7 @@ class CreateTeacherExercise
     if save && exercise.version > 1
       run(
         :update_assigned_exercise_version,
-        number: exercise.number,
-        profile: profile
+        number: exercise.number
       )
     end
 

--- a/app/routines/update_assigned_exercise_version.rb
+++ b/app/routines/update_assigned_exercise_version.rb
@@ -24,7 +24,7 @@ class UpdateAssignedExerciseVersion
       next if plan.out_to_students?
 
       plan.settings['exercises'].each {|ex| ex['id'] = new_version.id.to_s if ex['id'].in?(old_ids) }
-      plan.settings['page_ids'] << new_version.page.id.to_s
+      (plan.settings['page_ids'] ||= []) << new_version.page.id.to_s
       plan.settings['page_ids'].uniq!
       plan.save
 

--- a/app/routines/update_assigned_exercise_version.rb
+++ b/app/routines/update_assigned_exercise_version.rb
@@ -31,11 +31,13 @@ class UpdateAssignedExerciseVersion
       plan.settings['page_ids'].uniq!
       plan.save
 
-      Tasks::Models::TaskedExercise.where(id: tasked_ids).update_all(content_exercise_id: new_version.id)
-
       updated_task_plan_ids << plan.id
       updated_tasked_exercise_ids << tasked_ids
     end
+
+    Tasks::Models::TaskedExercise.where(id: updated_tasked_exercise_ids)
+                                 .in_batches
+                                 .update_all(content_exercise_id: new_version.id)
 
     outputs.updated_task_plan_ids = updated_task_plan_ids
     outputs.updated_tasked_exercise_ids = updated_tasked_exercise_ids.flatten

--- a/app/routines/update_assigned_exercise_version.rb
+++ b/app/routines/update_assigned_exercise_version.rb
@@ -24,14 +24,17 @@ class UpdateAssignedExerciseVersion
       plan = Tasks::Models::TaskPlan.find(plan_id)
       next if plan.out_to_students?
 
-      (plan.settings['exercises'] ||= []).each do |ex|
-        ex['id'] = new_version.id.to_s if ex['id'].in?(old_ids)
-      end
-      (plan.settings['page_ids'] ||= []) << new_version.page.id.to_s
-      plan.settings['page_ids'].uniq!
-      plan.save
+      if plan.settings['exercises']
+        plan.settings['exercises'].each do |ex|
+          ex['id'] = new_version.id.to_s if ex['id'].in?(old_ids)
+        end
+        (plan.settings['page_ids'] ||= []) << new_version.page.id.to_s
+        plan.settings['page_ids'].uniq!
+        plan.save
 
-      updated_task_plan_ids << plan.id
+        updated_task_plan_ids << plan.id
+      end
+
       updated_tasked_exercise_ids << tasked_ids
     end
 

--- a/app/routines/update_assigned_exercise_version.rb
+++ b/app/routines/update_assigned_exercise_version.rb
@@ -3,7 +3,7 @@ class UpdateAssignedExerciseVersion
 
   protected
 
-  def exec(number:, profile:)
+  def exec(number:)
     updated_task_plan_ids = []
     updated_tasked_exercise_ids = []
 
@@ -13,6 +13,7 @@ class UpdateAssignedExerciseVersion
     update_ids   = Content::Models::Exercise
                      .joins(tasked_exercises: { task_step: { task: :task_plan } })
                      .where(number: number)
+                     .where.not(user_profile_id: User::Models::OpenStaxProfile::ID)
                      .where.not(version: new_version.version)
                      .pluck('tasks_task_plans.id', 'tasks_tasked_exercises.id')
 

--- a/app/routines/update_assigned_exercise_version.rb
+++ b/app/routines/update_assigned_exercise_version.rb
@@ -24,7 +24,9 @@ class UpdateAssignedExerciseVersion
       plan = Tasks::Models::TaskPlan.find(plan_id)
       next if plan.out_to_students?
 
-      plan.settings['exercises'].each {|ex| ex['id'] = new_version.id.to_s if ex['id'].in?(old_ids) }
+      (plan.settings['exercises'] ||= []).each do |ex|
+        ex['id'] = new_version.id.to_s if ex['id'].in?(old_ids)
+      end
       (plan.settings['page_ids'] ||= []) << new_version.page.id.to_s
       plan.settings['page_ids'].uniq!
       plan.save

--- a/app/routines/update_assigned_exercise_version.rb
+++ b/app/routines/update_assigned_exercise_version.rb
@@ -1,0 +1,37 @@
+class UpdateAssignedExerciseVersion
+  lev_routine
+
+  protected
+
+  def exec(number:, profile:)
+    task_ids     = profile.roles.select {|r| r.role_type == 'teacher' }.map(&:course).map(&:tasks).flatten.map(&:id)
+    all_versions = Content::Models::Exercise.where(number: number)
+    new_version  = all_versions.max_by(&:version)
+    old_ids      = all_versions.without(new_version).map {|v| v.id.to_s }
+    update_ids   = Content::Models::Exercise
+                     .joins(tasked_exercises: { task_step: { task: :task_plan } })
+                     .where(tasked_exercises: { task_step: { tasks_task_id: task_ids } })
+                     .where(number: number)
+                     .where.not(version: new_version.version)
+                     .pluck('tasks_task_plans.id', 'tasks_tasked_exercises.id')
+
+    taskeds_by_plan_id = Hash.new {|hash, key| hash[key] = [] }
+    update_ids.each {|set| taskeds_by_plan_id[set[0]] << set[1] }
+
+    taskeds_by_plan_id.each do |plan_id, tasked_ids|
+      plan = Tasks::Models::TaskPlan.find(plan_id)
+      next if plan.out_to_students?
+
+      plan.settings['exercises'].each {|ex| ex['id'] = new_version.id.to_s if ex['id'].in?(old_ids) }
+      plan.settings['page_ids'] << new_version.page.id.to_s
+      plan.settings['page_ids'].uniq!
+      plan.save
+
+      Tasks::Models::TaskedExercise.where(id: tasked_ids).update_all(content_exercise_id: new_version.id)
+    end
+
+    outputs.updated_task_plan_ids = taskeds_by_plan_id.keys
+    outputs.updated_tasked_exercise_ids = taskeds_by_plan_id.values.flatten
+    outputs.content_exercise_ids = all_versions.map(&:id)
+  end
+end

--- a/spec/routines/update_assigned_exercise_version_spec.rb
+++ b/spec/routines/update_assigned_exercise_version_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe UpdateAssignedExerciseVersion, type: :routine do
+  context 'given a number with an old version' do
+    let(:ecosystem) { FactoryBot.create :content_ecosystem }
+    let(:book)      { FactoryBot.create :content_book, ecosystem: ecosystem }
+    let(:page)      { FactoryBot.create :content_page, book: book, ecosystem: ecosystem }
+    let(:page2)     { FactoryBot.create :content_page, book: book, ecosystem: ecosystem }
+    let(:course)    { FactoryBot.create :course_profile_course }
+    let(:period)    { FactoryBot.create :course_membership_period, course: course }
+
+    let!(:student_profile) do
+      FactoryBot.create(:user_profile).tap do |user|
+        AddUserAsPeriodStudent.call(user: user, period: period)
+      end
+    end
+    let!(:teacher_profile) do
+      FactoryBot.create(:user_profile).tap do |user|
+        AddUserAsCourseTeacher.call(user: user, course: period)
+      end
+    end
+
+    let!(:exercise_v1) do
+      exercise = FactoryBot.build(
+        :content_exercise, page: page, user_profile_id: teacher_profile.id, number: 1, version: 1, url: nil
+      )
+      exercise.save(validate: false)
+      exercise
+    end
+    let!(:exercise_v2) do
+      exercise = FactoryBot.build(
+        :content_exercise, page: page, user_profile_id: teacher_profile.id, number: 1, version: 2, url: nil
+      )
+      exercise.save(validate: false)
+      exercise
+    end
+
+    let(:homework_plan) do
+      FactoryBot.build(
+        :tasks_task_plan,
+        assistant: FactoryBot.create(
+          :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
+        ),
+        course: course,
+        type: 'homework',
+        ecosystem: ecosystem,
+        settings: {
+          exercises: [{ id: exercise_v1.id.to_s, points: [1] }],
+          page_ids: [exercise_v1.page.id.to_s],
+          exercises_count_dynamic: 1
+        }
+      ).tap do |homework_plan|
+        homework_plan.tasking_plans.first.target = period
+        homework_plan.save!
+        homework_plan.tasking_plans.each do |tp|
+          tp.update_attribute(:opens_at_ntz, Time.current + 1.day)
+        end
+      end
+    end
+    let(:homework_tasking_plan) { homework_plan.tasking_plans.first }
+    let(:exercise_ids) { [exercise_v1.id, exercise_v2.id] }
+    let(:exercises)    { Content::Models::Exercise.where(id: exercise_ids) }
+
+    before do
+      AddEcosystemToCourse.call ecosystem: ecosystem, course: course
+      DistributeTasks[task_plan: homework_plan]
+    end
+
+    it 'updates assignments that have not gone out to students with the new version' do
+      result = described_class.call number: 1, profile: teacher_profile
+      homework_plan.reload
+      tasked = homework_plan.tasks.first.task_steps.first.tasked
+      expect(result.outputs.updated_task_plan_ids).to eq([homework_plan.id])
+      expect(homework_plan.settings['exercises'][0]['id']).to eq(exercise_v2.id.to_s)
+      expect(tasked.content_exercise_id).to eq(exercise_v2.id)
+    end
+
+    it 'does not update assignments that have gone out to students' do
+      homework_plan.tasking_plans.each do |tp|
+        tp.update_attribute(:opens_at_ntz, Time.current - 1.day)
+      end
+      DistributeTasks[task_plan: homework_plan]
+
+      result = described_class.call number: 1, profile: teacher_profile
+      homework_plan.reload
+      tasked = homework_plan.tasks.first.task_steps.first.tasked
+
+      expect(result.outputs.updated_task_plan_ids).to eq([homework_plan.id])
+      expect(homework_plan.settings['exercises'][0]['id']).to eq(exercise_v1.id.to_s)
+      expect(tasked.content_exercise_id).to eq(exercise_v1.id)
+    end
+
+    it 'updates page ids if the new version changed pages' do
+      exercise_v2.update_attribute(:content_page_id, page2.id)
+      result = described_class.call number: 1, profile: teacher_profile
+      expect(homework_plan.reload.settings['page_ids']).to include(page2.id.to_s)
+    end
+  end
+end

--- a/spec/routines/update_assigned_exercise_version_spec.rb
+++ b/spec/routines/update_assigned_exercise_version_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe UpdateAssignedExerciseVersion, type: :routine do
 
   context 'given a number with an old version' do
     it 'updates assignments that have not gone out to students with the new version' do
-      result = described_class.call number: 1, profile: teacher_profile
+      result = described_class.call number: 1
       homework_plan.reload
       tasked = homework_plan.tasks.first.task_steps.first.tasked
       expect(result.outputs.updated_task_plan_ids).to eq([homework_plan.id])
@@ -81,7 +81,7 @@ RSpec.describe UpdateAssignedExerciseVersion, type: :routine do
       end
       DistributeTasks[task_plan: homework_plan]
 
-      result = described_class.call number: 1, profile: teacher_profile
+      result = described_class.call number: 1
       homework_plan.reload
       tasked = homework_plan.tasks.first.task_steps.first.tasked
 
@@ -92,7 +92,7 @@ RSpec.describe UpdateAssignedExerciseVersion, type: :routine do
 
     it 'updates page ids if the new version changed pages' do
       exercise_v2.update_attribute(:content_page_id, page2.id)
-      result = described_class.call number: 1, profile: teacher_profile
+      result = described_class.call number: 1
       expect(homework_plan.reload.settings['page_ids']).to include(page2.id.to_s)
     end
   end

--- a/spec/routines/update_assigned_exercise_version_spec.rb
+++ b/spec/routines/update_assigned_exercise_version_spec.rb
@@ -1,71 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe UpdateAssignedExerciseVersion, type: :routine do
+  let(:ecosystem) { FactoryBot.create :content_ecosystem }
+  let(:book)      { FactoryBot.create :content_book, ecosystem: ecosystem }
+  let(:page)      { FactoryBot.create :content_page, book: book, ecosystem: ecosystem }
+  let(:page2)     { FactoryBot.create :content_page, book: book, ecosystem: ecosystem }
+  let(:course)    { FactoryBot.create :course_profile_course }
+  let(:period)    { FactoryBot.create :course_membership_period, course: course }
+
+  let!(:student_profile) do
+    FactoryBot.create(:user_profile).tap do |user|
+      AddUserAsPeriodStudent.call(user: user, period: period)
+    end
+  end
+  let!(:teacher_profile) do
+    FactoryBot.create(:user_profile).tap do |user|
+      AddUserAsCourseTeacher.call(user: user, course: period)
+    end
+  end
+
+  let!(:exercise_v1) do
+    exercise = FactoryBot.build(
+      :content_exercise, page: page, user_profile_id: teacher_profile.id, number: 1, version: 1, url: nil
+    )
+    exercise.save(validate: false)
+    exercise
+  end
+  let!(:exercise_v2) do
+    exercise = FactoryBot.build(
+      :content_exercise, page: page, user_profile_id: teacher_profile.id, number: 1, version: 2, url: nil
+    )
+    exercise.save(validate: false)
+    exercise
+  end
+
+  let(:homework_plan) do
+    FactoryBot.build(
+      :tasks_task_plan,
+      assistant: FactoryBot.create(
+        :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
+      ),
+      course: course,
+      type: 'homework',
+      ecosystem: ecosystem,
+      settings: {
+        exercises: [{ id: exercise_v1.id.to_s, points: [1] }],
+        page_ids: [exercise_v1.page.id.to_s],
+        exercises_count_dynamic: 1
+      }
+    ).tap do |homework_plan|
+      homework_plan.tasking_plans.first.target = period
+      homework_plan.save!
+      homework_plan.tasking_plans.each do |tp|
+        tp.update_attribute(:opens_at_ntz, Time.current + 1.day)
+      end
+    end
+  end
+  let(:homework_tasking_plan) { homework_plan.tasking_plans.first }
+  let(:exercise_ids) { [exercise_v1.id, exercise_v2.id] }
+  let(:exercises)    { Content::Models::Exercise.where(id: exercise_ids) }
+
+  before do
+    AddEcosystemToCourse.call ecosystem: ecosystem, course: course
+    DistributeTasks[task_plan: homework_plan]
+  end
+
   context 'given a number with an old version' do
-    let(:ecosystem) { FactoryBot.create :content_ecosystem }
-    let(:book)      { FactoryBot.create :content_book, ecosystem: ecosystem }
-    let(:page)      { FactoryBot.create :content_page, book: book, ecosystem: ecosystem }
-    let(:page2)     { FactoryBot.create :content_page, book: book, ecosystem: ecosystem }
-    let(:course)    { FactoryBot.create :course_profile_course }
-    let(:period)    { FactoryBot.create :course_membership_period, course: course }
-
-    let!(:student_profile) do
-      FactoryBot.create(:user_profile).tap do |user|
-        AddUserAsPeriodStudent.call(user: user, period: period)
-      end
-    end
-    let!(:teacher_profile) do
-      FactoryBot.create(:user_profile).tap do |user|
-        AddUserAsCourseTeacher.call(user: user, course: period)
-      end
-    end
-
-    let!(:exercise_v1) do
-      exercise = FactoryBot.build(
-        :content_exercise, page: page, user_profile_id: teacher_profile.id, number: 1, version: 1, url: nil
-      )
-      exercise.save(validate: false)
-      exercise
-    end
-    let!(:exercise_v2) do
-      exercise = FactoryBot.build(
-        :content_exercise, page: page, user_profile_id: teacher_profile.id, number: 1, version: 2, url: nil
-      )
-      exercise.save(validate: false)
-      exercise
-    end
-
-    let(:homework_plan) do
-      FactoryBot.build(
-        :tasks_task_plan,
-        assistant: FactoryBot.create(
-          :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
-        ),
-        course: course,
-        type: 'homework',
-        ecosystem: ecosystem,
-        settings: {
-          exercises: [{ id: exercise_v1.id.to_s, points: [1] }],
-          page_ids: [exercise_v1.page.id.to_s],
-          exercises_count_dynamic: 1
-        }
-      ).tap do |homework_plan|
-        homework_plan.tasking_plans.first.target = period
-        homework_plan.save!
-        homework_plan.tasking_plans.each do |tp|
-          tp.update_attribute(:opens_at_ntz, Time.current + 1.day)
-        end
-      end
-    end
-    let(:homework_tasking_plan) { homework_plan.tasking_plans.first }
-    let(:exercise_ids) { [exercise_v1.id, exercise_v2.id] }
-    let(:exercises)    { Content::Models::Exercise.where(id: exercise_ids) }
-
-    before do
-      AddEcosystemToCourse.call ecosystem: ecosystem, course: course
-      DistributeTasks[task_plan: homework_plan]
-    end
-
     it 'updates assignments that have not gone out to students with the new version' do
       result = described_class.call number: 1, profile: teacher_profile
       homework_plan.reload

--- a/spec/routines/update_assigned_exercise_version_spec.rb
+++ b/spec/routines/update_assigned_exercise_version_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe UpdateAssignedExerciseVersion, type: :routine do
       homework_plan.reload
       tasked = homework_plan.tasks.first.task_steps.first.tasked
 
-      expect(result.outputs.updated_task_plan_ids).to eq([homework_plan.id])
+      expect(result.outputs.updated_task_plan_ids).to be_empty
       expect(homework_plan.settings['exercises'][0]['id']).to eq(exercise_v1.id.to_s)
       expect(tasked.content_exercise_id).to eq(exercise_v1.id)
     end


### PR DESCRIPTION
#### Overview 

When a new version of a teacher exercise is created (edited by the same profile that created the original version), find any tasked exercises that have an old version id, and if the task plan isn't open yet, update them to the new version id. This also updates the `settings` exercises and page ids (page ids _could_ change between versions) on the task plan.

#### A 🤔 filter thing
If you look at the diff here: https://github.com/openstax/tutor-server/commit/b1b2bd48bd3b1d2c9c2d81d2910aa371fbb78ce1#diff-dc0c01a1d84a4b8c0f82d31dfbe079880d0c619929f98e24811c501ef12d569cL7-L13, I was initially filtering by the task ids the profile has access to, but it doesn't feel like the extra query is necessary, since numbers are already associated so closely with the profile. The only long term issue I can think of is if a "community questions" area is added, and assignments can be created with someone else's number — you probably don't want their assignments getting updated if the original author updates their exercise. Thoughts?