### PR TITLE
fix teacher exercises not getting extra tags

### DIFF
--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -7,8 +7,8 @@ class CreateTeacherExercise
 
   protected
 
-  def exec(course:, page:, content:, profile:, derived_from_id: nil, images: nil, tags: [], copyable: nil, anonymize: nil, save: false)
-    tags << ['type:practice']
+  def exec(course:, page:, content:, profile:, derived_from_id: nil, images: nil, copyable: nil, anonymize: nil, save: false)
+    tags = content[:tags] + ['type:practice']
 
     wrapper = OpenStax::Exercises::V1::Exercise.new(content: content.to_json)
     derived_from = derived_from_id && find_derivable_exercise(course, derived_from_id)

--- a/spec/routines/create_teacher_exercise_spec.rb
+++ b/spec/routines/create_teacher_exercise_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe CreateTeacherExercise, type: :routine do
   let(:course)    { FactoryBot.create :course_profile_course }
   let(:page)      { FactoryBot.create :content_page }
   let(:profile)   { FactoryBot.create :user_profile }
-  let(:content)   { OpenStax::Exercises::V1::FakeClient.new_exercise_hash }
+  let(:tags)      { ['time:medium', 'difficulty:medium', 'blooms:1', 'dok:2'] }
+  let(:content)   { OpenStax::Exercises::V1::FakeClient.new_exercise_hash(tags: tags) }
   let!(:valid_derived) { FactoryBot.create :content_exercise, user_profile_id: profile.id }
   let!(:invalid_derived) { FactoryBot.create :content_exercise, user_profile_id: -1 }
 
@@ -26,6 +27,7 @@ RSpec.describe CreateTeacherExercise, type: :routine do
         )
       end.to change { Content::Models::Exercise.count }.by(1)
 
+      expect(@result.outputs.exercise.tags.count).to eq(tags.count + 1) # Plus default type:practice
       expect(@result.errors).to be_empty
     end
 


### PR DESCRIPTION
Teacher exercises were only getting 'type:practice' associated instead of the extra dok, blooms, etc.

They were still being set in the content json, which is why it looks correct on the frontend, but we will need this bug fix if we want to filter in the backend.