### PR TITLE
remap teacher exercises and practice questions

### DIFF
--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -5,6 +5,7 @@ class Content::ImportBook
   uses_routine Content::Routines::ImportExercises, as: :import_exercises
   uses_routine Content::Routines::TransformAndCachePageContent, as: :transform_and_cache_content
   uses_routine Content::Routines::PopulateExercisePools, as: :populate_exercise_pools
+  uses_routine Content::Routines::RemapTeacherExercises, as: :remap_teacher_exercises
 
   protected
 
@@ -131,6 +132,8 @@ class Content::ImportBook
       :import_exercises,
       ecosystem: ecosystem, page: page_block, query_hash: query_hash, all_tags: all_tags
     )
+
+    run(:remap_teacher_exercises, ecosystem: ecosystem, save: true)
 
     ordered_pages = run(
       :populate_exercise_pools, book: book, pages: ordered_pages, save: false

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -5,6 +5,7 @@ class Content::ImportBook
   uses_routine Content::Routines::ImportExercises, as: :import_exercises
   uses_routine Content::Routines::TransformAndCachePageContent, as: :transform_and_cache_content
   uses_routine Content::Routines::PopulateExercisePools, as: :populate_exercise_pools
+  uses_routine Content::Routines::RemapTeacherExercises, as: :remap_teacher_exercises
 
   protected
 
@@ -130,6 +131,10 @@ class Content::ImportBook
     run(
       :import_exercises,
       ecosystem: ecosystem, page: page_block, query_hash: query_hash, all_tags: all_tags
+    )
+
+    run(
+      :remap_teacher_exercises, ecosystem: ecosystem, save: true
     )
 
     ordered_pages = run(

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -6,6 +6,7 @@ class Content::ImportBook
   uses_routine Content::Routines::TransformAndCachePageContent, as: :transform_and_cache_content
   uses_routine Content::Routines::PopulateExercisePools, as: :populate_exercise_pools
   uses_routine Content::Routines::RemapTeacherExercises, as: :remap_teacher_exercises
+  uses_routine Content::Routines::RemapPracticeQuestionExercises, as: :remap_practice_exercises
 
   protected
 
@@ -135,6 +136,10 @@ class Content::ImportBook
 
     run(
       :remap_teacher_exercises, ecosystem: ecosystem, save: true
+    )
+
+    run(
+      :remap_practice_exercises, ecosystem: ecosystem, save: true
     )
 
     ordered_pages = run(

--- a/app/subsystems/content/import_book.rb
+++ b/app/subsystems/content/import_book.rb
@@ -5,8 +5,6 @@ class Content::ImportBook
   uses_routine Content::Routines::ImportExercises, as: :import_exercises
   uses_routine Content::Routines::TransformAndCachePageContent, as: :transform_and_cache_content
   uses_routine Content::Routines::PopulateExercisePools, as: :populate_exercise_pools
-  uses_routine Content::Routines::RemapTeacherExercises, as: :remap_teacher_exercises
-  uses_routine Content::Routines::RemapPracticeQuestionExercises, as: :remap_practice_exercises
 
   protected
 
@@ -132,14 +130,6 @@ class Content::ImportBook
     run(
       :import_exercises,
       ecosystem: ecosystem, page: page_block, query_hash: query_hash, all_tags: all_tags
-    )
-
-    run(
-      :remap_teacher_exercises, ecosystem: ecosystem, save: true
-    )
-
-    run(
-      :remap_practice_exercises, ecosystem: ecosystem, save: true
     )
 
     ordered_pages = run(

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -61,6 +61,9 @@ class Content::Models::Exercise < IndestructibleRecord
       ).arel.exists
     )
   end
+  scope :created_by_teacher, -> do
+    where.not(user_profile_id: User::Models::OpenStaxProfile::ID)
+  end
 
   def parser
     @parser ||= OpenStax::Exercises::V1::Exercise.new content: content

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -19,6 +19,8 @@ class Content::Models::Exercise < IndestructibleRecord
 
   has_many :tasked_exercises, subsystem: :tasks, dependent: :destroy, inverse_of: :exercise
 
+  has_many :practice_questions, subsystem: :tasks, dependent: :destroy, inverse_of: :exercise
+
   TEACHER_NUMBER_START = 1000000
 
   if respond_to?(:has_many_attached)

--- a/app/subsystems/content/routines/remap_practice_question_exercises.rb
+++ b/app/subsystems/content/routines/remap_practice_question_exercises.rb
@@ -5,11 +5,8 @@ class Content::Routines::RemapPracticeQuestionExercises
 
   def exec(ecosystem:, course:, save: false)
     mapped_ids = {}
-    new_ids_by_number = {}
-    old_ids_by_number = {}
-
-    role_ids = [course.students, course.teacher_students]
-                 .map {|p| p.pluck(:entity_role_id) }.flatten.uniq
+    role_ids   = [course.students, course.teacher_students]
+                   .map {|p| p.pluck(:entity_role_id) }.flatten.uniq
     new_ids_by_number = ecosystem.exercises.pluck(:number, :id).to_h
     old_ids_by_number = Tasks::Models::PracticeQuestion
                           .joins(:exercise)

--- a/app/subsystems/content/routines/remap_practice_question_exercises.rb
+++ b/app/subsystems/content/routines/remap_practice_question_exercises.rb
@@ -16,7 +16,7 @@ class Content::Routines::RemapPracticeQuestionExercises
 
     old_ids_by_number.each do |number, old_id|
       new_id = new_ids_by_number[number]
-      mapped_ids[old_id] = new_id if old_id != new_id
+      mapped_ids[old_id] = new_id if new_id && old_id != new_id
     end
 
     outputs.mapped_ids = mapped_ids

--- a/app/subsystems/content/routines/remap_practice_question_exercises.rb
+++ b/app/subsystems/content/routines/remap_practice_question_exercises.rb
@@ -1,0 +1,33 @@
+class Content::Routines::RemapPracticeQuestionExercises
+  lev_routine
+
+  protected
+
+  def exec(ecosystem:, save: false)
+    mapped_ids = {}
+    new_ids_by_number = {}
+    old_ids_by_number = {}
+
+    new_ids_by_number = ecosystem.exercises.pluck(:number, :id).to_h
+    old_ids_by_number = Tasks::Models::PracticeQuestion
+                          .joins(:exercise)
+                          .where(exercise: { number: new_ids_by_number.keys })
+                          .distinct.pluck(:number, :content_exercise_id)
+                          .to_h
+
+    old_ids_by_number.each do |number, old_id|
+      new_id = new_ids_by_number[number]
+      mapped_ids[old_id] = new_id if old_id != new_id
+    end
+
+    outputs.mapped_ids = mapped_ids
+
+    return unless save
+
+    mapped_ids.each do |old_id, new_id|
+      Tasks::Models::PracticeQuestion
+        .where(content_exercise_id: old_id)
+        .update_all(content_exercise_id: new_id)
+    end
+  end
+end

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -8,12 +8,17 @@ class Content::Routines::RemapTeacherExercises
   def exec(ecosystem:, save: false)
     updated_exercise_ids_by_page_id = {}
 
-    ecosystem_ids, page_ids = Content::Models::Exercise
+    ecosystem_ids = Content::Models::Exercise
                                 .created_by_teacher
                                 .joins(:book)
                                 .distinct
-                                .pluck(:content_ecosystem_id, :content_page_id)
-                                .transpose.map(&:uniq)
+                                .pluck(:content_ecosystem_id)
+
+    page_ids      = Content::Models::Exercise
+                      .created_by_teacher
+                      .distinct
+                      .pluck(:content_page_id)
+
     ecosystems = Content::Models::Ecosystem.where(id: ecosystem_ids)
 
     map = Content::Map.find_or_create_by(

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -40,6 +40,7 @@ class Content::Routines::RemapTeacherExercises
           resource: exercise,
           tags: exercise.tags.pluck(:value),
           tagging_class: Content::Models::ExerciseTag,
+          all_tags: exercise.tags,
           save_tags: save
         )
       end

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -9,11 +9,10 @@ class Content::Routines::RemapTeacherExercises
     updated_exercise_ids_by_page_id = {}
 
     ecosystem_ids = Content::Models::Exercise
-                                .created_by_teacher
-                                .joins(:book)
-                                .distinct
-                                .pluck(:content_ecosystem_id)
-
+                      .created_by_teacher
+                      .joins(:book)
+                      .distinct
+                      .pluck(:content_ecosystem_id)
     page_ids      = Content::Models::Exercise
                       .created_by_teacher
                       .distinct
@@ -33,6 +32,8 @@ class Content::Routines::RemapTeacherExercises
       updated_exercise_ids_by_page_id[from.to_s] = exercises.map(&:id)
       exercises.update_all(content_page_id: to) if save
 
+      next unless save
+
       exercises.each do |exercise|
         run(
           :tag,
@@ -40,8 +41,7 @@ class Content::Routines::RemapTeacherExercises
           resource: exercise,
           tags: exercise.tags.pluck(:value),
           tagging_class: Content::Models::ExerciseTag,
-          all_tags: exercise.tags,
-          save_tags: save
+          save_tags: true
         )
       end
     end

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -8,17 +8,15 @@ class Content::Routines::RemapTeacherExercises
   def exec(ecosystem:, save: false)
     updated_exercise_ids_by_page_id = {}
 
-    ecosystem_ids = Content::Models::Exercise
-                      .created_by_teacher
-                      .joins(:book)
-                      .distinct
-                      .pluck(:content_ecosystem_id)
-    page_ids      = Content::Models::Exercise
-                      .created_by_teacher
-                      .distinct
-                      .pluck(:content_page_id)
+    ecosystem_ids, page_ids = Content::Models::Exercise
+                                .created_by_teacher
+                                .joins(:book)
+                                .pluck(:content_ecosystem_id, :content_page_id)
+                                .transpose
 
-    ecosystems = Content::Models::Ecosystem.where(id: ecosystem_ids)
+    return unless ecosystem_ids && page_ids
+
+    ecosystems = Content::Models::Ecosystem.where(id: ecosystem_ids.uniq)
 
     map = Content::Map.find_or_create_by(
       from_ecosystems: ecosystems, to_ecosystem: ecosystem

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -29,7 +29,7 @@ class Content::Routines::RemapTeacherExercises
 
     mapped.each do |from, to|
       exercises = Content::Models::Exercise.created_by_teacher.where(content_page_id: from)
-      updated_exercise_ids_by_page_id[from.to_s] = exercises.map(&:id)
+      updated_exercise_ids_by_page_id[from.to_s] = exercises.map(&:id).sort
       exercises.update_all(content_page_id: to) if save
 
       next unless save

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -5,27 +5,24 @@ class Content::Routines::RemapTeacherExercises
 
   protected
 
-  def exec(ecosystem:, save: false)    
+  def exec(ecosystem:, save: false)
     updated_exercise_ids_by_page_id = {}
 
-    ecosystem_ids = Content::Models::Exercise
-                      .created_by_teacher
-                      .joins(:book)
-                      .distinct
-                      .pluck(:content_ecosystem_id)
+    ecosystem_ids, page_ids = Content::Models::Exercise
+                                .created_by_teacher
+                                .joins(:book)
+                                .distinct
+                                .pluck(:content_ecosystem_id, :content_page_id)
+                                .transpose.map(&:uniq)
     ecosystems = Content::Models::Ecosystem.where(id: ecosystem_ids)
-    page_ids   = Content::Models::Exercise
-                   .created_by_teacher
-                   .distinct
-                   .pluck(:content_page_id)
-    
+
     map = Content::Map.find_or_create_by(
       from_ecosystems: ecosystems, to_ecosystem: ecosystem
     )
     mapped = map.map_page_ids(page_ids: page_ids).compact.reject do |k, v|
       k.to_s == v.to_s
     end
-    
+
     mapped.each do |from, to|
       exercises = Content::Models::Exercise.created_by_teacher.where(content_page_id: from)
       updated_exercise_ids_by_page_id[from.to_s] = exercises.map(&:id)

--- a/app/subsystems/content/routines/remap_teacher_exercises.rb
+++ b/app/subsystems/content/routines/remap_teacher_exercises.rb
@@ -1,0 +1,49 @@
+class Content::Routines::RemapTeacherExercises
+  lev_routine
+
+  uses_routine Content::Routines::TagResource, as: :tag
+
+  protected
+
+  def exec(ecosystem:, save: false)    
+    updated_exercise_ids_by_page_id = {}
+
+    ecosystem_ids = Content::Models::Exercise
+                      .created_by_teacher
+                      .joins(:book)
+                      .distinct
+                      .pluck(:content_ecosystem_id)
+    ecosystems = Content::Models::Ecosystem.where(id: ecosystem_ids)
+    page_ids   = Content::Models::Exercise
+                   .created_by_teacher
+                   .distinct
+                   .pluck(:content_page_id)
+    
+    map = Content::Map.find_or_create_by(
+      from_ecosystems: ecosystems, to_ecosystem: ecosystem
+    )
+    mapped = map.map_page_ids(page_ids: page_ids).compact.reject do |k, v|
+      k.to_s == v.to_s
+    end
+    
+    mapped.each do |from, to|
+      exercises = Content::Models::Exercise.created_by_teacher.where(content_page_id: from)
+      updated_exercise_ids_by_page_id[from.to_s] = exercises.map(&:id)
+      exercises.update_all(content_page_id: to) if save
+
+      exercises.each do |exercise|
+        run(
+          :tag,
+          ecosystem: ecosystem,
+          resource: exercise,
+          tags: exercise.tags.pluck(:value),
+          tagging_class: Content::Models::ExerciseTag,
+          save_tags: save
+        )
+      end
+    end
+
+    outputs.updated_exercise_ids_by_page_id = updated_exercise_ids_by_page_id
+    outputs.mapped_page_ids = mapped
+  end
+end

--- a/app/subsystems/course_content/add_ecosystem_to_course.rb
+++ b/app/subsystems/course_content/add_ecosystem_to_course.rb
@@ -2,6 +2,8 @@
 class CourseContent::AddEcosystemToCourse
   lev_routine express_output: :ecosystem_map, use_jobba: true
 
+  uses_routine Content::Routines::RemapPracticeQuestionExercises, as: :remap_practice_exercises
+
   protected
 
   def exec(course:, ecosystem:)
@@ -26,6 +28,8 @@ class CourseContent::AddEcosystemToCourse
       .joins(taskings: { role: :student })
       .where(taskings: { role: { student: { course_profile_course_id: course.id } } })
       .pluck(:id)
+
+    run(:remap_practice_exercises, ecosystem: ecosystem, course: course, save: true)
 
     queue = course.is_preview ? :preview : :dashboard
     all_task_ids.each_slice(100) do |task_ids|

--- a/spec/subsystems/content/routines/remap_practice_question_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_practice_question_exercises_spec.rb
@@ -2,14 +2,30 @@ require 'rails_helper'
 
 RSpec.describe Content::Routines::RemapPracticeQuestionExercises, type: :routine do
   context 'with a new ecosystem' do
+    let(:course)       { FactoryBot.create :course_profile_course }
+    let(:period)       { FactoryBot.create :course_membership_period, course: course }
+    let(:student_user) { FactoryBot.create(:user_profile) }
+    let(:student_role) { AddUserAsPeriodStudent[user: student_user, period: period] }
+
+    let(:second_course) { FactoryBot.create :course_profile_course }
+    let(:second_period) { FactoryBot.create :course_membership_period, course: second_course }
+    let(:second_user)   { FactoryBot.create(:user_profile) }
+    let(:second_role)   { AddUserAsPeriodStudent[user: second_user, period: second_period] }
+
     let!(:old_exercise) { FactoryBot.create :content_exercise }
     let!(:new_exercise) { FactoryBot.create :content_exercise, number: old_exercise.number }
-    let!(:practice_question) { FactoryBot.create :tasks_practice_question, exercise: old_exercise }
+
+    let!(:practice_question) do
+      FactoryBot.create :tasks_practice_question, exercise: old_exercise, role: student_role
+    end
+    let!(:unmapped_practice_question) do
+      FactoryBot.create :tasks_practice_question, exercise: old_exercise, role: second_role
+    end
     let(:ecosystem) { new_exercise.ecosystem }
 
     it 'updates the exercise id to one in the new ecosystem' do
       old_exercise_id = practice_question.exercise.id
-      result = described_class.call(ecosystem: ecosystem, save: true).outputs
+      result = described_class.call(ecosystem: ecosystem, course: course, save: true).outputs
       practice_question.reload
 
       expect(result.mapped_ids).to eq({ old_exercise_id.to_s => practice_question.exercise.id })
@@ -19,7 +35,7 @@ RSpec.describe Content::Routines::RemapPracticeQuestionExercises, type: :routine
 
     it 'skips updating if the id did not change' do
       practice_question.update_column(:content_exercise_id, new_exercise.id)
-      result = described_class.call(ecosystem: ecosystem, save: true).outputs
+      result = described_class.call(ecosystem: ecosystem, course: course, save: true).outputs
       practice_question.reload
 
       expect(result.mapped_ids).to eq({})

--- a/spec/subsystems/content/routines/remap_practice_question_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_practice_question_exercises_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Content::Routines::RemapPracticeQuestionExercises, type: :routine do
+  context 'with a new ecosystem' do
+    let!(:old_exercise) { FactoryBot.create :content_exercise }
+    let!(:new_exercise) { FactoryBot.create :content_exercise, number: old_exercise.number }
+    let!(:practice_question) { FactoryBot.create :tasks_practice_question, exercise: old_exercise }
+    let(:ecosystem) { new_exercise.ecosystem }
+
+    it 'updates the exercise id to one in the new ecosystem' do
+      old_exercise_id = practice_question.exercise.id
+      result = described_class.call(ecosystem: ecosystem, save: true).outputs
+      practice_question.reload
+
+      expect(result.mapped_ids).to eq({ old_exercise_id.to_s => practice_question.exercise.id })
+      expect(practice_question.exercise.id).to eq(new_exercise.id)
+      expect(practice_question.exercise.ecosystem).to eq(ecosystem)
+    end
+
+    it 'skips updating if the id did not change' do
+      practice_question.update_column(:content_exercise_id, new_exercise.id)
+      result = described_class.call(ecosystem: ecosystem, save: true).outputs
+      practice_question.reload
+
+      expect(result.mapped_ids).to eq({})
+    end
+  end
+end

--- a/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
           e.tags << FactoryBot.create(:content_tag, value: 'test:tag')
         end
       end
+      let!(:exercise2) do
+        FactoryBot.build(
+          :content_exercise, user_profile_id: 1, number: 2, content_page_id: exercise.page.id
+        ).tap do |e|
+          e.save(validate: false)
+          e.tags << FactoryBot.create(:content_tag, value: 'test:tag')
+        end
+      end
       let!(:unmapped) do
         FactoryBot.build(:content_exercise, user_profile_id: 1, number: 1).tap do |e|
           e.save(validate: false)
@@ -16,7 +24,8 @@ RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
       end
 
       let!(:page) { FactoryBot.create :content_page, uuid: exercise.page.uuid }
-      let(:ecosystem) { page.ecosystem }
+      let!(:ecosystem) { page.ecosystem }
+      let!(:new_eco_tag) { FactoryBot.create(:content_tag, value: 'test:tag', ecosystem: ecosystem) }
 
       it 'updates the page and tags to a new ecosystem' do
         old_page_id = exercise.page.id
@@ -24,10 +33,13 @@ RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
         exercise.reload
         unmapped.reload
 
-        expect(result.updated_exercise_ids_by_page_id).to eq({ old_page_id.to_s => [exercise.id] })
+        expect(result.updated_exercise_ids_by_page_id).to(
+          eq({ old_page_id.to_s => [exercise.id, exercise2.id] })
+        )
         expect(exercise.content_page_id).to eq(page.id)
         expect(unmapped.content_page_id).not_to eq(page.id)
         expect(exercise.tags.map(&:ecosystem)).to include page.ecosystem
+        expect(exercise.tags).to include new_eco_tag
       end
     end
   end

--- a/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
@@ -4,16 +4,15 @@ RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
   context 'with a teacher-created exercise' do
     context 'in an old ecosystem' do
       let!(:exercise) do
-        exercise = FactoryBot.build :content_exercise, user_profile_id: 1, number: 1
-        exercise.save(validate: false)
-
-        exercise.tags << FactoryBot.create(:content_tag, value: 'test:tag')
-        exercise
+        FactoryBot.build(:content_exercise, user_profile_id: 1, number: 1).tap do |e|
+          e.save(validate: false)
+          e.tags << FactoryBot.create(:content_tag, value: 'test:tag')
+        end
       end
       let!(:unmapped) do
-        FactoryBot.build(:content_exercise,
-                         user_profile_id: 1,
-                         number: 1).tap {|exercise| exercise.save(validate: false) }
+        FactoryBot.build(:content_exercise, user_profile_id: 1, number: 1).tap do |e|
+          e.save(validate: false)
+        end
       end
 
       let!(:page) { FactoryBot.create :content_page, uuid: exercise.page.uuid }

--- a/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
@@ -33,13 +33,18 @@ RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
         exercise.reload
         unmapped.reload
 
+        dup_exercise  = ecosystem.exercises.find_by(number: exercise.number)
+        dup_exercise2 = ecosystem.exercises.find_by(number: exercise2.number)
+
         expect(result.updated_exercise_ids_by_page_id).to(
-          eq({ old_page_id.to_s => [exercise.id, exercise2.id] })
+          eq({ old_page_id.to_s => [[exercise.id, dup_exercise.id], [exercise2.id, dup_exercise2.id]] })
         )
-        expect(exercise.content_page_id).to eq(page.id)
+        expect(exercise.content_page_id).to eq(old_page_id)
+        expect(dup_exercise.content_page_id).to eq(page.id)
+        expect(dup_exercise.ecosystem).to eq(ecosystem)
         expect(unmapped.content_page_id).not_to eq(page.id)
-        expect(exercise.tags.map(&:ecosystem)).to include page.ecosystem
-        expect(exercise.tags).to include new_eco_tag
+        expect(dup_exercise.tags.map(&:ecosystem)).to include page.ecosystem
+        expect(dup_exercise.tags).to include new_eco_tag
         expect(result.mapped_page_ids).to eq({ old_page_id.to_s => page.id })
       end
 

--- a/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
+  context 'with a teacher-created exercise' do
+    context 'in an old ecosystem' do
+      let!(:exercise) do
+        exercise = FactoryBot.build :content_exercise, user_profile_id: 1, number: 1
+        exercise.save(validate: false)
+
+        exercise.tags << FactoryBot.create(:content_tag, value: 'test:tag')
+        exercise
+      end
+      let!(:unmapped) do
+        FactoryBot.build(:content_exercise,
+                         user_profile_id: 1,
+                         number: 1).tap {|exercise| exercise.save(validate: false) }
+      end
+
+      let!(:page) { FactoryBot.create :content_page, uuid: exercise.page.uuid }
+      let(:ecosystem) { page.ecosystem }
+
+      it 'updates the page and tags to a new ecosystem' do
+        old_page_id = exercise.page.id
+        result = described_class.call(ecosystem: ecosystem, save: true).outputs
+        exercise.reload
+        unmapped.reload
+
+        expect(result.updated_exercise_ids_by_page_id).to eq({ old_page_id.to_s => [exercise.id] })
+        expect(exercise.content_page_id).to eq(page.id)
+        expect(unmapped.content_page_id).not_to eq(page.id)
+        expect(exercise.tags.map(&:ecosystem)).to include page.ecosystem
+      end
+    end
+  end
+end

--- a/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
+++ b/spec/subsystems/content/routines/remap_teacher_exercises_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Content::Routines::RemapTeacherExercises, type: :routine do
         expect(unmapped.content_page_id).not_to eq(page.id)
         expect(exercise.tags.map(&:ecosystem)).to include page.ecosystem
         expect(exercise.tags).to include new_eco_tag
+        expect(result.mapped_page_ids).to eq({ old_page_id.to_s => page.id })
+      end
+
+      it 'does nothing if no updated mappings are found' do
+        exercise.update_column(:content_page_id, page.id)
+        exercise2.update_column(:content_page_id, page.id)
+        result = described_class.call(ecosystem: ecosystem, save: true).outputs
+        expect(result.updated_exercise_ids_by_page_id).to be_empty
       end
     end
   end


### PR DESCRIPTION
- Remap teacher exercises to new ecosystem page ids during book import
- Remap practice question exercise ids to the new id when updating course ecosystem
- Always run UpdateTaskPlanEcosystem when creating a task in a cloned course, which solves 1) always getting the latest teacher exercise version and 2) setting new page ids so the checked page/section is always correct when editing the details