### PR TITLE
only include id and created_at for exercise images

### DIFF
--- a/app/representers/api/v1/exercise_image_representer.rb
+++ b/app/representers/api/v1/exercise_image_representer.rb
@@ -1,0 +1,18 @@
+module Api::V1
+  class ExerciseImageRepresenter < Roar::Decorator
+
+    include Roar::JSON
+
+    property :id,
+             type: String,
+             readable: true,
+             writeable: false
+
+    property :created_at,
+             type: String,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { DateTimeUtilities.to_api_s(created_at) },
+             schema_info: { required: true }
+  end
+end

--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -40,8 +40,8 @@ module Api::V1
              },
              schema_info: { required: true }
 
-    property :images,
-             type: String,
+    collection :images,
+             extend: ExerciseImageRepresenter,
              readable: true,
              writeable: true
 


### PR DESCRIPTION
We need to exclude the "record" reverse association otherwise it'll send the entire exercise again