### PR TITLE
no longer move footnotes to end

### DIFF
--- a/lib/openstax/cnx/v1/page.rb
+++ b/lib/openstax/cnx/v1/page.rb
@@ -105,7 +105,6 @@ module OpenStax::Cnx::V1
       OpenStax::Cnx::V1::Fragment::Interactive.replace_interactive_links_with_iframes!(doc)
       absolutize_and_secure_urls!(doc)
       map_note_format!(doc)
-      move_footnotes!
       @content = doc.to_html
       @root = nil
     end
@@ -208,26 +207,6 @@ module OpenStax::Cnx::V1
 
         body.children = content
         note.add_child(body)
-      end
-    end
-
-   
-    def move_footnotes!
-      return if footnotes.none?
-      container = doc.at_css('[data-type="footnote-refs"]') ||
-                  root.add_child(<<-eofn)
-                    <div data-type="footnote-refs">
-                      <h3 data-type="section-title">Footnotes</h3>
-                      <div data-type="footnotes-list"></div>
-                    </div>
-                  eofn
-
-      list = container.at_css('[data-type="footnotes-list"]')
-      footnotes.each do |note|
-        wrapper = list.add_child('<div role="doc-footnote" />').first
-        wrapper['id'] = note['id']
-        wrapper.inner_html = note.inner_html
-        note.remove
       end
     end
 

--- a/spec/lib/openstax/cnx/v1/page_spec.rb
+++ b/spec/lib/openstax/cnx/v1/page_spec.rb
@@ -232,30 +232,6 @@ RSpec.describe OpenStax::Cnx::V1::Page, type: :external, vcr: VCR_OPTS do
     end
   end
 
-  context 'with inline footnotes' do
-    before(:all) do
-      @page = VCR.use_cassette('OpenStax_Cnx_V1_Page/Inline_Footnotes', VCR_OPTS) do
-        OpenStax::Cnx::V1::Page.new(
-          book: OpenStax::Cnx::V1::Book.new(
-            id: 'd380510e-6145-4625-b19a-4fa68204b6b1@11.1',
-            canonical_url: 'https://archive-staging.cnx.org/contents/d380510e-6145-4625-b19a-4fa68204b6b1@11.1',
-          ),
-          id: 'd7290d42-6efd-4a78-b863-eb5861e630c1@4',
-        )
-      end
-    end
-
-    it 'moves notes to a wrapper at the end of page' do
-      ids = %w[fs-idm328510320 fs-idm355745312 fs-idm365192080 fs-idm344190816]
-      expect(@page.footnotes.map{ |fn| fn['id'] }).to eq ids
-      @page.convert_content!
-      expect(@page.footnotes.length).to eq 4
-      expect(
-        @page.doc.css('[data-type="footnote-refs"] [role="doc-footnote"]').map{ |fn| fn['id'] }
-      ).to eq ids
-    end
-  end
-
   protected
 
   def page_for(hash)


### PR DESCRIPTION
CNX content now has them already at the end of the pages.

To test I re-imported college physics and checked 33.2 https://openstax.org/books/college-physics/pages/33-2-the-four-basic-forces

The footnotes appeared at the end of both browse the book and a reading