### PR TITLE
Return a 404 error for missing assets (instead of handing the request to the FE)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -442,6 +442,9 @@ Rails.application.routes.draw do
   # Local dev redirect to static error pages (these are served as static files in real servers)
   [ 404, 422, 500, 503 ].each { |code| get code.to_s, to: redirect("/assets/#{code}.html") }
 
+  # Return a 404 error for missing assets
+  get :'assets/*other', to: ->(env) { [404, {}, ['']] }
+
   # Catch-all frontend route, excluding active_storage
   # the constraint shouldn't be needed once upgrade to rails 6
   get :'*other', controller: :webview, action: :index, constraints: ->(req) do


### PR DESCRIPTION
FE now uses /dist instead of /assets so there's no purpose in sending those requests to it.