### PR TITLE
do not erase align attribute from img

### DIFF
--- a/app/routines/build_teacher_exercise_content_hash.rb
+++ b/app/routines/build_teacher_exercise_content_hash.rb
@@ -113,7 +113,7 @@ class TeacherExerciseScrubber < Rails::Html::PermitScrubber
     h4
   )
   ALLOWED_ATTRS = %w(
-    alt title src width height style data-math type
+    alt title src width height style data-math type align
   )
   ALLOWED_IFRAME_ATTRS = %w(
     allowfullscreen class frameborder height mozallowfullscreen


### PR DESCRIPTION
Checking the editor, only the `align` attribute was getting deleted.