### PR TITLE
Fix missing attribute when a WRQ is completed and then dropped

### DIFF
--- a/app/routines/ratings/update_period_book_parts.rb
+++ b/app/routines/ratings/update_period_book_parts.rb
@@ -35,6 +35,7 @@ class Ratings::UpdatePeriodBookParts
     tasked_exercises_by_id = Tasks::Models::TaskedExercise
       .select(
         :id,
+        :question_id,
         :answer_ids,
         :correct_answer_id,
         :answer_id,


### PR DESCRIPTION
Fix for ActiveModel::MissingAttributeError: missing attribute: question_id