### PR TITLE
Fixed flaky homework assistant and GetTaskCorePageIds specs

### DIFF
--- a/app/routines/get_task_core_page_ids.rb
+++ b/app/routines/get_task_core_page_ids.rb
@@ -10,7 +10,7 @@ class GetTaskCorePageIds
 
     unloaded_task_steps = Tasks::Models::TaskStep.where(
       tasks_task_id: unloaded_tasks.map(&:id), is_core: true
-    ).pluck(:tasks_task_id, :content_page_id).group_by(&:first)
+    ).order(:number).pluck(:tasks_task_id, :content_page_id).group_by(&:first)
 
     task_id_to_core_page_ids_map = {}
     loaded_tasks.each do |task|

--- a/spec/routines/get_task_core_page_ids_spec.rb
+++ b/spec/routines/get_task_core_page_ids_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe GetTaskCorePageIds, type: :routine do
   before do
-
-
     homework_assistant = FactoryBot.create(
       :tasks_assistant, code_class_name: 'Tasks::Assistants::HomeworkAssistant'
     )

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -103,7 +103,10 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant, vcr: VCR_
           expect(tasked_exercise).to be_a(Tasks::Models::TaskedExercise)
           expect(tasked_exercise.url).to eq(exercise.url)
           expect(tasked_exercise.title).to eq(exercise.title)
-          expect(JSON.parse(tasked_exercise.content)).to eq(JSON.parse(exercise.content))
+
+          # This check is not valid for multipart exercises
+          expect(JSON.parse(tasked_exercise.content)).to eq(JSON.parse(exercise.content)) \
+            unless exercise.is_multipart?
         end
       end
     end

--- a/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
+++ b/spec/subsystems/tasks/assistants/homework_assistant_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe Tasks::Assistants::HomeworkAssistant, type: :assistant, vcr: VCR_
           tasked_content = JSON.parse(tasked_exercise.content)
           exercise_content = JSON.parse(exercise.content)
           expect(tasked_content.except('questions')).to eq(exercise_content.except('questions'))
-          expect(tasked_content['questions'].first).to(
-            eq(exercise_content['questions'][question_index])
+          expect(tasked_content['questions']).to(
+            eq([ exercise_content['questions'][question_index] ])
           )
 
           if exercise_content['questions'].size > question_index + 1


### PR DESCRIPTION
In the end I couldn't reproduce the failures but one of my PRs got a failure that gave a complete diff of the homework assistant spec so I could debug from that.