### PR TITLE
Return stubbed LMS key/secret for courses copied from other environments

### DIFF
--- a/app/access_policies/course_access_policy.rb
+++ b/app/access_policies/course_access_policy.rb
@@ -11,7 +11,7 @@ class CourseAccessPolicy
     when :read_task_plans
       UserIsCourseTeacher[user: requestor, course: course] ||
       course.cloned_courses.any? { |clone| UserIsCourseTeacher[user: requestor, course: clone] }
-    when :export, :roster, :add_period, :update, :stats, :exercises
+    when :export, :roster, :add_period, :update, :stats, :exercises, :lms_connection_info
       UserIsCourseTeacher[user: requestor, course: course]
     when :create
       requestor.can_create_courses?
@@ -19,7 +19,7 @@ class CourseAccessPolicy
       requestor.can_create_courses? &&
       (course.offering.nil? || course.offering.is_available) &&
       UserIsCourseTeacher[user: requestor, course: course]
-    when :lms_connection_info, :lms_sync_scores, :lms_course_pair
+    when :lms_sync_scores, :lms_course_pair
       course.environment.current? && UserIsCourseTeacher[user: requestor, course: course]
     else
       false

--- a/app/controllers/api/v1/lms/courses_controller.rb
+++ b/app/controllers/api/v1/lms/courses_controller.rb
@@ -16,7 +16,11 @@ class Api::V1::Lms::CoursesController < Api::V1::ApiController
   def show
     OSU::AccessPolicy.require_action_allowed!(:lms_connection_info, current_api_user, @course)
 
-    app = ::Lms::Models::App.find_or_create_by(owner: @course)
+    app = if @course.environment.current?
+      ::Lms::Models::App.find_or_create_by owner: @course
+    else
+      ::Lms::Models::StubbedApp.new @course.environment
+    end
 
     respond_with(
       app,

--- a/app/subsystems/lms/models/stubbed_app.rb
+++ b/app/subsystems/lms/models/stubbed_app.rb
@@ -1,0 +1,9 @@
+class Lms::Models::StubbedApp
+  attr_reader :key, :secret
+
+  # This app is passed the course's original environment on initialization
+  # It is used with ::Api::V1::Lms::LinkingRepresenter to return a stubbed response
+  def initialize(environment)
+    @key = @secret = "Copied from #{environment.name}"
+  end
+end

--- a/spec/access_policies/course_access_policy_spec.rb
+++ b/spec/access_policies/course_access_policy_spec.rb
@@ -758,7 +758,7 @@ RSpec.describe CourseAccessPolicy, type: :access_policy do
 
       [
         :index, :create, :read, :create_practice, :performance, :read_task_plans,
-        :export, :roster, :add_period, :update, :stats, :exercises, :clone
+        :export, :roster, :add_period, :update, :stats, :exercises, :clone, :lms_connection_info
       ].each do |test_action|
         context test_action.to_s do
           let(:action) { test_action }
@@ -767,7 +767,7 @@ RSpec.describe CourseAccessPolicy, type: :access_policy do
         end
       end
 
-      [ :lms_connection_info, :lms_sync_scores, :lms_course_pair ].each do |test_action|
+      [ :lms_sync_scores, :lms_course_pair ].each do |test_action|
         context test_action.to_s do
           let(:action) { test_action }
 
@@ -785,7 +785,7 @@ RSpec.describe CourseAccessPolicy, type: :access_policy do
 
           [
             :index, :create, :read, :create_practice, :performance, :read_task_plans,
-            :export, :roster, :add_period, :update, :stats, :exercises, :clone
+            :export, :roster, :add_period, :update, :stats, :exercises, :clone, :lms_connection_info
           ].each do |test_action|
             context test_action.to_s do
               let(:action) { test_action }
@@ -794,7 +794,7 @@ RSpec.describe CourseAccessPolicy, type: :access_policy do
             end
           end
 
-          [ :lms_connection_info, :lms_sync_scores, :lms_course_pair ].each do |test_action|
+          [ :lms_sync_scores, :lms_course_pair ].each do |test_action|
             context test_action.to_s do
               let(:action) { test_action }
 
@@ -820,7 +820,7 @@ RSpec.describe CourseAccessPolicy, type: :access_policy do
 
           [
             :index, :read, :create_practice, :performance, :read_task_plans,
-            :export, :roster, :add_period, :update, :stats, :exercises
+            :export, :roster, :add_period, :update, :stats, :exercises, :lms_connection_info
           ].each do |test_action|
             context test_action.to_s do
               let(:action) { test_action }
@@ -829,7 +829,7 @@ RSpec.describe CourseAccessPolicy, type: :access_policy do
             end
           end
 
-          [ :lms_connection_info, :lms_sync_scores, :lms_course_pair ].each do |test_action|
+          [ :lms_sync_scores, :lms_course_pair ].each do |test_action|
             context test_action.to_s do
               let(:action) { test_action }
 

--- a/spec/representers/api/v1/lms/linking_representer_spec.rb
+++ b/spec/representers/api/v1/lms/linking_representer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Lms::LinkingRepresenter, type: :representer do
+  let(:app)               { FactoryBot.create :lms_app }
+  let(:environment)       { FactoryBot.create :environment }
+  let(:stubbed_app)       { Lms::Models::StubbedApp.new environment }
+
+  let(:configuration_url) { UrlGenerator.new.lms_configuration_url(format: :xml) }
+  let(:launch_url)        { UrlGenerator.new.lms_launch_url }
+
+  let(:xml)               { "<something>text</something>" }
+  let(:options)           { { user_options: { xml: xml } } }
+
+  it 'displays the info needed to link to the LMS' do
+    expect(described_class.new(app).to_hash(options).symbolize_keys).to eq(
+      key: app.key,
+      secret: app.secret,
+      configuration_url: configuration_url,
+      launch_url: launch_url,
+      xml: xml
+    )
+  end
+
+  it 'displays stubbed info when given a StubbedApp' do
+    stub = "Copied from #{environment.name}"
+
+    expect(described_class.new(stubbed_app).to_hash(options).symbolize_keys).to eq(
+      key: stub,
+      secret: stub,
+      configuration_url: configuration_url,
+      launch_url: launch_url,
+      xml: xml
+    )
+  end
+end


### PR DESCRIPTION
Instead of returning a 403 error, we return stubbed info for copied courses