### PR TITLE
Set is_provisional_score to false in some corner cases

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -560,9 +560,15 @@ class Tasks::Models::Task < ApplicationRecord
 
     # At this point we know a score is being displayed and the assignment has both MCQs and WRQs,
     # so we check if any feedback is unavailable or if the manual grading has not been completed
-    !auto_grading_feedback_available?(past_due: past_due) ||
-    !manual_grading_feedback_available? ||
-    !manual_grading_complete?
+    # Even if feedback is unavailable, that only makes the score provisional
+    # if the student actually completed any of the relevant task_steps
+    (
+      !auto_grading_feedback_available?(past_due: past_due) &&
+      auto_graded_steps.any?(&:completed?)
+    ) || (
+      !manual_grading_feedback_available? &&
+      manually_graded_steps.any?(&:completed?)
+    ) || !manual_grading_complete?
   end
 
   def withdrawn?


### PR DESCRIPTION
If feedback is unavailable but the student has not completed any relevant steps, then the score is 0 and not provisional.
This only affects future assignments, it does not attempt to fix existing assignments.

Devika will analyze the expected behavior on Monday.