### PR TITLE
Remove teacher exercises from pools

### DIFF
--- a/app/routines/create_teacher_exercise.rb
+++ b/app/routines/create_teacher_exercise.rb
@@ -7,8 +7,9 @@ class CreateTeacherExercise
 
   protected
 
-  def exec(course:, page:, content:, profile:, derived_from_id: nil, images: nil, copyable: nil, anonymize: nil, save: false)
-    tags = content[:tags] + ['assignment-type:homework', 'assignment-type:reading']
+  def exec(course:, page:, content:, profile:, derived_from_id: nil,
+           images: nil, copyable: nil, anonymize: nil, save: false)
+    tags = content[:tags] + [ 'assignment-type:homework' ]
 
     wrapper = OpenStax::Exercises::V1::Exercise.new(content: content.to_json)
     derived_from = derived_from_id && find_derivable_exercise(course, derived_from_id)

--- a/app/routines/find_or_create_practice_specific_topics_task.rb
+++ b/app/routines/find_or_create_practice_specific_topics_task.rb
@@ -11,7 +11,20 @@ class FindOrCreatePracticeSpecificTopicsTask
       code: :different_ecosystems, message: 'All page_ids given must belong to the same Ecosystem'
     ) if ecosystems.size > 1
     @ecosystem = ecosystems.first
-    @pages = pages.reject { |page| page.practice_widget_exercise_ids.empty? }
+    fatal_error(
+      code: :different_ecosystems,
+      message: "The given pages do not belong to any of the course's Ecosystems"
+    ) unless @course.ecosystems.include? @ecosystem
+
+    page_ids_with_teacher_exercises = Set.new(
+      Content::Models::Exercise.where(
+        content_page_id: pages.map(&:id), user_profile_id: @course.related_teacher_profile_ids
+      ).pluck(:content_page_id)
+    )
+
+    @pages = pages.filter do |page|
+      page_ids_with_teacher_exercises.include?(page.id) || page.practice_widget_exercise_ids.any?
+    end
     @page_ids = @pages.map(&:id).sort
 
     fatal_error(code: :invalid_page_ids) unless @course.ecosystems.include?(@ecosystem)

--- a/app/routines/get_exercises.rb
+++ b/app/routines/get_exercises.rb
@@ -28,6 +28,7 @@ class GetExercises
     exercise_ids_by_pool_type = run(
       :get_page_exercise_ids,
       ecosystem: ecosystem,
+      course: course,
       page_ids: page_ids,
       exercise_ids: exercise_ids,
       pool_types: pool_types
@@ -36,7 +37,7 @@ class GetExercises
     excl_exercise_numbers_set = Set.new(course.excluded_exercises.pluck(:exercise_number)) \
       unless course.nil?
 
-    profile_ids = [User::Models::OpenStaxProfile::ID]
+    profile_ids = [ User::Models::OpenStaxProfile::ID ]
     profile_ids << course.related_teacher_profile_ids if course
 
     # Preload exercises, pages and teks tags

--- a/app/routines/get_page_exercise_ids_by_pool_types.rb
+++ b/app/routines/get_page_exercise_ids_by_pool_types.rb
@@ -49,7 +49,7 @@ class GetPageExerciseIdsByPoolTypes
       content_page_id: pages.map(&:id), user_profile_id: course.related_teacher_profile_ids
     ).pluck(:id)
 
-    pool_types.each do |pool_type|
+    (pool_types - [ :reading_context, :reading_dynamic ]).each do |pool_type|
       outputs.exercise_ids_by_pool_type[pool_type].concat teacher_exercise_ids
     end
   end

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -63,6 +63,9 @@ class Content::Models::Exercise < IndestructibleRecord
       ).arel.exists
     )
   end
+  scope :created_by_openstax, -> do
+    where(user_profile_id: User::Models::OpenStaxProfile::ID)
+  end
   scope :created_by_teacher, -> do
     where.not(user_profile_id: User::Models::OpenStaxProfile::ID)
   end

--- a/app/subsystems/content/models/exercise.rb
+++ b/app/subsystems/content/models/exercise.rb
@@ -155,8 +155,12 @@ class Content::Models::Exercise < IndestructibleRecord
     coauthor_profile_ids.map {|id| profiles[id] }
   end
 
+  def authored_by_openstax?
+    user_profile_id == User::Models::OpenStaxProfile::ID
+  end
+
   def authored_by_teacher?
-    user_profile_id != User::Models::OpenStaxProfile::ID
+    !authored_by_openstax?
   end
 
   def derived_from_same_profile?

--- a/app/subsystems/content/routines/populate_exercise_pools.rb
+++ b/app/subsystems/content/routines/populate_exercise_pools.rb
@@ -15,7 +15,7 @@ class Content::Routines::PopulateExercisePools
     dynamic_multipart = DYNAMIC_MPQ_UUIDS.include?(book.uuid)
 
     pages.each do |page|
-      page.exercises.each do |exercise|
+      page.exercises.filter(&:authored_by_openstax?).each do |exercise|
         # All Exercises
         page.all_exercise_ids << exercise.id
 

--- a/app/subsystems/course_profile/build_preview_courses.rb
+++ b/app/subsystems/course_profile/build_preview_courses.rb
@@ -1,5 +1,4 @@
 class CourseProfile::BuildPreviewCourses
-
   lev_routine transaction: :no_transaction
 
   # We really want no transaction here, so we don't call uses_routine
@@ -110,9 +109,8 @@ class CourseProfile::BuildPreviewCourses
       )
       .where(is_preview_available: true)
       .where(preview_course_count.lt(desired_count))
-      .reorder(preview_course_count, :number)                  # Work on lower counts first
+      .reorder(preview_course_count, :number)                       # Work on lower counts first
       .lock('FOR NO KEY UPDATE OF "catalog_offerings" SKIP LOCKED') # Skip offerings being worked on
       .first                                                        # Lock 1 offering at a time
   end
-
 end

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -31,7 +31,8 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
 
     @page_ids_with_teacher_exercises = Set.new(
       Content::Models::Exercise.where(
-        content_page_id: @pages.map(&:id), user_profile_id: course.related_teacher_profile_ids
+        content_page_id: @pages.map(&:id),
+        user_profile_id: task_plan.course.related_teacher_profile_ids
       ).pluck(:content_page_id)
     )
   end

--- a/app/subsystems/tasks/assistants/i_reading_assistant.rb
+++ b/app/subsystems/tasks/assistants/i_reading_assistant.rb
@@ -28,13 +28,6 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
     page_ids = task_plan.core_page_ids.map(&:to_i)
     pages_by_id = ecosystem.pages.where(id: page_ids).index_by(&:id)
     @pages = pages_by_id.values_at(*page_ids).compact
-
-    @page_ids_with_teacher_exercises = Set.new(
-      Content::Models::Exercise.where(
-        content_page_id: @pages.map(&:id),
-        user_profile_id: task_plan.course.related_teacher_profile_ids
-      ).pluck(:content_page_id)
-    )
   end
 
   def build_tasks
@@ -81,8 +74,7 @@ class Tasks::Assistants::IReadingAssistant < Tasks::Assistants::FragmentAssistan
 
       # Don't add dynamic exercises if all the reading dynamic exercise pools are empty
       # This happens, for example, on intro pages
-      next if !@page_ids_with_teacher_exercises.include?(page.id) &&
-              page.reading_dynamic_exercise_ids.empty?
+      next if page.reading_dynamic_exercise_ids.empty?
 
       add_placeholder_steps!(
         task: task,

--- a/app/subsystems/tasks/fetch_assignment_pes.rb
+++ b/app/subsystems/tasks/fetch_assignment_pes.rb
@@ -24,8 +24,14 @@ class Tasks::FetchAssignmentPes
     end
 
     page_ids = task.task_steps.map(&:content_page_id).compact.uniq
-    exercise_ids = Content::Models::Page.where(id: page_ids).pluck(pool_method).flatten
-    exercises = Content::Models::Exercise.where(id: exercise_ids).to_a
+    pool_exercise_ids = Content::Models::Page.where(id: page_ids).pluck(pool_method).flatten
+
+    # Add teacher-created exercises
+    exercises = Content::Models::Exercise.where(id: pool_exercise_ids).to_a +
+                Content::Models::Exercise.where(
+      content_page_id: page_ids, user_profile_id: task.course.related_teacher_profile_ids
+    ).to_a
+
     exercises_by_page_id = exercises.group_by(&:content_page_id)
 
     outputs.eligible_page_ids = page_ids.sort

--- a/app/subsystems/tasks/fetch_assignment_pes.rb
+++ b/app/subsystems/tasks/fetch_assignment_pes.rb
@@ -26,11 +26,12 @@ class Tasks::FetchAssignmentPes
     page_ids = task.task_steps.map(&:content_page_id).compact.uniq
     pool_exercise_ids = Content::Models::Page.where(id: page_ids).pluck(pool_method).flatten
 
-    # Add teacher-created exercises
-    exercises = Content::Models::Exercise.where(id: pool_exercise_ids).to_a +
-                Content::Models::Exercise.where(
+    exercises = Content::Models::Exercise.where(id: pool_exercise_ids).to_a
+
+    # Add teacher-created exercises (except for reading assignments)
+    exercises += Content::Models::Exercise.where(
       content_page_id: page_ids, user_profile_id: task.course.related_teacher_profile_ids
-    ).to_a
+    ).to_a unless task.reading?
 
     exercises_by_page_id = exercises.group_by(&:content_page_id)
 

--- a/app/subsystems/tasks/fetch_assignment_spes.rb
+++ b/app/subsystems/tasks/fetch_assignment_spes.rb
@@ -68,6 +68,16 @@ class Tasks::FetchAssignmentSpes
     exercise_ids_by_page_id = ecosystem_map.map_page_ids_to_exercise_ids(
       page_ids: page_ids, pool_type: pool_type
     )
+
+    # Add teacher-created exercises
+    mapped_page_ids = ecosystem_map.map_page_ids_to_page_ids(page_ids: page_ids)
+    Content::Models::Exercise.where(
+      content_page_id: mapped_page_ids, user_profile_id: task.course.related_teacher_profile_ids
+    ).pluck(:content_page_id, :id).each do |page_id, exercise_id|
+      exercise_ids_by_page_id[page_id] ||= []
+      exercise_ids_by_page_id[page_id] << exercise_id
+    end
+
     exercises_by_id = Content::Models::Exercise.where(
       id: exercise_ids_by_page_id.values.flatten
     ).index_by(&:id)

--- a/app/subsystems/tasks/fetch_assignment_spes.rb
+++ b/app/subsystems/tasks/fetch_assignment_spes.rb
@@ -70,7 +70,7 @@ class Tasks::FetchAssignmentSpes
     )
 
     # Add teacher-created exercises
-    mapped_page_ids = ecosystem_map.map_page_ids_to_page_ids(page_ids: page_ids)
+    mapped_page_ids = ecosystem_map.map_page_ids(page_ids: page_ids)
     Content::Models::Exercise.where(
       content_page_id: mapped_page_ids, user_profile_id: task.course.related_teacher_profile_ids
     ).pluck(:content_page_id, :id).each do |page_id, exercise_id|

--- a/app/subsystems/tasks/fetch_assignment_spes.rb
+++ b/app/subsystems/tasks/fetch_assignment_spes.rb
@@ -69,13 +69,16 @@ class Tasks::FetchAssignmentSpes
       page_ids: page_ids, pool_type: pool_type
     )
 
-    # Add teacher-created exercises
-    mapped_page_ids = ecosystem_map.map_page_ids(page_ids: page_ids)
-    Content::Models::Exercise.where(
-      content_page_id: mapped_page_ids, user_profile_id: task.course.related_teacher_profile_ids
-    ).pluck(:content_page_id, :id).each do |page_id, exercise_id|
-      exercise_ids_by_page_id[page_id] ||= []
-      exercise_ids_by_page_id[page_id] << exercise_id
+    unless task.reading?
+      # Add teacher-created exercises
+      mapped_page_ids = ecosystem_map.map_page_ids(page_ids: page_ids)
+
+      Content::Models::Exercise.where(
+        content_page_id: mapped_page_ids, user_profile_id: task.course.related_teacher_profile_ids
+      ).pluck(:content_page_id, :id).each do |page_id, exercise_id|
+        exercise_ids_by_page_id[page_id] ||= []
+        exercise_ids_by_page_id[page_id] << exercise_id
+      end
     end
 
     exercises_by_id = Content::Models::Exercise.where(

--- a/db/migrate/20210315204108_remove_teacher_exercises_from_page_pools.rb
+++ b/db/migrate/20210315204108_remove_teacher_exercises_from_page_pools.rb
@@ -1,0 +1,24 @@
+class RemoveTeacherExercisesFromPagePools < ActiveRecord::Migration[5.2]
+  def up
+    teacher_exercise_ids = Content::Models::Exercise.created_by_teacher.pluck(:id)
+    page_ids = Content::Models::Exercise.created_by_teacher.distinct.pluck(:content_page_id)
+
+    Content::Models::Page.select(
+      :id, :content_book_id,
+      :all_exercise_ids, :homework_core_exercise_ids, :reading_dynamic_exercise_ids,
+      :reading_context_exercise_ids, :homework_dynamic_exercise_ids, :practice_widget_exercise_ids
+    ).where(id: page_ids).preload(:book, exercises: :tags).group_by(&:book).each do |book, pages|
+      page.all_exercise_ids -= teacher_exercise_ids
+      page.homework_core_exercise_ids -= teacher_exercise_ids
+      page.reading_dynamic_exercise_ids -= teacher_exercise_ids
+      page.reading_context_exercise_ids -= teacher_exercise_ids
+      page.homework_dynamic_exercise_ids -= teacher_exercise_ids
+      page.practice_widget_exercise_ids -= teacher_exercise_ids
+      page.save!
+    end
+  end
+
+  def down
+    # We'll write this if we need to
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_08_231233) do
+ActiveRecord::Schema.define(version: 2021_03_15_204108) do
 
   create_sequence "active_storage_attachments_id_seq"
   create_sequence "active_storage_blobs_id_seq"


### PR DESCRIPTION
- Remove teacher exercises from pools
- Manually add them to personalized exercises, spaced practice, reading assistant code that determines if pages get personalized exercises and practice tasks, all using the related_teacher_profile_ids