### PR TITLE
Retry ActiveRecord::PreparedStatementCacheExpired exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,9 @@ gem 'nokogiri'
 # Background job status store
 gem 'jobba', '~> 1.8.0'
 
+# Retry failed database transactions
+gem 'transaction_retry', github: 'openstax/transaction_retry'
+
 # Lev framework
 gem 'lev', '~> 10.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
     keyword_search (1.6.0)
 
 GIT
+  remote: https://github.com/openstax/transaction_retry.git
+  revision: 5a148396c3b332a7e6a1ad5c7e6eb86b68f09829
+  specs:
+    transaction_retry (1.0.3)
+      activerecord (>= 3.0.11)
+      transaction_isolation (>= 1.0.2)
+
+GIT
   remote: https://github.com/randym/axlsx.git
   revision: c8ac844572b25fda358cc01d2104720c4c42f450
   ref: c8ac844572b25fda358cc01d2104720c4c42f450
@@ -699,9 +707,6 @@ GEM
     timeliness (0.3.10)
     transaction_isolation (1.0.5)
       activerecord (>= 3.0.11)
-    transaction_retry (1.0.3)
-      activerecord (>= 3.0.11)
-      transaction_isolation (>= 1.0.2)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -857,6 +862,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   timecop
+  transaction_retry!
   turbolinks
   uglifier (>= 1.3.0)
   validates_timeliness

--- a/config/initializers/transaction_retry.rb
+++ b/config/initializers/transaction_retry.rb
@@ -1,0 +1,4 @@
+# TransactionRetry.max_retries = 3
+# TransactionRetry.wait_times = [0, 1, 2, 4, 8, 16, 32] # seconds to sleep after retry n
+TransactionRetry.retry_on = ActiveRecord::PreparedStatementCacheExpired # or an array of classes is valid too (ActiveRecord::TransactionIsolationConflict is by default always included)
+# TransactionRetry.before_retry = ->(retry_num, error) { ... }

--- a/spec/lib/transaction_retry_spec.rb
+++ b/spec/lib/transaction_retry_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+# Need truncation: true because transaction_retry only retries top-level transactions
+RSpec.describe TransactionRetry, type: :lib, truncation: true do
+  it 'retries ActiveRecord::PreparedStatementCacheExpired' do
+    result = nil
+
+    ActiveRecord::Base.transaction do
+      if result.nil?
+        result = 21
+
+        raise ActiveRecord::PreparedStatementCacheExpired.new('test')
+      else
+        result = 42
+      end
+    end
+
+    expect(result).to eq 42
+  end
+end


### PR DESCRIPTION
Hopefully makes the system more resilient when migrating with the servers still running.