### PR TITLE
Removed pdf_url and webview_url from catalog offerings

### DIFF
--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -118,24 +118,6 @@ module Api::V1
                description: 'Whether or not this preview course should be reused.'
              }
 
-    property :book_pdf_url,
-             type: String,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { offering&.pdf_url },
-             schema_info: {
-               description: "The book's PDF url, if available."
-             }
-
-    property :webview_url,
-             type: String,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { offering&.webview_url },
-             schema_info: {
-               description: "The book's webview url, if available."
-             }
-
     property :is_preview,
              readable: true,
              writeable: true,

--- a/app/representers/api/v1/demo/import/catalog_offering_representer.rb
+++ b/app/representers/api/v1/demo/import/catalog_offering_representer.rb
@@ -19,16 +19,4 @@ class Api::V1::Demo::Import::CatalogOfferingRepresenter < Api::V1::Demo::Catalog
            type: String,
            readable: true,
            writeable: true
-
-  property :webview_url_base,
-           type: String,
-           getter: ->(*) { "#{webview_url}/contents/" },
-           readable: true,
-           writeable: true
-
-  property :pdf_url_base,
-           type: String,
-           getter: ->(*) { "#{pdf_url}/exports/" },
-           readable: true,
-           writeable: true
 end

--- a/app/routines/demo/import.rb
+++ b/app/routines/demo/import.rb
@@ -49,9 +49,7 @@ class Demo::Import < Demo::Base
       :description,
       :appearance_code,
       :salesforce_book_name,
-      :default_course_name,
-      :webview_url_base,
-      :pdf_url_base
+      :default_course_name
     ).merge(
       is_tutor: true,
       is_concept_coach: false,
@@ -72,10 +70,6 @@ class Demo::Import < Demo::Base
           attrs[:salesforce_book_name] ||= attrs[:title]
           attrs[:default_course_name] ||= attrs[:title]
           attrs[:description] ||= attrs[:default_course_name]
-          attrs[:webview_url_base] ||= book[:archive_url_base].sub('archive.', '')
-          attrs[:webview_url] = "#{attrs.delete(:webview_url_base)}#{book_cnx_id}"
-          attrs[:pdf_url_base] ||= book[:archive_url_base].sub('/contents/', '/exports/')
-          attrs[:pdf_url] = "#{attrs.delete(:pdf_url_base)}#{book_cnx_id}"
           if @retries > 0
             attrs[:number] = (Catalog::Models::Offering.maximum(:number) || 0) + @retries + 1
           end
@@ -83,11 +77,6 @@ class Demo::Import < Demo::Base
           # Create the catalog offering
           Catalog::CreateOffering[attrs]
         else
-          attrs[:webview_url] = "#{attrs.delete(:webview_url_base)}#{book_cnx_id}" \
-            unless attrs[:webview_url_base].blank?
-          attrs[:pdf_url] = "#{attrs.delete(:pdf_url_base)}#{book_cnx_id}" \
-            unless attrs[:pdf_url_base].blank?
-
           # Update the catalog offering and existing courses
           offering.update_attributes attrs
           offering.courses.each do |course|

--- a/app/subsystems/catalog/models/offering.rb
+++ b/app/subsystems/catalog/models/offering.rb
@@ -8,7 +8,6 @@ class Catalog::Models::Offering < ApplicationRecord
   has_many :courses, subsystem: :course_profile
 
   validates :salesforce_book_name,  presence: true
-  validates :webview_url, presence: true
   validates :title, presence: true
   validates :description, presence: true
 end

--- a/app/views/admin/catalog_offerings/_display_row.html.erb
+++ b/app/views/admin/catalog_offerings/_display_row.html.erb
@@ -52,12 +52,6 @@
     <b>Costs students:</b> <%= tf_to_yn(offering.does_cost) %>
   </div>
   <div>
-    <b>PDF URL:</b> <%= link_to offering.pdf_url, offering.pdf_url %>
-  </div>
-  <div>
-    <b>Webview:</b> <%= link_to offering.webview_url, offering.webview_url %>
-  </div>
-  <div>
     <b>Default Course Name:</b> <%= offering.default_course_name || '[not set]' %>
     <span style="float: right">
       <b>Full Tutor?</b>&nbsp;&nbsp;&nbsp;<%= tf_to_yn(offering.is_tutor) %>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/app/views/admin/catalog_offerings/_edit_row.html.erb
+++ b/app/views/admin/catalog_offerings/_edit_row.html.erb
@@ -37,14 +37,6 @@
     <%= form.text_field :os_book_id, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <%= form.label :pdf_url %>
-    <%= form.text_field :pdf_url, class: 'form-control' %>
-  </div>
-  <div class="form-group">
-    <%= form.label :webview_url %>
-    <%= form.text_field :webview_url, class: 'form-control' %>
-  </div>
-  <div class="form-group">
     <%= form.label "Ecosystem" %>
     <%= form.collection_select :content_ecosystem_id,
        @ecosystems, :id, :unique_title, { include_blank: true }, class: 'form-control' %>

--- a/app/views/admin/demo/import/_fields.html.erb
+++ b/app/views/admin/demo/import/_fields.html.erb
@@ -86,20 +86,4 @@
                                       placeholder: 'Same as Default course name'
     %>
   </div>
-
-  <div class="form-group">
-    <%= fields.label :webview_url_base %>
-    <%=
-      fields.text_field :webview_url_base, class: 'form-control',
-                                           placeholder: 'Derived from Archive url base'
-    %>
-  </div>
-
-  <div class="form-group">
-    <%= fields.label :pdf_url_base %>
-    <%=
-      fields.text_field :pdf_url_base, class: 'form-control',
-                                       placeholder: 'Derived from Archive url base'
-    %>
-  </div>
 <% end %>

--- a/db/migrate/20151016170440_create_catalog_offerings.rb
+++ b/db/migrate/20151016170440_create_catalog_offerings.rb
@@ -1,5 +1,4 @@
 class CreateCatalogOfferings < ActiveRecord::Migration[4.2]
-
   def change
     create_table :catalog_offerings do |t|
       t.string :identifier, null: false, index: { unique: true }
@@ -13,5 +12,4 @@ class CreateCatalogOfferings < ActiveRecord::Migration[4.2]
 
     add_column :course_profile_profiles, :catalog_offering_identifier, :string
   end
-
 end

--- a/db/migrate/20210329195114_make_catalog_offering_urls_nullable.rb
+++ b/db/migrate/20210329195114_make_catalog_offering_urls_nullable.rb
@@ -1,0 +1,6 @@
+class MakeCatalogOfferingUrlsNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :catalog_offerings, :webview_url, true
+    change_column_null :catalog_offerings, :pdf_url, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -131,8 +131,8 @@ ActiveRecord::Schema.define(version: 2021_03_31_164251) do
     t.boolean "is_tutor", default: false, null: false
     t.boolean "is_concept_coach", default: false, null: false
     t.string "description", null: false
-    t.string "webview_url", null: false
-    t.string "pdf_url", null: false
+    t.string "webview_url"
+    t.string "pdf_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "default_course_name"

--- a/spec/factories/catalog/offerings.rb
+++ b/spec/factories/catalog/offerings.rb
@@ -6,8 +6,6 @@ FactoryBot.define do
     appearance_code      { Faker::Lorem.word                                      }
     title                { Faker::Lorem.words(2).join(' ').capitalize             }
     description          { Faker::Company.bs                                      }
-    webview_url          { Faker::Internet.url                                    }
-    pdf_url              { Faker::Internet.url                                    }
     default_course_name  { Faker::Lorem.words(2).join(' ').capitalize             }
     is_concept_coach     { false }
     is_tutor             { true }

--- a/spec/representers/api/v1/course_representer_shared_examples.rb
+++ b/spec/representers/api/v1/course_representer_shared_examples.rb
@@ -7,8 +7,6 @@ module Api::V1
     let(:catalog_offering) do
       FactoryBot.create :catalog_offering, salesforce_book_name: 'book',
                                             appearance_code: 'appearance',
-                                            webview_url: 'web_url',
-                                            pdf_url: 'pdf_url',
                                             description: 'desc',
                                             ecosystem: ecosystem
     end
@@ -50,14 +48,6 @@ module Api::V1
     it 'shows the offering appearance_code if the course appearance_code is blank' do
       course.update_attribute(:appearance_code, nil)
       expect(represented['appearance_code']).to eq 'appearance'
-    end
-
-    it 'shows the book_pdf_url if available' do
-      expect(represented['book_pdf_url']).to eq 'pdf_url'
-    end
-
-    it 'shows the webview_url if avail' do
-      expect(represented['webview_url']).to eq 'web_url'
     end
 
     it 'shows whether or not the course is a preview course' do

--- a/spec/requests/admin/catalog_offerings_controller_spec.rb
+++ b/spec/requests/admin/catalog_offerings_controller_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe Admin::CatalogOfferingsController, type: :request do
   context '#update' do
     it 'complains about blank fields' do
       attrs = attributes.dup
-      attrs['webview_url'] = ''
+      attrs['salesforce_book_name'] = ''
 
       expect do
         put admin_catalog_offering_url(offering.id), params: { offering: attrs }
       end.to_not change(Catalog::Models::Offering, :count)
-      expect(flash.now[:error]).to eq("Webview url can't be blank")
+      expect(flash.now[:error]).to eq("Salesforce book name can't be blank")
     end
 
     it 'can update an offering' do

--- a/spec/routines/demo/export_spec.rb
+++ b/spec/routines/demo/export_spec.rb
@@ -61,9 +61,7 @@ RSpec.describe Demo::Export, type: :routine do
             description: offering.description,
             appearance_code: offering.appearance_code,
             salesforce_book_name: offering.salesforce_book_name,
-            default_course_name: offering.default_course_name,
-            webview_url_base: "#{offering.webview_url}/contents/",
-            pdf_url_base: "#{offering.pdf_url}/exports/"
+            default_course_name: offering.default_course_name
           }
         )
       when 'config/demo/spec/users/Spec Course 1.yml.erb'

--- a/spec/subsystems/catalog/models/offering_spec.rb
+++ b/spec/subsystems/catalog/models/offering_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Catalog::Models::Offering, type: :model do
   it { is_expected.to have_many(:courses) }
 
   it { is_expected.to validate_presence_of(:salesforce_book_name) }
-  it { is_expected.to validate_presence_of(:webview_url) }
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:description) }
 

--- a/spec/subsystems/catalog/update_offering_spec.rb
+++ b/spec/subsystems/catalog/update_offering_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe Catalog::UpdateOffering, type: :routine do
       is_preview_available: true,
       is_available: true,
       title: 'New Book',
-      description: 'Newest of the new',
-      webview_url: 'https://www.example.com',
-      pdf_url: 'https://www.example.pdf'
+      description: 'Newest of the new'
     }
   end
 


### PR DESCRIPTION
Due to ZDT, the database columns need to be removed in a separate release.