### PR TITLE
make the homepage font and sidebar variable by viewport sizes

### DIFF
--- a/app/javascript/styles/homepage.scss
+++ b/app/javascript/styles/homepage.scss
@@ -10,6 +10,10 @@
   @media screen and (min-width: 1000px) { @content }
 }
 
+@mixin desktop-large {
+  @media screen and (min-width: 1440px) { @content }
+}
+
 @mixin dark {
   @include desktop {
     color: #fff;
@@ -145,8 +149,8 @@
 
   nav .logo {
     background-size: cover;
-    width: 227px;
-    height: 40px;
+    width: var(--logo-width);
+    height: var(--logo-height);
     display: block;
   }
 
@@ -264,9 +268,17 @@
   @include desktop {
     text-align: unset;
 
+    .wrapper {
+      min-height: 100vh;
+      width: var(--wrapper-width);
+      padding-right: var(--wrapper-padding);
+      max-width: 640px;
+    }
+
     .content-header, .content, .content-footer:not([data-carousel=true]) {
-      max-width: 500px;
-      margin-left: 8rem;
+      width: auto;
+
+      margin-left: var(--wrapper-padding);
 
       .links {
         justify-content: start;
@@ -277,16 +289,14 @@
       }
     }
     .content-header {
-      margin: 4rem 0 0 8rem;
+      margin: 4rem 0 0 var(--wrapper-padding);
+
       .rice-logo {
         display: block;
         position: absolute;
         top: 4rem;
         right: 3.2rem;
       }
-    }
-    .wrapper {
-      min-height: 100vh;
     }
     .login-buttons {
       display: flex;
@@ -394,26 +404,37 @@
     --content-top-margin: 4.2rem;
     --header-font-size: 3.2rem;
     --header-line-height: 4rem;
+    --logo-width: 136px;
+    --logo-height: 24px;
   }
   @include tablet {
     --body-padding: 3.2rem;
     --content-top-margin: 10.4rem;
     --header-font-size: 6rem;
     --header-line-height: 7.5rem;
+    --logo-width: 181px;
+    --logo-height: 32px;
   }
   @include desktop {
     --body-padding: 0;
-    --content-top-margin: 14.5rem;
+    --content-top-margin: calc(10vh);
+    --header-font-size: 4rem;
+    --header-line-height: 5.5rem;
+    --header-letter-spacing: -0.1rem;
+    --wrapper-padding: calc(3.5vw);
+    --logo-width: 181px;
+    --logo-height: 32px;
+  }
+
+  @include desktop-large {
     --header-font-size: 6rem;
     --header-line-height: 7.5rem;
-    --header-letter-spacing: -0.1rem;
+    --logo-width: 227px;
+    --logo-height: 40px;
   }
 
   --carousel-side-padding: 8rem;
-
-  // Helps the play button find its center when
-  // using appearance-dark.with-light-bg
-  --wrapper-width: 640px;
+  --wrapper-width: calc(40vw); // Also used to place the play button
 }
 
 html {
@@ -492,7 +513,6 @@ a {
       @include desktop {
         .wrapper {
           background: #000;
-          max-width: 640px;
         }
       }
     }


### PR DESCRIPTION
- Moves the desktop size to a new `desktop-large` breakpoint, and makes the header font size and logo smaller on regular desktop.
- Makes the content area width and margins on desktop scale by viewport width and height.
- Makes the OS logo smaller on tablet and mobile

Desktop Large

![image](https://user-images.githubusercontent.com/34174/114064545-9cc59e80-984e-11eb-9e46-3c8e77c4b25e.png)

Desktop

![image](https://user-images.githubusercontent.com/34174/114064639-b2d35f00-984e-11eb-936b-decc183ae0a5.png)

Desktop small height

![image](https://user-images.githubusercontent.com/34174/114065155-32f9c480-984f-11eb-987c-14a976c8de7e.png)


Tablet 

![image](https://user-images.githubusercontent.com/34174/114064743-c8e11f80-984e-11eb-9c00-8aa5c3606635.png)

Mobile

![image](https://user-images.githubusercontent.com/34174/114064766-ce3e6a00-984e-11eb-8153-671a57219ccf.png)
