### PR TITLE
remove home cache

### DIFF
--- a/app/controllers/webview_controller.rb
+++ b/app/controllers/webview_controller.rb
@@ -13,7 +13,6 @@ class WebviewController < ApplicationController
       redirect_to dashboard_path
     end
 
-    expires_in 1.minute, public: true
     @homepage = HOMEPAGE_CONFIG[:default]
   end
 

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -39,7 +39,7 @@
 
       <div class="login-buttons">
         <%= link_to 'Log in', openstax_accounts_login_path, class: 'button primary' %>
-        <a class="button" href="https://accounts.openstax.org/i/signup">Sign up</a>
+        <a class="button" href="<%= Rails.application.secrets.openstax[:accounts][:url] %>/i/signup">Sign up</a>
       </div>
       <p class="hint">Log in with your OpenStax credentials or sign up for an account.</p>
     </div>


### PR DESCRIPTION
This was causing the browser to reuse the cached response post-login instead of hitting the route and letting us check for a signed in status to redirect to the dashboard.