### PR TITLE
add validation for is_preview_available if offering is_available

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -87,8 +87,18 @@ $(document).ready(function() {
     window.location.search = $.param(paramsObject);
   });
 
+  $('#offering_is_available').change(function(e) {
+    if ($(this).is(':checked')) {
+      $('#offering_is_preview_available').prop('checked', true);
+      onIsPreviewChange();
+    }
+  });
+
   //========== Hides and shows the preview message box when is_preview selected ==========//
   function onIsPreviewChange() {
+    if ($('#offering_is_available').is(':checked')) {
+      $(this).prop('checked', true)
+    }
     const previewFG = $('#offering_preview_message').closest('.form-group');
     if ($('#offering_is_preview_available').is(":checked")) {
       previewFG.show();
@@ -99,7 +109,6 @@ $(document).ready(function() {
   $('#offering_is_preview_available').change(onIsPreviewChange);
   onIsPreviewChange();
 
-  
   //========== Changes the course form when a course offering is selected ==========//
   function updateCourseForm() {
     var offering = $('#course_catalog_offering_id option:selected').first();

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
   //========== Hides and shows the preview message box when is_preview selected ==========//
   function onIsPreviewChange() {
     if ($('#offering_is_available').is(':checked')) {
-      $(this).prop('checked', true)
+      $('#offering_is_preview_available').prop('checked', true)
     }
     const previewFG = $('#offering_preview_message').closest('.form-group');
     if ($('#offering_is_preview_available').is(":checked")) {

--- a/app/subsystems/catalog/models/offering.rb
+++ b/app/subsystems/catalog/models/offering.rb
@@ -10,4 +10,12 @@ class Catalog::Models::Offering < ApplicationRecord
   validates :salesforce_book_name,  presence: true
   validates :title, presence: true
   validates :description, presence: true
+
+  validate :preview_must_be_available
+
+  def preview_must_be_available
+    if is_available && !is_preview_available
+      errors.add(:is_preview_available, 'must be true when course is available')
+    end
+  end
 end

--- a/spec/requests/api/v1/offerings_controller_spec.rb
+++ b/spec/requests/api/v1/offerings_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::OfferingsController, type: :request, api: true, version: :v1 do
   let!(:available_offering_1) { FactoryBot.create :catalog_offering, number: 2 }
   let!(:available_offering_2) { FactoryBot.create :catalog_offering, number: 1 }
-  let!(:unavailable_preview)  { FactoryBot.create :catalog_offering, is_preview_available: false }
+  let!(:unavailable_preview)  { FactoryBot.create :catalog_offering, is_available: false, is_preview_available: false }
   let!(:unavailable_offering) { FactoryBot.create :catalog_offering, is_available: false }
 
   let(:anon)                  { User::Models::Profile.anonymous }

--- a/spec/subsystems/catalog/models/offering_spec.rb
+++ b/spec/subsystems/catalog/models/offering_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe Catalog::Models::Offering, type: :model do
     end.to  not_change { Catalog::Models::Offering.count }
        .and change     { offering.reload.deleted_at }.from(nil)
   end
+
+  it 'validates preview course availability' do
+    offering.is_available = true
+    offering.is_preview_available = false
+    offering.valid?
+    expect(offering.errors.full_messages).to include('Is preview available must be true when course is available')
+
+    offering.is_available = false
+    offering.is_preview_available = false
+    expect(offering.valid?).to be true
+
+    offering.is_available = true
+    offering.is_preview_available = true
+    expect(offering.valid?).to be true
+  end
 end


### PR DESCRIPTION
- Validate `is_preview_available` to be true if `is_available` is true.
- Add JS to auto-check `is_preview_available` when checking `is_available` and prevent it from being unchecked when it shouldn't be.