### PR TITLE
Updated uglifier gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -722,7 +722,7 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (4.1.20)
+    uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.1)
     uniform_notifier (1.12.1)
@@ -893,4 +893,4 @@ DEPENDENCIES
   will_paginate (~> 3.1.7)
 
 BUNDLED WITH
-   2.2.9
+   2.2.15


### PR DESCRIPTION
delayed_job_worker_pool is failing to terminate properly when RAILS_ENV=production
The problem seems to be that uglifier initializes V8 before forking and V8 is not fork-safe
https://github.com/lautis/uglifier/issues/165
Fixed in uglifier 4.2.0