### PR TITLE
Redirect to login if non-logged-in user tries to access status page

### DIFF
--- a/config/initializers/openstax_utilities.rb
+++ b/config/initializers/openstax_utilities.rb
@@ -1,3 +1,9 @@
 OpenStax::Utilities.configure do |config|
-  config.status_authenticate = -> { raise SecurityTransgression unless current_user.is_admin? }
+  config.status_authenticate = -> do
+    authenticate_user!
+
+    next if performed? || current_user.is_admin?
+
+    raise SecurityTransgression
+  end
 end


### PR DESCRIPTION
Just convenience for admins who keep getting logged out