### PR TITLE
Renamed dropped_method to drop_method

### DIFF
--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -185,9 +185,16 @@ module Api::V1::Tasks
              writeable: false,
              if: FEEDBACK_AVAILABLE
 
-    property :dropped_method,
+    property :drop_method,
             type: String,
             readable: true,
             writeable: false
+
+    # TODO: Remove after 1 release
+    property :dropped_method,
+            type: String,
+            readable: true,
+            writeable: false,
+            getter: ->(*) { drop_method }
   end
 end

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -306,7 +306,7 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
     end
   end
 
-  def dropped_method
+  def drop_method
     dropped_question = task_step.task&.task_plan&.dropped_questions&.find do |dq|
       dq.question_id == question_id
     end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       allow(exercise).to receive(:published_late_work_point_penalty).and_return(0.25)
       allow(exercise).to receive(:published_points).and_return(0.5)
       allow(exercise).to receive(:published_comments).and_return('Hi')
-      allow(exercise).to receive(:dropped_method).and_return(nil)
+      allow(exercise).to receive(:drop_method).and_return(nil)
       allow(exercise).to receive(:cache_key).and_return('tasks/models/tasked_exercises/42')
       allow(exercise).to receive(:cache_version).and_return('test')
     end


### PR DESCRIPTION
Leaves the old key in for 1 release for backwards compatibility.