### PR TITLE
Invalidate task score caches when the task_plan is updated

### DIFF
--- a/app/subsystems/tasks/models/dropped_question.rb
+++ b/app/subsystems/tasks/models/dropped_question.rb
@@ -1,5 +1,5 @@
 class Tasks::Models::DroppedQuestion < ApplicationRecord
-  belongs_to :task_plan, inverse_of: :dropped_questions
+  belongs_to :task_plan, inverse_of: :dropped_questions, touch: true
 
   enum drop_method: [ :zeroed, :full_credit ]
 

--- a/app/subsystems/tasks/models/extension.rb
+++ b/app/subsystems/tasks/models/extension.rb
@@ -1,5 +1,5 @@
 class Tasks::Models::Extension < ApplicationRecord
-  belongs_to :task_plan, inverse_of: :extensions
+  belongs_to :task_plan, inverse_of: :extensions, touch: true
   belongs_to :role, subsystem: :entity, inverse_of: :extensions
 
   delegate :timezone, :time_zone, to: :task_plan

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -232,7 +232,7 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def cached?
-    task_plan.nil? || updated_at >= task_plan.updated_at
+    updated_at.nil? || task_plan.nil? || updated_at >= task_plan.updated_at
   end
 
   def completion


### PR DESCRIPTION
Hopefully helps with reloading the scores after dropping questions