### PR TITLE
Fix missing teacher exercises

### DIFF
--- a/app/routines/get_page_exercise_ids_by_pool_types.rb
+++ b/app/routines/get_page_exercise_ids_by_pool_types.rb
@@ -45,9 +45,11 @@ class GetPageExerciseIdsByPoolTypes
     # Add teacher-created exercises if course is provided
     return if course.nil?
 
-    teacher_exercise_ids = Content::Models::Exercise.where(
+    teacher_exercises = Content::Models::Exercise.where(
       content_page_id: pages.map(&:id), user_profile_id: course.related_teacher_profile_ids
-    ).pluck(:id)
+    )
+    teacher_exercises = teacher_exercises.where(id: exercise_ids) unless exercise_ids.nil?
+    teacher_exercise_ids = teacher_exercises.pluck(:id)
 
     (pool_types - [ :reading_context, :reading_dynamic ]).each do |pool_type|
       outputs.exercise_ids_by_pool_type[pool_type].concat teacher_exercise_ids

--- a/app/routines/get_page_exercise_ids_by_pool_types.rb
+++ b/app/routines/get_page_exercise_ids_by_pool_types.rb
@@ -28,7 +28,7 @@ class GetPageExerciseIdsByPoolTypes
       page_ids = page_ids.map(&:to_i)
       ecosystem.pages.select { |page| page_ids.include? page.id }
     else
-      ecosystem.pages.select(*pool_method_name_by_pool_type.values).where(id: page_ids)
+      ecosystem.pages.select(:id, *pool_method_name_by_pool_type.values).where(id: page_ids)
     end
 
     # Build map of pool types to pools


### PR DESCRIPTION
The pages were loaded without the page id, so when they were used later the id was nil (which is a suprise to me, thought you'd get an error, but I guess id is special).

Also filter them by exercise_ids if given