### PR TITLE
fix admin not pulling in jquery ui theme for calendar

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -6,6 +6,8 @@
 @import "jquery-ui";
 @import "admin_navbar";
 @import "manager";
+@import "jquery-ui/core";
+@import "jquery-ui/theme";
 
 .underlined-spaced-row {
   border-bottom: 1px solid gray;


### PR DESCRIPTION
The Payment Due field was hard to use because the jquery ui theme wasn't being loaded. Strangely, there are still some width issues on the date cells, but it's much more usable.

![image](https://user-images.githubusercontent.com/34174/122464822-250da180-cf6c-11eb-9cde-427d5b8c44da.png)
