### PR TITLE
[No merge] Temporarily revert fix for scores after dropping questions to fix scores not loading for big courses

### DIFF
--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -232,6 +232,7 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def cached?
+    return true
     updated_at.nil? || task_plan.nil? || updated_at >= task_plan.updated_at
   end
 


### PR DESCRIPTION
cached? is returning false all the time right now due to the order things update