### PR TITLE
Fixed logic for determining when the task cache should be valid and added specs

### DIFF
--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -294,8 +294,7 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
   def distribute_tasks(task_plan)
     preview_only = !task_plan.is_publish_requested && !task_plan.is_published?
 
-    task_plan.publish_last_requested_at = Time.current \
-      unless preview_only || task_plan.out_to_students?
+    task_plan.publish_last_requested_at = Time.current unless preview_only
     task_plan.save
     return if task_plan.errors.any?
 

--- a/app/controllers/api/v1/task_plans_controller.rb
+++ b/app/controllers/api/v1/task_plans_controller.rb
@@ -294,7 +294,10 @@ class Api::V1::TaskPlansController < Api::V1::ApiController
   def distribute_tasks(task_plan)
     preview_only = !task_plan.is_publish_requested && !task_plan.is_published?
 
-    task_plan.publish_last_requested_at = Time.current unless preview_only
+    current_time = Time.current
+    task_plan.updated_by_instructor_at = current_time
+    task_plan.publish_last_requested_at = current_time \
+      unless preview_only || task_plan.out_to_students?
     task_plan.save
     return if task_plan.errors.any?
 

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -232,13 +232,10 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def cache_valid?
-    return true if updated_at.nil? || task_plan.nil?
-
-    last_published_at = [
-      task_plan.publish_last_requested_at, task_plan.last_published_at
-    ].compact.max
-
-    last_published_at.nil? || updated_at >= last_published_at
+    updated_at.nil? ||
+    task_plan.nil? ||
+    task_plan.updated_by_instructor_at.nil? ||
+    updated_at >= task_plan.updated_by_instructor_at
   end
 
   def completion

--- a/app/subsystems/tasks/models/task_plan.rb
+++ b/app/subsystems/tasks/models/task_plan.rb
@@ -1,6 +1,9 @@
 require 'json-schema'
 
 class Tasks::Models::TaskPlan < ApplicationRecord
+  # Allow use of 'type' column without STI
+  self.inheritance_column = nil
+
   acts_as_paranoid column: :withdrawn_at, without_default_scope: true
 
   UPDATEABLE_ATTRIBUTES_AFTER_OPEN = [
@@ -9,7 +12,8 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     'last_published_at',
     'tasks_grading_template_id',
     'gradable_step_count',
-    'ungraded_step_count'
+    'ungraded_step_count',
+    'updated_by_instructor_at'
   ]
 
   CACHE_COLUMNS = [
@@ -18,9 +22,6 @@ class Tasks::Models::TaskPlan < ApplicationRecord
   ]
 
   attr_accessor :is_publish_requested
-
-  # Allow use of 'type' column without STI
-  self.inheritance_column = nil
 
   belongs_to :cloned_from, foreign_key: 'cloned_from_id',
                            class_name: 'Tasks::Models::TaskPlan',
@@ -76,6 +77,13 @@ class Tasks::Models::TaskPlan < ApplicationRecord
     @unarchived_period_tasking_plans = nil
 
     super
+  end
+
+  def updated_by_instructor_at
+    val = super
+    return val unless val.nil?
+
+    publish_last_requested_at
   end
 
   def withdrawn?

--- a/db/migrate/20210622152149_add_updated_by_instructor_at_to_tasks_task_plans.rb
+++ b/db/migrate/20210622152149_add_updated_by_instructor_at_to_tasks_task_plans.rb
@@ -1,0 +1,5 @@
+class AddUpdatedByInstructorAtToTasksTaskPlans < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks_task_plans, :updated_by_instructor_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_19_211921) do
+ActiveRecord::Schema.define(version: 2021_06_22_152149) do
 
   create_sequence "active_storage_attachments_id_seq"
   create_sequence "active_storage_blobs_id_seq"
@@ -1001,6 +1001,7 @@ ActiveRecord::Schema.define(version: 2021_04_19_211921) do
     t.integer "ungraded_step_count", default: 0, null: false
     t.integer "wrq_count", default: 0, null: false
     t.integer "gradable_step_count", default: 0, null: false
+    t.datetime "updated_by_instructor_at"
     t.index ["cloned_from_id"], name: "index_tasks_task_plans_on_cloned_from_id"
     t.index ["content_ecosystem_id"], name: "index_tasks_task_plans_on_content_ecosystem_id"
     t.index ["course_profile_course_id"], name: "index_tasks_task_plans_on_course_profile_course_id"

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
         described_class.call(task_plan: reading_plan)
         new_user.roles.each { |role| role.taskings.each { |tasking| tasking.task.really_destroy! } }
         expect(reading_plan.reload).to be_out_to_students
-        reading_plan.update_attribute :publish_last_requested_at, Time.current
+        reading_plan.update_attribute :updated_by_instructor_at, Time.current
         reading_plan.tasks.each { |task| expect(task).not_to be_cache_valid }
       end
 

--- a/spec/routines/distribute_tasks_spec.rb
+++ b/spec/routines/distribute_tasks_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
 
         homework_plan.tasks.each do | task |
           expect(task.task_steps.map(&:group_type)).to eq(expected_step_types)
+          expect(task).to be_cache_valid
         end
       end
     end
@@ -113,6 +114,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
 
         homework_plan.tasks.each do | task |
           expect(task.task_steps.map(&:group_type)).to eq(expected_step_types)
+          expect(task).to be_cache_valid
         end
       end
 
@@ -181,6 +183,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
           expect(task.points).to eq 9.0
           expect(task.score_without_lateness).to eq 1.0
           expect(task.score).to eq 1.0
+          expect(task).to be_cache_valid
         end
       end
     end
@@ -220,6 +223,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
             task = reading_plan.tasks.first
             expect(task.taskings.first.role).to eq teacher_student_role
             expect(task.opens_at).to be_within(1e-6).of(reading_tasking_plan.opens_at)
+            expect(task).to be_cache_valid
           end
 
           it 'does not save plan if it is new' do
@@ -241,6 +245,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
           expect(reading_plan).not_to be_out_to_students
           reading_plan.tasks.each do |task|
             expect(task.opens_at).to be_within(1e-6).of(reading_tasking_plan.opens_at)
+            expect(task).to be_cache_valid
           end
         end
 
@@ -289,6 +294,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
           expect(reading_plan).to be_out_to_students
           reading_plan.tasks.each do |task|
             expect(task.opens_at).to be_within(1e-6).of(reading_tasking_plan.opens_at)
+            expect(task).to be_cache_valid
           end
 
           reading_tasking_plan.update_attribute :due_at, reading_tasking_plan.time_zone.now + 1.hour
@@ -299,6 +305,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
           expect(reading_plan).to be_out_to_students
           reading_plan.tasks.each do |task|
             expect(task.due_at).to be_within(1e-6).of(reading_tasking_plan.due_at)
+            expect(task).to be_cache_valid
           end
         end
 
@@ -331,6 +338,8 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
         described_class.call(task_plan: reading_plan)
         new_user.roles.each { |role| role.taskings.each { |tasking| tasking.task.really_destroy! } }
         expect(reading_plan.reload).to be_out_to_students
+        reading_plan.update_attribute :publish_last_requested_at, Time.current
+        reading_plan.tasks.each { |task| expect(task).not_to be_cache_valid }
       end
 
       context 'before the open date' do
@@ -351,6 +360,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
           expect(reading_plan).not_to be_out_to_students
           reading_plan.tasks.each do |task|
             expect(task.opens_at).to be_within(1e-6).of(reading_tasking_plan.opens_at)
+            expect(task).to be_cache_valid
           end
         end
 
@@ -411,6 +421,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
               expect(task.closes_at).to                be_within(1e-6).of(new_closes_at)
               expect(task.auto_grading_feedback_on).to eq gt.auto_grading_feedback_on
               expect(task.manual_grading_feedback_on).to eq gt.manual_grading_feedback_on
+              expect(task).to be_cache_valid
             end
           end
         end
@@ -446,6 +457,7 @@ RSpec.describe DistributeTasks, type: :routine, truncation: true, speed: :medium
               expect(task.closes_at).to   be_within(1e-6).of(new_closes_at)
               expect(task.auto_grading_feedback_on).to eq gt.auto_grading_feedback_on
               expect(task.manual_grading_feedback_on).to eq gt.manual_grading_feedback_on
+              expect(task).to be_cache_valid
             end
           end
         end


### PR DESCRIPTION
Follow up to today's hotfix

We wanted something like publish_last_requested_at, but that column is not updated in some cases so I added a new column that is always updated.