### PR TITLE
Added compatibility layer for pages with serialized fragments

### DIFF
--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -224,3 +224,8 @@ class Content::Models::Page < IndestructibleRecord
     )
   end
 end
+
+# Compatibility: Many existing pages have serialized fragments saved as OpenStax::CNX::V1::Fragment
+module OpenStax::CNX
+  V1 = ::OpenStax::Content
+end

--- a/app/subsystems/content/models/page.rb
+++ b/app/subsystems/content/models/page.rb
@@ -225,7 +225,7 @@ class Content::Models::Page < IndestructibleRecord
   end
 end
 
-# Compatibility: Many existing pages have serialized fragments saved as OpenStax::CNX::V1::Fragment
-module OpenStax::CNX
+# Compatibility: Many existing pages have serialized fragments saved as OpenStax::Cnx::V1::Fragment
+module OpenStax::Cnx
   V1 = ::OpenStax::Content
 end


### PR DESCRIPTION
Many existing pages have serialized fragments using OpenStax::CNX::V1::Fragment
Those need to be redirected to OpenStax::Content::Fragment instead.