### PR TITLE
Exclude references from the Soc book readings by default

### DIFF
--- a/config/reading_processing_instructions.yml
+++ b/config/reading_processing_instructions.yml
@@ -174,9 +174,9 @@ psychology:
 
 sociology:
   - css: >-
-      .section-quiz, .short-answer, .further-research, [data-element-type="section-quiz"],
-      [data-element-type="short-answer"], [data-element-type="further-research"],
-      [data-type="glossary"]
+      .section-quiz, .short-answer, .further-research, .references,
+      [data-element-type="section-quiz"], [data-element-type="short-answer"],
+      [data-element-type="further-research"], [data-type="glossary"]
     fragments: []
 
 u-physics:


### PR DESCRIPTION
Requested by the content team