### PR TITLE
Added warnings about modifying the book toc representers

### DIFF
--- a/app/representers/api/v1/book_part_toc_representer.rb
+++ b/app/representers/api/v1/book_part_toc_representer.rb
@@ -1,3 +1,4 @@
+# If you modify this representer, you must run `Content::Models::Ecosystem.find_each(&:touch)`
 module Api::V1
   class BookPartTocRepresenter < Roar::Decorator
     include Roar::JSON

--- a/app/representers/api/v1/book_toc_representer.rb
+++ b/app/representers/api/v1/book_toc_representer.rb
@@ -1,3 +1,4 @@
+# If you modify this representer, you must run `Content::Models::Ecosystem.find_each(&:touch)`
 module Api::V1
   class BookTocRepresenter < BookPartTocRepresenter
     property :id,

--- a/app/representers/api/v1/book_tocs_representer.rb
+++ b/app/representers/api/v1/book_tocs_representer.rb
@@ -1,3 +1,4 @@
+# If you modify this representer, you must run `Content::Models::Ecosystem.find_each(&:touch)`
 class Api::V1::BookTocsRepresenter < Roar::Decorator
   include Representable::JSON::Collection
 


### PR DESCRIPTION
Since the API that uses these calls `stale?(ecosystem)`, some users had the old response cached, causing issues.