### PR TITLE
change migration make sure existing tasked exercises get set to 0 attempts

### DIFF
--- a/db/migrate/20210803214129_add_attempt_number_to_tasks_tasked_exercises.rb
+++ b/db/migrate/20210803214129_add_attempt_number_to_tasks_tasked_exercises.rb
@@ -1,6 +1,5 @@
 class AddAttemptNumberToTasksTaskedExercises < ActiveRecord::Migration[5.2]
   def change
-    add_column :tasks_tasked_exercises, :attempt_number, :integer
-    change_column_default :tasks_tasked_exercises, :attempt_number, 0
+    add_column :tasks_tasked_exercises, :attempt_number, :integer, default: 0
   end
 end


### PR DESCRIPTION
Small change to make sure existing records also have 0 in the column instead of NULL, otherwise existing assignments will complain that 0 is a new attempt. 

I was surprised that the Rails _changed? behavior doesn't use the default value in the comparison even though it uses it when calling the getter:

```
irb(main):040:0> old = Tasks::Models::TaskedExercise.find(5001)
irb(main):045:0> old.attempt_number
=> 0
irb(main):041:0> old.attribute_in_database('attempt_number')
=> nil
irb(main):042:0> old.attempt_number = 0
=> 0
irb(main):043:0> old.attempt_number_change
=> [nil, 0]
```