### PR TITLE
Delayed job worker pool improvements

### DIFF
--- a/config/delayed_job_worker_pool.rb
+++ b/config/delayed_job_worker_pool.rb
@@ -1,66 +1,78 @@
+require 'etc'
 require 'sd_notify'
 
 # Notify systemd that we are the main process
 SdNotify.mainpid Process.pid
 
-require 'etc'
+preload_app
 
 worker_group do |group|
   group.workers = Integer(ENV['NUM_WORKERS'] || Etc.nprocessors)
   group.queues = (ENV['QUEUES'] || ENV['QUEUE'] || '').split(',')
 end
 
-preload_app
+# Monkeypatches
+DelayedJobWorkerPool::WorkerPool.class_exec do
+  # Notify systemd and start a watchdog thread after all workers have been booted
+  def run
+    log("Starting master #{Process.pid}")
 
-# This runs in the master process after it preloads the app
-after_preload_app do
-  puts "Master #{Process.pid} preloaded app"
+    install_signal_handlers
 
-  # Don't hang on to database connections from the master after we've completed initialization
-  ActiveRecord::Base.connection_pool.disconnect!
+    if preload_app?
+      load_app
+      invoke_callback(:after_preload_app)
+    end
 
-  if SdNotify.watchdog?
-    watchdog_thread_sleep_interval = Integer(ENV['WATCHDOG_USEC']) / 2000000
+    log_uninheritable_threads
 
-    # Start the watchdog thread with high priority
-    Thread.new do
-      loop do
-        sleep watchdog_thread_sleep_interval
+    fork_workers
 
-        SdNotify.watchdog
-      end
-    end.priority = Integer(ENV['WATCHDOG_PRIORITY'] || 100)
+    if SdNotify.watchdog?
+      watchdog_thread_sleep_interval = Integer(ENV['WATCHDOG_USEC']) / 2000000
+      log "Starting watchdog thread with sleep interval #{watchdog_thread_sleep_interval} seconds"
+
+      # Start the watchdog thread with high priority
+      Thread.new do
+        loop do
+          sleep watchdog_thread_sleep_interval
+
+          SdNotify.watchdog
+        end
+      end.priority = Integer(ENV['WATCHDOG_PRIORITY'] || 100)
+    end
+
+    # Notify systemd of our PID and that we have finished booting up
+    log 'Notifying systemd that we are ready'
+    SdNotify.ready
+
+    monitor_workers
+
+    exit
+  ensure
+    master_alive_write_pipe.close if master_alive_write_pipe
+    master_alive_read_pipe.close if master_alive_read_pipe
   end
 
-  # Notify systemd of our PID and that we have finished booting up
-  SdNotify.ready
-end
-
-# This runs in the worker processes after they have been forked
-on_worker_boot do |worker_info|
-  puts "Worker #{Process.pid} started"
-
-  # Reconnect to the database
-  ActiveRecord::Base.establish_connection
-end
-
-# This runs in the master process after a worker starts
-after_worker_boot do |worker_info|
-  puts "Master #{Process.pid} booted worker #{worker_info.name} with " \
-       "process id #{worker_info.process_id}"
-end
-
-# This runs in the master process after a worker shuts down
-after_worker_shutdown do |worker_info|
-  puts "Master #{Process.pid} detected dead worker #{worker_info.name} " \
-       "with process id #{worker_info.process_id}"
-end
-
-# Monkeypatch to notify systemd when delayed_job_worker_pool is stopping (no hooks exist)
-DelayedJobWorkerPool::WorkerPool.class_exec do
   private
 
+  # Don't complain about fork-safe threads (Rails 6.1)
+  def log_uninheritable_threads
+    Thread.list.reject { |t| t.thread_variable_get(:fork_safe) }.each do |t|
+      next if t == Thread.current
+
+      if t.respond_to?(:backtrace)
+        log("WARNING: Thread will not be inherited by workers: #{t.inspect} - " \
+            "#{t.backtrace ? t.backtrace.first : ''}")
+      else
+        log("WARNING: Thread will not be inherited by workers: #{t.inspect}")
+      end
+    end
+  end
+
+  # Notify systemd when delayed_job_worker_pool is stopping
   def shutdown(signal)
+    log 'Notifying systemd that we are shutting down'
     SdNotify.stopping
     log("Shutting down master #{Process.pid} with signal #{signal}")
     self.shutting_down = true


### PR DESCRIPTION
- Don't disconnect from the database when forking (automatically handled by Rails 5.2+)
- Notify systemd that we are ready only after all the workers boot

Hopefully prevents background stack deployment failures