### PR TITLE
Don't delete LMS callbacks for dropped students

### DIFF
--- a/app/subsystems/course_membership/inactivate_student.rb
+++ b/app/subsystems/course_membership/inactivate_student.rb
@@ -12,11 +12,6 @@ module CourseMembership
 
       RefundPayment.perform_later(uuid: student.uuid) if student.is_refund_allowed
 
-      Lms::Models::CourseScoreCallback.where(
-        profile: student.role.profile,
-        course: student.course,
-      ).destroy_all
-
       period_id = student.period.id
       queue = student.course.is_preview ? :preview : :dashboard
       task_plan_ids = Tasks::Models::Task.joins(:taskings).where(


### PR DESCRIPTION
I didn't even realize this was here... the code that sends scores to the LMS already skips callbacks for dropped students. Don't delete them when dropping because that is not recoverable if they get re-added.