### PR TITLE
fix practice questions not showing up when saved in older ecosystem

### DIFF
--- a/app/controllers/api/v1/ecosystems_controller.rb
+++ b/app/controllers/api/v1/ecosystems_controller.rb
@@ -80,12 +80,11 @@ class Api::V1::EcosystemsController < Api::V1::ApiController
     #{json_schema(Api::V1::ExerciseSearchRepresenter, include: :readable)}
   EOS
   def practice_exercises
-    exercise_ids = @role.practice_questions
-                    .where(content_exercise_id: params[:exercise_ids])
-                    .pluck(:content_exercise_id)
-
-    exercises = GetExercises.call(course: @course,
-                                  exercise_ids: exercise_ids).outputs.exercises
+    exercises = GetPracticeQuestionExercises[
+      role: @role,
+      course: @course,
+      exercise_ids: params[:exercise_ids]
+    ]
 
     respond_with(exercises,
                  represent_with: Api::V1::ExerciseSearchRepresenter,

--- a/app/routines/get_practice_question_exercises.rb
+++ b/app/routines/get_practice_question_exercises.rb
@@ -1,0 +1,29 @@
+class GetPracticeQuestionExercises
+  lev_routine transaction: :no_transaction, express_output: :exercises
+
+  def exec(role:, course:, exercise_ids:)
+    exercise_and_ecosystem_ids = role.practice_questions
+                                   .joins(exercise: :ecosystem)
+                                   .where(content_exercise_id: exercise_ids)
+                                   .pluck("content_ecosystems.id", :content_exercise_id)
+
+    exercises = []
+    exercise_ids_grouped_by_ecosystem_id = Hash.new {|h,k| h[k] = [] }
+
+    exercise_and_ecosystem_ids.map do |id_group|
+      exercise_ids_grouped_by_ecosystem_id[id_group[0]] << id_group[1]
+    end
+
+    exercise_ids_grouped_by_ecosystem_id.each do |ecosystem_id, exercise_ids|
+      ecosystem = Content::Models::Ecosystem.find(ecosystem_id)
+
+      exercises << GetExercises.call(
+        course: course,
+        ecosystem: ecosystem,
+        exercise_ids: exercise_ids
+      ).outputs.exercises
+    end
+
+    outputs.exercises = exercises.flatten
+  end
+end

--- a/spec/routines/get_practice_question_exercises_spec.rb
+++ b/spec/routines/get_practice_question_exercises_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe GetPracticeQuestionExercises, type: :routine do
+  let(:course)          { FactoryBot.create :course_profile_course }
+  let(:period)          { FactoryBot.create :course_membership_period, course: course }
+
+  let(:student_user) { FactoryBot.create(:user_profile) }
+  let(:student_role) { AddUserAsPeriodStudent[user: student_user, period: period] }
+  let(:book)       { FactoryBot.create(:content_book, :standard_contents_1) }
+
+  let!(:ecosystem) do
+    book.ecosystem.reload.tap do |ecosystem|
+      CourseContent::AddEcosystemToCourse.call(course: course, ecosystem: ecosystem)
+    end
+  end
+
+  let(:new_ecosystem) { FactoryBot.create :mini_ecosystem }
+  let(:new_book) { FactoryBot.create(:content_book, ecosystem: new_ecosystem) }
+  let(:old_book) { ecosystem.books.first }
+  let(:old_page) { old_book.pages.first }
+
+  let(:new_page) do
+    FactoryBot.create(:content_page, book: new_book, ecosystem: new_ecosystem).tap do |page|
+      page.uuid = old_page.uuid
+      page.save!
+    end
+  end
+
+  let(:old_exercise) do
+    FactoryBot.create(:content_exercise, page: old_page).tap do |exercise|
+      old_page.homework_dynamic_exercise_ids << exercise.id
+      old_page.save!
+    end
+  end
+  let(:new_exercise) do
+    FactoryBot.create(:content_exercise, page: new_page).tap do |exercise|
+      new_page.homework_dynamic_exercise_ids << exercise.id
+      new_page.save!
+    end
+  end
+
+  it 'returns exercises saved in new and old ecosystems' do
+    AddEcosystemToCourse[course: course, ecosystem: new_ecosystem]
+    old_practice = FactoryBot.create(:tasks_practice_question,
+                                     role: student_role,
+                                     content_exercise_id: old_exercise.id)
+    new_practice = FactoryBot.create(:tasks_practice_question,
+                                     role: student_role,
+                                     content_exercise_id: new_exercise.id)
+    exercise_ids = [old_exercise.id, new_exercise.id]
+
+    outputs = described_class.call(
+      role: student_role,
+      course: course,
+      exercise_ids: exercise_ids
+    ).outputs
+
+    expect(outputs.exercises.map(&:id)).to eq(exercise_ids)
+  end
+end


### PR DESCRIPTION
If you saved an exercise to practice when the course's ecosystem was 5, and then the ecosystem was updated to 6, the saved exercise id will not be found in 6, so we need to start querying for each ecosystem an exercise belongs to.

So far no issues have been found with creating a practice exercise with mixed ecosystems, but we should do a lot of testing on QA.