### PR TITLE
Remove serialized nokogiri nodes and update content-ruby

### DIFF
--- a/db/background_migrate/20211005155727_remove_serialized_nokogiri_nodes_in_background.rb
+++ b/db/background_migrate/20211005155727_remove_serialized_nokogiri_nodes_in_background.rb
@@ -1,0 +1,20 @@
+class RemoveSerializedNokogiriNodesInBackground < ActiveRecord::Migration[5.2]
+  BATCH_SIZE = 100
+
+  def up
+    loop do
+      break if Content::Models::Page.where(
+        '"fragments" ILIKE \'%\\\\nnode: !ruby/object:Nokogiri::HTML::DocumentFragment {}\\\\n%\''
+      ).limit(BATCH_SIZE).update_all(
+        <<~UPDATE_SQL
+          "fragments" = REPLACE(
+            "fragments", '\\nnode: !ruby/object:Nokogiri::HTML::DocumentFragment {}\\n', '\\n'
+          )
+        UPDATE_SQL
+      ) < BATCH_SIZE
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20211005155701_remove_serialized_nokogiri_nodes.rb
+++ b/db/migrate/20211005155701_remove_serialized_nokogiri_nodes.rb
@@ -1,0 +1,9 @@
+class RemoveSerializedNokogiriNodes < ActiveRecord::Migration[5.2]
+  def up
+    BackgroundMigrate.perform_later 'up', 20211005155727
+  end
+
+  def down
+    BackgroundMigrate.perform_later 'down', 20211005155727
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_153151) do
+ActiveRecord::Schema.define(version: 2021_10_05_155727) do
 
   create_sequence "teacher_exercise_number", start: 1000000
 


### PR DESCRIPTION
Use Postgres REPLACE to remove blank serialized nokogiri nodes