### PR TITLE
Salesforce sync failures admin page

### DIFF
--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -1,9 +1,7 @@
 module Admin
   class SalesforceController < BaseController
     def failures
-      terms = CourseProfile::Models::Course.terms.values_at(
-        :spring, :summer, :fall, :winter, :preview
-      )
+      terms = CourseProfile::Models::Course.terms.values_at :spring, :summer, :fall, :winter
 
       @courses = CourseProfile::Models::Course
         .not_ended
@@ -38,7 +36,7 @@ module Admin
                     "openstax_accounts_accounts"."salesforce_contact_id" IS NOT NULL
             )
           WHERE_SQL
-        ).preload(:students, teachers: { role: { profile: :account } })
+        ).order(:id).preload(:students, teachers: { role: { profile: :account } })
     end
   end
 end

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -6,36 +6,13 @@ module Admin
       @courses = CourseProfile::Models::Course
         .not_ended
         .where(is_test: false, is_preview: false, is_excluded_from_salesforce: false, term: terms)
-        .where(
-          <<~WHERE_SQL
-            (
-              EXISTS (
-                SELECT *
-                FROM "course_membership_teachers"
-                WHERE "course_membership_teachers"."course_profile_course_id" =
-                        "course_profile_courses"."id" AND
-                      "course_membership_teachers"."deleted_at" IS NULL
-              ) OR EXISTS (
-                SELECT *
-                FROM "course_membership_students"
-                WHERE "course_membership_students"."course_profile_course_id" =
-                        "course_profile_courses"."id" AND
-                      "course_membership_students"."dropped_at" IS NULL
-              )
-            ) AND NOT EXISTS (
-              SELECT *
-              FROM "course_membership_teachers"
-              INNER JOIN "entity_roles"
-                ON "entity_roles"."id" = "course_membership_teachers"."entity_role_id"
-              INNER JOIN "user_profiles"
-                ON "user_profiles"."id" = "entity_roles"."user_profile_id"
-              INNER JOIN "openstax_accounts_accounts"
-                ON "openstax_accounts_accounts"."id" = "user_profiles"."account_id"
-              WHERE "course_membership_teachers"."course_profile_course_id" =
-                      "course_profile_courses"."id" AND
-                    "openstax_accounts_accounts"."salesforce_contact_id" IS NOT NULL
-            )
-          WHERE_SQL
+        .where.not(
+          CourseMembership::Models::Teacher.joins(role: { profile: :account }).where(
+            <<~WHERE_SQL
+              "course_membership_teachers"."course_profile_course_id" =
+                "course_profile_courses"."id"
+            WHERE_SQL
+          ).where.not(role: { profile: { account: { salesforce_contact_id: nil } } }).arel.exists
         ).order(:id).preload(:students, teachers: { role: { profile: :account } })
     end
   end

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -1,17 +1,44 @@
 module Admin
   class SalesforceController < BaseController
-    def show
-    end
+    def failures
+      terms = CourseProfile::Models::Course.terms.values_at(
+        :spring, :summer, :fall, :winter, :preview
+      )
 
-    def update
-      outputs = PushSalesforceCourseStats.call
-
-      flash[:notice] = "Ran on #{outputs[:num_courses]} course(s); " +
-                       "updated #{outputs[:num_updates]} course(s); " +
-                       "#{outputs[:num_errors]} error(s) occurred; " +
-                       "#{outputs[:num_skips]} skip(s)"
-
-      redirect_to admin_salesforce_path
+      @courses = CourseProfile::Models::Course
+        .not_ended
+        .where(is_test: false, is_preview: false, is_excluded_from_salesforce: false, term: terms)
+        .where(
+          <<~WHERE_SQL
+            (
+              EXISTS (
+                SELECT *
+                FROM "course_membership_teachers"
+                WHERE "course_membership_teachers"."course_profile_course_id" =
+                        "course_profile_courses"."id" AND
+                      "course_membership_teachers"."deleted_at" IS NULL
+              ) OR EXISTS (
+                SELECT *
+                FROM "course_membership_students"
+                WHERE "course_membership_students"."course_profile_course_id" =
+                        "course_profile_courses"."id" AND
+                      "course_membership_students"."dropped_at" IS NULL
+              )
+            ) AND NOT EXISTS (
+              SELECT *
+              FROM "course_membership_teachers"
+              INNER JOIN "entity_roles"
+                ON "entity_roles"."id" = "course_membership_teachers"."entity_role_id"
+              INNER JOIN "user_profiles"
+                ON "user_profiles"."id" = "entity_roles"."user_profile_id"
+              INNER JOIN "openstax_accounts_accounts"
+                ON "openstax_accounts_accounts"."id" = "user_profiles"."account_id"
+              WHERE "course_membership_teachers"."course_profile_course_id" =
+                      "course_profile_courses"."id" AND
+                    "openstax_accounts_accounts"."salesforce_contact_id" IS NOT NULL
+            )
+          WHERE_SQL
+        ).preload(:students, teachers: { role: { profile: :account } })
     end
   end
 end

--- a/app/views/admin/salesforce/_course.html.erb
+++ b/app/views/admin/salesforce/_course.html.erb
@@ -1,0 +1,28 @@
+<%
+  teachers = course.teachers.reject { |teacher| teacher.role.nil? }
+  students = course.students.to_a
+  num_students = students.size
+  dropped_students = students.count(&:dropped?)
+  enrolled_students = num_students - dropped_students
+%>
+
+<tr>
+  <td><%= link_to course.id, edit_admin_course_path(course.id) %></td>
+  <td>
+    <%= '---' if teachers.empty? %>
+    <% teachers.each do |teacher| %>
+      <%=
+        link_to teacher.name, edit_admin_user_path(teacher.role.profile.id)
+      %><%= ' (deleted)' if teacher.deleted? %><%= '; ' unless teacher == teachers.last %>
+    <% end %>
+  </td>
+  <td>
+    <%= link_to enrolled_students, admin_course_students_path(course.id) %>
+  </td>
+  <td>
+    <%= link_to dropped_students, admin_course_students_path(course.id) %>
+  </td>
+  <td>
+    <%= link_to num_students, admin_course_students_path(course.id) %>
+  </td>
+</tr>

--- a/app/views/admin/salesforce/_course.html.erb
+++ b/app/views/admin/salesforce/_course.html.erb
@@ -1,9 +1,9 @@
 <%
   teachers = course.teachers.reject { |teacher| teacher.role.nil? }
   students = course.students.to_a
-  num_students = students.size
+  total_students = students.size
   dropped_students = students.count(&:dropped?)
-  enrolled_students = num_students - dropped_students
+  enrolled_students = total_students - dropped_students
 %>
 
 <tr>
@@ -16,13 +16,7 @@
       %><%= ' (deleted)' if teacher.deleted? %><%= '; ' unless teacher == teachers.last %>
     <% end %>
   </td>
-  <td>
-    <%= link_to enrolled_students, admin_course_students_path(course.id) %>
-  </td>
-  <td>
-    <%= link_to dropped_students, admin_course_students_path(course.id) %>
-  </td>
-  <td>
-    <%= link_to num_students, admin_course_students_path(course.id) %>
-  </td>
+  <td><%= link_to enrolled_students, admin_course_students_path(course.id) %></td>
+  <td><%= link_to dropped_students, admin_course_students_path(course.id) %></td>
+  <td><%= link_to total_students, admin_course_students_path(course.id) %></td>
 </tr>

--- a/app/views/admin/salesforce/failures.html.erb
+++ b/app/views/admin/salesforce/failures.html.erb
@@ -1,0 +1,20 @@
+<h2>Salesforce Update Failures</h2>
+
+<p>
+  The following courses are currently active, non-preview and would be eligible to be sent to
+  Salesforce except they have no teachers with a valid Salesforce Contact:
+</p>
+
+<table class="table">
+  <tr>
+    <th scope="col">Course</th>
+    <th scope="col">Instructors</th>
+    <th scope="col">Enrolled Students</th>
+    <th scope="col">Dropped Students</th>
+    <th scope="col">Total Students</th>
+  </tr>
+
+<% @courses.each do |course| %>
+  <%= render partial: 'course', locals: { course: course } %>
+<% end %>
+</table>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -71,6 +71,13 @@
             <li><%= link_to 'Research Data', main_app.admin_research_data_path %></li>
 
             <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Salesforce<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><%= link_to 'Failures', main_app.failures_admin_salesforce_path %></li>
+              </ul>
+            </li>
+
+            <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">System Setting<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><%= link_to 'Settings', main_app.admin_rails_settings_ui_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,7 +312,9 @@ Rails.application.routes.draw do
 
     resources :research_data, only: [ :index, :create ]
 
-    resource :salesforce, only: [ :show, :update ]
+    resource :salesforce, controller: :salesforce, only: [] do
+      get :failures
+    end
 
     resource :cron, only: :update
 

--- a/spec/requests/admin/salesforce_controller_spec.rb
+++ b/spec/requests/admin/salesforce_controller_spec.rb
@@ -7,19 +7,21 @@ RSpec.describe Admin::SalesforceController, type: :request do
   end
   let!(:failed_courses) do
     [
+      FactoryBot.create(:course_profile_course, term: terms.sample),
       FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
         FactoryBot.create :course_membership_teacher, course: course
       end,
       FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
-        FactoryBot.create :course_membership_student, course: course
+        period = FactoryBot.create(:course_membership_period, course: course)
+        FactoryBot.create :course_membership_student, period: period
       end,
       FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
         FactoryBot.create :course_membership_teacher, course: course
-        FactoryBot.create :course_membership_student, course: course
+        period = FactoryBot.create(:course_membership_period, course: course)
+        FactoryBot.create :course_membership_student, period: period
       end
     ]
   end
-  let!(:empty_course)      { FactoryBot.create :course_profile_course, term: terms.sample }
   let!(:successful_course) do
     FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
       FactoryBot.create(

--- a/spec/requests/admin/salesforce_controller_spec.rb
+++ b/spec/requests/admin/salesforce_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Admin::SalesforceController, type: :request do
         FactoryBot.create :course_membership_teacher, course: course
       end,
       FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
-        period = FactoryBot.create(:course_membership_period, course: course)
+        period = FactoryBot.create :course_membership_period, course: course
         FactoryBot.create :course_membership_student, period: period
       end,
       FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
         FactoryBot.create :course_membership_teacher, course: course
-        period = FactoryBot.create(:course_membership_period, course: course)
+        period = FactoryBot.create :course_membership_period, course: course
         FactoryBot.create :course_membership_student, period: period
       end
     ]
@@ -27,7 +27,8 @@ RSpec.describe Admin::SalesforceController, type: :request do
       FactoryBot.create(
         :course_membership_teacher, course: course
       ).role.profile.account.update_attribute :salesforce_contact_id, SecureRandom.uuid
-      FactoryBot.create :course_membership_student, course: course
+      period = FactoryBot.create :course_membership_period, course: course
+      FactoryBot.create :course_membership_student, period: period
     end
   end
 

--- a/spec/requests/admin/salesforce_controller_spec.rb
+++ b/spec/requests/admin/salesforce_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SalesforceController, type: :request do
+  let(:admin)           { FactoryBot.create(:user_profile, :administrator) }
+  let(:terms)           do
+    CourseProfile::Models::Course.terms.values_at :spring, :summer, :fall, :winter
+  end
+  let!(:failed_courses) do
+    [
+      FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
+        FactoryBot.create :course_membership_teacher, course: course
+      end,
+      FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
+        FactoryBot.create :course_membership_student, course: course
+      end,
+      FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
+        FactoryBot.create :course_membership_teacher, course: course
+        FactoryBot.create :course_membership_student, course: course
+      end
+    ]
+  end
+  let!(:empty_course)      { FactoryBot.create :course_profile_course, term: terms.sample }
+  let!(:successful_course) do
+    FactoryBot.create(:course_profile_course, term: terms.sample).tap do |course|
+      FactoryBot.create(
+        :course_membership_teacher, course: course
+      ).role.profile.account.update_attribute :salesforce_contact_id, SecureRandom.uuid
+      FactoryBot.create :course_membership_student, course: course
+    end
+  end
+
+  before { sign_in! admin }
+
+  context 'GET #failures' do
+    it 'assigns failed_courses to @courses' do
+      get failures_admin_salesforce_url
+
+      expect(assigns[:courses]).to eq(failed_courses)
+    end
+  end
+end

--- a/spec/views/admin/salesforce/failures.html.erb_spec.rb
+++ b/spec/views/admin/salesforce/failures.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/salesforce/failures', type: :view do
+  let(:courses) do
+    [
+      FactoryBot.create(:course_profile_course),
+      FactoryBot.create(:course_membership_teacher).course,
+      FactoryBot.create(:course_membership_student).course
+    ]
+  end
+
+  before(:each) { assign :courses, courses }
+
+  it 'renders the given courses' do
+    expect { render }.not_to raise_error
+
+    expect(rendered).to include('Salesforce Update Failures')
+
+    expect(rendered).to include('The following courses')
+    expect(rendered).to include('have no teachers with a valid Salesforce Contact:')
+
+    expect(rendered).to include('Course')
+    expect(rendered).to include('Instructors')
+    expect(rendered).to include('Enrolled Students')
+    expect(rendered).to include('Dropped Students')
+    expect(rendered).to include('Total Students')
+
+    courses.each do |course|
+      expect(rendered).to include(course.id.to_s)
+
+      teachers = course.teachers.to_a
+      expect(rendered).to include(teachers.empty? ? '---' : teachers.map(&:name).join('; '))
+
+      students = course.students.to_a
+      expect(rendered).to include(students.reject(&:dropped?).size.to_s)
+      expect(rendered).to include(students.count(&:dropped?).to_s)
+      expect(rendered).to include(students.size.to_s)
+    end
+  end
+end


### PR DESCRIPTION
- Removed what remained of the admin Salesforce controller and routes (it did not have links to it or template files)
- Added an admin page listing Salesforce sync failures
- Tests

![Screen Shot 2021-10-29 at 4 45 09 PM](https://user-images.githubusercontent.com/1017808/139493372-76e78c6c-dc7f-4ff7-9534-c63de99fa5c3.png)


