### PR TITLE
Cleanup roles in course APIs

### DIFF
--- a/app/controllers/api/v1/periods_controller.rb
+++ b/app/controllers/api/v1/periods_controller.rb
@@ -98,8 +98,8 @@ class Api::V1::PeriodsController < Api::V1::ApiController
     result = CreateOrResetTeacherStudent.call(user: current_human_user, period: @period)
 
     render_api_errors(result.errors) || respond_with(
-      result.outputs.role,
-      represent_with: Api::V1::RoleRepresenter,
+      result.outputs.role.teacher_student,
+      represent_with: Api::V1::TeacherStudentRepresenter,
       responder: ResponderWithPutPatchDeleteContent
     )
   end

--- a/app/representers/api/v1/course_clone_representer.rb
+++ b/app/representers/api/v1/course_clone_representer.rb
@@ -1,5 +1,5 @@
 class Api::V1::CourseCloneRepresenter < Api::V1::CourseRepresenter
-
+  # Not writeable, unlike the original CourseRepresenter
   property :catalog_offering_id,
            inherit: true,
            writeable: false
@@ -11,5 +11,4 @@ class Api::V1::CourseCloneRepresenter < Api::V1::CourseRepresenter
              required: true,
              type: 'boolean'
            }
-
 end

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -236,7 +236,6 @@ module Api::V1
                readable: true,
                writeable: false
 
-    # TODO: Remove if no longer used?
     collection :roles,
                extend: Api::V1::RoleRepresenter,
                readable: true,

--- a/app/representers/api/v1/course_representer.rb
+++ b/app/representers/api/v1/course_representer.rb
@@ -1,6 +1,5 @@
 module Api::V1
   class CourseRepresenter < Roar::Decorator
-
     include Roar::JSON
     include Representable::Coercion
 
@@ -237,30 +236,54 @@ module Api::V1
                readable: true,
                writeable: false
 
-    collection :students,
-               readable: true,
-               writeable: false,
-               extend: Api::V1::StudentRepresenter
-
-    collection :teachers,
-               readable: true,
-               writeable: false,
-               extend: Api::V1::TeacherRepresenter
-
+    # TODO: Remove if no longer used?
     collection :roles,
                extend: Api::V1::RoleRepresenter,
                readable: true,
                writeable: false,
-               if: ->(*) { respond_to?(:roles) }
+               if: ->(*) { respond_to?(:roles) },
+               schema_info: { description: "The user's own roles in the course" }
 
-    property :related_teacher_profile_ids,
+    # TODO: Remove when no longer used
+    collection :teachers,
+               readable: true,
+               writeable: false,
+               extend: Api::V1::TeacherRepresenter,
+               schema_info: { description: "The user's own teacher records in the course" }
+
+    property :teacher_record,
+             extend: Api::V1::TeacherRepresenter,
              readable: true,
-             writeable: false
+             writeable: false,
+             schema_info: { description: "The user's own teacher record in the course" }
+
+    # TODO: Remove when no longer used
+    collection :students,
+               readable: true,
+               writeable: false,
+               extend: Api::V1::StudentRepresenter,
+               schema_info: { description: "The user's own student records in the course" }
+
+    property :student_record,
+             extend: Api::V1::StudentRepresenter,
+             readable: true,
+             writeable: false,
+             schema_info: { description: "The user's own student record in the course" }
+
+    collection :teacher_student_records,
+               extend: Api::V1::TeacherStudentRepresenter,
+               readable: true,
+               writeable: false,
+               schema_info: { description: "The user's own teacher_student records in the course" }
 
     collection :teacher_profiles,
               extend: Api::V1::UserProfileRepresenter,
               readable: true,
               writeable: false
+
+    property :related_teacher_profile_ids,
+             readable: true,
+             writeable: false
 
     property :spy_info,
              type: Object,
@@ -271,6 +294,5 @@ module Api::V1
              type: String,
              readable: true,
              writeable: true
-
   end
 end

--- a/app/representers/api/v1/enrollment/period_with_course_representer.rb
+++ b/app/representers/api/v1/enrollment/period_with_course_representer.rb
@@ -1,5 +1,4 @@
 module Api::V1::Enrollment
-
   class Teacher < Roar::Decorator
     include Roar::JSON
 
@@ -20,7 +19,6 @@ module Api::V1::Enrollment
   end
 
   class PeriodWithCourseRepresenter < Roar::Decorator
-
     include Roar::JSON
     include Representable::Coercion
 
@@ -69,8 +67,6 @@ module Api::V1::Enrollment
                type: Integer,
                readable: true,
                writeable: false
-
     end
-
   end
 end

--- a/app/representers/api/v1/role_representer.rb
+++ b/app/representers/api/v1/role_representer.rb
@@ -9,15 +9,15 @@ module Api::V1
              writeable: false,
              schema_info: { required: true }
 
-    property :period_id,
-             getter: ->(*) { teacher? ? nil : course_member.course_membership_period_id },
+    property :role_type,
+             as: :type,
              type: String,
              readable: true,
              writeable: false,
              schema_info: { required: true }
 
-    property :role_type,
-             as: :type,
+    property :period_id,
+             getter: ->(*) { teacher? ? nil : course_member.course_membership_period_id },
              type: String,
              readable: true,
              writeable: false,

--- a/app/representers/api/v1/shared_role_representer.rb
+++ b/app/representers/api/v1/shared_role_representer.rb
@@ -1,5 +1,5 @@
 module Api::V1
-  class RoleRepresenter < Roar::Decorator
+  class SharedRoleRepresenter < Roar::Decorator
     include Roar::JSON
     include Representable::Coercion
 
@@ -9,19 +9,23 @@ module Api::V1
              writeable: false,
              schema_info: { required: true }
 
-    property :period_id,
-             getter: ->(*) { teacher? ? nil : course_member.course_membership_period_id },
+    property :course_profile_course_id,
+             as: :course_id,
              type: String,
+             writeable: true,
              readable: true,
-             writeable: false,
-             schema_info: { required: true }
+             schema_info: {
+               required: true
+             }
 
-    property :role_type,
-             as: :type,
+    property :role_id,
              type: String,
-             readable: true,
              writeable: false,
-             schema_info: { required: true }
+             readable: true,
+             getter: ->(*) { respond_to?(:role_id) ? role_id : entity_role_id },
+             schema_info: {
+               required: true
+             }
 
     property :research_identifier,
              type: String,
@@ -33,13 +37,6 @@ module Api::V1
              readable: true,
              writeable: false,
              getter: ->(*) { DateTimeUtilities.to_api_s(created_at) },
-             schema_info: { required: true }
-
-    property :latest_enrollment_at,
-             type: String,
-             readable: true,
-             writeable: false,
-             getter: ->(*) { DateTimeUtilities.to_api_s(latest_enrollment_at) },
              schema_info: { required: true }
   end
 end

--- a/app/representers/api/v1/students_representer.rb
+++ b/app/representers/api/v1/students_representer.rb
@@ -1,7 +1,0 @@
-module Api::V1
-  class StudentsRepresenter < Roar::Decorator
-    include Representable::JSON::Collection
-
-    items extend: StudentRepresenter
-  end
-end

--- a/app/representers/api/v1/teacher_representer.rb
+++ b/app/representers/api/v1/teacher_representer.rb
@@ -1,35 +1,5 @@
 module Api::V1
-  class TeacherRepresenter < Roar::Decorator
-
-    include Roar::JSON
-    include Representable::Coercion
-
-    property :id,
-             type: String,
-             writeable: false,
-             readable: true,
-             schema_info: {
-               required: true
-             }
-
-    property :course_profile_course_id,
-             as: :course_id,
-             type: String,
-             writeable: true,
-             readable: true,
-             schema_info: {
-               required: true
-             }
-
-    property :role_id,
-             type: String,
-             writeable: false,
-             readable: true,
-             getter: ->(*) { respond_to?(:role_id) ? role_id : entity_role_id },
-             schema_info: {
-               required: true
-             }
-
+  class TeacherRepresenter < SharedRoleRepresenter
     property :profile_id,
              type: String,
              writeable: false,
@@ -54,7 +24,10 @@ module Api::V1
     property :is_active,
              readable: true,
              writeable: false,
-             getter: ->(*) { !try!(:deleted_at) }
-
+             getter: ->(*) { !deleted_at? },
+             schema_info: {
+                required: true,
+                description: 'Teacher is deleted if false'
+             }
   end
 end

--- a/app/representers/api/v1/teacher_student_representer.rb
+++ b/app/representers/api/v1/teacher_student_representer.rb
@@ -1,0 +1,27 @@
+module Api::V1
+  class TeacherStudentRepresenter < SharedRoleRepresenter
+    property :uuid,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: { required: true }
+
+    property :course_membership_period_id,
+             as: :period_id,
+             type: String,
+             writeable: true,
+             readable: true,
+             schema_info: {
+               required: true
+             }
+
+    property :is_active,
+             writeable: false,
+             readable: true,
+             getter: ->(*) { !deleted? },
+             schema_info: {
+                required: true,
+                description: 'TeacherStudent is deleted if false'
+             }
+  end
+end

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -13,8 +13,9 @@ class CollectCourseInfo
     outputs.courses = courses.map do |course|
       offering = course.offering
       roles = roles_by_course_id.fetch(course.id, [])
-      students = roles.map(&:student).compact
       teachers = roles.map(&:teacher).compact
+      students = roles.map(&:student).compact
+      teacher_students = roles.map(&:teacher_student).compact
 
       # If the user is an active teacher, return all course periods
       # Otherwise, return only the periods the user is in
@@ -58,11 +59,14 @@ class CollectCourseInfo
         ecosystem: course.ecosystem,
         should_reuse_preview?: course.should_reuse_preview?,
         periods: periods,
-        students: students,
-        teachers: teachers,
-        roles: roles,
-        related_teacher_profile_ids: course.related_teacher_profile_ids,
+        roles: roles,       # TODO: Remove?
+        teachers: teachers, # TODO: Remove
+        teacher_record: teachers.sort_by(&:created_at).last,
+        students: students, # TODO: Remove
+        student_record: students.sort_by(&:created_at).last,
+        teacher_student_records: teacher_students,
         teacher_profiles: course.teacher_profiles,
+        related_teacher_profile_ids: course.related_teacher_profile_ids,
         spy_info: course.spy_info,
         code: course.code.nil? ? "" : course.code,
       )

--- a/app/routines/collect_course_info.rb
+++ b/app/routines/collect_course_info.rb
@@ -59,7 +59,7 @@ class CollectCourseInfo
         ecosystem: course.ecosystem,
         should_reuse_preview?: course.should_reuse_preview?,
         periods: periods,
-        roles: roles,       # TODO: Remove?
+        roles: roles,
         teachers: teachers, # TODO: Remove
         teacher_record: teachers.sort_by(&:created_at).last,
         students: students, # TODO: Remove

--- a/spec/representers/api/v1/course_representer_shared_examples.rb
+++ b/spec/representers/api/v1/course_representer_shared_examples.rb
@@ -2,28 +2,34 @@ require 'rails_helper'
 
 module Api::V1
   RSpec.shared_examples 'api_v1_course_representer' do
-    let(:ecosystem)        { FactoryBot.create :content_ecosystem }
-
+    let(:ecosystem) { FactoryBot.create :content_ecosystem }
     let(:catalog_offering) do
       FactoryBot.create :catalog_offering, salesforce_book_name: 'book',
                                             appearance_code: 'appearance',
                                             description: 'desc',
                                             ecosystem: ecosystem
     end
-
     let(:original_course)  { FactoryBot.create :course_profile_course }
-
-    let(:course)           do
+    let(:course) do
       FactoryBot.create :course_profile_course, name: 'Test course',
-                                                 appearance_code: 'appearance override',
-                                                 offering: catalog_offering,
-                                                 is_preview: true,
-                                                 is_concept_coach: true,
-                                                 is_college: false,
-                                                 cloned_from: original_course
+                                                appearance_code: 'appearance override',
+                                                offering: catalog_offering,
+                                                is_preview: true,
+                                                is_concept_coach: true,
+                                                is_college: false,
+                                                cloned_from: original_course
+    end
+    let(:period) { FactoryBot.create :course_membership_period, course: course }
+    let(:user) do
+      FactoryBot.create(:course_membership_teacher, course: course).role.profile.tap do |profile|
+        AddUserAsPeriodStudent[user: profile, period: period]
+        CreateOrResetTeacherStudent[user: profile, period: period]
+      end
     end
 
-    subject(:represented) { described_class.new(course).as_json }
+    subject(:represented) do
+      described_class.new(CollectCourseInfo[courses: course, user: user].first).as_json
+    end
 
     it 'shows the course id' do
       expect(represented['id']).to eq course.id.to_s
@@ -62,13 +68,19 @@ module Api::V1
       expect(represented['is_college']).to eq false
 
       course.update_attribute :is_college, nil
-      expect(described_class.new(course).as_json['is_college']).to eq true
+      expect(
+        described_class.new(CollectCourseInfo[courses: course, user: user].first
+      ).as_json['is_college']).to eq true
 
       course.update_attribute :is_college, true
-      expect(described_class.new(course).as_json['is_college']).to eq true
+      expect(
+        described_class.new(CollectCourseInfo[courses: course, user: user].first
+      ).as_json['is_college']).to eq true
 
       course.update_attribute :is_college, false
-      expect(described_class.new(course).as_json['is_college']).to eq false
+      expect(
+        described_class.new(CollectCourseInfo[courses: course, user: user].first
+      ).as_json['is_college']).to eq false
     end
 
     it "shows the id of the source course's catalog offering" do
@@ -79,26 +91,37 @@ module Api::V1
       expect(represented['cloned_from_id']).to eq original_course.id.to_s
     end
 
-    it 'shows students' do
-      period = FactoryBot.create :course_membership_period, course: course
-      student_1_user = FactoryBot.create :user_profile
-      student_2_user = FactoryBot.create :user_profile
-      student_1 = AddUserAsPeriodStudent[user: student_1_user, period: period].student
-      student_2 = AddUserAsPeriodStudent[user: student_2_user, period: period].student
-
-      expect(represented["students"]).to(
-        match_array [a_hash_including("id" => student_1.id.to_s),
-                     a_hash_including("id" => student_2.id.to_s)]
-      )
-    end
-
     it 'shows the number of sections in the course' do
       period_1 = FactoryBot.create :course_membership_period, course: course
       period_2 = FactoryBot.create :course_membership_period, course: course
       period_3 = FactoryBot.create :course_membership_period, course: course
       period_4 = FactoryBot.create :course_membership_period, course: course
 
-      expect(represented["num_sections"]).to eq 4
+      expect(represented['num_sections']).to eq course.periods.count
+    end
+
+    it "shows the user's own roles" do
+      expect(represented['roles']).to match_array [
+        a_hash_including('type' => 'teacher'),
+        a_hash_including('type' => 'student'),
+        a_hash_including('type' => 'teacher_student')
+      ]
+    end
+
+    it "shows the user's teacher record" do
+      expect(represented['teacher_record']).to match a_hash_including('profile_id' => user.id.to_s)
+    end
+
+    it "shows the user's student record" do
+      expect(represented['student_record']).to match(
+        a_hash_including('latest_enrollment_at' => kind_of(String))
+      )
+    end
+
+    it "shows the user's teacher_student records" do
+      expect(represented['teacher_student_records']).to match(
+        [ a_hash_including('period_id' => period.id.to_s) ]
+      )
     end
 
     it 'shows does_cost' do

--- a/spec/representers/api/v1/student_representer_spec.rb
+++ b/spec/representers/api/v1/student_representer_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe Api::V1::StudentRepresenter, type: :representer do
     expect(representation).to match(
       'id' => student.id.to_s,
       'uuid' => student.uuid,
+      'course_id' => course.id.to_s,
       'period_id' => period.id.to_s,
       'role_id' => student.role.id.to_s,
+      'research_identifier' => student.research_identifier,
       'first_name' => student.first_name,
       'last_name' => student.last_name,
       'name' => student.name,
+      'latest_enrollment_at' => DateTimeUtilities.to_api_s(student.latest_enrollment_at),
       'is_active' => !student.dropped?,
       'is_paid' => false,
       'is_comped' => false,
@@ -25,7 +28,8 @@ RSpec.describe Api::V1::StudentRepresenter, type: :representer do
       'first_paid_at' => be_kind_of(String),
       'is_refund_pending' => false,
       'is_refund_allowed' => false,
-      'prompt_student_to_pay' => false
+      'prompt_student_to_pay' => false,
+      'joined_at' => DateTimeUtilities.to_api_s(student.created_at)
     )
 
     [:first_paid_at, :payment_due_at].each do |date_method|

--- a/spec/representers/api/v1/teacher_representer_spec.rb
+++ b/spec/representers/api/v1/teacher_representer_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe Api::V1::TeacherRepresenter, type: :representer do
       'id' => teacher.id.to_s,
       'course_id' => course.id.to_s,
       'role_id' => teacher.role.id.to_s,
+      'research_identifier' => teacher.research_identifier,
       'first_name' => teacher.first_name,
       'last_name' => teacher.last_name,
       'profile_id' => teacher.role.profile.id.to_s,
       'name' => teacher.name,
-      'is_active' => true
+      'is_active' => true,
+      'joined_at' => DateTimeUtilities.to_api_s(teacher.created_at)
     )
   end
 end

--- a/spec/requests/api/v1/courses_controller_spec.rb
+++ b/spec/requests/api/v1/courses_controller_spec.rb
@@ -1137,7 +1137,9 @@ RSpec.describe Api::V1::CoursesController, type: :request, api: true,
       let(:expected_year)      { @course.year + 1 }
       let(:expected_term_year) { TermYear.new(@course.term, expected_year) }
       let(:expected_response)  do
-        Api::V1::CourseRepresenter.new(@course).as_json.deep_symbolize_keys.merge(
+        Api::V1::CourseRepresenter.new(
+          CollectCourseInfo[courses: @course, user: @user_1].first
+        ).as_json.deep_symbolize_keys.merge(
           id: a_kind_of(String),
           uuid: a_kind_of(String),
           code: @course.code,
@@ -1148,9 +1150,9 @@ RSpec.describe Api::V1::CoursesController, type: :request, api: true,
           is_active: be_in([true, false]),
           is_access_switchable: be_in([true, false]),
           periods: [a_kind_of(Hash)] * @course.num_sections,
-          students: [],
-          teachers: [a_kind_of(Hash)],
           roles: [a_kind_of(Hash)],
+          teacher_record: a_kind_of(Hash),
+          teachers: [a_kind_of(Hash)],
           is_lms_enabling_allowed: true,
           ecosystem_id: @course.offering.content_ecosystem_id.to_s,
           cloned_from_id: @course.id.to_s,
@@ -1167,10 +1169,10 @@ RSpec.describe Api::V1::CoursesController, type: :request, api: true,
 
         expect(response).to have_http_status(:success)
         new_course = response.body_as_hash
-        # the new course will have a different id, uuid and teachers
+        # the new course will have a different id, uuid and teacher_record
         expect(new_course[:id]).not_to eq(expected_response[:id])
         expect(new_course[:uuid]).not_to eq(expected_response[:uuid])
-        expect(new_course[:teachers]).not_to eq(expected_response[:teachers])
+        expect(new_course[:teacher_record]).not_to eq(expected_response[:teacher_record])
         # but will otherwise be the same
         expect(new_course).to match expected_response
       end

--- a/spec/requests/api/v1/periods_controller_spec.rb
+++ b/spec/requests/api/v1/periods_controller_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe Api::V1::PeriodsController, type: :request, api: true, version: :
 
       expect(response).to have_http_status(:ok)
 
-      role = CourseMembership::Models::TeacherStudent.order(:created_at).last.role
-      expect(response.body).to eq Api::V1::RoleRepresenter.new(role).to_json
+      teacher_student = CourseMembership::Models::TeacherStudent.order(:created_at).last
+      expect(response.body).to eq Api::V1::TeacherStudentRepresenter.new(teacher_student).to_json
     end
 
     it 'ensures the person is a teacher of the course' do


### PR DESCRIPTION
Goes with https://github.com/openstax/tutor-js/pull/3823

- Added a new SharedRoleRepresenter and TeacherStudentRepresenter
- Replaced arrays of teachers and students in the course with single objects
- Updated tests

I have not removed any of the old fields yet because we'll want to update the FE and release that before we take them out.