### PR TITLE
use uuids for practice questions

### DIFF
--- a/app/controllers/api/v1/ecosystems_controller.rb
+++ b/app/controllers/api/v1/ecosystems_controller.rb
@@ -82,8 +82,7 @@ class Api::V1::EcosystemsController < Api::V1::ApiController
   def practice_exercises
     exercises = GetPracticeQuestionExercises[
       role: @role,
-      course: @course,
-      exercise_ids: params[:exercise_ids]
+      course: @course
     ]
 
     respond_with(exercises,

--- a/app/controllers/api/v1/practice_questions_controller.rb
+++ b/app/controllers/api/v1/practice_questions_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::PracticeQuestionsController < Api::V1::ApiController
     standard_create ::Tasks::Models::PracticeQuestion.new, Api::V1::PracticeQuestionRepresenter do |question|
       question.role = @role
       question.tasked_exercise = step.tasked
-      question.content_exercise_id = step.tasked.exercise.id
+      question.exercise = step.tasked.exercise
     end
   end
 

--- a/app/controllers/api/v1/practice_questions_controller.rb
+++ b/app/controllers/api/v1/practice_questions_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::PracticeQuestionsController < Api::V1::ApiController
     #{json_schema(Api::V1::PracticeQuestionsRepresenter, include: :readable)}
   EOS
   def index
-    questions = @role.practice_questions.preload(tasked_exercise: { task_step: { task: { task_plan: :grading_template } } })
+    questions = @role.practice_questions.preload(tasked_exercise: { task_step: { task: { task_plan: :grading_template } } }).preload(:exercise)
     respond_with questions, represent_with: Api::V1::PracticeQuestionsRepresenter
   end
 
@@ -39,7 +39,7 @@ class Api::V1::PracticeQuestionsController < Api::V1::ApiController
     standard_create ::Tasks::Models::PracticeQuestion.new, Api::V1::PracticeQuestionRepresenter do |question|
       question.role = @role
       question.tasked_exercise = step.tasked
-      question.exercise = step.tasked.exercise
+      question.content_exercise_id = step.tasked.exercise.id
     end
   end
 

--- a/app/representers/api/v1/practice_question_representer.rb
+++ b/app/representers/api/v1/practice_question_representer.rb
@@ -17,8 +17,13 @@ module Api::V1
              readable: true,
              schema_info: { required: true }
 
-    property :uuid,
-             as: :exercise_uuid,
+    property :exercise_id,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: { required: true }
+
+    property :exercise_uuid,
              type: String,
              writeable: false,
              readable: true,

--- a/app/representers/api/v1/practice_question_representer.rb
+++ b/app/representers/api/v1/practice_question_representer.rb
@@ -17,7 +17,8 @@ module Api::V1
              readable: true,
              schema_info: { required: true }
 
-    property :exercise_id,
+    property :content_exercise_id,
+             as: :exercise_id,
              type: String,
              writeable: false,
              readable: true,

--- a/app/representers/api/v1/practice_question_representer.rb
+++ b/app/representers/api/v1/practice_question_representer.rb
@@ -17,8 +17,8 @@ module Api::V1
              readable: true,
              schema_info: { required: true }
 
-    property :content_exercise_id,
-             as: :exercise_id,
+    property :uuid,
+             as: :exercise_uuid,
              type: String,
              writeable: false,
              readable: true,

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -19,6 +19,16 @@ module Api::V1::Tasks
                description: "The id of the exercise tasked"
              }
 
+    property :exercise_uuid,
+             type: String,
+             writeable: false,
+             readable: true,
+             schema_info: {
+               required: false,
+               description: "The UUID of the exercise tasked"
+             },
+             getter: ->(*) { exercise.uuid }
+
     property :title,
              type: String,
              writeable: false,
@@ -44,7 +54,7 @@ module Api::V1::Tasks
              readable: true,
              schema_info: {
                required: false,
-               description: "The UUID of the exercise, steps with identical uid will be grouped together into a MPQ"
+               description: "The number@version of the exercise, steps with identical uid will be grouped together into a MPQ"
              }
 
     property :labels,

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -26,8 +26,7 @@ module Api::V1::Tasks
              schema_info: {
                required: false,
                description: "The UUID of the exercise tasked"
-             },
-             getter: ->(*) { exercise.uuid }
+             }
 
     property :title,
              type: String,

--- a/app/routines/find_or_create_practice_saved_task.rb
+++ b/app/routines/find_or_create_practice_saved_task.rb
@@ -7,13 +7,13 @@ class FindOrCreatePracticeSavedTask
   protected
 
   def setup(**args)
-    @exercise_uuids = get_exercise_uuids(args[:question_ids])
+    @exercise_uuids = questions(args[:question_ids]).map(&:exercise_uuid)
     @task_type = :practice_saved
     @ecosystem = run(:get_course_ecosystem, course: @course).outputs.ecosystem
   end
 
-  def get_exercise_uuids(question_ids)
-    @role.practice_questions.where(id: question_ids).map(&:exercise_uuid)
+  def questions(question_ids)
+    @role.practice_questions.where(id: question_ids)
   end
 
   def add_task_steps

--- a/app/routines/find_or_create_practice_saved_task.rb
+++ b/app/routines/find_or_create_practice_saved_task.rb
@@ -13,7 +13,7 @@ class FindOrCreatePracticeSavedTask
   end
 
   def questions(question_ids)
-    @role.practice_questions.where(id: question_ids)
+    @role.practice_questions.preload(:exercise).where(id: question_ids)
   end
 
   def add_task_steps

--- a/app/routines/get_practice_question_exercises.rb
+++ b/app/routines/get_practice_question_exercises.rb
@@ -3,8 +3,8 @@ class GetPracticeQuestionExercises
 
   def exec(role:, course:)
     exercise_and_ecosystem_ids = role.practice_questions
-                                    .joins(exercise: :ecosystem)
-                                    .pluck("content_ecosystems.id", :content_exercise_id)
+                                   .joins(exercise: :ecosystem)
+                                   .pluck("content_ecosystems.id", :content_exercise_id)
 
     exercises = []
     exercise_ids_grouped_by_ecosystem_id = Hash.new {|h,k| h[k] = [] }

--- a/app/routines/get_practice_question_exercises.rb
+++ b/app/routines/get_practice_question_exercises.rb
@@ -30,6 +30,6 @@ class GetPracticeQuestionExercises
       ).outputs.exercises
     end
 
-    outputs.exercises = exercises.flatten.uniq(&:uuid)
+    outputs.exercises = exercises.flatten
   end
 end

--- a/app/routines/get_practice_question_exercises.rb
+++ b/app/routines/get_practice_question_exercises.rb
@@ -2,16 +2,9 @@ class GetPracticeQuestionExercises
   lev_routine transaction: :no_transaction, express_output: :exercises
 
   def exec(role:, course:)
-    uuids = role.practice_questions
-                .joins(tasked_exercise: :exercise)
-                .pluck("content_exercises.uuid").uniq
-
-    exercise_and_ecosystem_ids =
-      Content::Models::Exercise.select('DISTINCT ON ("content_exercises"."number") "content_exercises".*')
-        .joins(book: :ecosystem)
-        .where(book: { content_ecosystem_id: course.ecosystems.map(&:id) }, uuid: uuids)
-        .order(:number, version: :desc)
-        .pluck("content_ecosystems.id", "content_exercises.id")
+    exercise_and_ecosystem_ids = role.practice_questions
+                                    .joins(exercise: :ecosystem)
+                                    .pluck("content_ecosystems.id", :content_exercise_id)
 
     exercises = []
     exercise_ids_grouped_by_ecosystem_id = Hash.new {|h,k| h[k] = [] }

--- a/app/subsystems/tasks/models/practice_question.rb
+++ b/app/subsystems/tasks/models/practice_question.rb
@@ -1,13 +1,13 @@
 class Tasks::Models::PracticeQuestion < ApplicationRecord
   belongs_to :tasked_exercise, subsystem: :tasks
-  has_one :exercise, through: :tasked_exercise, subsystem: :content
+  belongs_to :exercise, subsystem: :content
   belongs_to :role, subsystem: :entity, inverse_of: :practice_questions
 
   validates :tasks_tasked_exercise_id, presence: true,
                                        uniqueness: { scope: [:tasks_tasked_exercise_id, :entity_role_id] }
   validates :content_exercise_id, presence: true,
                                   uniqueness: { scope: [:content_exercise_id, :entity_role_id] }
-  delegate :uuid, to: :exercise
+  delegate :uuid, :id, to: :exercise, prefix: :exercise
 
   def available?
     tasked_exercise.parts.all?(&:feedback_available?)

--- a/app/subsystems/tasks/models/practice_question.rb
+++ b/app/subsystems/tasks/models/practice_question.rb
@@ -1,12 +1,13 @@
 class Tasks::Models::PracticeQuestion < ApplicationRecord
   belongs_to :tasked_exercise, subsystem: :tasks
-  belongs_to :exercise, subsystem: :content
+  has_one :exercise, through: :tasked_exercise, subsystem: :content
   belongs_to :role, subsystem: :entity, inverse_of: :practice_questions
 
   validates :tasks_tasked_exercise_id, presence: true,
                                        uniqueness: { scope: [:tasks_tasked_exercise_id, :entity_role_id] }
   validates :content_exercise_id, presence: true,
                                   uniqueness: { scope: [:content_exercise_id, :entity_role_id] }
+  delegate :uuid, to: :exercise
 
   def available?
     tasked_exercise.parts.all?(&:feedback_available?)

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -36,6 +36,8 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
            :correct_question_answers, :correct_question_answer_ids,
            :feedback_map, :solutions, :collaborator_solutions, :content_hash_for_students, to: :parser
 
+  delegate :uuid, to: :exercise, prefix: :exercise
+
   def attempt_number_was
     val = super
     return val unless val.nil?

--- a/spec/factories/tasks/practice_questions.rb
+++ b/spec/factories/tasks/practice_questions.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :tasks_practice_question, class: '::Tasks::Models::PracticeQuestion' do
     association :role, factory: :entity_role
     association :tasked_exercise, factory: :tasks_tasked_exercise
-    association :exercise, factory: :content_exercise
+    content_exercise_id { nil }
   end
 end

--- a/spec/factories/tasks/practice_questions.rb
+++ b/spec/factories/tasks/practice_questions.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :tasks_practice_question, class: '::Tasks::Models::PracticeQuestion' do
     association :role, factory: :entity_role
     association :tasked_exercise, factory: :tasks_tasked_exercise
-    content_exercise_id { nil }
+    association :exercise, factory: :content_exercise
   end
 end

--- a/spec/representers/api/v1/practice_question_representer_spec.rb
+++ b/spec/representers/api/v1/practice_question_representer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V1::PracticeQuestionRepresenter, type: :representer do
       id: question.id,
       tasked_exercise_id: question.tasked_exercise.id,
       exercise_id: question.exercise.id,
+      exercise_uuid: question.exercise.uuid,
       available: question.available?,
     }.stringify_keys)
   end

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
@@ -25,6 +25,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       ## TaskedExercise-specific properties
       allow(exercise).to receive(:id).and_return(1)
       allow(exercise).to receive(:content_exercise_id).and_return(1)
+      allow(exercise).to receive(:exercise_uuid).and_return('Some uuid')
       allow(exercise).to receive(:title).and_return('Some title')
       allow(exercise).to receive(:context).and_return('Some Context')
       allow(exercise).to receive(:attempt_number).and_return(1)

--- a/spec/requests/api/v1/ecosystems_controller_spec.rb
+++ b/spec/requests/api/v1/ecosystems_controller_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
             old_page.save!
           end
         end
+
         let(:new_exercise) do
           FactoryBot.create(:content_exercise, page: new_page).tap do |exercise|
             new_page.homework_dynamic_exercise_ids << exercise.id
@@ -186,26 +187,32 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
           end
         end
 
+        let(:old_tasked) { FactoryBot.create(:tasks_tasked_exercise, exercise: old_exercise) }
+        let(:new_tasked) { FactoryBot.create(:tasks_tasked_exercise, exercise: new_exercise) }
+
 
        it 'includes exercises saved in both' do
           AddEcosystemToCourse[course: course, ecosystem: new_ecosystem]
 
+
+
           old_practice = FactoryBot.create(:tasks_practice_question,
-                                                    role: student_role,
-                                                    content_exercise_id: old_exercise.id)
+                                           role: student_role,
+                                           tasked_exercise: old_tasked,
+                                           content_exercise_id: old_exercise.id)
           new_practice = FactoryBot.create(:tasks_practice_question,
-                                                    role: student_role,
-                                                    content_exercise_id: new_exercise.id)
-          exercise_ids = [old_exercise.id, new_exercise.id]
+                                           role: student_role,
+                                           tasked_exercise: new_tasked,
+                                           content_exercise_id: new_exercise.id)
 
           api_get exercises_api_ecosystem_path(
-            ecosystem.id, course_id: course.id, exercise_ids: exercise_ids, role_id: student_role.id
+            ecosystem.id, course_id: course.id, role_id: student_role.id
           ), student_user_token
 
           hash = response.body_as_hash
           hash_ids = hash[:items].map{|i| i[:id].to_i}
           expect(hash[:total_count]).to eq(2)
-          expect(hash_ids).to eq(exercise_ids)
+          expect(hash_ids).to contain_exactly(old_exercise.id, new_exercise.id)
         end
       end
     end

--- a/spec/requests/api/v1/ecosystems_controller_spec.rb
+++ b/spec/requests/api/v1/ecosystems_controller_spec.rb
@@ -190,8 +190,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
         let(:old_tasked) { FactoryBot.create(:tasks_tasked_exercise, exercise: old_exercise) }
         let(:new_tasked) { FactoryBot.create(:tasks_tasked_exercise, exercise: new_exercise) }
 
-
-       it 'includes exercises saved in both' do
+        it 'includes exercises saved in both' do
           AddEcosystemToCourse[course: course, ecosystem: new_ecosystem]
 
 
@@ -307,10 +306,12 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
 
       it 'allows students to only see exercises that have been saved to practice' do
         exercise_ids = Content::Models::Exercise.all.map(&:id)
-        exercise_id  = ecosystem.exercises.first.id
+        exercise  = ecosystem.exercises.first
+        tasked = FactoryBot.create(:tasks_tasked_exercise, exercise: exercise)
         FactoryBot.create(:tasks_practice_question,
                           role: student_role,
-                          content_exercise_id: exercise_id)
+                          tasked_exercise: tasked,
+                          content_exercise_id: exercise.id)
 
         api_get exercises_api_ecosystem_path(
           ecosystem.id, course_id: course.id, exercise_ids: exercise_ids, role_id: student_role.id
@@ -318,7 +319,7 @@ RSpec.describe Api::V1::EcosystemsController, type: :request, api: true,
 
         hash = response.body_as_hash
         expect(hash[:total_count]).to eq(1)
-        expect(hash[:items].first[:id]).to eq(exercise_id.to_s)
+        expect(hash[:items].first[:id]).to eq(exercise.id.to_s)
 
         # Ensure content_hash_for_student was used
         keys = hash[:items][0][:content][:questions][0][:answers].map(&:keys).flatten.uniq

--- a/spec/requests/api/v1/practices_controller_spec.rb
+++ b/spec/requests/api/v1/practices_controller_spec.rb
@@ -205,12 +205,11 @@ RSpec.describe Api::V1::PracticesController, type: :request, api: true, version:
     end
 
     context 'with some practice exercises' do
-      let(:num_practice_exercises) { 5 }
+      let(:question_1) { FactoryBot.create :tasks_practice_question, role: role, exercise: exercise_1 }
+      let(:question_2) { FactoryBot.create :tasks_practice_question, role: role, exercise: exercise_2 }
 
       before do
-        allow_any_instance_of(FindOrCreatePracticeSavedTask).to receive(:questions).and_return(
-          num_practice_exercises.times.map { FactoryBot.create(:tasks_practice_question) }
-        )
+        allow_any_instance_of(FindOrCreatePracticeSavedTask).to receive(:questions).and_return([question_1, question_2])
       end
 
       it 'returns the practice task data' do
@@ -223,7 +222,7 @@ RSpec.describe Api::V1::PracticesController, type: :request, api: true, version:
           id: task.id.to_s,
           title: 'Practice',
           type: 'practice_saved',
-          steps: have(num_practice_exercises).items
+          steps: have(2).items
         )
       end
 
@@ -240,7 +239,7 @@ RSpec.describe Api::V1::PracticesController, type: :request, api: true, version:
           id: task.id.to_s,
           title: 'Practice',
           type: 'practice_saved',
-          steps: have(num_practice_exercises).items
+          steps: have(2).items
         )
       end
 

--- a/spec/routines/get_practice_question_exercises_spec.rb
+++ b/spec/routines/get_practice_question_exercises_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GetPracticeQuestionExercises, type: :routine do
 
   let(:student_user) { FactoryBot.create(:user_profile) }
   let(:student_role) { AddUserAsPeriodStudent[user: student_user, period: period] }
-  let(:book)       { FactoryBot.create(:content_book, :standard_contents_1) }
+  let(:book)         { FactoryBot.create(:content_book, :standard_contents_1) }
 
   let!(:ecosystem) do
     book.ecosystem.reload.tap do |ecosystem|
@@ -26,35 +26,40 @@ RSpec.describe GetPracticeQuestionExercises, type: :routine do
     end
   end
 
-  let(:old_exercise) do
+  let!(:old_exercise) do
     FactoryBot.create(:content_exercise, page: old_page).tap do |exercise|
       old_page.homework_dynamic_exercise_ids << exercise.id
       old_page.save!
     end
   end
-  let(:new_exercise) do
+  let!(:new_exercise) do
     FactoryBot.create(:content_exercise, page: new_page).tap do |exercise|
       new_page.homework_dynamic_exercise_ids << exercise.id
       new_page.save!
     end
   end
+  let!(:old_tasked)   { FactoryBot.create(:tasks_tasked_exercise, exercise: old_exercise) }
+  let!(:new_tasked)   { FactoryBot.create(:tasks_tasked_exercise, exercise: new_exercise) }
+  let!(:old_practice) { FactoryBot.create(:tasks_practice_question, role: student_role,
+                                        tasked_exercise: old_tasked,
+                                        content_exercise_id: old_exercise.id) }
+  let!(:new_practice) { FactoryBot.create(:tasks_practice_question,
+                                     role: student_role,
+                                     tasked_exercise: new_tasked,
+                                     content_exercise_id: new_exercise.id) }
+
 
   it 'returns exercises saved in new and old ecosystems' do
     AddEcosystemToCourse[course: course, ecosystem: new_ecosystem]
-    old_practice = FactoryBot.create(:tasks_practice_question,
-                                     role: student_role,
-                                     content_exercise_id: old_exercise.id)
-    new_practice = FactoryBot.create(:tasks_practice_question,
-                                     role: student_role,
-                                     content_exercise_id: new_exercise.id)
-    exercise_ids = [old_exercise.id, new_exercise.id]
+
+    expect(old_tasked.exercise.id).to eq(old_practice.tasked_exercise.exercise.id)
+    exercise_uuids = [old_exercise.uuid, new_exercise.uuid]
 
     outputs = described_class.call(
       role: student_role,
-      course: course,
-      exercise_ids: exercise_ids
+      course: course
     ).outputs
 
-    expect(outputs.exercises.map(&:id)).to eq(exercise_ids)
+    expect(outputs.exercises.map(&:uuid)).to eq(exercise_uuids)
   end
 end

--- a/spec/routines/get_practice_question_exercises_spec.rb
+++ b/spec/routines/get_practice_question_exercises_spec.rb
@@ -40,13 +40,6 @@ RSpec.describe GetPracticeQuestionExercises, type: :routine do
     end
   end
 
-  let!(:old_exercise_in_new_eco) do
-    FactoryBot.create(:content_exercise, page: new_page, uuid: old_exercise.uuid).tap do |exercise|
-      new_page.homework_dynamic_exercise_ids << exercise.id
-      new_page.save!
-    end
-  end
-
   let!(:old_tasked) { FactoryBot.create(:tasks_tasked_exercise, exercise: old_exercise) }
   let!(:new_tasked) { FactoryBot.create(:tasks_tasked_exercise, exercise: new_exercise) }
 

--- a/spec/routines/get_practice_question_exercises_spec.rb
+++ b/spec/routines/get_practice_question_exercises_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe GetPracticeQuestionExercises, type: :routine do
       course: course
     ).outputs
 
-    expect(outputs.exercises.map(&:uuid)).to contain_exactly(old_exercise.uuid, new_exercise.uuid)
-    expect(outputs.exercises.map(&:id)).to contain_exactly(old_exercise_in_new_eco.id, new_exercise.id)
+    expect(outputs.exercises.map(&:id)).to eq([old_exercise.id, new_exercise.id])
   end
 end


### PR DESCRIPTION
Goes with https://github.com/openstax/tutor-js/pull/3825

- Add`exercise_uuid` in the representer, which allows the FE to match PracticeQuestions by uuid to avoid issues with ecosystem updates. (Maybe we should remove `exercise_id` in the future, but some FE things broke and need to be updated.)
- Stop accepting exercise ids from the FE, we can get them off the tasked, which makes the endpoint and routine simpler.
- Dedup if multiple matching versions were picked when creating the practice task (thanks @Dantemss for the query)

I left `content_exercise_id` in there for now to minimize the scope of this change, but I wonder if we should change it to `content_exercise_uuid` over a couple of deploys and background migrations (or remove it and get it from tasked?)