### PR TITLE
Shuffle choices

### DIFF
--- a/app/representers/api/v1/grading_template_representer.rb
+++ b/app/representers/api/v1/grading_template_representer.rb
@@ -136,4 +136,12 @@ class Api::V1::GradingTemplateRepresenter < Roar::Decorator
              required: true,
              type: 'boolean'
            }
+
+  property :shuffle_answer_choices,
+           readable: true,
+           writeable: true,
+           schema_info: {
+             required: true,
+             type: 'boolean'
+           }
 end

--- a/app/representers/api/v1/task_representer.rb
+++ b/app/representers/api/v1/task_representer.rb
@@ -94,6 +94,13 @@ module Api::V1
               type: 'boolean'
             }
 
+    property :shuffle_answer_choices,
+             readable: true,
+             writeable: false,
+             schema_info: {
+               type: 'boolean'
+             }
+
     property :completion_weight,
              type: Float,
              readable: true,

--- a/app/representers/api/v1/tasks/tasked_exercise_representer.rb
+++ b/app/representers/api/v1/tasks/tasked_exercise_representer.rb
@@ -88,6 +88,13 @@ module Api::V1::Tasks
                description: "The answer id that was recorded for the Exercise"
              }
 
+    property :answer_id_order,
+             writeable: true,
+             readable: true,
+             schema_info: {
+               description: "The order of the answer ids for the first attempt"
+             }
+
     property :free_response,
              type: String,
              writeable: true,

--- a/app/routines/build_teacher_exercise_content_hash.rb
+++ b/app/routines/build_teacher_exercise_content_hash.rb
@@ -19,7 +19,6 @@ class BuildTeacherExerciseContentHash
 
     question = {
       id: SecureRandom.uuid,
-      is_answer_order_important: true,
       stimulus_html: "",
       stem_html: sanitize(data[:questionText]),
       title: sanitize(data[:questionName]),
@@ -44,6 +43,16 @@ class BuildTeacherExerciseContentHash
         solution_type: 'detailed',
         content_html: sanitize(data[:detailedSolution])
       }
+    end
+
+    can_set_order_importance = question[:answers].length > 2 &&
+                               !data[:isAnswerOrderImportant].nil?
+
+
+    question[:is_answer_order_important] = if can_set_order_importance
+      data[:isAnswerOrderImportant].to_s == 'true'
+    else
+      true
     end
 
     question[:formats] = [].tap do |formats|

--- a/app/subsystems/tasks/models/grading_template.rb
+++ b/app/subsystems/tasks/models/grading_template.rb
@@ -53,7 +53,8 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
       default_due_time: '21:00',
       default_due_date_offset_days: 7,
       default_close_date_offset_days: 7,
-      allow_auto_graded_multiple_attempts: false
+      allow_auto_graded_multiple_attempts: false,
+      shuffle_answer_choices: true
     },
     {
       task_plan_type: :reading,
@@ -68,7 +69,8 @@ class Tasks::Models::GradingTemplate < ApplicationRecord
       default_due_time: '07:00',
       default_due_date_offset_days: 7,
       default_close_date_offset_days: 7,
-      allow_auto_graded_multiple_attempts: false
+      allow_auto_graded_multiple_attempts: false,
+      shuffle_answer_choices: true
     }
   ]
 

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -224,6 +224,10 @@ class Tasks::Models::Task < ApplicationRecord
     !!grading_template&.allow_auto_graded_multiple_attempts
   end
 
+  def shuffle_answer_choices
+    !!grading_template&.shuffle_answer_choices
+  end
+
   def late_work_penalty_applied
     grading_template&.late_work_penalty_applied || 'not_accepted'
   end

--- a/app/subsystems/tasks/models/task.rb
+++ b/app/subsystems/tasks/models/task.rb
@@ -225,7 +225,8 @@ class Tasks::Models::Task < ApplicationRecord
   end
 
   def shuffle_answer_choices
-    !!grading_template&.shuffle_answer_choices
+    value = grading_template&.shuffle_answer_choices
+    value.nil? ? true : value
   end
 
   def late_work_penalty_applied

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -43,7 +43,7 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
   end
 
   def answer_id_order=(order)
-    return unless attempt_number == 0
+    return unless attempt_number_was == 0
     answer_ids.sort_by! {|i| order.index(i) || 0 }
   end
 

--- a/app/subsystems/tasks/models/tasked_exercise.rb
+++ b/app/subsystems/tasks/models/tasked_exercise.rb
@@ -38,6 +38,15 @@ class Tasks::Models::TaskedExercise < IndestructibleRecord
 
   delegate :uuid, to: :exercise, prefix: :exercise
 
+  def answer_id_order
+    answer_ids
+  end
+
+  def answer_id_order=(order)
+    return unless attempt_number == 0
+    answer_ids.sort_by! {|i| order.index(i) || 0 }
+  end
+
   def attempt_number_was
     val = super
     return val unless val.nil?

--- a/db/migrate/20211103150618_add_shuffle_answer_choices_fields.rb
+++ b/db/migrate/20211103150618_add_shuffle_answer_choices_fields.rb
@@ -1,0 +1,5 @@
+class AddShuffleAnswerChoicesFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks_grading_templates, :shuffle_answer_choices, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_155727) do
+ActiveRecord::Schema.define(version: 2021_11_03_150618) do
 
   create_sequence "teacher_exercise_number", start: 1000000
 
@@ -883,6 +883,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_155727) do
     t.datetime "updated_at", null: false
     t.bigint "cloned_from_id"
     t.boolean "allow_auto_graded_multiple_attempts", default: false, null: false
+    t.boolean "shuffle_answer_choices", default: false, null: false
     t.index ["cloned_from_id"], name: "index_tasks_grading_templates_on_cloned_from_id"
     t.index ["course_profile_course_id", "name"], name: "index_tasks_grading_templates_on_course_and_name", unique: true
     t.index ["course_profile_course_id", "task_plan_type", "deleted_at"], name: "index_tasks_grading_templates_on_course_type_and_deleted"

--- a/spec/factories/tasks/grading_templates.rb
+++ b/spec/factories/tasks/grading_templates.rb
@@ -15,5 +15,6 @@ FactoryBot.define do
     default_due_date_offset_days        { 7 }
     default_close_date_offset_days      { 7 }
     allow_auto_graded_multiple_attempts { false }
+    shuffle_answer_choices              { true }
   end
 end

--- a/spec/representers/api/v1/grading_template_representer_spec.rb
+++ b/spec/representers/api/v1/grading_template_representer_spec.rb
@@ -211,4 +211,32 @@ RSpec.describe Api::V1::GradingTemplateRepresenter, type: :representer do
       end.not_to change { represented.has_task_plans? }
     end
   end
+
+  context 'allow_auto_graded_multiple_attempts' do
+    it 'can be read' do
+      expect(representation['allow_auto_graded_multiple_attempts']).to(
+        eq represented.allow_auto_graded_multiple_attempts
+      )
+    end
+
+    it 'can be written' do
+      expect do
+        representer.from_hash('allow_auto_graded_multiple_attempts' => true)
+      end.to change { represented.allow_auto_graded_multiple_attempts }.to(true)
+    end
+  end
+
+  context 'shuffle_answer_choices' do
+    it 'can be read' do
+      expect(representation['shuffle_answer_choices']).to(
+        eq represented.shuffle_answer_choices
+      )
+    end
+
+    it 'can be written' do
+      expect do
+        representer.from_hash('shuffle_answer_choices' => false)
+      end.to change { represented.shuffle_answer_choices }.to(false)
+    end
+  end
 end

--- a/spec/representers/api/v1/task_representer_spec.rb
+++ b/spec/representers/api/v1/task_representer_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe Api::V1::TaskRepresenter, type: :representer do
     expect(described_class.new(task).to_hash['allow_auto_graded_multiple_attempts']).to be false
   end
 
+  it 'includes shuffle_answer_choices' do
+    task.task_plan.grading_template.shuffle_answer_choices = true
+    expect(described_class.new(task).to_hash['shuffle_answer_choices']).to be true
+
+    task.task_plan.grading_template.shuffle_answer_choices = false
+    expect(described_class.new(task).to_hash['shuffle_answer_choices']).to be false
+  end
+
   it 'includes completion_weight' do
     task.task_plan.grading_template.completion_weight = 0.0
     expect(described_class.new(task).to_hash['completion_weight']).to eq 0.0

--- a/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
+++ b/spec/representers/api/v1/tasks/tasked_exercise_representer_shared_examples.rb
@@ -39,6 +39,7 @@ RSpec.shared_examples 'a tasked_exercise representer' do
       allow(exercise).to receive(:correct_answer_feedback).and_return('More feedback')
       allow(exercise).to receive(:free_response).and_return(nil)
       allow(exercise).to receive(:answer_id).and_return(nil)
+      allow(exercise).to receive(:answer_id_order).and_return(['1', '2'])
       allow(exercise).to receive(:last_completed_at).and_return(Time.current)
       allow(exercise).to receive(:first_completed_at).and_return(Time.current - 1.week)
       allow(exercise).to receive(:feedback_available?).and_return(false)

--- a/spec/requests/api/v1/task_steps_controller_spec.rb
+++ b/spec/requests/api/v1/task_steps_controller_spec.rb
@@ -292,18 +292,26 @@ RSpec.describe Api::V1::TaskStepsController, type: :request, api: true, version:
                 params: { free_response: 'Ipsum Lorem', answer_id: tasked.answer_ids.last }.to_json
       end
 
-      it 'updates the answer order of the exercise' do
+      fit 'updates the answer order of the exercise' do
         tasked.free_response = 'Ipsum lorem'
-        tasked.answer_ids = ['1', '2']
+        tasked.answer_ids = ['1', '2', '3', '4']
         tasked.save!
         answer_id = tasked.answer_ids.first
         original_order = tasked.answer_ids
-        new_order = ['2', '1']
+        new_order = tasked.answer_ids.reverse
 
         expect do
           api_put api_step_url(tasked.task_step.id), @user_1_token,
                   params: { answer_id: answer_id.to_s, answer_id_order: new_order }.to_json
         end.to change { tasked.reload.answer_ids }.from(original_order).to(new_order)
+
+        expect(response).to have_http_status(:success)
+
+        # Does not update after the first attempt
+        expect do
+          api_put api_step_url(tasked.task_step.id), @user_1_token,
+                  params: { answer_id: answer_id.to_s, answer_id_order: new_order.reverse }.to_json
+        end.not_to change { tasked.reload.answer_ids }
 
         expect(response).to have_http_status(:success)
       end

--- a/spec/requests/api/v1/task_steps_controller_spec.rb
+++ b/spec/requests/api/v1/task_steps_controller_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Api::V1::TaskStepsController, type: :request, api: true, version:
                 params: { free_response: 'Ipsum Lorem', answer_id: tasked.answer_ids.last }.to_json
       end
 
-      fit 'updates the answer order of the exercise' do
+      it 'updates the answer order of the exercise' do
         tasked.free_response = 'Ipsum lorem'
         tasked.answer_ids = ['1', '2', '3', '4']
         tasked.save!

--- a/spec/requests/api/v1/task_steps_controller_spec.rb
+++ b/spec/requests/api/v1/task_steps_controller_spec.rb
@@ -291,6 +291,22 @@ RSpec.describe Api::V1::TaskStepsController, type: :request, api: true, version:
         api_put api_step_url(tasked.task_step.id), @user_1_token,
                 params: { free_response: 'Ipsum Lorem', answer_id: tasked.answer_ids.last }.to_json
       end
+
+      it 'updates the answer order of the exercise' do
+        tasked.free_response = 'Ipsum lorem'
+        tasked.answer_ids = ['1', '2']
+        tasked.save!
+        answer_id = tasked.answer_ids.first
+        original_order = tasked.answer_ids
+        new_order = ['2', '1']
+
+        expect do
+          api_put api_step_url(tasked.task_step.id), @user_1_token,
+                  params: { answer_id: answer_id.to_s, answer_id_order: new_order }.to_json
+        end.to change { tasked.reload.answer_ids }.from(original_order).to(new_order)
+
+        expect(response).to have_http_status(:success)
+      end
     end
 
     context 'reading' do

--- a/spec/routines/build_teacher_exercise_content_hash_spec.rb
+++ b/spec/routines/build_teacher_exercise_content_hash_spec.rb
@@ -139,4 +139,71 @@ RSpec.describe BuildTeacherExerciseContentHash, type: :routine do
       expect(errors.first.code).to eq(:multiple_choice_must_have_valid_correctness)
     end
   end
+
+  context 'answer order importance' do
+    it 'can be set' do
+      data = {
+        isAnswerOrderImportant: false,
+        questionText: 'Question?',
+        questionName: 'Title',
+        options: [
+          {
+            content: 'answer',
+            correctness: '1.0',
+            feedback: 'feedback'
+          },
+          {
+            content: 'answer',
+            correctness: '0.0',
+            feedback: 'feedback'
+          },
+          {
+            content: 'answer',
+            correctness: '0.0',
+            feedback: 'feedback'
+          }
+        ],
+        tags: { tagDifficulty: { value: 'easy' }, tagBloom: { value: '2' } }
+      }
+
+      result = described_class.call(data: data)
+      question = result.outputs.content_hash.deep_symbolize_keys[:questions][0]
+      expect(question[:is_answer_order_important]).to eq(false)
+      expect(result.errors).to be_empty
+
+      result = described_class.call data: data.merge({ isAnswerOrderImportant: 'true' })
+      question = result.outputs.content_hash.deep_symbolize_keys[:questions][0]
+      expect(question[:is_answer_order_important]).to eq(true)
+
+      result = described_class.call data: data.merge({ isAnswerOrderImportant: 'noboolean' })
+      question = result.outputs.content_hash.deep_symbolize_keys[:questions][0]
+      expect(question[:is_answer_order_important]).to eq(false)
+    end
+
+    it 'is always true if there are only 2 options' do
+      data = {
+        isAnswerOrderImportant: false,
+        questionText: 'Question?',
+        questionName: 'Title',
+        options: [
+          {
+            content: 'answer',
+            correctness: '1.0',
+            feedback: 'feedback'
+          },
+          {
+            content: 'answer',
+            correctness: '0.0',
+            feedback: 'feedback'
+          }
+        ],
+        tags: { tagDifficulty: { value: 'easy' }, tagBloom: { value: '2' } }
+      }
+
+      result = described_class.call(data: data)
+      question = result.outputs.content_hash.deep_symbolize_keys[:questions][0]
+      expect(question[:is_answer_order_important]).to eq(true)
+      expect(result.errors).to be_empty
+    end
+  end
 end

--- a/spec/subsystems/tasks/models/task_spec.rb
+++ b/spec/subsystems/tasks/models/task_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe Tasks::Models::Task, type: :model, speed: :medium do
     expect(task.reload.is_shared?).to eq true
   end
 
+  it 'defaults shuffle_answer_choices to true' do
+    task.grading_template.shuffle_answer_choices = true
+    expect(task.shuffle_answer_choices).to eq true
+
+    task.grading_template.shuffle_answer_choices = false
+    expect(task.shuffle_answer_choices).to eq false
+
+    task_plan.grading_template = nil
+    expect(task.shuffle_answer_choices).to eq true
+  end
+
   context 'with research cohort' do
     let(:student)  { role.student }
     let(:study)    { FactoryBot.create :research_study }

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -238,4 +238,30 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
     tasked_exercise = described_class.find id
     expect(tasked_exercise.available_points).to eq 2.0
   end
+
+  context '#answer_id_order' do
+    it 'can order the answer_ids by the submitted order on the first attempt' do
+      original_order = ['3', '2', '1']
+      new_order      = ['1', '2', '3']
+
+      tasked_exercise.attempt_number = 0
+      tasked_exercise.answer_ids = original_order
+      expect(tasked_exercise.answer_ids).to eq (original_order)
+
+      tasked_exercise.answer_id_order = new_order
+      expect(tasked_exercise.answer_ids).to eq (new_order)
+
+      tasked_exercise.attempt_number = 2
+      tasked_exercise.answer_id_order = original_order
+      expect(tasked_exercise.answer_ids).to eq(new_order)
+    end
+
+    it 'cannot change answer ids' do
+      tasked_exercise.attempt_number = 0
+      tasked_exercise.answer_ids = ['3', '2', '1']
+      tasked_exercise.answer_id_order = ['1', '4', '2', '3']
+
+      expect(tasked_exercise.answer_ids).to eq(['1', '2', '3'])
+    end
+  end
 end

--- a/spec/subsystems/tasks/models/tasked_exercise_spec.rb
+++ b/spec/subsystems/tasks/models/tasked_exercise_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe Tasks::Models::TaskedExercise, type: :model do
       expect(tasked_exercise.answer_ids).to eq (new_order)
 
       tasked_exercise.attempt_number = 2
+      tasked_exercise.save
       tasked_exercise.answer_id_order = original_order
       expect(tasked_exercise.answer_ids).to eq(new_order)
     end


### PR DESCRIPTION
The main pieces to this are:
- Add `shuffle_answer_choices` field on the grading template
- Use `answer_id_order` param on the first attempt only to sort the tasked's `answer_ids` field so we can use that on the front end to preserve the submitted order
- Allow teacher-created exercises to set `is_answer_order_important` field if there are more than 2 answers.