### PR TITLE
Added gems to create RDS snapshots before migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,8 +224,10 @@ gem 'bootsnap', '~> 1.4.0', require: false
 # Get env variables from .env file
 gem 'dotenv-rails'
 
+# ActiveStorage S3 support
 gem 'aws-sdk-s3'
 
+# Bundle JS assets using webpack
 gem 'webpacker'
 
 group :development, :test do
@@ -326,12 +328,14 @@ group :production, :test do
 end
 
 group :production do
+  # Used to backup the database before migrations
+  gem 'aws-sdk-rds', require: false
+
+  # Used to record a lifecycle action heartbeat after creating the RDS snapshot before migrating
+  gem 'aws-sdk-autoscaling', require: false
+
   # Used to send custom delayed_job metrics to Cloudwatch
   gem 'aws-sdk-cloudwatch', require: false
-
-  # Used to fetch secrets from the AWS parameter store and secrets manager
-  gem 'aws-sdk-ssm', require: false
-  gem 'aws-sdk-secretsmanager', require: false
 
   # Lograge for consistent logging
   gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,15 +112,12 @@ GEM
     aws-sdk-kms (1.44.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-rds (1.130.0)
+      aws-sdk-core (~> 3, >= 3.122.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.96.1)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-secretsmanager (1.43.0)
-      aws-sdk-core (~> 3, >= 3.109.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-ssm (1.95.0)
-      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
@@ -782,10 +779,10 @@ DEPENDENCIES
   apipie-rails
   ar-sequence
   awesome_print
+  aws-sdk-autoscaling
   aws-sdk-cloudwatch
+  aws-sdk-rds
   aws-sdk-s3
-  aws-sdk-secretsmanager
-  aws-sdk-ssm
   axlsx!
   best_in_place
   bootsnap (~> 1.4.0)

--- a/lib/date_time_utilities.rb
+++ b/lib/date_time_utilities.rb
@@ -20,6 +20,9 @@ module DateTimeUtilities
     RequestStore.store[:apply_tz_cache] ||= Hash.new { |hash, key| hash[key] = {} }
     RequestStore.store[:apply_tz_cache][date_time][timezone] ||= begin
       time_in_zone = date_time.in_time_zone(timezone)
+
+      # There's some ambiguity here if time_in_zone falls right on the DST transition
+      # and the utc_offset changes as a result of this subtraction
       time_in_zone - time_in_zone.utc_offset
     end
   end


### PR DESCRIPTION
- Add aws-sdk-rds to backup the DB before migrating
- Add aws-sdk-autoscaling to record a lifecycle action heartbeat after creating the RDS snapshot before migrating
- Remove unused aws-sdk-ssm and aws-sdk-secretsmanager

The script that copies secrets is now in python (because of ospayments) so we don't need the ssm and secretsmanager gems anymore.