### PR TITLE
Fixed a bug that manifested when trying to upload stats for unknown background job queues to CloudWatch

### DIFF
--- a/lib/tasks/aws/update_cloudwatch_metrics.rake
+++ b/lib/tasks/aws/update_cloudwatch_metrics.rake
@@ -40,7 +40,7 @@ namespace :aws do
           min_effective_run_at = if queue.blank?
             min_effective_run_at_by_queue.values.compact.min
           elsif queue == 'other'
-            min_effective_run_at_by_queue.except(*known_queues).compact.min
+            min_effective_run_at_by_queue.except(*known_queues).values.compact.min
           else
             min_effective_run_at_by_queue[queue]
           end


### PR DESCRIPTION
This would cause `min_effective_run_at` to be an array instead of a time and cause errors when trying to subtract it later.