### PR TITLE
remove mathjax from webview

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -5,7 +5,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script type='text/javascript' src='https://c.la2-c2-dfw.salesforceliveagent.com/content/g/js/39.0/deployment.js'></script>
   <%= OpenStax::Utilities::Assets.tags_for("tutor") %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
No longer needed now that MathJax 3.2 is loaded in the app js: https://github.com/openstax/tutor-js/pull/3834