### PR TITLE
Research Export Fix

### DIFF
--- a/app/routines/export_and_upload_research_data.rb
+++ b/app/routines/export_and_upload_research_data.rb
@@ -194,7 +194,7 @@ class ExportAndUploadResearchData
 
               row.concat(
                 step.exercise? ? [
-                  "#{step.exercise_url.gsub('org', 'org/api')}.json",
+                  "#{step.exercise_url&.gsub('org', 'org/api')}.json",
                   step.exercise_url,
                   array_decoder.decode(step.tags_array).join(','),
                   step.question_index.to_i + 1,

--- a/spec/routines/get_practice_question_exercises_spec.rb
+++ b/spec/routines/get_practice_question_exercises_spec.rb
@@ -61,6 +61,6 @@ RSpec.describe GetPracticeQuestionExercises, type: :routine do
       course: course
     ).outputs
 
-    expect(outputs.exercises.map(&:id)).to eq([old_exercise.id, new_exercise.id])
+    expect(Set.new outputs.exercises.map(&:id)).to eq(Set[old_exercise.id, new_exercise.id])
   end
 end


### PR DESCRIPTION
Don't blow up on nil `step.exercise_url`. Apparently some exercise steps have a nil `step.exercise_url` somehow.